### PR TITLE
Server-enforced ACLs

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -224,6 +224,7 @@ glusterfs_ctx_defaults_init (glusterfs_ctx_t *ctx)
         pthread_mutex_init (&(ctx->lock), NULL);
 
         cmd_args = &ctx->cmd_args;
+	cmd_args->default_permissions = _gf_true;
 
         INIT_LIST_HEAD (&cmd_args->xlator_options);
 

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -175,6 +175,8 @@ static struct argp_option gf_options[] = {
          "Dump fuse traffic to PATH"},
         {"volfile-check", ARGP_VOLFILE_CHECK_KEY, 0, 0,
          "Enable strict volume file checking"},
+	{"default-permissions", ARGP_DEFAULT_PERMISSIONS_KEY, "BOOL",
+	 OPTION_HIDDEN, "use FUSE default_permissions option"},
         {0, 0, 0, 0, "Miscellaneous Options:"},
         {0, }
 };
@@ -637,6 +639,12 @@ parse_opts (int key, char *arg, struct argp_state *state)
                 argp_failure (state, -1, 0,
                               "unknown client pid %s", arg);
                 break;
+
+	case ARGP_DEFAULT_PERMISSIONS_KEY:
+		if (gf_string2boolean(arg, &b) == 0) {
+			cmd_args->default_permissions = b;
+		}
+		break;
 
         case ARGP_VOLFILE_CHECK_KEY:
                 cmd_args->volfile_check = 1;

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -76,6 +76,7 @@ enum argp_option_keys {
         ARGP_BRICK_NAME_KEY               = 151,
         ARGP_BRICK_PORT_KEY               = 152,
         ARGP_CLIENT_PID_KEY               = 153,
+	ARGP_DEFAULT_PERMISSIONS_KEY      = 154,
 };
 
 int glusterfs_mgmt_pmap_signout (glusterfs_ctx_t *ctx);

--- a/libglusterfs/src/glusterfs.h
+++ b/libglusterfs/src/glusterfs.h
@@ -288,6 +288,7 @@ struct _cmd_args {
 	int              fuse_nosuid;
 	char            *dump_fuse;
         pid_t            client_pid;
+	int              default_permissions;
         int              client_pid_set;
 
 	/* key args */

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3485,6 +3485,7 @@ init (xlator_t *this_xl)
         int                i = 0;
         int                xl_name_allocated = 0;
         int                fsname_allocated = 0;
+	char              *fuse_opts;
 
         if (this_xl == NULL)
                 return -1;
@@ -3628,9 +3629,12 @@ init (xlator_t *this_xl)
                 fsname = "glusterfs";
 
 
-        priv->fd = gf_fuse_mount (priv->mount_point, fsname,
-                                  "allow_other,default_permissions,"
-                                  "max_read=131072");
+	if (cmd_args->default_permissions) {
+		fuse_opts = "allow_other,default_permissions,max_read=131072";
+	} else {
+		fuse_opts = "allow_other,max_read=131072";
+	}
+        priv->fd = gf_fuse_mount (priv->mount_point, fsname, fuse_opts);
         if (priv->fd == -1)
                 goto cleanup_exit;
 

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -55,9 +55,6 @@
 #include "list.h"
 #include "dict.h"
 
-/* TODO: when supporting posix acl, remove this definition */
-#define DISABLE_POSIX_ACL
-
 #ifdef GF_LINUX_HOST_OS
 #define FUSE_OP_HIGH (FUSE_POLL + 1)
 #endif

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -113,6 +113,8 @@ struct posix_private {
 /* janitor thread which cleans up /.trash (created by replicate) */
         pthread_t       janitor;
         gf_boolean_t    janitor_present;
+
+	gf_boolean_t    use_set_fsid;	/* use setfs*id to deal with perms */
         char *          trash_path;
 };
 


### PR DESCRIPTION
This is the feature requested by one of my CloudFS/GlusterFS users.  Commit comment follows...

By default, the behavior is the same as currently - ACLs are interpreted and
enforced on the client.  To use server-side ACLs:

(1) Make sure that your server-side filesystems support the "acl" option and
    are mounted with it.

(2) Add "option use-set-fsid true" to all of your server-side storage/posix
    translators.

(3) Mount with "-o default-permissions=false" on the client side.

Note that the GlusterFS native protocol has no way to transmit supplementary
group IDs, so accesses relying on those might fail even if the ACL is set
correctly.  This might be the subject of a future patch.
