### PR TITLE
glusterfsd: do not return an error for GF_GLUSTERD_PROCESS in create_fuse_mount()

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -220,7 +220,7 @@ create_fuse_mount (glusterfs_ctx_t *ctx)
         if (ctx->process_mode != GF_CLIENT_PROCESS) {
                 gf_log("glusterfsd", GF_LOG_ERROR,
                        "Not a client process, not performing mount operation");
-                return -1;
+                return 0;
         }
 
         master = GF_CALLOC (1, sizeof (*master),


### PR DESCRIPTION
The check in create_fuse_mount() for GF_GLUSTERD_PROCESS should not return an error. It will cause glusterfsd to exit and so glusterd process will not be started.
