### PR TITLE
Building an RPM on a RedHat-like system that lacks a redhat-release file...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ fi
 
 # Check the distribution where you are compiling glusterfs on 
 
-GF_DISTRIBUTION=
+GF_DISTRIBUTION=Redhat
 AC_CHECK_FILE([/etc/debian_version])
 AC_CHECK_FILE([/etc/SuSE-release])
 AC_CHECK_FILE([/etc/redhat-release])


### PR DESCRIPTION
... fails since it cannot find the correct init script to bundle in the RPM.
