### PR TITLE
Missing condition when bricks not already mounted would lead to gluster mount failing.

### DIFF
--- a/extras/Ubuntu/mounting-glusterfs.conf
+++ b/extras/Ubuntu/mounting-glusterfs.conf
@@ -1,7 +1,7 @@
 author "Louis Zuckerman <me@louiszuckerman.com>"
 description "Block the mounting event for glusterfs filesystems until glusterd is running"
 
-start on mounting TYPE=glusterfs
+start on local-filesystems and mounting TYPE=glusterfs
 task
 exec start wait-for-state WAIT_FOR=glusterd WAITER=mounting-glusterfs
 


### PR DESCRIPTION
With XFS bricks, there is race condition at boot when bricks filesystem is not already mounted and glusterd fails to start up.
By adding "local-filesystems" event to the mounting script, it schedules mounting glusterfs mountpoint only _after_ all bricks available.
