### PR TITLE
nfs3: only truncate if requested size != current size

### DIFF
--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -971,7 +971,8 @@ nfs3svc_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
          * truncation and also only if this is not a directory.
          */
         if ((gf_attr_size_set (cs->setattr_valid)) &&
-            (!IA_ISDIR (postop->ia_type))) {
+            (!IA_ISDIR (postop->ia_type)) &&
+            (preop->ia_size != cs->stbuf.ia_size)) {
                 nfs_request_user_init (&nfu, cs->req);
                 ret = nfs_truncate (cs->nfsx, cs->vol, &nfu, &cs->resolvedloc,
                                     cs->stbuf.ia_size, nfs3svc_truncate_cbk,cs);


### PR DESCRIPTION
- nfs3svc_setattr_cbk: only truncate if requested size != current size

Existing code says:
/\* Only truncate if the size is not already same as the requested truncation and also only if this is not a directory. */

But nothing actually implements the size check. This code adds that check to bypass the truncate call if unnecessary.
