### PR TITLE
DHT: cluster.min-free-disk option should validate correctly

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -1449,8 +1449,7 @@ gf_string2bytesize_uint64 (const char *str, uint64_t *n)
 }
 
 int
-gf_string2percent_or_bytesize (const char *str,
-			       uint64_t *n,
+gf_string2percent_or_bytesize (const char *str, double *n,
 			       gf_boolean_t *is_percent)
 {
         double value = 0ULL;
@@ -1485,6 +1484,7 @@ gf_string2percent_or_bytesize (const char *str,
         if (errno == 0)
                 errno = old_errno;
 
+        /*Maximum accepted value for 64 bit OS will be (2^14 -1)PB*/
         if (tail[0] != '\0') {
                 if (strcasecmp (tail, GF_UNIT_KB_STRING) == 0)
                         value *= GF_UNIT_KB;
@@ -1508,7 +1508,7 @@ gf_string2percent_or_bytesize (const char *str,
                 return -1;
         }
 
-        *n = (uint64_t) value;
+        *n = value;
 
         return 0;
 }

--- a/libglusterfs/src/common-utils.h
+++ b/libglusterfs/src/common-utils.h
@@ -580,7 +580,7 @@ int gf_string2uint64_base10 (const char *str, uint64_t *n);
 int gf_string2bytesize (const char *str, uint64_t *n);
 int gf_string2bytesize_size (const char *str, size_t *n);
 int gf_string2bytesize_uint64 (const char *str, uint64_t *n);
-int gf_string2percent_or_bytesize (const char *str, uint64_t *n,
+int gf_string2percent_or_bytesize (const char *str, double *n,
 				   gf_boolean_t *is_percent);
 
 int gf_string2boolean (const char *str, gf_boolean_t *b);

--- a/tests/bugs/glusterd/bug-1163108-min-free-disk-option-validation.t
+++ b/tests/bugs/glusterd/bug-1163108-min-free-disk-option-validation.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+## Test case for cluster.min-free-disk option validation.
+
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+## Start glusterd
+TEST glusterd
+TEST pidof glusterd
+
+## Lets create and start volume
+TEST $CLI volume create $V0 $H0:$B0/brick1 $H0:$B0/brick2
+TEST $CLI volume start $V0
+
+## Setting invalid value for option cluster.min-free-disk should fail
+TEST ! $CLI volume set $V0 min-free-disk ""
+TEST ! $CLI volume set $V0 min-free-disk 143.!/12
+TEST ! $CLI volume set $V0 min-free-disk 123%
+TEST ! $CLI volume set $V0 min-free-disk 194.34%
+
+## Setting fractional value as a size (unit is byte) for option
+## cluster.min-free-disk should fail
+TEST ! $CLI volume set $V0 min-free-disk 199.051
+TEST ! $CLI volume set $V0 min-free-disk 111.999
+
+## Setting valid value for option cluster.min-free-disk should pass
+TEST  $CLI volume set $V0 min-free-disk 12%
+TEST  $CLI volume set $V0 min-free-disk 56.7%
+TEST  $CLI volume set $V0 min-free-disk 120
+TEST  $CLI volume set $V0 min-free-disk 369.0000
+
+
+cleanup;


### PR DESCRIPTION
PROBLEM:
Previously gluster accepting input value as a percentage which is out of range
[0-100] and accepting input value as a size (unit is byte) which is fractional
for option cluster.min-free-disk.

FIX:
Now with this change it will refer to correct validation function
and it will accept value that is in range [0-100] for input value as a
percentage and unsigned integer value for input as a size (unit in byte)
for option cluster.min-free-disk.

Change-Id: Iee1962a100542e146276cfc8a4068abddee2bf2d
BUG: 1163108
Signed-off-by: Gaurav Kumar Garg <ggarg@redhat.com>