### PR TITLE
Bring back support for mounting volumes with volume files

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -590,16 +590,15 @@ main ()
             volume_id="$volume_str";
         }
         volfile_loc="";
-    }
-
-    [ -z "$volume_id" -o -z "$server_ip" ] && {
-        cat <<EOF >&2
+        [ -z "$volume_id" -o -z "$server_ip" ] && {
+            cat <<EOF >&2
 ERROR: Server name/volume name unspecified cannot proceed further..
 Please specify correct format
 Usage:
 man 8 $0
 EOF
-        exit 1;
+            exit 1;
+        }
     }
 
     grep_ret=$(echo ${mount_point} | grep '^\-o');


### PR DESCRIPTION
Mounting a Gluster volume with a volume file was not possible due to a small bug in mount script: http://fpaste.org/206575/14279954/

When using volume files to mount glusterfs volume, this line is always true:

```
[ -z "$volume_id" -o -z "$server_ip" ] && {
```

That's because at this place, $volume_id and $server_ip are set only and only if the $volfile_loc file was unreadable or undefined.