### PR TITLE
cli: gluster volume help should give sufficient information for bitrot

### DIFF
--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -2677,14 +2677,25 @@ struct cli_cmd volume_cmds[] = {
          cli_cmd_volume_getopt_cbk,
          "Get the value of the all options or given option for volume <VOLNAME>"
         },
-        { "volume bitrot <volname> {enable|disable} |\n"
-          "volume bitrot <volname> {scrub-throttle frozen|lazy|normal"
-          "|aggressive} |\n"
-          "volume bitrot <volname> {scrub-frequency daily|weekly|biweekly"
-          "|monthly} |\n"
-          "volume bitrot <volname> {scrub pause|resume}",
+        {"volume bitrot <VOLNAME> {enable|disable}",
+         cli_cmd_bitrot_cbk,
+         "Enable/disable bitrot for volume <VOLNAME>"
+        },
+        {"volume bitrot <VOLNAME> {scrub-throttle frozen|lazy|normal"
+         "|aggressive}",
+         cli_cmd_bitrot_cbk,
+         "Scrub-throttle value is a measure of how fast or slow the scrubber "
+         "scrubs the filesystem for volume <VOLNAME>"
+        },
+        {"volume bitrot <VOLNAME> {scrub-frequency daily|weekly|biweekly"
+         "|monthly",
+         cli_cmd_bitrot_cbk,
+         "Scrub frequency for volume <VOLNAME>"
+        },
+        {"volume bitrot <VOLNAME> {scrub pause|resume}",
           cli_cmd_bitrot_cbk,
-          "Bitrot translator specific operations."
+         "Pause/Resume scrub. Upon resume, scrubber continues where it "
+         "left off."
         },
         { NULL, NULL, NULL }
 };


### PR DESCRIPTION
Previously command "gluster volume help | grep bitrot" was not giving
sufficient information for bitrot.

With this fix command "gluster volume help" will give appropriate information
for bitrot.

Change-Id: Ic385c760d4ecbfb16ff5d90dba8940b3616035e5
BUG: 1207532
Signed-off-by: Gaurav Kumar Garg <ggarg@redhat.com>