### PR TITLE
Add support for sparse file to tarssh

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -958,7 +958,7 @@ class SlaveRemote(object):
         logging.debug("files: " + ", ".join(files))
         (host, rdir) = slaveurl.split(':')
         tar_cmd = ["tar"] + \
-            ["-cf", "-", "--files-from", "-"]
+            [ "--sparse", "-cf", "-", "--files-from", "-"]
         ssh_cmd = gconf.ssh_command_tar.split() + \
             [host, "tar"] + \
             ["--overwrite", "-xf", "-", "-C", rdir]


### PR DESCRIPTION
Without '--sparse' option tar will not properly archive sparse file
and geo-replication will result in non-sparse file on the remote end.

Here is more on how I arrived at this http://markelov.org/wiki/index.php/GlusterFS_3.6.1_on_CentOS_6.5:_geo-replication_and_sparse_files_problem