### PR TITLE
A bug about "run.h"

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -32,6 +32,8 @@
 #include <errno.h>
 #include <pwd.h>
 
+//include "run.h"
+
 #ifndef _CONFIG_H
 #define _CONFIG_H
 #include "config.h"
@@ -75,6 +77,8 @@
 
 #include "daemon.h"
 #include "tw.h"
+
+#include "run.h"
 
 /* process mode definitions */
 #define GF_SERVER_PROCESS   0


### PR DESCRIPTION
**#include "run.h"** at line 35, then make the project, I got an error, as follows:

**In file included from glusterfsd.c:35:0:
../../libglusterfs/src/run.h:92:53: error: unknown type name 'gf_loglevel_t'
 void runner_log (runner_t *runner, const char *dom, gf_loglevel_t lvl,**

Then, I put **#include "run.h"** to line 81, make again, no error occured.
