### PR TITLE
Workaround script for auto mounts after bootup on Ubuntu

### DIFF
--- a/extras/Ubuntu/glusterfs-mount.sh
+++ b/extras/Ubuntu/glusterfs-mount.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Description:  GlusterFS volumes are mounted in the background
+#               when interfaces are brought up; this script waits
+#               for them to be mounted before carrying on.
+#
+# Author: Sebastian Kraetzig <info@ts3-tools.info>
+# Version: 2016-08-15
+#
+
+BOOLEAN=true;
+
+while ${BOOLEAN}; do
+        VOLUME_STATUS=$(gluster volume info | grep -i status | head -1 | cut -d ':' -f 2 | tr -d '[:space:]')
+
+        if [[ ${VOLUME_STATUS} == "Started" ]]; then
+                if [[ $(mount -a -t glusterfs,fuse.glusterfs) ]]; then
+                        BOOLEAN=false;
+                fi
+        fi
+done
+
+exit 0;


### PR DESCRIPTION
Ubuntu tries to mount the volumes even before they are online (started) and this results in a non-mounted volume all the time after a bootup. Since the fstab/mount option '_netdev' isn't supported anymore, you've to mount shared network storage by your own using own shell scripts or by logging in via SSH for example and run the mount command "mount -a" or "mount [mount point]".

For further information regarding this problem, please read these articles:
- http://unix.stackexchange.com/questions/169697/how-does-netdev-mount-option-in-etc-fstab-work
- http://askubuntu.com/questions/763498/systemd-seems-to-ignore-netdev-option-for-nfs-in-ubuntu-16-04
- https://help.ubuntu.com/community/Fstab

NFS should be mountable by using the option 'vers=3', but this requires a NFS version 3. GlusterFS can be mounted by using NFS, but Ubuntu does not mount it even with the options 'vers=3' and '_netdev'.

If you want to mount a GlusterFS volume on a GlusterFS server at bootup, you have to install this script on your GlusterFS server. Just add this script anywhere on your server and add the absolute path of the script to the _/etc/rc.local_ file above the line "exit 0". And don't forget to adjust the permissions:

```
chmod 755 /root/glusterfs-mount.sh
chown root:root /root/glusterfs-mount.sh
```

To mount GlusterFS volumes automatic, just add your volumes to the /etc/fstab like this:
`server01:/<VOLUME-NAME> <MOUNT-POINT> glusterfs log-file=/var/log/glusterfs-<VOLUME-NAME>.log,acl,selinux,backupvolfile-server=server02:server03 0  0`

Or, if multiple servers does provide the volume like this:
`server01:/<VOLUME-NAME> <MOUNT-POINT> glusterfs log-file=/var/log/glusterfs-<VOLUME-NAME>.log,acl,selinux,backupvolfile-server=server02:server03 0  0`

The mentioned workaround for the Bug 765014 by the Gluster team, does not work (anymore). I've also tried to figure out, if I can improve the LSBInitScript, but I had no success. Ubuntu always tried to mount GlusterFS volumes before they were online (started).
