### PR TITLE
Optimize err path

### DIFF
--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -2254,9 +2254,8 @@ log:
 
         pthread_mutex_unlock (&ctx->log.logfile_mutex);
 
-err:
         GF_FREE (msg);
-
+err:
         GF_FREE (str1);
 
         FREE (str2);


### PR DESCRIPTION
During all transmissions to err, we do not msg init.

Must fix
[root@xintel2 ~]# ASAN_OPTIONS="verbosity=1" LD_PRELOAD=/usr/lib64/libasan.so.2 /usr/bin/ganesha.nfsd -F

**\* Error in `/usr/bin/ganesha.nfsd': munmap_chunk(): invalid pointer: 0x000060700000a7b0 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x7b194)[0x7fc2ebbc5194]
/lib64/libglusterfs.so.0(_gf_log+0x23e)[0x7fc2e6fe2d8e]
/usr/lib64/glusterfs/3.8.2/rpc-transport/socket.so(+0x8ddf)[0x7fc2d9d46ddf]
/usr/lib64/glusterfs/3.8.2/rpc-transport/socket.so(+0x917f)[0x7fc2d9d4717f]
/lib64/libglusterfs.so.0(+0x82b00)[0x7fc2e703bb00]
/lib64/libpthread.so.0(+0x7dc5)[0x7fc2ec572dc5]
/lib64/libc.so.6(clone+0x6d)[0x7fc2ebc40ced]
======= Memory map: ========

(gdb) list *_gf_log+0x22e
0x29d7e is in _gf_log (logging.c:2271).
2266    err:
2267            GF_FREE (msg);
2268
2269            GF_FREE (str1);
2270
2271            FREE (str2);
2272
2273    out:
2274            va_end (ap);
2275            return (0);
