### PR TITLE
  nfs: chmod/chown failed

### DIFF
--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -3693,8 +3693,8 @@ nfs3_fh_resolve_inode_lookup_cbk (call_frame_t *frame, void *cookie,
                 nfs3_call_resume (cs);
                 goto err;
         }
-
-        memcpy (&cs->stbuf, buf, sizeof(*buf));
+        if (!cs->setattr_valid)
+            memcpy (&cs->stbuf, buf, sizeof(*buf));
         memcpy (&cs->postparent, buf, sizeof(*postparent));
         linked_inode = inode_link (inode, cs->resolvedloc.parent,
                                    cs->resolvedloc.name, buf);

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -1019,10 +1019,10 @@ nfs3svc_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
          */
         if ((gf_attr_size_set (cs->setattr_valid)) &&
             (!IA_ISDIR (postop->ia_type)) &&
-            (preop->ia_size != cs->attr_in.ia_size)) {
+            (preop->ia_size != cs->stbuf.ia_size)) {
                 nfs_request_user_init (&nfu, cs->req);
                 ret = nfs_truncate (cs->nfsx, cs->vol, &nfu, &cs->resolvedloc,
-                                    cs->attr_in.ia_size, nfs3svc_truncate_cbk,
+                                    cs->stbuf.ia_size, nfs3svc_truncate_cbk,
                                     cs);
 
                 if (ret < 0)
@@ -1106,7 +1106,7 @@ nfs3_setattr_resume (void *carg)
         nfs3_check_fh_resolve_status (cs, stat, nfs3err);
         nfs_request_user_init (&nfu, cs->req);
         ret = nfs_setattr (cs->nfsx, cs->vol, &nfu, &cs->resolvedloc,
-                           &cs->attr_in, cs->setattr_valid,
+                           &cs->stbuf, cs->setattr_valid,
                            nfs3svc_setattr_cbk, cs);
 
         if (ret < 0)
@@ -1148,7 +1148,7 @@ nfs3_setattr (rpcsvc_request_t *req, struct nfs3_fh *fh, sattr3 *sattr,
         nfs3_check_rw_volaccess (nfs3, fh->exportid, stat, nfs3err);
         nfs3_handle_call_state_init (nfs3, cs, req, vol, stat, nfs3err);
 
-        cs->setattr_valid = nfs3_sattr3_to_setattr_valid (sattr, &cs->attr_in,
+        cs->setattr_valid = nfs3_sattr3_to_setattr_valid (sattr, &cs->stbuf,
                                                           NULL);
         if (guard->check) {
                 gf_msg_trace (GF_NFS3, 0, "Guard check required");

--- a/xlators/nfs/server/src/nfs3.h
+++ b/xlators/nfs/server/src/nfs3.h
@@ -225,7 +225,6 @@ struct nfs3_local {
         cookie3                 cookie;
         struct iovec            datavec;
         mode_t                  mode;
-        struct iatt             attr_in;
 
         /* NFSv3 FH resolver state */
         int                     hardresolved;


### PR DESCRIPTION
  nfs3_setattr stores the input arguments in cs->stbuf.
  However, inode/entry resolution code overwrites cs->stbuf
  after a successful resolution, thereby overwriting the
  input arguments with iatt values stored on backend.
  Hence operations like chmod/chown turns out to be a NOP.
  Specifically following are the functions that overwrite
  cs->stbuf:
           nfs3_fh_resolve_inode_lookup_cbk
  I use  nfs3_sattr3_to_setattr_valid to store input ATTR
  arguments for setattr/mkdir/create/mknod operations and
  set cs->setattr_valid to non-zero. The value of cs->stbuf
  would not be overwritten only if cs->setattr is non-zero
  in nfs3_fh_resolve_inode_lookup_cbk().
