### PR TITLE
Unpoison system because of glibc sysmacros.h change

### DIFF
--- a/libglusterfs/src/compat.h
+++ b/libglusterfs/src/compat.h
@@ -508,9 +508,9 @@ int gf_mkostemp (char *tmpl, int suffixlen, int flags);
 
 #if defined(__GNUC__) && !defined(RELAX_POISONING)
 /* Use run API, see run.h */
-#include <stdlib.h> /* system(), mkostemp() */
+#include <stdlib.h> /* mkostemp() */
 #include <stdio.h> /* popen() */
-#pragma GCC poison system mkostemp popen
+#pragma GCC poison mkostemp popen
 #endif
 
 int gf_umount_lazy(char *xlname, char *path, int rmdir);


### PR DESCRIPTION
glibc 2.25 and above use an unquoted warning in sysmacros.h with
the word "system" in it and this falls foul of Gluster's poison
pragma. This currently affects Gentoo because it stopped
implicitly including sysmacros.h via types.h ahead of time. It's
pure luck that the current include order does not affect other
distributions like Fedora.