### PR TITLE
Fix Bash command completion script to namespace global variables.

### DIFF
--- a/extras/command-completion/gluster.bash
+++ b/extras/command-completion/gluster.bash
@@ -26,28 +26,28 @@ GLUSTER_TOP_SUBOPTIONS2="
 "
 GLUSTER_TOP_OPTIONS="
         {open
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {read
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {write
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {opendir
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {readdir
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {clear
-                [ $TOP_SUBOPTIONS1 ]
+                [ $GLUSTER_TOP_SUBOPTIONS1 ]
         },
         {read-perf
-                [ $TOP_SUBOPTIONS2 ]
+                [ $GLUSTER_TOP_SUBOPTIONS2 ]
         },
         {write-perf
-                [ $TOP_SUBOPTIONS2 ]
+                [ $GLUSTER_TOP_SUBOPTIONS2 ]
         }
 "
 
@@ -282,16 +282,16 @@ _gluster_throw () {
         exit
 }
 
-declare FINAL_LIST=''
-declare LIST=''
-declare -i TOP=0
+declare GLUSTER_FINAL_LIST=''
+declare GLUSTER_LIST=''
+declare -i GLUSTER_TOP=0
 _gluster_push () {
-        TOP=$((TOP + 1))
-        return $TOP
+        GLUSTER_TOP=$((GLUSTER_TOP + 1))
+        return $GLUSTER_TOP
 }
 _gluster_pop () {
-        TOP=$((TOP - 1))
-        return $TOP
+        GLUSTER_TOP=$((GLUSTER_TOP - 1))
+        return $GLUSTER_TOP
 }
 
 _gluster_goto_end ()
@@ -333,7 +333,7 @@ _gluster_form_list ()
                 top=$?
                 read -r key
                 if [ "X$cur_word" == "X" -o "${cur_word:0:1}" == "${key:0:1}" -o "${key:0:1}" == "_" ]; then
-                        LIST="$LIST $key"
+                        GLUSTER_LIST="$GLUSTER_LIST $key"
                 fi
 
                 _gluster_goto_end $top
@@ -455,7 +455,7 @@ _gluster_parse ()
                 LIST="$tmp_token"
         fi
 
-        echo $LIST
+        echo $GLUSTER_LIST
 }
 
 _gluster_handle_list ()
@@ -479,12 +479,12 @@ _gluster_handle_list ()
 
 _gluster_completion ()
 {
-        FINAL_LIST=`echo $GLUSTER_COMMAND_TREE |                              \
+        GLUSTER_FINAL_LIST=`echo $GLUSTER_COMMAND_TREE |                      \
                 egrep -ao --color=never "([A-Za-z0-9_.-]+)|[[:space:]]+|." |  \
                         egrep -v --color=never "^[[:space:]]*$" |             \
                                 _gluster_parse`
 
-        ARG="FINAL_LIST"
+        ARG="GLUSTER_FINAL_LIST"
         _gluster_handle_list $ARG ${COMP_WORDS[COMP_CWORD]}
         return
 }


### PR DESCRIPTION
In the original submitted script, it looks like there was effort
put into namespacing all global variables. However a few mistakes
remained.

GLUSTER_TOP_SUBOPTIONSx were defined, but TOP_SUBOPTIONSx were
referenced. This was likely an unrecognized defect in the
original code submission? These are now corrected to refer to
GLUSTER_TOP_SUBOPTIONSx.

FINAL_LIST, LIST, and TOP were leaked into all Bash shells and
used by the command completion functions. The most problematic
of these was TOP, which was declared with "-i" making it an
integer. This cause other code which used TOP to define a path
to fail like this:

    $ bash
    $ TOP=/abc
    bash: /abc: syntax error: operand expected (error token is "/abc")

These are now qualified as GLUSTER_FINAL_LIST, GLUSTER_LIST, and
GLUSTER_TOP to reduce impact on scripts that might choose to use
these extremely common variable names.

Many thanks for your interest in improving GlusterFS!

GlusterFS does not use GitHub Pull-Requests. Instead, changes are reviewed
on the Gerrit instance of the Gluster Community at https://review.gluster.org

In order to send your changes for review, follow these steps:

1. login on https://review.gluster.org with your GitHub account
2. add a public ssh-key to your profile on https://review.gluster.org/#/settings/ssh-keys
3. add the Gerrit remote to your locally cloned git repository

   $ git remote add gerrit ssh://$USER@review.gluster.org/glusterfs.git

4. configure the commit hooks

   $ git review --setup

5. post your changes to Gerrit

   $ git review


You may need to install the 'git-review' package if 'git review' is not
available. Note that the hooks for the repository make sure to add a ChangeId
label in the commit messages. Gerrit uses the ChangeId to track single patches
and its updated versions.

For more details, see the documented development workflow at
  http://gluster.readthedocs.io/en/latest/Developer-guide/Simplified-Development-Workflow/

If there are any troubles or difficulties with these instructions, please
contact us on gluster-devel@gluster.org or on Freenode IRC in the #gluster-dev
channel.
