### PR TITLE
Failure when glusterd is configured to bind specific IPv6 address. If bind-address is IPv6, *addr_len will be non-zero and it goes to ret = -1 branch, which will cause listen failure eventually	

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -362,6 +362,9 @@ af_inet_server_get_local_sockaddr(rpc_transport_t *this, struct sockaddr *addr,
     dict_t *options = NULL;
     int32_t ret = 0;
 
+   /* initializes addr_len */
+    *addr_len = 0;
+
     options = this->options;
 
     listen_port_data = dict_get(options, "transport.socket.listen-port");
@@ -413,11 +416,13 @@ af_inet_server_get_local_sockaddr(rpc_transport_t *this, struct sockaddr *addr,
         }
     }
 
-    if (!(*addr_len) && res && res->ai_addr) {
-        memcpy(addr, res->ai_addr, res->ai_addrlen);
-        *addr_len = res->ai_addrlen;
-    } else {
-        ret = -1;
+   if (!(*addr_len)) {
+        if (res && res->ai_addr) {
+            memcpy(addr, res->ai_addr, res->ai_addrlen);
+            *addr_len = res->ai_addrlen;
+        } else {
+            ret = -1;
+        }
     }
 
     freeaddrinfo(res);


### PR DESCRIPTION
Many thanks for your interest in improving GlusterFS!

GlusterFS does not use GitHub Pull-Requests. Instead, changes are reviewed
on the Gerrit instance of the Gluster Community at https://review.gluster.org

In order to send your changes for review, follow these steps:

1. login on https://review.gluster.org with your GitHub account
2. add a public ssh-key to your profile on https://review.gluster.org/#/settings/ssh-keys
3. add the Gerrit remote to your locally cloned git repository

   $ git remote add gerrit ssh://$USER@review.gluster.org/glusterfs.git

4. configure the commit hooks

   $ git review --setup

5. post your changes to Gerrit

   $ git review


You may need to install the 'git-review' package if 'git review' is not
available. Note that the hooks for the repository make sure to add a ChangeId
label in the commit messages. Gerrit uses the ChangeId to track single patches
and its updated versions.

For more details, see the documented development workflow at
  http://gluster.readthedocs.io/en/latest/Developer-guide/Simplified-Development-Workflow/

If there are any troubles or difficulties with these instructions, please
contact us on gluster-devel@gluster.org or on Freenode IRC in the #gluster-dev
channel.
