### PR TITLE
Fix error throwing gluster webhook update.

### DIFF
--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -353,8 +353,7 @@ class WebhookModCmd(Cmd):
                                     errcode=ERROR_WEBHOOK_NOT_EXISTS,
                                     json_output=args.json)
 
-            if isinstance(data[args.url], str) or \
-               isinstance(data[args.url], unicode):
+            if isinstance(data[args.url], str):
                 data[args.url]["token"] = data[args.url]
 
             if args.bearer_token != "":


### PR DESCRIPTION
As there is no "unicode" in py3 so removing it

Fixes: #1226

Signed-off-by: Ritesh Chikatwar <rchikatw@redhat.com>

