### PR TITLE
all: return value signature changes

### DIFF
--- a/doc/developer-guide/coding-standard.md
+++ b/doc/developer-guide/coding-standard.md
@@ -643,7 +643,7 @@ int32_t
 sample_fop (call_frame_t *frame, xlator_t *this, ...)
 {
         char *            var1     = NULL;
-        int32_t           op_ret   = -1;
+        gf_return_t           op_ret   = -1;
         int32_t           op_errno = 0;
         DIR *             dir      = NULL;
         struct posix_fd * pfd      = NULL;

--- a/extras/create_new_xlator/new-xlator.c.tmpl
+++ b/extras/create_new_xlator/new-xlator.c.tmpl
@@ -1,5 +1,5 @@
 #pragma fragment CBK_TEMPLATE
-int32_t @FOP_PREFIX@_@NAME@_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+int32_t @FOP_PREFIX@_@NAME@_cbk(call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
              int32_t op_errno, @UNWIND_PARAMS@)
 {
     STACK_UNWIND_STRICT(@NAME@, frame, op_ret, op_errno, @UNWIND_ARGS@);
@@ -17,7 +17,7 @@ If you are generating the leaf xlators, remove the STACK_WIND and replace the
                FIRST_CHILD(this)->fops->@NAME@, @WIND_ARGS@);
     return 0;
 err:
-    STACK_UNWIND_STRICT(@NAME@, frame, -1, errno, @ERROR_ARGS@);
+    STACK_UNWIND_STRICT(@NAME@, frame, gf_error, errno, @ERROR_ARGS@);
     return 0;
 }
 

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -715,7 +715,7 @@ int
 glusterfs_handle_translator_op(rpcsvc_request_t *req)
 {
     int32_t ret = -1;
-    int32_t op_ret = 0;
+    int op_ret = 0;
     gd1_mgmt_brick_op_req xlator_req = {
         0,
     };

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -62,7 +62,7 @@ typedef struct glfs_info {
     int (*print_heal_op_summary)(int ret, num_entries_t *num_entries);
     int (*print_heal_status)(char *path, uuid_t gfid, char *status);
     int (*print_spb_status)(char *path, uuid_t gfid, char *status);
-    int (*end)(int op_ret, char *op_errstr);
+    int (*end)(int ret, char *op_errstr);
 } glfsh_info_t;
 
 glfsh_info_t *glfsh_output = NULL;
@@ -88,19 +88,18 @@ glfsh_init()
 }
 
 int
-glfsh_end_op_granular_entry_heal(int op_ret, char *op_errstr)
+glfsh_end_op_granular_entry_heal(int ret, char *op_errstr)
 {
     /* If error string is available, give it higher precedence.*/
-
     if (op_errstr) {
         printf("%s\n", op_errstr);
-    } else if (op_ret < 0) {
-        if (op_ret == -EAGAIN)
+    } else if (ret < 0) {
+        if (ret == -EAGAIN)
             printf(
                 "One or more entries need heal. Please execute "
                 "the command again after there are no entries "
                 "to be healed\n");
-        else if (op_ret == -ENOTCONN)
+        else if (ret == -ENOTCONN)
             printf(
                 "One or more bricks could be down. Please "
                 "execute the command again after bringing all "
@@ -110,13 +109,13 @@ glfsh_end_op_granular_entry_heal(int op_ret, char *op_errstr)
             printf(
                 "Command failed - %s. Please check the logs for"
                 " more details\n",
-                strerror(-op_ret));
+                strerror(-ret));
     }
     return 0;
 }
 
 int
-glfsh_end(int op_ret, char *op_errstr)
+glfsh_end(int ret, char *op_errstr)
 {
     if (op_errstr)
         printf("%s\n", op_errstr);
@@ -183,7 +182,6 @@ glfsh_xml_end(int op_ret, char *op_errstr)
 
     if (op_ret < 0) {
         op_errno = -op_ret;
-        op_ret = -1;
         if (op_errstr == NULL) {
             op_errstr = gf_strdup(strerror(op_errno));
             alloc = _gf_true;

--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -53,9 +53,9 @@ out:
 }
 
 call_stub_t *
-fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, inode_t *inode, struct iatt *buf,
-                    dict_t *xdata, struct iatt *postparent)
+fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     call_stub_t *stub = NULL;
 
@@ -86,7 +86,7 @@ out:
 }
 
 call_stub_t *
-fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, int32_t op_ret,
+fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -115,7 +115,7 @@ out:
 }
 
 call_stub_t *
-fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, int32_t op_ret,
+fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -148,7 +148,7 @@ out:
 
 call_stub_t *
 fop_truncate_cbk_stub(call_frame_t *frame, fop_truncate_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -181,8 +181,8 @@ out:
 
 call_stub_t *
 fop_ftruncate_cbk_stub(call_frame_t *frame, fop_ftruncate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -215,8 +215,8 @@ out:
 }
 
 call_stub_t *
-fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, dict_t *xdata)
+fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -248,7 +248,7 @@ out:
 
 call_stub_t *
 fop_readlink_cbk_stub(call_frame_t *frame, fop_readlink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, const char *path,
+                      gf_return_t op_ret, int32_t op_errno, const char *path,
                       struct iatt *stbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -281,7 +281,7 @@ out:
 }
 
 call_stub_t *
-fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, int32_t op_ret,
+fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata)
@@ -316,7 +316,7 @@ out:
 }
 
 call_stub_t *
-fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, int32_t op_ret,
+fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata)
@@ -352,9 +352,10 @@ out:
 }
 
 call_stub_t *
-fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -387,7 +388,7 @@ out:
 }
 
 call_stub_t *
-fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, int32_t op_ret,
+fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -422,10 +423,10 @@ out:
 }
 
 call_stub_t *
-fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata)
+fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -458,8 +459,8 @@ out:
 }
 
 call_stub_t *
-fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *buf,
+fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata)
@@ -495,7 +496,7 @@ out:
 }
 
 call_stub_t *
-fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, int32_t op_ret,
+fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, inode_t *inode, struct iatt *buf,
                   struct iatt *preparent, struct iatt *postparent,
                   dict_t *xdata)
@@ -530,9 +531,9 @@ out:
 }
 
 call_stub_t *
-fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -565,7 +566,7 @@ out:
 }
 
 call_stub_t *
-fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, int32_t op_ret,
+fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -595,7 +596,7 @@ out:
 }
 
 call_stub_t *
-fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, int32_t op_ret,
+fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iovec *vector, int32_t count,
                    struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
@@ -631,9 +632,9 @@ out:
 }
 
 call_stub_t *
-fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                    dict_t *xdata)
+fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -662,7 +663,7 @@ out:
 }
 
 call_stub_t *
-fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, int32_t op_ret,
+fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -692,7 +693,7 @@ out:
 }
 
 call_stub_t *
-fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, int32_t op_ret,
+fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
                    dict_t *xdata)
 {
@@ -726,8 +727,9 @@ out:
 }
 
 call_stub_t *
-fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, fd_t *fd, dict_t *xdata)
+fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -757,7 +759,7 @@ out:
 
 call_stub_t *
 fop_fsyncdir_cbk_stub(call_frame_t *frame, fop_fsyncdir_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -787,8 +789,9 @@ out:
 }
 
 call_stub_t *
-fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -820,7 +823,7 @@ out:
 
 call_stub_t *
 fop_setxattr_cbk_stub(call_frame_t *frame, fop_setxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -852,7 +855,7 @@ out:
 
 call_stub_t *
 fop_getxattr_cbk_stub(call_frame_t *frame, fop_getxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -885,7 +888,7 @@ out:
 
 call_stub_t *
 fop_fsetxattr_cbk_stub(call_frame_t *frame, fop_fsetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -917,7 +920,7 @@ out:
 
 call_stub_t *
 fop_fgetxattr_cbk_stub(call_frame_t *frame, fop_fgetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -951,7 +954,7 @@ out:
 
 call_stub_t *
 fop_removexattr_cbk_stub(call_frame_t *frame, fop_removexattr_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -984,7 +987,7 @@ out:
 
 call_stub_t *
 fop_fremovexattr_cbk_stub(call_frame_t *frame, fop_fremovexattr_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1015,7 +1018,7 @@ out:
 }
 
 call_stub_t *
-fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, int32_t op_ret,
+fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, gf_return_t op_ret,
                 int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1047,8 +1050,8 @@ out:
 }
 
 call_stub_t *
-fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata)
+fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1080,8 +1083,8 @@ out:
 }
 
 call_stub_t *
-fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata)
+fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1112,8 +1115,8 @@ out:
 }
 
 call_stub_t *
-fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata)
+fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1144,7 +1147,7 @@ out:
 
 call_stub_t *
 fop_fentrylk_cbk_stub(call_frame_t *frame, fop_fentrylk_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1159,8 +1162,8 @@ out:
 
 call_stub_t *
 fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdirp_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
-                      dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      gf_dirent_t *entries, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1174,8 +1177,9 @@ out:
 }
 
 call_stub_t *
-fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
+fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1237,8 +1241,9 @@ out:
 
 call_stub_t *
 fop_rchecksum_cbk_stub(call_frame_t *frame, fop_rchecksum_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1253,8 +1258,9 @@ out:
 }
 
 call_stub_t *
-fop_xattrop_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xattr, dict_t *xdata)
+fop_xattrop_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1269,7 +1275,7 @@ out:
 
 call_stub_t *
 fop_fxattrop_cbk_stub(call_frame_t *frame, fop_fxattrop_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1318,8 +1324,8 @@ out:
 }
 
 call_stub_t *
-fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1335,9 +1341,10 @@ out:
 }
 
 call_stub_t *
-fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata)
+fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1387,8 +1394,9 @@ out:
 
 call_stub_t *
 fop_fallocate_cbk_stub(call_frame_t *frame, fop_fallocate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                       struct iatt *statpost, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *statpre, struct iatt *statpost,
+                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1421,8 +1429,8 @@ out:
 }
 
 call_stub_t *
-fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1457,8 +1465,9 @@ out:
 
 call_stub_t *
 fop_zerofill_cbk_stub(call_frame_t *frame, fop_zerofill_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1491,7 +1500,7 @@ out:
 }
 
 call_stub_t *
-fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, int32_t op_ret,
+fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1523,7 +1532,7 @@ out:
 }
 
 call_stub_t *
-fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, int32_t op_ret,
+fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1556,7 +1565,7 @@ out:
 }
 
 call_stub_t *
-fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, int32_t op_ret,
+fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, off_t offset, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1590,7 +1599,7 @@ out:
 
 call_stub_t *
 fop_getactivelk_cbk_stub(call_frame_t *frame, fop_getactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *lmi, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1628,7 +1637,7 @@ out:
 
 call_stub_t *
 fop_setactivelk_cbk_stub(call_frame_t *frame, fop_setactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1689,7 +1698,7 @@ out:
 
 call_stub_t *
 fop_copy_file_range_cbk_stub(call_frame_t *frame, fop_copy_file_range_cbk_t fn,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata)
 {
@@ -1728,7 +1737,7 @@ out:
 }
 
 call_stub_t *
-fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, int32_t op_ret,
+fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, inode_t *inode, struct iatt *buf,
                  struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
@@ -1768,7 +1777,7 @@ out:
 }
 
 static void
-args_icreate_store_cbk(default_args_cbk_t *args, int32_t op_ret,
+args_icreate_store_cbk(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        dict_t *xdata)
 {
@@ -1783,9 +1792,9 @@ args_icreate_store_cbk(default_args_cbk_t *args, int32_t op_ret,
 }
 
 call_stub_t *
-fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xdata)
+fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1823,7 +1832,7 @@ out:
 }
 
 static void
-args_namelink_store_cbk(default_args_cbk_t *args, int32_t op_ret,
+args_namelink_store_cbk(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata)
 {
@@ -1840,7 +1849,7 @@ args_namelink_store_cbk(default_args_cbk_t *args, int32_t op_ret,
 
 call_stub_t *
 fop_namelink_cbk_stub(call_frame_t *frame, fop_namelink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -2401,7 +2410,7 @@ out:
 }
 
 void
-call_unwind_error(call_stub_t *stub, int op_ret, int op_errno)
+call_unwind_error(call_stub_t *stub, gf_return_t op_ret, int op_errno)
 {
     xlator_t *old_THIS = NULL;
 
@@ -2422,7 +2431,7 @@ call_unwind_error(call_stub_t *stub, int op_ret, int op_errno)
 }
 
 void
-call_unwind_error_keep_stub(call_stub_t *stub, int op_ret, int op_errno)
+call_unwind_error_keep_stub(call_stub_t *stub, gf_return_t op_ret, int op_errno)
 {
     xlator_t *old_THIS = NULL;
 

--- a/libglusterfs/src/cluster-syncop.c
+++ b/libglusterfs/src/cluster-syncop.c
@@ -98,7 +98,7 @@ cluster_fop_success_fill(default_args_cbk_t *replies, int numsubvols,
     int count = 0;
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret >= 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             success[i] = 1;
             count++;
         } else {
@@ -124,7 +124,7 @@ cluster_replies_wipe(default_args_cbk_t *replies, int numsubvols)
 
 int32_t
 cluster_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     FOP_CBK(lookup, frame, cookie, op_ret, op_errno, inode, buf, xdata,
@@ -134,7 +134,7 @@ cluster_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     FOP_CBK(stat, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -143,7 +143,7 @@ cluster_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(truncate, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -152,7 +152,7 @@ cluster_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(ftruncate, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -161,7 +161,7 @@ cluster_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(access, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -169,7 +169,7 @@ cluster_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     FOP_CBK(readlink, frame, cookie, op_ret, op_errno, path, buf, xdata);
@@ -178,7 +178,7 @@ cluster_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -189,7 +189,7 @@ cluster_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -200,7 +200,7 @@ cluster_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(unlink, frame, cookie, op_ret, op_errno, preparent, postparent,
@@ -210,7 +210,7 @@ cluster_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(rmdir, frame, cookie, op_ret, op_errno, preparent, postparent,
@@ -220,7 +220,7 @@ cluster_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -231,7 +231,7 @@ cluster_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -243,7 +243,7 @@ cluster_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -254,8 +254,8 @@ cluster_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(create, frame, cookie, op_ret, op_errno, fd, inode, buf, preparent,
@@ -265,7 +265,7 @@ cluster_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     FOP_CBK(open, frame, cookie, op_ret, op_errno, fd, xdata);
     return 0;
@@ -273,7 +273,7 @@ cluster_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -284,7 +284,7 @@ cluster_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(writev, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -293,7 +293,7 @@ cluster_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -304,7 +304,7 @@ cluster_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(flush, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -312,7 +312,7 @@ cluster_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(fsync, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -321,7 +321,7 @@ cluster_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     FOP_CBK(fstat, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -330,7 +330,8 @@ cluster_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     FOP_CBK(opendir, frame, cookie, op_ret, op_errno, fd, xdata);
     return 0;
@@ -338,7 +339,7 @@ cluster_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fsyncdir, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -346,7 +347,7 @@ cluster_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     FOP_CBK(statfs, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -355,7 +356,7 @@ cluster_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(setxattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -363,7 +364,7 @@ cluster_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fsetxattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -371,7 +372,7 @@ cluster_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     FOP_CBK(fgetxattr, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -380,7 +381,7 @@ cluster_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     FOP_CBK(getxattr, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -389,7 +390,7 @@ cluster_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     FOP_CBK(xattrop, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -398,7 +399,7 @@ cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     FOP_CBK(fxattrop, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -407,7 +408,7 @@ cluster_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(removexattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -415,7 +416,7 @@ cluster_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fremovexattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -423,7 +424,7 @@ cluster_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata)
 {
     FOP_CBK(lk, frame, cookie, op_ret, op_errno, lock, xdata);
@@ -432,7 +433,7 @@ cluster_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(inodelk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -440,7 +441,7 @@ cluster_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(finodelk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -448,7 +449,7 @@ cluster_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(entrylk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -456,7 +457,7 @@ cluster_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fentrylk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -464,8 +465,9 @@ cluster_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata)
 {
     FOP_CBK(rchecksum, frame, cookie, op_ret, op_errno, weak_checksum,
             strong_checksum, xdata);
@@ -474,7 +476,7 @@ cluster_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     FOP_CBK(readdir, frame, cookie, op_ret, op_errno, entries, xdata);
@@ -483,7 +485,7 @@ cluster_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     FOP_CBK(readdirp, frame, cookie, op_ret, op_errno, entries, xdata);
@@ -492,7 +494,7 @@ cluster_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     FOP_CBK(setattr, frame, cookie, op_ret, op_errno, statpre, statpost, xdata);
@@ -501,7 +503,7 @@ cluster_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     FOP_CBK(fsetattr, frame, cookie, op_ret, op_errno, statpre, statpost,
@@ -511,7 +513,7 @@ cluster_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                       struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(fallocate, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -520,7 +522,7 @@ cluster_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(discard, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -529,7 +531,7 @@ cluster_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(zerofill, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -538,7 +540,7 @@ cluster_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(ipc, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -1077,7 +1079,7 @@ cluster_inodelk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, F_SETLK, &flock, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1147,7 +1149,7 @@ cluster_entrylk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, name, ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);
@@ -1187,7 +1189,7 @@ cluster_tiebreaker_inodelk(xlator_t **subvols, unsigned char *on,
                &loc, F_SETLK, &flock, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             num_success++;
             continue;
         }
@@ -1195,7 +1197,7 @@ cluster_tiebreaker_inodelk(xlator_t **subvols, unsigned char *on,
         /* TODO: If earlier subvols fail with an error other
          * than EAGAIN, we could still have 2 clients competing
          * for the lock*/
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1235,11 +1237,11 @@ cluster_tiebreaker_entrylk(xlator_t **subvols, unsigned char *on,
                &loc, name, ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             num_success++;
             continue;
         }
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);

--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -26,7 +26,7 @@ args_lookup_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_lookup_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_lookup_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, inode_t *inode, struct iatt *buf,
                       dict_t *xdata, struct iatt *postparent)
 {
@@ -55,12 +55,12 @@ args_stat_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_stat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    struct iatt *buf, dict_t *xdata)
+args_stat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->stat = *buf;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -80,8 +80,8 @@ args_fstat_store(default_args_t *args, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_fstat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *buf, dict_t *xdata)
+args_fstat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -105,7 +105,7 @@ args_truncate_store(default_args_t *args, loc_t *loc, off_t off, dict_t *xdata)
 }
 
 int
-args_truncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_truncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata)
 {
@@ -135,7 +135,7 @@ args_ftruncate_store(default_args_t *args, fd_t *fd, off_t off, dict_t *xdata)
 }
 
 int
-args_ftruncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_ftruncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *prebuf,
                          struct iatt *postbuf, dict_t *xdata)
 {
@@ -163,7 +163,7 @@ args_access_store(default_args_t *args, loc_t *loc, int32_t mask, dict_t *xdata)
 }
 
 int
-args_access_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_access_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -187,7 +187,7 @@ args_readlink_store(default_args_t *args, loc_t *loc, size_t size,
 }
 
 int
-args_readlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, const char *path, struct iatt *stbuf,
                         dict_t *xdata)
 {
@@ -218,9 +218,10 @@ args_mknod_store(default_args_t *args, loc_t *loc, mode_t mode, dev_t rdev,
 }
 
 int
-args_mknod_cbk_store(default_args_cbk_t *args, int op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+args_mknod_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -253,9 +254,10 @@ args_mkdir_store(default_args_t *args, loc_t *loc, mode_t mode, mode_t umask,
 }
 
 int
-args_mkdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+args_mkdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -285,7 +287,7 @@ args_unlink_store(default_args_t *args, loc_t *loc, int xflag, dict_t *xdata)
 }
 
 int
-args_unlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_unlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -312,9 +314,9 @@ args_rmdir_store(default_args_t *args, loc_t *loc, int flags, dict_t *xdata)
 }
 
 int
-args_rmdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata)
+args_rmdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -342,7 +344,7 @@ args_symlink_store(default_args_t *args, const char *linkname, loc_t *loc,
 }
 
 int
-args_symlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_symlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        struct iatt *preparent, struct iatt *postparent,
                        dict_t *xdata)
@@ -376,7 +378,7 @@ args_rename_store(default_args_t *args, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-args_rename_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rename_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *buf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
@@ -414,9 +416,10 @@ args_link_store(default_args_t *args, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-args_link_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+args_link_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, inode_t *inode, struct iatt *buf,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -450,7 +453,7 @@ args_create_store(default_args_t *args, loc_t *loc, int32_t flags, mode_t mode,
 }
 
 int
-args_create_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_create_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, fd_t *fd, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
@@ -488,8 +491,8 @@ args_open_store(default_args_t *args, loc_t *loc, int32_t flags, fd_t *fd,
 }
 
 int
-args_open_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    fd_t *fd, dict_t *xdata)
+args_open_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -518,13 +521,13 @@ args_readv_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readv_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iovec *vector, int32_t count, struct iatt *stbuf,
-                     struct iobref *iobref, dict_t *xdata)
+args_readv_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iovec *vector, int32_t count,
+                     struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->vector = iov_dup(vector, count);
         args->count = count;
         args->stat = *stbuf;
@@ -554,13 +557,13 @@ args_writev_store(default_args_t *args, fd_t *fd, struct iovec *vector,
 }
 
 int
-args_writev_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_writev_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->poststat = *postbuf;
     if (prebuf)
         args->prestat = *prebuf;
@@ -591,13 +594,14 @@ args_put_store(default_args_t *args, loc_t *loc, mode_t mode, mode_t umask,
 }
 
 int
-args_put_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                   struct iatt *postparent, dict_t *xdata)
+args_put_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, inode_t *inode, struct iatt *buf,
+                   struct iatt *preparent, struct iatt *postparent,
+                   dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->stat = *buf;
     if (inode)
         args->inode = inode_ref(inode);
@@ -621,8 +625,8 @@ args_flush_store(default_args_t *args, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_flush_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     dict_t *xdata)
+args_flush_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -645,8 +649,9 @@ args_fsync_store(default_args_t *args, fd_t *fd, int32_t datasync,
 }
 
 int
-args_fsync_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
+args_fsync_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *prebuf,
+                     struct iatt *postbuf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -673,7 +678,7 @@ args_opendir_store(default_args_t *args, loc_t *loc, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_opendir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_opendir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -698,7 +703,7 @@ args_fsyncdir_store(default_args_t *args, fd_t *fd, int32_t datasync,
     return 0;
 }
 int
-args_fsyncdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsyncdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -719,12 +724,12 @@ args_statfs_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_statfs_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_statfs_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct statvfs *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->statvfs = *buf;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -747,7 +752,7 @@ args_setxattr_store(default_args_t *args, loc_t *loc, dict_t *dict,
 }
 
 int
-args_setxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -772,7 +777,7 @@ args_getxattr_store(default_args_t *args, loc_t *loc, const char *name,
 }
 
 int
-args_getxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -800,7 +805,7 @@ args_fsetxattr_store(default_args_t *args, fd_t *fd, dict_t *dict,
 }
 
 int
-args_fsetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -825,7 +830,7 @@ args_fgetxattr_store(default_args_t *args, fd_t *fd, const char *name,
 }
 
 int
-args_fgetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fgetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -850,7 +855,7 @@ args_removexattr_store(default_args_t *args, loc_t *loc, const char *name,
 }
 
 int
-args_removexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_removexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -873,7 +878,7 @@ args_fremovexattr_store(default_args_t *args, fd_t *fd, const char *name,
 }
 
 int
-args_fremovexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fremovexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                             int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -898,12 +903,12 @@ args_lk_store(default_args_t *args, fd_t *fd, int32_t cmd,
 }
 
 int
-args_lk_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                  struct gf_flock *lock, dict_t *xdata)
+args_lk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                  int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->lock = *lock;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -927,7 +932,7 @@ args_inodelk_store(default_args_t *args, const char *volume, loc_t *loc,
 }
 
 int
-args_inodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_inodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -957,7 +962,7 @@ args_finodelk_store(default_args_t *args, const char *volume, fd_t *fd,
 }
 
 int
-args_finodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_finodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -990,7 +995,7 @@ args_entrylk_store(default_args_t *args, const char *volume, loc_t *loc,
 }
 
 int
-args_entrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_entrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1022,7 +1027,7 @@ args_fentrylk_store(default_args_t *args, const char *volume, fd_t *fd,
 }
 
 int
-args_fentrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fentrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1046,14 +1051,14 @@ args_readdirp_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readdirp_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdirp_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *stub_entry = NULL, *entry = NULL;
 
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         list_for_each_entry(entry, &entries->list, list)
         {
             stub_entry = gf_dirent_for_name(entry->d_name);
@@ -1090,14 +1095,14 @@ args_readdir_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *stub_entry = NULL, *entry = NULL;
 
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         list_for_each_entry(entry, &entries->list, list)
         {
             stub_entry = gf_dirent_for_name(entry->d_name);
@@ -1128,13 +1133,13 @@ args_rchecksum_store(default_args_t *args, fd_t *fd, off_t offset, int32_t len,
 }
 
 int
-args_rchecksum_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rchecksum_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, uint32_t weak_checksum,
                          uint8_t *strong_checksum, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->weak_checksum = weak_checksum;
         args->strong_checksum = gf_memdup(strong_checksum,
                                           SHA256_DIGEST_LENGTH);
@@ -1160,7 +1165,7 @@ args_xattrop_store(default_args_t *args, loc_t *loc, gf_xattrop_flags_t optype,
 }
 
 int
-args_xattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_xattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xattr, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1188,7 +1193,7 @@ args_fxattrop_store(default_args_t *args, fd_t *fd, gf_xattrop_flags_t optype,
 }
 
 int
-args_fxattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fxattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xattr, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1218,7 +1223,7 @@ args_setattr_store(default_args_t *args, loc_t *loc, struct iatt *stbuf,
 }
 
 int
-args_setattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata)
 {
@@ -1251,7 +1256,7 @@ args_fsetattr_store(default_args_t *args, fd_t *fd, struct iatt *stbuf,
     return 0;
 }
 int
-args_fsetattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata)
 {
@@ -1284,7 +1289,7 @@ args_fallocate_store(default_args_t *args, fd_t *fd, int32_t mode, off_t offset,
 }
 
 int
-args_fallocate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fallocate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata)
 {
@@ -1316,7 +1321,7 @@ args_discard_store(default_args_t *args, fd_t *fd, off_t offset, size_t len,
 }
 
 int
-args_discard_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_discard_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata)
 {
@@ -1348,7 +1353,7 @@ args_zerofill_store(default_args_t *args, fd_t *fd, off_t offset, off_t len,
 }
 
 int
-args_zerofill_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_zerofill_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata)
 {
@@ -1375,8 +1380,8 @@ args_ipc_store(default_args_t *args, int32_t op, dict_t *xdata)
 }
 
 int
-args_ipc_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   dict_t *xdata)
+args_ipc_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -1402,8 +1407,8 @@ args_seek_store(default_args_t *args, fd_t *fd, off_t offset,
 }
 
 int
-args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    off_t offset, dict_t *xdata)
+args_seek_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, off_t offset, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -1415,7 +1420,7 @@ args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
 }
 
 int
-args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getactivelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, lock_migration_info_t *locklist,
                            dict_t *xdata)
 {
@@ -1425,7 +1430,7 @@ args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
     args->op_ret = op_ret;
     args->op_errno = op_errno;
     /*op_ret needs to carry the number of locks present in the list*/
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         list_for_each_entry(entry, &locklist->list, list)
         {
             stub_entry = GF_CALLOC(1, sizeof(*stub_entry), gf_common_mt_char);
@@ -1509,12 +1514,12 @@ args_lease_store(default_args_t *args, loc_t *loc, struct gf_lease *lease,
 }
 
 void
-args_lease_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct gf_lease *lease, dict_t *xdata)
+args_lease_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->lease = *lease;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -1562,14 +1567,14 @@ args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off64_t off_in,
 }
 
 int
-args_copy_file_range_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_copy_file_range_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                                int32_t op_errno, struct iatt *stbuf,
                                struct iatt *prebuf_dst,
                                struct iatt *postbuf_dst, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (postbuf_dst)
             args->poststat = *postbuf_dst;
         if (prebuf_dst)

--- a/libglusterfs/src/gen-defaults.py
+++ b/libglusterfs/src/gen-defaults.py
@@ -8,15 +8,15 @@ FAILURE_CBK_TEMPLATE = """
 int32_t
 default_@NAME@_failure_cbk (call_frame_t *frame, int32_t op_errno)
 {
-	STACK_UNWIND_STRICT (@NAME@, frame, -1, op_errno, @ERROR_ARGS@);
-	return 0;
+    STACK_UNWIND_STRICT (@NAME@, frame, gf_error, op_errno, @ERROR_ARGS@);
+    return 0;
 }
 """
 
 CBK_RESUME_TEMPLATE = """
 int32_t
 default_@NAME@_cbk_resume (call_frame_t *frame, void *cookie, xlator_t *this,
-			   int32_t op_ret, int32_t op_errno, @LONG_ARGS@)
+			   gf_return_t op_ret, int32_t op_errno, @LONG_ARGS@)
 {
 	STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno,
 			     @SHORT_ARGS@);
@@ -27,7 +27,7 @@ default_@NAME@_cbk_resume (call_frame_t *frame, void *cookie, xlator_t *this,
 CBK_TEMPLATE = """
 int32_t
 default_@NAME@_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-		    int32_t op_ret, int32_t op_errno, @LONG_ARGS@)
+		    gf_return_t op_ret, int32_t op_errno, @LONG_ARGS@)
 {
 	STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno,
 			     @SHORT_ARGS@);

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -86,6 +86,16 @@ const char *gf_upcall_list[GF_UPCALL_FLAGS_MAXVALUE] = {
     [GF_UPCALL_LEASE_RECALL] = "LEASE_RECALL",
 };
 
+const char *gf_xlator_list[GF_XLATOR_MAXVALUE] = {
+    [GF_XLATOR_BACKEND] = "backend-filesystem",
+    [GF_XLATOR_POSIX] = "storage/posix",
+    [GF_XLATOR_DHT] = "cluster/distribute",
+    [GF_XLATOR_AFR] = "cluster/replicate",
+};
+
+const gf_return_t gf_error = {-1};
+const gf_return_t gf_success = {0};
+
 /* THIS */
 
 /* This global ctx is a bad hack to prevent some of the libgfapi crashes.
@@ -106,6 +116,9 @@ static __thread struct syncopctx thread_syncopctx = {};
 static __thread char thread_uuid_buf[GF_UUID_BUF_SIZE] = {};
 static __thread char thread_lkowner_buf[GF_LKOWNER_BUF_SIZE] = {};
 static __thread char thread_leaseid_buf[GF_LEASE_ID_BUF_SIZE] = {};
+
+/* TODO: add macro for size */
+static __thread char thread_errorcode_buf[1024] = {};
 
 int
 gf_global_mem_acct_enable_get(void)
@@ -299,6 +312,14 @@ glusterfs_leaseid_buf_get()
     }
 
     return buf;
+}
+
+// ERRORCODE_BUFFER
+
+char *
+glusterfs_errorcode_buf_get()
+{
+    return thread_errorcode_buf;
 }
 
 char *

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -147,18 +147,18 @@ fop_lookup_stub(call_frame_t *frame, fop_lookup_t fn, loc_t *loc,
                 dict_t *xdata);
 
 call_stub_t *
-fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, inode_t *inode, struct iatt *buf,
-                    dict_t *xdata, struct iatt *postparent);
+fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                    struct iatt *buf, dict_t *xdata, struct iatt *postparent);
 call_stub_t *
 fop_stat_stub(call_frame_t *frame, fop_stat_t fn, loc_t *loc, dict_t *xdata);
 call_stub_t *
-fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, int32_t op_ret,
+fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, struct iatt *buf, dict_t *xdata);
 call_stub_t *
 fop_fstat_stub(call_frame_t *frame, fop_fstat_t fn, fd_t *fd, dict_t *xdata);
 call_stub_t *
-fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, int32_t op_ret,
+fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
@@ -167,7 +167,7 @@ fop_truncate_stub(call_frame_t *frame, fop_truncate_t fn, loc_t *loc, off_t off,
 
 call_stub_t *
 fop_truncate_cbk_stub(call_frame_t *frame, fop_truncate_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
@@ -176,16 +176,17 @@ fop_ftruncate_stub(call_frame_t *frame, fop_ftruncate_t fn, fd_t *fd, off_t off,
 
 call_stub_t *
 fop_ftruncate_cbk_stub(call_frame_t *frame, fop_ftruncate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_access_stub(call_frame_t *frame, fop_access_t fn, loc_t *loc, int32_t mask,
                 dict_t *xdata);
 
 call_stub_t *
-fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, dict_t *xdata);
+fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_readlink_stub(call_frame_t *frame, fop_readlink_t fn, loc_t *loc,
@@ -193,7 +194,7 @@ fop_readlink_stub(call_frame_t *frame, fop_readlink_t fn, loc_t *loc,
 
 call_stub_t *
 fop_readlink_cbk_stub(call_frame_t *frame, fop_readlink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, const char *path,
+                      gf_return_t op_ret, int32_t op_errno, const char *path,
                       struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
@@ -201,7 +202,7 @@ fop_mknod_stub(call_frame_t *frame, fop_mknod_t fn, loc_t *loc, mode_t mode,
                dev_t rdev, mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, int32_t op_ret,
+fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata);
@@ -211,7 +212,7 @@ fop_mkdir_stub(call_frame_t *frame, fop_mkdir_t fn, loc_t *loc, mode_t mode,
                mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, int32_t op_ret,
+fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata);
@@ -221,16 +222,17 @@ fop_unlink_stub(call_frame_t *frame, fop_unlink_t fn, loc_t *loc, int xflag,
                 dict_t *xdata);
 
 call_stub_t *
-fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata);
+fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata);
 
 call_stub_t *
 fop_rmdir_stub(call_frame_t *frame, fop_rmdir_t fn, loc_t *loc, int flags,
                dict_t *xdata);
 
 call_stub_t *
-fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, int32_t op_ret,
+fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
@@ -239,18 +241,18 @@ fop_symlink_stub(call_frame_t *frame, fop_symlink_t fn, const char *linkname,
                  loc_t *loc, mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata);
+fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata);
 
 call_stub_t *
 fop_rename_stub(call_frame_t *frame, fop_rename_t fn, loc_t *oldloc,
                 loc_t *newloc, dict_t *xdata);
 
 call_stub_t *
-fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *buf,
+fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata);
@@ -260,7 +262,7 @@ fop_link_stub(call_frame_t *frame, fop_link_t fn, loc_t *oldloc, loc_t *newloc,
               dict_t *xdata);
 
 call_stub_t *
-fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, int32_t op_ret,
+fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, inode_t *inode, struct iatt *buf,
                   struct iatt *preparent, struct iatt *postparent,
                   dict_t *xdata);
@@ -270,9 +272,9 @@ fop_create_stub(call_frame_t *frame, fop_create_t fn, loc_t *loc, int32_t flags,
                 mode_t mode, mode_t umask, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
 call_stub_t *
@@ -280,7 +282,7 @@ fop_open_stub(call_frame_t *frame, fop_open_t fn, loc_t *loc, int32_t flags,
               fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, int32_t op_ret,
+fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
@@ -288,7 +290,7 @@ fop_readv_stub(call_frame_t *frame, fop_readv_t fn, fd_t *fd, size_t size,
                off_t off, uint32_t flags, dict_t *xdata);
 
 call_stub_t *
-fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, int32_t op_ret,
+fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iovec *vector, int32_t count,
                    struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
 
@@ -298,15 +300,15 @@ fop_writev_stub(call_frame_t *frame, fop_writev_t fn, fd_t *fd,
                 struct iobref *iobref, dict_t *xdata);
 
 call_stub_t *
-fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                    dict_t *xdata);
+fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
 fop_flush_stub(call_frame_t *frame, fop_flush_t fn, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, int32_t op_ret,
+fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
@@ -314,7 +316,7 @@ fop_fsync_stub(call_frame_t *frame, fop_fsync_t fn, fd_t *fd, int32_t datasync,
                dict_t *xdata);
 
 call_stub_t *
-fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, int32_t op_ret,
+fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
                    dict_t *xdata);
 
@@ -323,8 +325,9 @@ fop_opendir_stub(call_frame_t *frame, fop_opendir_t fn, loc_t *loc, fd_t *fd,
                  dict_t *xdata);
 
 call_stub_t *
-fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, fd_t *fd, dict_t *xdata);
+fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata);
 
 call_stub_t *
 fop_fsyncdir_stub(call_frame_t *frame, fop_fsyncdir_t fn, fd_t *fd,
@@ -332,15 +335,16 @@ fop_fsyncdir_stub(call_frame_t *frame, fop_fsyncdir_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fsyncdir_cbk_stub(call_frame_t *frame, fop_fsyncdir_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_statfs_stub(call_frame_t *frame, fop_statfs_t fn, loc_t *loc,
                 dict_t *xdata);
 
 call_stub_t *
-fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct statvfs *buf, dict_t *xdata);
+fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    dict_t *xdata);
 
 call_stub_t *
 fop_setxattr_stub(call_frame_t *frame, fop_setxattr_t fn, loc_t *loc,
@@ -348,7 +352,7 @@ fop_setxattr_stub(call_frame_t *frame, fop_setxattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_setxattr_cbk_stub(call_frame_t *frame, fop_setxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_getxattr_stub(call_frame_t *frame, fop_getxattr_t fn, loc_t *loc,
@@ -356,7 +360,7 @@ fop_getxattr_stub(call_frame_t *frame, fop_getxattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_getxattr_cbk_stub(call_frame_t *frame, fop_getxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *value,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *value,
                       dict_t *xdata);
 
 call_stub_t *
@@ -365,7 +369,7 @@ fop_fsetxattr_stub(call_frame_t *frame, fop_fsetxattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fsetxattr_cbk_stub(call_frame_t *frame, fop_fsetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fgetxattr_stub(call_frame_t *frame, fop_fgetxattr_t fn, fd_t *fd,
@@ -373,7 +377,7 @@ fop_fgetxattr_stub(call_frame_t *frame, fop_fgetxattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fgetxattr_cbk_stub(call_frame_t *frame, fop_fgetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *value,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *value,
                        dict_t *xdata);
 
 call_stub_t *
@@ -382,7 +386,7 @@ fop_removexattr_stub(call_frame_t *frame, fop_removexattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_removexattr_cbk_stub(call_frame_t *frame, fop_removexattr_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fremovexattr_stub(call_frame_t *frame, fop_fremovexattr_t fn, fd_t *fd,
@@ -390,14 +394,14 @@ fop_fremovexattr_stub(call_frame_t *frame, fop_fremovexattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fremovexattr_cbk_stub(call_frame_t *frame, fop_fremovexattr_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_lk_stub(call_frame_t *frame, fop_lk_t fn, fd_t *fd, int32_t cmd,
             struct gf_flock *lock, dict_t *xdata);
 
 call_stub_t *
-fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, int32_t op_ret,
+fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, gf_return_t op_ret,
                 int32_t op_errno, struct gf_flock *lock, dict_t *xdata);
 
 call_stub_t *
@@ -419,20 +423,20 @@ fop_fentrylk_stub(call_frame_t *frame, fop_fentrylk_t fn, const char *volume,
                   entrylk_type type, dict_t *xdata);
 
 call_stub_t *
-fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata);
+fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata);
+fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata);
+fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_fentrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata);
+fop_fentrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_readdir_stub(call_frame_t *frame, fop_readdir_t fn, fd_t *fd, size_t size,
@@ -443,12 +447,14 @@ fop_readdirp_stub(call_frame_t *frame, fop_readdirp_t fn, fd_t *fd, size_t size,
                   off_t off, dict_t *xdata);
 
 call_stub_t *
-fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
+fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      gf_dirent_t *entries, dict_t *xdata);
 
 call_stub_t *
-fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
+fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     dict_t *xdata);
 
 call_stub_t *
 fop_rchecksum_stub(call_frame_t *frame, fop_rchecksum_t fn, fd_t *fd,
@@ -456,8 +462,9 @@ fop_rchecksum_stub(call_frame_t *frame, fop_rchecksum_t fn, fd_t *fd,
 
 call_stub_t *
 fop_rchecksum_cbk_stub(call_frame_t *frame, fop_rchecksum_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_xattrop_stub(call_frame_t *frame, fop_xattrop_t fn, loc_t *loc,
@@ -465,7 +472,7 @@ fop_xattrop_stub(call_frame_t *frame, fop_xattrop_t fn, loc_t *loc,
 
 call_stub_t *
 fop_xattrop_stub_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fxattrop_stub(call_frame_t *frame, fop_fxattrop_t fn, fd_t *fd,
@@ -473,15 +480,15 @@ fop_fxattrop_stub(call_frame_t *frame, fop_fxattrop_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fxattrop_stub_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_setattr_stub(call_frame_t *frame, fop_setattr_t fn, loc_t *loc,
                  struct iatt *stbuf, int32_t valid, dict_t *xdata);
 
 call_stub_t *
-fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 call_stub_t *
@@ -489,9 +496,10 @@ fop_fsetattr_stub(call_frame_t *frame, fop_fsetattr_t fn, fd_t *fd,
                   struct iatt *stbuf, int32_t valid, dict_t *xdata);
 
 call_stub_t *
-fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata);
+fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata);
 
 call_stub_t *
 fop_fallocate_stub(call_frame_t *frame, fop_fallocate_t fn, fd_t *fd,
@@ -499,16 +507,17 @@ fop_fallocate_stub(call_frame_t *frame, fop_fallocate_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fallocate_cbk_stub(call_frame_t *frame, fop_fallocate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                       struct iatt *statpost, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *statpre, struct iatt *statpost,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_discard_stub(call_frame_t *frame, fop_discard_t fn, fd_t *fd, off_t offset,
                  size_t len, dict_t *xdata);
 
 call_stub_t *
-fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 call_stub_t *
@@ -517,14 +526,15 @@ fop_zerofill_stub(call_frame_t *frame, fop_zerofill_t fn, fd_t *fd,
 
 call_stub_t *
 fop_zerofill_cbk_stub(call_frame_t *frame, fop_zerofill_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata);
 
 call_stub_t *
 fop_ipc_stub(call_frame_t *frame, fop_ipc_t fn, int32_t op, dict_t *xdata);
 
 call_stub_t *
-fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, int32_t op_ret,
+fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
@@ -532,7 +542,7 @@ fop_seek_stub(call_frame_t *frame, fop_seek_t fn, fd_t *fd, off_t offset,
               gf_seek_what_t what, dict_t *xdata);
 
 call_stub_t *
-fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, int32_t op_ret,
+fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, off_t offset, dict_t *xdata);
 
 call_stub_t *
@@ -540,7 +550,7 @@ fop_lease_stub(call_frame_t *frame, fop_lease_t fn, loc_t *loc,
                struct gf_lease *lease, dict_t *xdata);
 
 call_stub_t *
-fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, int32_t op_ret,
+fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct gf_lease *lease, dict_t *xdata);
 
 call_stub_t *
@@ -549,7 +559,7 @@ fop_getactivelk_stub(call_frame_t *frame, fop_getactivelk_t fn, loc_t *loc,
 
 call_stub_t *
 fop_getactivelk_cbk_stub(call_frame_t *frame, fop_getactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *lmi, dict_t *xdata);
 
 call_stub_t *
@@ -558,7 +568,7 @@ fop_setactivelk_stub(call_frame_t *frame, fop_setactivelk_t fn, loc_t *loc,
 
 call_stub_t *
 fop_setactivelk_cbk_stub(call_frame_t *frame, fop_setactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_put_stub(call_frame_t *frame, fop_put_t fn, loc_t *loc, mode_t mode,
@@ -566,7 +576,7 @@ fop_put_stub(call_frame_t *frame, fop_put_t fn, loc_t *loc, mode_t mode,
              off_t offset, struct iobref *iobref, dict_t *xattr, dict_t *xdata);
 
 call_stub_t *
-fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, int32_t op_ret,
+fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, inode_t *inode, struct iatt *buf,
                  struct iatt *preparent, struct iatt *postparent,
                  dict_t *xdata);
@@ -580,13 +590,13 @@ fop_namelink_stub(call_frame_t *frame, fop_namelink_t fn, loc_t *loc,
                   dict_t *xdata);
 
 call_stub_t *
-fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xdata);
+fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
 fop_namelink_cbk_stub(call_frame_t *frame, fop_namelink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
@@ -597,7 +607,7 @@ fop_copy_file_range_stub(call_frame_t *frame, fop_copy_file_range_t fn,
 
 call_stub_t *
 fop_copy_file_range_cbk_stub(call_frame_t *frame, fop_copy_file_range_cbk_t fn,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata);
 
@@ -608,9 +618,10 @@ call_resume_keep_stub(call_stub_t *stub);
 void
 call_stub_destroy(call_stub_t *stub);
 void
-call_unwind_error(call_stub_t *stub, int op_ret, int op_errno);
+call_unwind_error(call_stub_t *stub, gf_return_t op_ret, int op_errno);
 void
-call_unwind_error_keep_stub(call_stub_t *stub, int op_ret, int op_errno);
+call_unwind_error_keep_stub(call_stub_t *stub, gf_return_t op_ret,
+                            int op_errno);
 
 /*
  * Sometimes we might want to call just this, perhaps repeatedly, without

--- a/libglusterfs/src/glusterfs/cluster-syncop.h
+++ b/libglusterfs/src/glusterfs/cluster-syncop.h
@@ -215,7 +215,7 @@ cluster_fop_success_fill(default_args_cbk_t *replies, int numsubvols,
 
 int32_t
 cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata);
 
 int

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1253,4 +1253,9 @@ gf_tsdiff(struct timespec *start, struct timespec *end)
            (double)(t.tv_nsec - start->tv_nsec);
 }
 
+char *
+gf_strerror_r(gf_return_t code, char *str, size_t size);
+char *
+gf_strerror(gf_return_t code);
+
 #endif /* _COMMON_UTILS_H */

--- a/libglusterfs/src/glusterfs/default-args.h
+++ b/libglusterfs/src/glusterfs/default-args.h
@@ -18,224 +18,229 @@
 #include "glusterfs/xlator.h"
 
 int
-args_lookup_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_lookup_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, inode_t *inode, struct iatt *buf,
                       dict_t *xdata, struct iatt *postparent);
 
 int
-args_stat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    struct iatt *buf, dict_t *xdata);
+args_stat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 int
-args_fstat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *buf, dict_t *xdata);
+args_fstat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 int
-args_truncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_truncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata);
 
 int
-args_ftruncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_ftruncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *prebuf,
                          struct iatt *postbuf, dict_t *xdata);
 
 int
-args_access_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_access_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, dict_t *xdata);
 
 int
-args_readlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, const char *path, struct iatt *stbuf,
                         dict_t *xdata);
 
 int
-args_mknod_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata);
-
-int
-args_mkdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata);
-
-int
-args_unlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
-                      int32_t op_errno, struct iatt *preparent,
-                      struct iatt *postparent, dict_t *xdata);
-
-int
-args_rmdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
+args_mknod_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
                      struct iatt *preparent, struct iatt *postparent,
                      dict_t *xdata);
 
 int
-args_symlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_mkdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata);
+
+int
+args_unlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                      int32_t op_errno, struct iatt *preparent,
+                      struct iatt *postparent, dict_t *xdata);
+
+int
+args_rmdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata);
+
+int
+args_symlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        struct iatt *preparent, struct iatt *postparent,
                        dict_t *xdata);
 
 int
-args_rename_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rename_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *buf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t *xdata);
 
 int
-args_link_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata);
+args_link_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, inode_t *inode, struct iatt *buf,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata);
 
 int
-args_create_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_create_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, fd_t *fd, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata);
 
 int
-args_open_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    fd_t *fd, dict_t *xdata);
+args_open_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int
-args_readv_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iovec *vector, int32_t count, struct iatt *stbuf,
-                     struct iobref *iobref, dict_t *xdata);
+args_readv_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iovec *vector, int32_t count,
+                     struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
 
 int
-args_writev_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_writev_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 int
-args_put_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                   struct iatt *postparent, dict_t *xdata);
+args_put_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, inode_t *inode, struct iatt *buf,
+                   struct iatt *preparent, struct iatt *postparent,
+                   dict_t *xdata);
 
 int
-args_flush_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     dict_t *xdata);
+args_flush_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, dict_t *xdata);
 
 int
-args_fsync_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata);
+args_fsync_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *prebuf,
+                     struct iatt *postbuf, dict_t *xdata);
 
 int
-args_opendir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_opendir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int
-args_fsyncdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsyncdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_statfs_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_statfs_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct statvfs *buf, dict_t *xdata);
 
 int
-args_setxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_getxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *dict, dict_t *xdata);
 
 int
-args_fsetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *xdata);
 
 int
-args_fgetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fgetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *dict, dict_t *xdata);
 
 int
-args_removexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_removexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, dict_t *xdata);
 
 int
-args_fremovexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fremovexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                             int32_t op_errno, dict_t *xdata);
 
 int
-args_lk_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                  struct gf_flock *lock, dict_t *xdata);
+args_lk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                  int32_t op_errno, struct gf_flock *lock, dict_t *xdata);
 
 int
-args_inodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_inodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata);
 
 int
-args_finodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_finodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_entrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_entrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata);
 
 int
-args_fentrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fentrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_readdirp_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdirp_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
 
 int
-args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
 
 int
-args_rchecksum_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rchecksum_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, uint32_t weak_checksum,
                          uint8_t *strong_checksum, dict_t *xdata);
 
 int
-args_xattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_xattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xattr, dict_t *xdata);
 
 int
-args_fxattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fxattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xattr, dict_t *xdata);
 
 int
-args_setattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata);
 
 int
-args_fsetattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata);
 
 int
-args_fallocate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fallocate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata);
 
 int
-args_discard_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_discard_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata);
 
 int
-args_zerofill_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_zerofill_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata);
 
 int
-args_ipc_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   dict_t *xdata);
+args_ipc_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, dict_t *xdata);
 
 int
-args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    off_t offset, dict_t *xdata);
+args_seek_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, off_t offset, dict_t *xdata);
 
 void
-args_lease_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct gf_lease *lease, dict_t *xdata);
+args_lease_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct gf_lease *lease, dict_t *xdata);
 
 int
-args_copy_file_range_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_copy_file_range_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                                int32_t op_errno, struct iatt *stbuf,
                                struct iatt *prebuf_dst,
                                struct iatt *postbuf_dst, dict_t *xdata);
@@ -430,7 +435,7 @@ args_lease_store(default_args_t *args, loc_t *loc, struct gf_lease *lease,
                  dict_t *xdata);
 
 int
-args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getactivelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, lock_migration_info_t *locklist,
                            dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/defaults.h
+++ b/libglusterfs/src/glusterfs/defaults.h
@@ -18,8 +18,8 @@
 #include "glusterfs/xlator.h"
 
 typedef struct {
-    int op_ret;
-    int op_errno;
+    int32_t op_errno;
+    gf_return_t op_ret;
     inode_t *inode;
     struct iatt stat;
     struct iatt prestat;
@@ -566,262 +566,273 @@ default_copy_file_range_resume(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
 
 int32_t
 default_lookup_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, inode_t *inode,
+                          gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata,
                           struct iatt *postparent);
 
 int32_t
 default_stat_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         dict_t *xdata);
 
 int32_t
 default_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata);
 
 int32_t
 default_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *prebuf, struct iatt *postbuf,
                              dict_t *xdata);
 
 int32_t
 default_access_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_readlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, const char *path,
-                            struct iatt *buf, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            const char *path, struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_mknod_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *buf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_mkdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *buf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata);
 
 int32_t
 default_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct iatt *preparent, struct iatt *postparent,
                          dict_t *xdata);
 
 int32_t
 default_symlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, inode_t *inode,
+                           gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                            struct iatt *buf, struct iatt *preparent,
                            struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          struct iatt *preoldparent, struct iatt *postoldparent,
-                          struct iatt *prenewparent, struct iatt *postnewparent,
-                          dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, struct iatt *preoldparent,
+                          struct iatt *postoldparent, struct iatt *prenewparent,
+                          struct iatt *postnewparent, dict_t *xdata);
 
 int32_t
 default_link_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, inode_t *inode,
+                        gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                         struct iatt *buf, struct iatt *preparent,
                         struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_create_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, fd_t *fd,
+                          gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                           inode_t *inode, struct iatt *buf,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata);
 
 int32_t
 default_open_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, fd_t *fd,
+                        gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                         dict_t *xdata);
 
 int32_t
 default_readv_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                         int32_t count, struct iatt *stbuf,
-                         struct iobref *iobref, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iovec *vector, int32_t count,
+                         struct iatt *stbuf, struct iobref *iobref,
+                         dict_t *xdata);
 
 int32_t
 default_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata);
 
 int32_t
 default_flush_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                         struct iatt *postbuf, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *prebuf, struct iatt *postbuf,
+                         dict_t *xdata);
 
 int32_t
 default_fstat_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                         gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                          dict_t *xdata);
 
 int32_t
 default_opendir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            dict_t *xdata);
 
 int32_t
 default_fsyncdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_statfs_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct statvfs *buf,
-                          dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct statvfs *buf, dict_t *xdata);
 
 int32_t
 default_setxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_fsetxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                             gf_return_t op_ret, int32_t op_errno,
+                             dict_t *xdata);
 
 int32_t
 default_fgetxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *dict,
+                             gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                              dict_t *xdata);
 
 int32_t
 default_getxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *dict,
+                            gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata);
 
 int32_t
 default_xattrop_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata);
 
 int32_t
 default_fxattrop_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *dict,
+                            gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata);
 
 int32_t
 default_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata);
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_lk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
-                      dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct gf_flock *lock, dict_t *xdata);
 
 int32_t
 default_inodelk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_finodelk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_entrylk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fentrylk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_rchecksum_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              uint32_t weak_checksum, uint8_t *strong_checksum,
                              dict_t *xdata);
 
 int32_t
 default_readdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno,
+                           gf_return_t op_ret, int32_t op_errno,
                            gf_dirent_t *entries, dict_t *xdata);
 
 int32_t
 default_readdirp_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             gf_dirent_t *entries, dict_t *xdata);
 
 int32_t
 default_setattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno,
+                           gf_return_t op_ret, int32_t op_errno,
                            struct iatt *statpre, struct iatt *statpost,
                            dict_t *xdata);
 
 int32_t
 default_fsetattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *statpre, struct iatt *statpost,
                             dict_t *xdata);
 
 int32_t
 default_fallocate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                             struct iatt *post, dict_t *xdata);
+                             gf_return_t op_ret, int32_t op_errno,
+                             struct iatt *pre, struct iatt *post,
+                             dict_t *xdata);
 
 int32_t
 default_discard_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                           struct iatt *post, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno,
+                           struct iatt *pre, struct iatt *post, dict_t *xdata);
 
 int32_t
 default_zerofill_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                            struct iatt *post, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            struct iatt *pre, struct iatt *post, dict_t *xdata);
 int32_t
 default_ipc_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_seek_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, off_t offset,
+                        gf_return_t op_ret, int32_t op_errno, off_t offset,
                         dict_t *xdata);
 
 int32_t
 default_getspec_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, char *spec_data);
+                           gf_return_t op_ret, int32_t op_errno,
+                           char *spec_data);
 
 int32_t
 default_lease_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct gf_lease *lease, dict_t *xdata);
 
 int32_t
 default_getactivelk_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno,
                                lock_migration_info_t *locklist, dict_t *xdata);
 
 int32_t
 default_setactivelk_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata);
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_put_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *buf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata);
 
@@ -835,7 +846,7 @@ default_namelink_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 default_copy_file_range_cbk_resume(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *stbuf,
                                    struct iatt *prebuf_dst,
                                    struct iatt *postbuf_dst, dict_t *xdata);
@@ -843,264 +854,267 @@ default_copy_file_range_cbk_resume(call_frame_t *frame, void *cookie,
 /* _CBK */
 int32_t
 default_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent);
 
 int32_t
 default_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata);
 
 int32_t
 default_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata);
 
 int32_t
 default_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int32_t
 default_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata);
 
 int32_t
 default_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata);
 
 int32_t
 default_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata);
 
 int32_t
 default_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata);
 
 int32_t
 default_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata);
 
 int32_t
 default_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata);
 
 int32_t
 default_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata);
 
 int32_t
 default_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata);
 
 int32_t
 default_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata);
 
 int32_t
 default_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata);
 
 int32_t
 default_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata);
 
 int32_t
 default_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata);
 
 int32_t
 default_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata);
 
 int32_t
 default_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 int32_t
 default_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                       struct iatt *post, dict_t *xdata);
 
 int32_t
 default_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata);
 
 int32_t
 default_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata);
 
 int32_t
 default_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, off_t offset,
+                 dict_t *xdata);
 
 int32_t
 default_getspec_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, char *spec_data);
+                    gf_return_t op_ret, int32_t op_errno, char *spec_data);
 
 int32_t
 default_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                   dict_t *xdata);
 
 int32_t
 default_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         lock_migration_info_t *locklist, dict_t *xdata);
 
 int32_t
 default_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *stbuf, struct iatt *prebuf_dst,
                             struct iatt *postbuf_dst, dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -142,6 +142,8 @@ glusterfs_this_set(xlator_t *);
 
 extern xlator_t global_xlator;
 extern struct volume_options global_xl_options[];
+extern const gf_return_t gf_error;
+extern const gf_return_t gf_success;
 
 /* syncopctx */
 void *
@@ -164,6 +166,9 @@ char *
 glusterfs_leaseid_buf_get(void);
 char *
 glusterfs_leaseid_exist(void);
+/* errorcode_buf */
+char *
+glusterfs_errorcode_buf_get(void);
 
 /* init */
 int
@@ -179,6 +184,7 @@ glusterfs_ctx_tw_put(glusterfs_ctx_t *ctx);
 
 extern const char *gf_fop_list[];
 extern const char *gf_upcall_list[];
+extern const char *gf_xlator_list[];
 
 /* mem acct enable/disable */
 int

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -43,8 +43,14 @@
 #define GF_YES 1
 #define GF_NO 0
 
-#define IS_ERROR(ret) ((ret) < 0)
-#define IS_SUCCESS(ret) ((ret) >= 0)
+typedef struct _gf_return {
+    int32_t op_ret;
+} gf_return_t;
+
+#define IS_ERROR(ret) (((ret).op_ret) < 0)
+#define IS_SUCCESS(ret) (((ret).op_ret) >= 0)
+#define GET_RET(ret) ((ret).op_ret)
+#define SET_RET(ret, val) ((ret).op_ret = (val))
 
 #ifndef O_LARGEFILE
 /* savannah bug #20053, patch for compiling on darwin */
@@ -425,7 +431,7 @@ static const char *const FOP_PRI_STRINGS[] = {"HIGH", "NORMAL", "LOW", "LEAST"};
 static inline const char *
 fop_pri_to_string(gf_fop_pri_t pri)
 {
-    if (IS_ERROR(pri))
+    if (pri < 0)
         return "UNSPEC";
 
     if (pri >= GF_FOP_PRI_MAX)

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -170,8 +170,8 @@ struct syncbarrier {
 typedef struct syncbarrier syncbarrier_t;
 
 struct syncargs {
-    int op_ret;
     int op_errno;
+    gf_return_t op_ret;
 
     /*
      * The below 3 iatt structures are used in the fops
@@ -280,7 +280,7 @@ struct syncopctx {
             frame = syncop_create_frame(THIS);                                 \
                                                                                \
         if (!frame) {                                                          \
-            stb->op_ret = -1;                                                  \
+            stb->op_ret = gf_error;                                            \
             stb->op_errno = errno;                                             \
             break;                                                             \
         }                                                                      \
@@ -677,7 +677,7 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 syncop_setactivelk(xlator_t *subvol, loc_t *loc,
@@ -692,7 +692,7 @@ syncop_put(xlator_t *subvol, loc_t *loc, mode_t mode, mode_t umask,
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 syncop_icreate(xlator_t *subvol, loc_t *loc, mode_t mode, dict_t *xdata_out);
@@ -711,7 +711,7 @@ syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
 
 int
 syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, struct iatt *stbuf,
+                           gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                            struct iatt *prebuf_dst, struct iatt *postbuf_dst,
                            dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -54,6 +54,28 @@ typedef struct _loc loc_t;
 typedef int32_t (*event_notify_fn_t)(xlator_t *this, int32_t event, void *data,
                                      ...);
 
+enum _gf_xlator_list {
+    GF_XLATOR_NONE = 0,
+    GF_XLATOR_POSIX = 1,
+    GF_XLATOR_AFR,
+    GF_XLATOR_DHT,
+    GF_XLATOR_EC,
+    GF_XLATOR_ACL,
+    GF_XLATOR_SELINUX,
+    GF_XLATOR_LOCKS,
+    GF_XLATOR_LEASES,
+    GF_XLATOR_INDEX,
+    GF_XLATOR_FUSE,
+    GF_XLATOR_IOT,
+    GF_XLATOR_MARKER,
+    GF_XLATOR_IO_STATS,
+    GF_XLATOR_SERVER,
+    GF_XLATOR_BACKEND = 125,
+    GF_XLATOR_EXTERNAL = 126,
+    GF_XLATOR_MAXVALUE = 127,
+};
+typedef enum _gf_xlator_list gf_xlator_list_t;
+
 #include "glusterfs/list.h"
 #include "glusterfs/gf-dirent.h"
 #include "glusterfs/stack.h"
@@ -79,11 +101,11 @@ struct _loc {
 };
 
 typedef int32_t (*fop_getspec_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, char *spec_data);
 
 typedef int32_t (*fop_rchecksum_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, uint32_t weak_checksum,
                                        uint8_t *strong_checksum, dict_t *xdata);
 
@@ -95,70 +117,70 @@ typedef int32_t (*fop_rchecksum_t)(call_frame_t *frame, xlator_t *this,
                                    dict_t *xdata);
 
 typedef int32_t (*fop_lookup_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, inode_t *inode,
                                     struct iatt *buf, dict_t *xdata,
                                     struct iatt *postparent);
 
 typedef int32_t (*fop_stat_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, struct iatt *buf,
                                   dict_t *xdata);
 
 typedef int32_t (*fop_fstat_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *buf,
                                    dict_t *xdata);
 
 typedef int32_t (*fop_truncate_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, struct iatt *prebuf,
                                       struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_ftruncate_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, struct iatt *prebuf,
                                        struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_access_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_readlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, const char *path,
                                       struct iatt *buf, dict_t *xdata);
 
 typedef int32_t (*fop_mknod_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, inode_t *inode,
                                    struct iatt *buf, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_mkdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, inode_t *inode,
                                    struct iatt *buf, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_unlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *preparent,
                                     struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_rmdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_symlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, inode_t *inode,
                                      struct iatt *buf, struct iatt *preparent,
                                      struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_rename_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *buf,
                                     struct iatt *preoldparent,
                                     struct iatt *postoldparent,
@@ -166,196 +188,196 @@ typedef int32_t (*fop_rename_cbk_t)(call_frame_t *frame, void *cookie,
                                     struct iatt *postnewparent, dict_t *xdata);
 
 typedef int32_t (*fop_link_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, inode_t *inode,
                                   struct iatt *buf, struct iatt *preparent,
                                   struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_create_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, fd_t *fd, inode_t *inode,
                                     struct iatt *buf, struct iatt *preparent,
                                     struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_open_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 typedef int32_t (*fop_readv_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iovec *vector,
                                    int32_t count, struct iatt *stbuf,
                                    struct iobref *iobref, dict_t *xdata);
 
 typedef int32_t (*fop_writev_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *prebuf,
                                     struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_flush_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fsync_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *prebuf,
                                    struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_opendir_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 typedef int32_t (*fop_fsyncdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_statfs_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct statvfs *buf,
                                     dict_t *xdata);
 
 typedef int32_t (*fop_setxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_getxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *dict,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_fsetxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fgetxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, dict_t *dict,
                                        dict_t *xdata);
 
 typedef int32_t (*fop_removexattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fremovexattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                          xlator_t *this, int32_t op_ret,
+                                          xlator_t *this, gf_return_t op_ret,
                                           int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_lk_cbk_t)(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, struct gf_flock *flock,
                                 dict_t *xdata);
 
 typedef int32_t (*fop_inodelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_finodelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_entrylk_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fentrylk_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_readdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, gf_dirent_t *entries,
                                      dict_t *xdata);
 
 typedef int32_t (*fop_readdirp_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, gf_dirent_t *entries,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_xattrop_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xattr,
                                      dict_t *xdata);
 
 typedef int32_t (*fop_fxattrop_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xattr,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_setattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, struct iatt *preop_stbuf,
                                      struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_fsetattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno,
                                       struct iatt *preop_stbuf,
                                       struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_fallocate_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno,
                                        struct iatt *preop_stbuf,
                                        struct iatt *postop_stbuf,
                                        dict_t *xdata);
 
 typedef int32_t (*fop_discard_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, struct iatt *preop_stbuf,
                                      struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_zerofill_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno,
                                       struct iatt *preop_stbuf,
                                       struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_ipc_cbk_t)(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_seek_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, off_t offset,
                                   dict_t *xdata);
 
 typedef int32_t (*fop_lease_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct gf_lease *lease,
                                    dict_t *xdata);
 typedef int32_t (*fop_compound_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, void *data,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_getactivelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno,
                                          lock_migration_info_t *locklist,
                                          dict_t *xdata);
 
 typedef int32_t (*fop_setactivelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_put_cbk_t)(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, struct iatt *preparent,
                                  struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_icreate_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, inode_t *inode,
                                      struct iatt *buf, dict_t *xdata);
 
 typedef int32_t (*fop_namelink_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, struct iatt *prebuf,
                                       struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_copy_file_range_cbk_t)(
-    call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+    call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
     int32_t op_errno, struct iatt *stbuf, struct iatt *prebuf_dst,
     struct iatt *postbuf_dst, dict_t *xdata);
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -2024,13 +2024,13 @@ inode_needs_lookup(inode_t *inode, xlator_t *this)
 {
     uint64_t need_lookup = 0;
     gf_boolean_t ret = _gf_false;
-    int op_ret = -1;
+    int op_ret;
 
     if (!inode || !this)
         return ret;
 
     op_ret = inode_ctx_get(inode, this, &need_lookup);
-    if (op_ret == -1) {
+    if (op_ret < 0) {
         ret = _gf_true;
     } else if (need_lookup == LOOKUP_NEEDED) {
         ret = _gf_true;

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -589,6 +589,7 @@ gf_dnscache_deinit
 gf_errno_to_error
 gf_error_to_errno
 _gf_event
+gf_error
 gf_fd_fdptr_get
 gf_fd_fdtable_alloc
 gf_fd_fdtable_copy_all_fds
@@ -697,6 +698,8 @@ gf_store_save_value
 gf_store_save_items
 gf_store_unlink_tmppath
 gf_store_unlock
+gf_strerror
+gf_strerror_r
 gf_string2boolean
 gf_string2bytesize_int64
 gf_string2bytesize_uint64
@@ -743,6 +746,7 @@ gf_vasprintf
 gf_volfile_reconfigure
 gf_xxh64_wrapper
 gf_zero_fill_stat
+gf_success
 gid_cache_add
 gid_cache_init
 gid_cache_lookup

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -1310,9 +1310,9 @@ syncbarrier_wake(struct syncbarrier *barrier)
 /* FOPS */
 
 int
-syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, inode_t *inode, struct iatt *iatt,
-                  dict_t *xdata, struct iatt *parent)
+syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, inode_t *inode,
+                  struct iatt *iatt, dict_t *xdata, struct iatt *parent)
 {
     struct syncargs *args = NULL;
 
@@ -1323,7 +1323,7 @@ syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *iatt;
         args->iatt2 = *parent;
     }
@@ -1353,14 +1353,14 @@ syncop_lookup(xlator_t *subvol, loc_t *loc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1378,12 +1378,12 @@ syncop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
             if (!tmp) {
-                args->op_ret = -1;
+                args->op_ret = gf_error;
                 args->op_errno = ENOMEM;
                 gf_dirent_free(&(args->entries));
                 break;
@@ -1423,14 +1423,14 @@ syncop_readdirp(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1448,12 +1448,12 @@ syncop_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
             if (!tmp) {
-                args->op_ret = -1;
+                args->op_ret = gf_error;
                 args->op_errno = ENOMEM;
                 gf_dirent_free(&(args->entries));
                 break;
@@ -1493,14 +1493,15 @@ syncop_readdir(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1532,14 +1533,14 @@ syncop_opendir(xlator_t *subvol, loc_t *loc, fd_t *fd, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1571,14 +1572,14 @@ syncop_fsyncdir(xlator_t *subvol, fd_t *fd, int datasync, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1610,14 +1611,14 @@ syncop_removexattr(xlator_t *subvol, loc_t *loc, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1649,14 +1650,14 @@ syncop_fremovexattr(xlator_t *subvol, fd_t *fd, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1688,14 +1689,14 @@ syncop_setxattr(xlator_t *subvol, loc_t *loc, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1727,14 +1728,15 @@ syncop_fsetxattr(xlator_t *subvol, fd_t *fd, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *dict,
+                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1745,7 +1747,7 @@ syncop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->xattr = dict_ref(dict);
 
     __wake(args);
@@ -1774,9 +1776,9 @@ syncop_listxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1800,9 +1802,9 @@ syncop_getxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1826,14 +1828,14 @@ syncop_fgetxattr(xlator_t *subvol, fd_t *fd, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                   dict_t *xdata)
 
 {
@@ -1846,7 +1848,7 @@ syncop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->statvfs_buf = *buf;
     }
 
@@ -1874,14 +1876,14 @@ syncop_statfs(xlator_t *subvol, loc_t *loc, struct statvfs *buf,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *preop,
+                   gf_return_t op_ret, int op_errno, struct iatt *preop,
                    struct iatt *postop, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1893,7 +1895,7 @@ syncop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *preop;
         args->iatt2 = *postop;
     }
@@ -1925,9 +1927,9 @@ syncop_setattr(xlator_t *subvol, loc_t *loc, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1952,14 +1954,14 @@ syncop_fsetattr(xlator_t *subvol, fd_t *fd, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1991,14 +1993,14 @@ syncop_open(xlator_t *subvol, loc_t *loc, int32_t flags, fd_t *fd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                 gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                  int32_t count, struct iatt *stbuf, struct iobref *iobref,
                  dict_t *xdata)
 {
@@ -2013,7 +2015,7 @@ syncop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (args->op_ret >= 0) {
+    if (IS_SUCCESS(args->op_ret)) {
         if (iobref)
             args->iobref = iobref_ref(iobref);
         args->vector = iov_dup(vector, count);
@@ -2046,7 +2048,7 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
     if (iatt)
         *iatt = args.iatt1;
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         goto out;
 
     if (vector)
@@ -2064,15 +2066,15 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
         iobref_unref(args.iobref);
 
 out:
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                  dict_t *xdata)
+syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2083,7 +2085,7 @@ syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2116,9 +2118,9 @@ syncop_writev(xlator_t *subvol, fd_t *fd, const struct iovec *vector,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2144,9 +2146,9 @@ syncop_write(xlator_t *subvol, fd_t *fd, const char *buf, int size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2159,8 +2161,8 @@ syncop_close(fd_t *fd)
 
 int32_t
 syncop_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *buf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2199,14 +2201,14 @@ syncop_create(xlator_t *subvol, loc_t *loc, int32_t flags, mode_t mode,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -2249,15 +2251,15 @@ syncop_put(xlator_t *subvol, loc_t *loc, mode_t mode, mode_t umask,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+syncop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2289,15 +2291,15 @@ syncop_unlink(xlator_t *subvol, loc_t *loc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *preparent, struct iatt *postparent,
-                 dict_t *xdata)
+syncop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                 struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2329,14 +2331,14 @@ syncop_rmdir(xlator_t *subvol, loc_t *loc, int flags, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -2376,15 +2378,15 @@ syncop_link(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -2419,15 +2421,15 @@ syncop_rename(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2439,7 +2441,7 @@ syncop_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2470,9 +2472,9 @@ syncop_ftruncate(xlator_t *subvol, fd_t *fd, off_t offset, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2491,14 +2493,14 @@ syncop_truncate(xlator_t *subvol, loc_t *loc, off_t offset, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2510,7 +2512,7 @@ syncop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2541,14 +2543,14 @@ syncop_fsync(xlator_t *subvol, fd_t *fd, int dataonly, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2577,14 +2579,14 @@ syncop_flush(xlator_t *subvol, fd_t *fd, dict_t *xdata_in, dict_t **xdata_out)
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                  dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2596,7 +2598,7 @@ syncop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->iatt1 = *stbuf;
 
     __wake(args);
@@ -2623,9 +2625,9 @@ syncop_fstat(xlator_t *subvol, fd_t *fd, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2647,14 +2649,14 @@ syncop_stat(xlator_t *subvol, loc_t *loc, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2694,14 +2696,14 @@ syncop_symlink(xlator_t *subvol, loc_t *loc, const char *newpath,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, const char *path,
+                    gf_return_t op_ret, int op_errno, const char *path,
                     struct iatt *stbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2713,7 +2715,7 @@ syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if ((op_ret != -1) && path)
+    if (IS_SUCCESS(op_ret) && path)
         args->buffer = gf_strdup(path);
 
     __wake(args);
@@ -2742,14 +2744,14 @@ syncop_readlink(xlator_t *subvol, loc_t *loc, char **buffer, size_t size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2789,14 +2791,14 @@ syncop_mknod(xlator_t *subvol, loc_t *loc, mode_t mode, dev_t rdev,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2836,14 +2838,14 @@ syncop_mkdir(xlator_t *subvol, loc_t *loc, mode_t mode, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2890,14 +2892,14 @@ syncop_access(xlator_t *subvol, loc_t *loc, int32_t mask, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_errno;
 }
 
 int
 syncop_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2930,14 +2932,14 @@ syncop_fallocate(xlator_t *subvol, fd_t *fd, int32_t keep_size, off_t offset,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2970,14 +2972,14 @@ syncop_discard(xlator_t *subvol, fd_t *fd, off_t offset, size_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3010,14 +3012,14 @@ syncop_zerofill(xlator_t *subvol, fd_t *fd, off_t offset, off_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, dict_t *xdata)
+syncop_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3055,14 +3057,14 @@ syncop_ipc(xlator_t *subvol, int32_t op, dict_t *xdata_in, dict_t **xdata_out)
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, off_t offset, dict_t *xdata)
+syncop_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, off_t offset, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3090,18 +3092,19 @@ syncop_seek(xlator_t *subvol, fd_t *fd, off_t offset, gf_seek_what_t what,
     SYNCOP(subvol, (&args), syncop_seek_cbk, subvol->fops->seek, fd, offset,
            what, xdata_in);
 
-    if (args.op_ret < 0) {
+    if (IS_ERROR(args.op_ret)) {
         return -args.op_errno;
     } else {
         if (off)
             *off = args.offset;
-        return args.op_ret;
+        return GET_RET(args.op_ret);
     }
 }
 
 int
-syncop_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct gf_lease *lease, dict_t *xdata)
+syncop_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct gf_lease *lease,
+                 dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3145,14 +3148,15 @@ syncop_lease(xlator_t *subvol, loc_t *loc, struct gf_lease *lease,
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct gf_flock *flock, dict_t *xdata)
+syncop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct gf_flock *flock,
+              dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3188,14 +3192,14 @@ syncop_lk(xlator_t *subvol, fd_t *fd, int cmd, struct gf_flock *flock,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3227,15 +3231,15 @@ syncop_inodelk(xlator_t *subvol, const char *volume, loc_t *loc, int32_t cmd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3266,15 +3270,15 @@ syncop_entrylk(xlator_t *subvol, const char *volume, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3315,10 +3319,10 @@ syncop_xattrop(xlator_t *subvol, loc_t *loc, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -3343,15 +3347,15 @@ syncop_fxattrop(xlator_t *subvol, fd_t *fd, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        lock_migration_info_t *locklist, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3367,7 +3371,7 @@ syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         list_for_each_entry(tmp, &locklist->list, list)
         {
             entry = GF_CALLOC(1, sizeof(lock_migration_info_t),
@@ -3420,15 +3424,15 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3462,15 +3466,15 @@ syncop_setactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3492,7 +3496,7 @@ syncop_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 syncop_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3542,12 +3546,12 @@ syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
     }
 
     errno = args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, struct iatt *stbuf,
+                           gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                            struct iatt *prebuf_dst, struct iatt *postbuf_dst,
                            dict_t *xdata)
 {
@@ -3560,7 +3564,7 @@ syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *stbuf;
         args->iatt2 = *prebuf_dst;
         args->iatt3 = *postbuf_dst;

--- a/tests/basic/afr/inodelk.t
+++ b/tests/basic/afr/inodelk.t
@@ -11,6 +11,8 @@ TEST glusterd;
 TEST pidof glusterd
 
 TEST $CLI volume create $V0 replica 3 arbiter 1 $H0:$B0/${V0}{0..5}
+TEST $CLI volume set  $V0 client-log-level DEBUG
+TEST $CLI volume set  $V0 brick-log-level DEBUG
 TEST $CLI volume start $V0
 TEST $GFS -s $H0 --volfile-id=$V0 $M0
 
@@ -62,6 +64,8 @@ TEST ! stat $B0/${V0}4/dir2
 TEST ! stat $B0/${V0}5/dir2
 
 #Bring the bricks back up and try mv once more, it should succeed.
+TEST $CLI volume set $V0 brick-log-level TRACE
+TEST $CLI volume set $V0 client-log-level TRACE
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 3
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 4

--- a/tests/basic/ec/self-heal-read-write-fail.t
+++ b/tests/basic/ec/self-heal-read-write-fail.t
@@ -53,6 +53,7 @@ TEST $CLI volume reset $V0 debug.error-fops
 TEST $CLI volume reset $V0 debug.error-number
 TEST $CLI volume reset $V0 debug.error-failure
 
+TEST $CLI volume set $V0 client-log-level TRACE
 TEST $CLI volume start $V0
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0
 EXPECT_WITHIN $HEAL_TIMEOUT "^2$" get_pending_heal_count $V0

--- a/tests/bugs/readdir-ahead/bug-1390050.c
+++ b/tests/bugs/readdir-ahead/bug-1390050.c
@@ -54,7 +54,8 @@ main(int argc, char *argv[])
 
     ret = stat(filepath, &stbuf);
     if (ret < 0) {
-        fprintf(stderr, "stat failed on path %s (%s)\n", strerror(errno));
+        fprintf(stderr, "stat failed on path %s (%s)\n", filepath,
+                strerror(errno));
         goto err;
     }
 

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -87,7 +87,7 @@ afr_fill_success_replies(afr_local_t *local, afr_private_t *priv,
     int i = 0;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].valid && local->replies[i].op_ret == 0) {
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret)) {
             replies[i] = 1;
         } else {
             replies[i] = 0;
@@ -106,15 +106,15 @@ afr_discover_done(call_frame_t *frame, xlator_t *this);
 
 int
 afr_dom_lock_acquire_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int i = (long)cookie;
 
-    local->cont.lk.dom_lock_op_ret[i] = op_ret;
+    local->cont.lk.dom_lock_op_ret[i] = GET_RET(op_ret);
     local->cont.lk.dom_lock_op_errno[i] = op_errno;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to acquire %s on %s",
                uuid_utoa(local->fd->inode->gfid), AFR_LK_HEAL_DOM,
@@ -192,13 +192,13 @@ blocking_lock:
 
 int
 afr_dom_lock_release_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int i = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to release %s on %s", local->loc.path,
                AFR_LK_HEAL_DOM, priv->children[i]->name);
@@ -366,7 +366,7 @@ out:
 
 int
 afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                   dict_t *xdata)
 {
     afr_local_t *local = frame->local;
@@ -375,7 +375,7 @@ afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[i].valid = 1;
     local->replies[i].op_ret = op_ret;
     local->replies[i].op_errno = op_errno;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "Failed to heal lock on child %d for %s", i,
                uuid_utoa(local->fd->inode->gfid));
@@ -385,8 +385,9 @@ afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
-afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     int i = (long)cookie;
@@ -394,7 +395,7 @@ afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local->replies[i].valid = 1;
     local->replies[i].op_ret = op_ret;
     local->replies[i].op_errno = op_errno;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "Failed getlk for %s", uuid_utoa(local->fd->inode->gfid));
     } else {
@@ -436,7 +437,7 @@ afr_does_lk_owner_match(call_frame_t *frame, afr_private_t *priv,
     }
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!local->replies[i].valid || local->replies[i].op_ret != 0)
+        if (!local->replies[i].valid || IS_ERROR(local->replies[i].op_ret))
             continue;
         if (local->cont.lk.getlk_rsp[i].l_type == F_UNLCK)
             continue;
@@ -528,7 +529,8 @@ afr_lock_heal_do(call_frame_t *frame, afr_private_t *priv,
         for (i = 0; i < priv->child_count; i++) {
             if (!wind_on[i])
                 continue;
-            if ((!local->replies[i].valid) || (local->replies[i].op_ret != 0)) {
+            if ((!local->replies[i].valid) ||
+                IS_ERROR(local->replies[i].op_ret)) {
                 continue;
             }
 
@@ -966,7 +968,7 @@ afr_is_symmetric_error(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret != -1) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             /* Operation succeeded on at least one subvol,
                so it is not a failed-everywhere situation.
             */
@@ -1564,7 +1566,9 @@ post_unlock:
     inode_invalidate(inode);
 out:
     GF_FREE(data);
-    AFR_STACK_UNWIND(setxattr, frame, ret, op_errno, NULL);
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(setxattr, frame, op_ret, op_errno, NULL);
     return 0;
 }
 
@@ -1653,7 +1657,7 @@ afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
 
     for (i = 0; i < priv->child_count; i++) {
         if (replies) { /* Lookup */
-            if (!replies[i].valid || replies[i].op_ret == -1 ||
+            if (!replies[i].valid || IS_ERROR(replies[i].op_ret) ||
                 (replies[i].xdata &&
                  dict_get_sizen(replies[i].xdata, GLUSTERFS_BAD_INODE))) {
                 data_readable[i] = 0;
@@ -1761,7 +1765,7 @@ afr_inode_refresh_err(call_frame_t *frame, xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].valid && !local->replies[i].op_ret) {
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret)) {
             err = 0;
             goto ret;
         }
@@ -1907,7 +1911,7 @@ refresh_done:
 
 void
 afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int op_ret, int op_errno, struct iatt *buf,
+                             gf_return_t op_ret, int op_errno, struct iatt *buf,
                              dict_t *xdata, struct iatt *par)
 {
     afr_local_t *local = NULL;
@@ -1920,7 +1924,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[call_child].valid = 1;
     local->replies[call_child].op_ret = op_ret;
     local->replies[call_child].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[call_child].poststat = *buf;
         if (par)
             local->replies[call_child].postparent = *par;
@@ -1949,7 +1953,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 afr_inode_refresh_subvol_with_lookup_cbk(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int op_errno, inode_t *inode,
                                          struct iatt *buf, dict_t *xdata,
                                          struct iatt *par)
@@ -1987,7 +1991,7 @@ afr_inode_refresh_subvol_with_lookup(call_frame_t *frame, xlator_t *this, int i,
 
 int
 afr_inode_refresh_subvol_with_fstat_cbk(call_frame_t *frame, void *cookie,
-                                        xlator_t *this, int32_t op_ret,
+                                        xlator_t *this, gf_return_t op_ret,
                                         int32_t op_errno, struct iatt *buf,
                                         dict_t *xdata)
 {
@@ -2819,7 +2823,7 @@ afr_get_parent_read_subvol(xlator_t *this, inode_t *parent,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (par_read_subvol_iter == -1) {
@@ -2880,7 +2884,7 @@ afr_first_up_child(call_frame_t *frame, xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++)
-        if (local->replies[i].valid && local->replies[i].op_ret == 0)
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret))
             return i;
     return -1;
 }
@@ -2917,7 +2921,7 @@ afr_attempt_readsubvol_set(call_frame_t *frame, xlator_t *this,
         /* If quorum is enabled and we do not have a
            readable yet, it means all good copies are down.
         */
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg(this->name, GF_LOG_WARNING, 0, AFR_MSG_READ_SUBVOL_ERROR,
                "no read "
@@ -2975,7 +2979,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
        issued
     */
     if (local->cont.lookup.needs_fresh_lookup) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ESTALE;
         goto error;
     }
@@ -2990,7 +2994,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             if (locked_entry && replies[i].op_errno == ENOENT) {
                 in_flight_create = _gf_true;
             }
@@ -3001,12 +3005,12 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
             read_subvol = i;
             gf_uuid_copy(read_gfid, replies[i].poststat.ia_gfid);
             ia_type = replies[i].poststat.ia_type;
-            local->op_ret = 0;
+            local->op_ret = gf_success;
         }
     }
 
     if (in_flight_create && !afr_has_quorum(success_replies, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOENT;
         goto error;
     }
@@ -3019,7 +3023,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
        readable[] but the mismatching GFID subvol is not.
     */
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1) {
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret)) {
             continue;
         }
 
@@ -3044,7 +3048,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
             goto cant_interpret;
 
         /* LOG ERROR */
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EIO;
         goto error;
     }
@@ -3084,8 +3088,8 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
     afr_handle_quota_size(frame, this);
 
     afr_set_need_heal(this, local);
-    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && local->op_ret == 0) {
-        local->op_ret = -1;
+    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && IS_SUCCESS(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg_debug(this->name, 0,
                      "Arbiter cannot be a read subvol "
@@ -3101,7 +3105,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_DICT_SET_FAILED,
                    "Error setting gfid-heal-msg dict");
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
         }
     }
@@ -3150,7 +3154,7 @@ afr_final_errno(afr_local_t *local, afr_private_t *priv)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret >= 0)
+        if (IS_SUCCESS(local->replies[i].op_ret))
             continue;
         tmp_errno = local->replies[i].op_errno;
         op_errno = afr_higher_errno(op_errno, tmp_errno);
@@ -3161,7 +3165,7 @@ afr_final_errno(afr_local_t *local, afr_private_t *priv)
 
 static int32_t
 afr_local_discovery_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *dict,
+                        gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
 {
     int ret = 0;
@@ -3170,7 +3174,7 @@ afr_local_discovery_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     afr_private_t *priv = NULL;
     int32_t child_index = -1;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3249,7 +3253,7 @@ afr_lookup_sh_metadata_wrap(void *opaque)
     replies = local->replies;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         first = i;
         break;
@@ -3352,7 +3356,7 @@ afr_can_start_metadata_self_heal(call_frame_t *frame, xlator_t *this)
         return _gf_false;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (first == -1) {
             first = i;
@@ -3459,7 +3463,7 @@ afr_lookup_selfheal_wrap(void *opaque)
     return 0;
 
 unwind:
-    AFR_STACK_UNWIND(lookup, frame, -1, EIO, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, EIO, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3497,7 +3501,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == 0) {
+        if (IS_SUCCESS(replies[i].op_ret)) {
             if (gf_uuid_is_null(gfid)) {
                 gf_uuid_copy(gfid, replies[i].poststat.ia_gfid);
             }
@@ -3511,7 +3515,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         }
 
         /*gfid is missing, needs heal*/
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA)) {
             goto name_heal;
         }
 
@@ -3520,11 +3524,11 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
             continue;
         }
 
-        if (replies[i].op_ret != replies[first].op_ret) {
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first].op_ret)) {
             name_state_mismatch = _gf_true;
         }
 
-        if (replies[i].op_ret == 0) {
+        if (GET_RET(replies[i].op_ret) == 0) {
             /* Rename after this lookup may succeed if we don't do
              * a name-heal and the destination may not have pending xattrs
              * to indicate which name is good and which is bad so always do
@@ -3545,7 +3549,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         for (i = 0; i < priv->child_count; i++) {
             if (!replies[i].valid)
                 continue;
-            if (par_readables[i] && replies[i].op_ret < 0 &&
+            if (par_readables[i] && IS_ERROR(replies[i].op_ret) &&
                 replies[i].op_errno != ENOTCONN) {
                 goto name_heal;
             }
@@ -3574,9 +3578,9 @@ metadata_heal:
 }
 
 int
-afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-               struct iatt *postparent)
+afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, inode_t *inode,
+               struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -3605,7 +3609,7 @@ afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     } else {
         local->replies[child_index].need_heal = need_heal;
     }
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
@@ -3638,10 +3642,10 @@ afr_discover_unwind(call_frame_t *frame, xlator_t *this)
 
     afr_fill_success_replies(local, priv, success_replies);
     if (AFR_COUNT(success_replies, priv->child_count) > 0)
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
-    if (local->op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(frame->local, this->private);
         goto error;
     }
@@ -3663,8 +3667,8 @@ unwind:
     if (read_subvol == -1)
         goto error;
 
-    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && local->op_ret == 0) {
-        local->op_ret = -1;
+    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && IS_SUCCESS(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg_debug(this->name, 0,
                      "Arbiter cannot be a read subvol "
@@ -3771,9 +3775,9 @@ unwind:
 }
 
 int
-afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-                 struct iatt *postparent)
+afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, inode_t *inode,
+                 struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -3788,14 +3792,14 @@ afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local->replies[child_index].valid = 1;
     local->replies[child_index].op_ret = op_ret;
     local->replies[child_index].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
             local->replies[child_index].xdata = dict_ref(xdata);
     }
 
-    if (local->do_discovery && (op_ret == 0))
+    if (local->do_discovery && IS_SUCCESS(op_ret))
         afr_attempt_local_discovery(this, child_index);
 
     if (xdata) {
@@ -3853,7 +3857,7 @@ afr_discover_do(call_frame_t *frame, xlator_t *this, int err)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, local->op_errno, 0, 0, 0, 0);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, local->op_errno, 0, 0, 0, 0);
     return 0;
 }
 
@@ -3917,7 +3921,7 @@ afr_discover(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3959,7 +3963,7 @@ afr_lookup_do(call_frame_t *frame, xlator_t *this, int err)
     }
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, local->op_errno, 0, 0, 0, 0);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, local->op_errno, 0, 0, 0, 0);
     return 0;
 }
 
@@ -4057,7 +4061,7 @@ afr_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
 
     return 0;
 }
@@ -4201,8 +4205,8 @@ out:
 /* {{{ flush */
 
 int
-afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, dict_t *xdata)
+afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -4211,7 +4215,7 @@ afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret != -1) {
+        if (IS_SUCCESS(op_ret)) {
             local->op_ret = op_ret;
             if (!local->xdata_rsp && xdata)
                 local->xdata_rsp = dict_ref(xdata);
@@ -4336,13 +4340,13 @@ afr_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     return 0;
 }
 
 int
 afr_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -4351,8 +4355,8 @@ afr_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == 0) {
-            local->op_ret = 0;
+        if (IS_SUCCESS(op_ret)) {
+            local->op_ret = gf_success;
             if (!local->xdata_rsp && xdata)
                 local->xdata_rsp = dict_ref(xdata);
         } else {
@@ -4401,7 +4405,7 @@ afr_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -4412,15 +4416,15 @@ static int
 afr_serialized_lock_wind(call_frame_t *frame, xlator_t *this);
 
 static gf_boolean_t
-afr_is_conflicting_lock_present(int32_t op_ret, int32_t op_errno)
+afr_is_conflicting_lock_present(gf_return_t op_ret, int32_t op_errno)
 {
-    if (op_ret == -1 && op_errno == EAGAIN)
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN)
         return _gf_true;
     return _gf_false;
 }
 
 static void
-afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, int32_t op_ret,
+afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, gf_return_t op_ret,
                     int32_t op_errno, dict_t *xdata)
 {
     switch (op) {
@@ -4444,7 +4448,7 @@ afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, int32_t op_ret,
 static void
 afr_fop_lock_wind(call_frame_t *frame, xlator_t *this, int child_index,
                   int32_t (*lock_cbk)(call_frame_t *, void *, xlator_t *,
-                                      int32_t, int32_t, dict_t *))
+                                      gf_return_t, int32_t, dict_t *))
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
@@ -4514,7 +4518,7 @@ afr_fop_lock_proceed(call_frame_t *frame)
      * both the mounts only got partial locks, afr treats them as failure in
      * gaining the locks and unwinds with EAGAIN errno.
      */
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = EUCLEAN;
     local->fop_lock_state = AFR_FOP_LOCK_SERIAL;
     afr_local_replies_wipe(local, priv);
@@ -4549,7 +4553,7 @@ afr_fop_lock_proceed(call_frame_t *frame)
 
 static int32_t
 afr_unlock_partial_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     afr_local_t *local = NULL;
@@ -4561,7 +4565,7 @@ afr_unlock_partial_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     priv = this->private;
 
-    if (op_ret < 0 && op_errno != ENOTCONN) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN) {
         if (local->fd)
             gf_uuid_copy(gfid, local->fd->inode->gfid);
         else
@@ -4621,7 +4625,7 @@ afr_unlock_locks_and_proceed(call_frame_t *frame, xlator_t *this,
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret == -1)
+        if (IS_ERROR(local->replies[i].op_ret))
             continue;
 
         afr_fop_lock_wind(frame, this, i, afr_unlock_partial_lock_cbk);
@@ -4652,23 +4656,23 @@ afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret == 0) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             lock_count++;
             success[i] = 1;
         }
 
-        if (local->op_ret == -1 && local->op_errno == EAGAIN)
+        if (IS_ERROR(local->op_ret) && local->op_errno == EAGAIN)
             continue;
 
-        if ((local->replies[i].op_ret == -1) &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             (local->replies[i].op_errno == EAGAIN)) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EAGAIN;
             continue;
         }
 
-        if (local->replies[i].op_ret == 0)
-            local->op_ret = 0;
+        if (IS_SUCCESS(local->replies[i].op_ret))
+            local->op_ret = gf_success;
 
         local->op_errno = local->replies[i].op_errno;
     }
@@ -4680,7 +4684,7 @@ afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
         afr_unlock_locks_and_proceed(frame, this, lock_count);
     } else if (priv->quorum_count && !afr_has_quorum(success, this, NULL)) {
         local->fop_lock_state = AFR_FOP_LOCK_QUORUM_FAILED;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
         if (local->op_errno == 0)
             local->op_errno = afr_quorum_errno(priv);
@@ -4698,7 +4702,7 @@ unwind:
 
 static int
 afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int child_index = (long)cookie;
@@ -4708,7 +4712,7 @@ afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[child_index].valid = 1;
     local->replies[child_index].op_ret = op_ret;
     local->replies[child_index].op_errno = op_errno;
-    if (op_ret == 0 && xdata) {
+    if (IS_SUCCESS(op_ret) && xdata) {
         local->replies[child_index].xdata = dict_ref(xdata);
         LOCK(&frame->lock);
         {
@@ -4722,7 +4726,7 @@ afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 afr_serialized_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     afr_local_t *local = NULL;
@@ -4772,7 +4776,7 @@ afr_serialized_lock_wind(call_frame_t *frame, xlator_t *this)
 
 static int32_t
 afr_parallel_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     int call_count = 0;
@@ -4891,7 +4895,7 @@ afr_handle_inodelk(call_frame_t *frame, xlator_t *this, glusterfs_fop_t fop,
         goto out;
     return 0;
 out:
-    afr_fop_lock_unwind(frame, fop, -1, op_errno, NULL);
+    afr_fop_lock_unwind(frame, fop, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -4951,7 +4955,7 @@ afr_handle_entrylk(call_frame_t *frame, xlator_t *this, glusterfs_fop_t fop,
 
     return 0;
 out:
-    afr_fop_lock_unwind(frame, fop, -1, op_errno, NULL);
+    afr_fop_lock_unwind(frame, fop, gf_error, op_errno, NULL);
     return 0;
 }
 
@@ -4976,8 +4980,9 @@ afr_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
 }
 
 int
-afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct statvfs *statvfs, dict_t *xdata)
+afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct statvfs *statvfs,
+               dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = 0;
@@ -4987,7 +4992,7 @@ afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret != 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -5062,14 +5067,14 @@ afr_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 afr_lk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                   dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -5079,7 +5084,7 @@ afr_lk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5137,8 +5142,9 @@ afr_lk_unlock(call_frame_t *frame, xlator_t *this)
 }
 
 int32_t
-afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+           dict_t *xdata)
 {
     afr_local_t *local = NULL;
     afr_private_t *priv = NULL;
@@ -5150,16 +5156,16 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
+        local->op_ret = gf_error;
         local->op_errno = EAGAIN;
 
         afr_lk_unlock(frame, this);
         return 0;
     }
 
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
         local->cont.lk.ret_flock = *lock;
@@ -5175,12 +5181,12 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                           local->xdata_req);
     } else if (priv->quorum_count &&
                !afr_has_quorum(local->cont.lk.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
 
         afr_lk_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
 
         AFR_STACK_UNWIND(lk, frame, local->op_ret, local->op_errno,
@@ -5198,7 +5204,7 @@ afr_lk_transaction_cbk(int ret, call_frame_t *frame, void *opaque)
 
 int
 afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                    gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                     dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -5207,8 +5213,8 @@ afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     child_index = (long)cookie;
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
         local->cont.lk.ret_flock = *lock;
@@ -5219,14 +5225,14 @@ afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 afr_lk_txn_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
-                      dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct gf_flock *lock, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int child_index = (long)cookie;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5283,7 +5289,7 @@ afr_lk_transaction(void *opaque)
 
     if (priv->quorum_count &&
         !afr_has_quorum(local->cont.lk.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
         goto unlock;
     } else {
@@ -5292,7 +5298,7 @@ afr_lk_transaction(void *opaque)
         else
             ret = afr_add_lock_to_saved_locks(frame, this);
         if (ret) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = -ret;
             goto unlock;
         }
@@ -5307,7 +5313,7 @@ unlock:
     AFR_ONLIST(local->cont.lk.locked_nodes, frame, afr_lk_txn_unlock_cbk, lk,
                local->fd, F_SETLK, &local->cont.lk.user_flock, NULL);
 err:
-    AFR_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     return -1;
 }
 
@@ -5366,15 +5372,15 @@ afr_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 afr_lease_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
-                     dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct gf_lease *lease, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -5428,8 +5434,9 @@ afr_lease_unlock(call_frame_t *frame, xlator_t *this)
 }
 
 int32_t
-afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
+afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
+              dict_t *xdata)
 {
     afr_local_t *local = NULL;
     afr_private_t *priv = NULL;
@@ -5441,16 +5448,16 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
+        local->op_ret = gf_error;
         local->op_errno = EAGAIN;
 
         afr_lease_unlock(frame, this);
         return 0;
     }
 
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lease.locked_nodes[child_index] = 1;
         local->cont.lease.ret_lease = *lease;
@@ -5464,12 +5471,12 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                           &local->cont.lease.user_lease, xdata);
     } else if (priv->quorum_count &&
                !afr_has_quorum(local->cont.lease.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
 
         afr_lease_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
         AFR_STACK_UNWIND(lease, frame, local->op_ret, local->op_errno,
                          &local->cont.lease.ret_lease, NULL);
@@ -5511,14 +5518,14 @@ afr_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int
-afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, dict_t *xdata)
+afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int child_index = (long)cookie;
@@ -5549,7 +5556,7 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret < 0 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno != ENOTCONN) {
             local->op_ret = local->replies[i].op_ret;
             local->op_errno = local->replies[i].op_errno;
@@ -5562,9 +5569,9 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             failed = _gf_true;
             break;
         }
-        if (local->replies[i].op_ret == 0) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             succeeded = _gf_true;
-            local->op_ret = 0;
+            local->op_ret = gf_success;
             local->op_errno = 0;
             if (!local->xdata_rsp && local->replies[i].xdata) {
                 local->xdata_rsp = dict_ref(local->replies[i].xdata);
@@ -5573,7 +5580,7 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
 
     if (!succeeded && !failed) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
     }
 
@@ -5630,7 +5637,7 @@ afr_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
 err:
     if (op_errno == -1)
         op_errno = errno;
-    AFR_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
 
     return 0;
 
@@ -6470,7 +6477,7 @@ int
 afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno)
 {
     int __ret = -1;
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = EUCLEAN;
 
     __ret = syncbarrier_init(&local->barrier);
@@ -6561,7 +6568,7 @@ afr_internal_lock_init(afr_internal_lock_t *lk, size_t child_count)
     if (NULL == lk->lower_locked_nodes)
         goto out;
 
-    lk->lock_op_ret = -1;
+    lk->lock_op_ret = gf_error;
     lk->lock_op_errno = EUCLEAN;
 
     ret = 0;
@@ -6850,7 +6857,7 @@ afr_update_heal_status(xlator_t *this, struct afr_reply *replies,
     sprintf(key2, "%s:%s", GLUSTERFS_INODELK_DOM_PREFIX, priv->sh_domain);
 
     for (i = 0; i < priv->child_count; i++) {
-        if ((replies[i].valid != 1) || (replies[i].op_ret != 0))
+        if ((replies[i].valid != 1) || IS_ERROR(replies[i].op_ret))
             continue;
         if (!io_domain_lk_count) {
             ret1 = dict_get_int32(replies[i].xdata, key1, &io_domain_lk_count);
@@ -6911,7 +6918,7 @@ afr_lockless_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
     if (ret)
         goto out;
     for (i = 0; i < priv->child_count; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             valid_on[i] = 1;
         }
     }
@@ -7070,7 +7077,9 @@ out:
         heal_frame->local = heal_local;
         AFR_STACK_DESTROY(heal_frame);
     }
-    AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     if (dict)
         dict_unref(dict);
     if (inode)
@@ -7171,6 +7180,7 @@ afr_get_split_brain_status(void *opaque)
     xlator_t *this = NULL;
     loc_t *loc = NULL;
     afr_spb_status_t *data = NULL;
+    gf_return_t op_ret = {0};
 
     data = opaque;
     frame = data->frame;
@@ -7250,8 +7260,11 @@ afr_get_split_brain_status(void *opaque)
     }
 
     ret = 0;
+
 out:
-    AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     if (dict)
         dict_unref(dict);
     if (inode)
@@ -7312,10 +7325,13 @@ out:
         heal_frame->local = heal_local;
         AFR_STACK_DESTROY(heal_frame);
     }
+
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     if (local->op == GF_FOP_GETXATTR)
-        AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+        AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     else if (local->op == GF_FOP_SETXATTR)
-        AFR_STACK_UNWIND(setxattr, frame, ret, op_errno, NULL);
+        AFR_STACK_UNWIND(setxattr, frame, op_ret, op_errno, NULL);
     if (dict)
         dict_unref(dict);
     return ret;
@@ -7507,7 +7523,7 @@ afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
 
     keylen = strlen(local->cont.getxattr.name);
     for (i = 0; i < priv->child_count; i++) {
-        if (!local->replies[i].valid || local->replies[i].op_ret) {
+        if (!local->replies[i].valid || IS_ERROR(local->replies[i].op_ret)) {
             str_len = strlen(default_str);
             buf = strncat(buf, default_str, str_len);
             len += str_len;
@@ -7852,7 +7868,7 @@ afr_handle_replies_quorum(call_frame_t *frame, xlator_t *this)
         local->op_errno = afr_final_errno(local, priv);
         if (!local->op_errno)
             local->op_errno = afr_quorum_errno(priv);
-        local->op_ret = -1;
+        local->op_ret = gf_error;
     }
 }
 

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -224,7 +224,7 @@ out:
     loc_wipe(&loc);
 
     if (read_subvol == -1) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
     }
     afr_read_txn_wind(frame, this, read_subvol);
@@ -241,7 +241,7 @@ afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
     local = frame->local;
     ta_frame = afr_ta_frame_create(this);
     if (!ta_frame) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_THIN_ARB,
                "Failed to create ta_frame");
@@ -254,7 +254,7 @@ afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
                "Failed to launch "
                "afr_ta_read_txn synctask for gfid %s.",
                uuid_utoa(local->inode->gfid));
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         STACK_DESTROY(ta_frame->root);
         goto out;
@@ -414,18 +414,18 @@ afr_read_txn(call_frame_t *frame, xlator_t *this, inode_t *inode,
     local->transaction.type = type;
 
     if (priv->quorum_count && !afr_has_quorum(local->child_up, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_quorum_errno(priv);
         goto read;
     }
 
     if (!afr_is_consistent_io_possible(local, priv, &local->op_errno)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         goto read;
     }
 
     if (priv->thin_arbiter_count && !afr_ta_has_quorum(priv, local)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = -afr_quorum_errno(priv);
         goto read;
     }

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -17,8 +17,9 @@
 
 #define HAS_HOLES(i) ((i->ia_blocks * 512) < (i->ia_size))
 static int
-__checksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, uint32_t weak, uint8_t *strong, dict_t *xdata)
+__checksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, uint32_t weak, uint8_t *strong,
+               dict_t *xdata)
 {
     afr_local_t *local = NULL;
     struct afr_reply *replies = NULL;
@@ -84,7 +85,7 @@ __afr_can_skip_data_block_heal(call_frame_t *frame, xlator_t *this, fd_t *fd,
     if (xdata)
         dict_unref(xdata);
 
-    if (!replies[source].valid || replies[source].op_ret != 0)
+    if (!replies[source].valid || IS_ERROR(replies[source].op_ret))
         return _gf_false;
 
     for (i = 0; i < priv->child_count; i++) {
@@ -297,7 +298,7 @@ afr_selfheal_data_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd,
     AFR_ONLIST(healed_sinks, frame, afr_sh_generic_fop_cbk, fsync, fd, 0, NULL);
 
     for (i = 0; i < priv->child_count; i++)
-        if (healed_sinks[i] && local->replies[i].op_ret != 0)
+        if (healed_sinks[i] && IS_ERROR(local->replies[i].op_ret))
             /* fsync() failed. Do NOT consider this server
                as successfully healed. Mark it so.
             */
@@ -410,7 +411,7 @@ __afr_selfheal_truncate_sinks(call_frame_t *frame, xlator_t *this, fd_t *fd,
                NULL);
 
     for (i = 0; i < priv->child_count; i++)
-        if (healed_sinks[i] && local->replies[i].op_ret == -1)
+        if (healed_sinks[i] && IS_ERROR(local->replies[i].op_ret))
             /* truncate() failed. Do NOT consider this server
                as successfully healed. Mark it so.
             */
@@ -450,7 +451,7 @@ afr_does_size_mismatch(xlator_t *this, unsigned char *sources,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (!sources[i])
@@ -773,7 +774,7 @@ out:
 
 int
 afr_selfheal_data_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -828,7 +829,7 @@ afr_selfheal_data_open(xlator_t *this, inode_t *inode, fd_t **fd)
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret < 0) {
+        if (IS_ERROR(local->replies[i].op_ret)) {
             ret = -local->replies[i].op_errno;
             continue;
         }

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -143,7 +143,7 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret != 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (mtime_ns(&replies[i].poststat) <= mtime)
@@ -167,7 +167,7 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret != 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         child_ia = replies[i].poststat;

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -72,7 +72,7 @@ __afr_selfheal_name_impunge(call_frame_t *frame, xlator_t *this,
     gf_uuid_copy(parent->gfid, pargfid);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_compare(replies[i].poststat.ia_gfid,
@@ -108,7 +108,7 @@ __afr_selfheal_name_expunge(xlator_t *this, inode_t *parent, uuid_t pargfid,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         ret |= afr_selfheal_entry_delete(this, parent, bname, inode, i,
@@ -132,7 +132,7 @@ afr_selfheal_name_need_heal_check(xlator_t *this, struct afr_reply *replies)
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA))
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA))
             need_heal = _gf_true;
 
         if (first_idx == -1) {
@@ -140,14 +140,14 @@ afr_selfheal_name_need_heal_check(xlator_t *this, struct afr_reply *replies)
             continue;
         }
 
-        if (replies[i].op_ret != replies[first_idx].op_ret)
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first_idx].op_ret))
             need_heal = _gf_true;
 
         if (gf_uuid_compare(replies[i].poststat.ia_gfid,
                             replies[first_idx].poststat.ia_gfid))
             need_heal = _gf_true;
 
-        if ((replies[i].op_ret == 0) &&
+        if (IS_SUCCESS(replies[i].op_ret) &&
             (gf_uuid_is_null(replies[i].poststat.ia_gfid)))
             need_heal = _gf_true;
     }
@@ -169,7 +169,7 @@ afr_selfheal_name_type_mismatch_check(xlator_t *this, struct afr_reply *replies,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (replies[i].poststat.ia_type == IA_INVAL)
@@ -229,7 +229,7 @@ afr_selfheal_name_gfid_mismatch_check(xlator_t *this, struct afr_reply *replies,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_is_null(replies[i].poststat.ia_gfid))
@@ -287,7 +287,7 @@ afr_selfheal_name_source_empty_check(xlator_t *this, struct afr_reply *replies,
         if (!sources[i])
             continue;
 
-        if (replies[i].op_ret == -1 && replies[i].op_errno == ENOENT)
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == ENOENT)
             continue;
 
         source_is_empty = _gf_false;
@@ -547,7 +547,7 @@ afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA)) {
             *need_heal = _gf_true;
             break;
         }
@@ -557,7 +557,7 @@ afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
             continue;
         }
 
-        if (replies[i].op_ret != replies[first_idx].op_ret) {
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first_idx].op_ret)) {
             *need_heal = _gf_true;
             break;
         }

--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -209,7 +209,7 @@ afr_selfheal_extract_xattr(xlator_t *this, struct afr_reply *replies,
 
 int
 afr_sh_generic_fop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *pre,
+                       gf_return_t op_ret, int op_errno, struct iatt *pre,
                        struct iatt *post, dict_t *xdata);
 
 int
@@ -242,7 +242,7 @@ afr_inode_find(xlator_t *this, uuid_t gfid);
 
 int
 afr_selfheal_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, inode_t *inode,
+                          gf_return_t op_ret, int op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata, struct iatt *parbuf);
 void
 afr_reply_copy(struct afr_reply *dst, struct afr_reply *src);
@@ -334,7 +334,7 @@ afr_selfheal_do(call_frame_t *frame, xlator_t *this, uuid_t gfid);
 
 int
 afr_selfheal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 afr_locked_fill(call_frame_t *frame, xlator_t *this, unsigned char *locked_on);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -54,13 +54,13 @@
 #define REBAL_NODEUUID_MINE 0x01
 
 typedef int (*dht_selfheal_dir_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 typedef int (*dht_defrag_cbk_fn_t)(xlator_t *this, xlator_t *dst_node,
                                    call_frame_t *frame, int ret);
 
 typedef int (*dht_refresh_layout_unlock)(call_frame_t *frame, xlator_t *this,
-                                         int op_ret, int invoke_cbk);
+                                         int ret, int invoke_cbk);
 
 typedef int (*dht_refresh_layout_done_handle)(call_frame_t *frame);
 
@@ -200,7 +200,7 @@ typedef struct {
     dht_reaction_type_t reaction;
 
     /* whether locking failed on _any_ of the "locks" above */
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
 } dht_ilock_wrap_t;
 
@@ -212,7 +212,7 @@ typedef struct {
     dht_reaction_type_t reaction;
 
     /* whether locking failed on _any_ of the "locks" above */
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
 } dht_elock_wrap_t;
 
@@ -244,7 +244,7 @@ struct dht_local {
     loc_t loc;
     loc_t loc2;
     int call_cnt;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     int layout_mismatch;
     /* Use stbuf as the postbuf, when we require both
@@ -340,7 +340,7 @@ struct dht_local {
     int32_t parent_disk_layout[4];
 
     /* rename rollback */
-    int *ret_cache;
+    gf_return_t *ret_cache;
 
     loc_t loc2_copy;
 
@@ -663,7 +663,7 @@ typedef struct dht_fd_ctx {
     GF_REF_DECL;
 } dht_fd_ctx_t;
 
-#define ENTRY_MISSING(op_ret, op_errno) (op_ret == -1 && op_errno == ENOENT)
+#define ENTRY_MISSING(op_ret, op_errno) (IS_ERROR(op_ret) && op_errno == ENOENT)
 
 #define is_revalidate(loc)                                                     \
     (dht_inode_ctx_layout_get((loc)->inode, this, NULL) == 0)
@@ -792,7 +792,7 @@ int
 dht_layouts_init(xlator_t *this, dht_conf_t *conf);
 int
 dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
-                 int op_ret, int op_errno, dict_t *xattr);
+                 gf_return_t op_ret, int op_errno, dict_t *xattr);
 
 int
 dht_disk_layout_extract(xlator_t *this, dht_layout_t *layout, int pos,
@@ -884,7 +884,7 @@ int
 dht_rename_cleanup(call_frame_t *frame);
 int
 dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
@@ -1097,41 +1097,44 @@ dht_notify(xlator_t *this, int32_t event, void *data, ...);
 /* definitions for nufa/switch */
 int
 dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent);
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
 dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent);
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
 dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, dict_t *xattr,
                         struct iatt *postparent);
 int
-dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, inode_t *inode, struct iatt *stbuf, dict_t *xattr,
-               struct iatt *postparent);
+dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, inode_t *inode,
+               struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
-dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-               struct iatt *preparent, struct iatt *postparent, dict_t *xdata);
+dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+               struct iatt *stbuf, struct iatt *preparent,
+               struct iatt *postparent, dict_t *xdata);
 int
-dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, inode_t *inode, struct iatt *stbuf,
-                struct iatt *preparent, struct iatt *postparent, dict_t *xdata);
+dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, inode_t *inode,
+                struct iatt *stbuf, struct iatt *preparent,
+                struct iatt *postparent, dict_t *xdata);
 
 int
 dht_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
-dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, dict_t *xattr, dict_t *xdata);
+dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, dict_t *xattr,
+                 dict_t *xdata);
 
 int
 dht_common_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata);
 int
 gf_defrag_status_get(dht_conf_t *conf, dict_t *dict);
@@ -1208,7 +1211,7 @@ int
 dht_heal_full_path(void *data);
 
 int
-dht_heal_full_path_done(int op_ret, call_frame_t *frame, void *data);
+dht_heal_full_path_done(int ret, call_frame_t *frame, void *data);
 
 int
 dht_layout_missing_dirs(dht_layout_t *layout);
@@ -1244,7 +1247,7 @@ dht_get_lock_subvolume(xlator_t *this, struct gf_flock *lock,
                        dht_local_t *local);
 
 int
-dht_lk_inode_unref(call_frame_t *frame, int32_t op_ret);
+dht_lk_inode_unref(call_frame_t *frame, gf_return_t op_ret);
 
 int
 dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *subvol);
@@ -1255,60 +1258,61 @@ dht_check_and_open_fd_on_subvol(xlator_t *this, call_frame_t *frame);
 /* FD fop callbacks */
 
 int
-dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-               dict_t *xdata);
+dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+               struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, dict_t *xdata);
+dht_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
+dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                dict_t *xdata);
+dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
+dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iovec *vector, int count,
+              struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
+
+int
+dht_file_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                   dict_t *xdata);
 
 int
-dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
-
-int
-dht_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata);
-
-int
-dht_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iovec *vector, int count, struct iatt *stbuf,
-              struct iobref *iobref, dict_t *xdata);
-
-int
-dht_file_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *stbuf, dict_t *xdata);
-
-int
 dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 /* All custom xattr heal functions */
 int
@@ -1363,11 +1367,12 @@ dht_pt_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
               dict_t *xdata);
 
 int32_t
-dht_check_remote_fd_failed_error(dht_local_t *local, int op_ret, int op_errno);
+dht_check_remote_fd_failed_error(dht_local_t *local, gf_return_t op_ret,
+                                 int op_errno);
 
 int
 dht_common_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata);
 
 int32_t

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -16,8 +16,9 @@
 #include <glusterfs/events.h>
 
 int
-dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct statvfs *statvfs, dict_t *xdata)
+dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct statvfs *statvfs,
+                dict_t *xdata)
 {
     dht_conf_t *conf = NULL;
     xlator_t *prev = NULL;
@@ -32,7 +33,7 @@ dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     conf = this->private;
     prev = cookie;
 
-    if (op_ret == -1 || !statvfs) {
+    if (IS_ERROR(op_ret) || !statvfs) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno,
                DHT_MSG_GET_DISK_INFO_ERROR, "failed to get disk info from %s",
                prev->name);

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -306,7 +306,7 @@ dht_disk_layout_merge(xlator_t *this, dht_layout_t *layout, int pos,
 
 int
 dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
-                 int op_ret, int op_errno, dict_t *xattr)
+                 gf_return_t op_ret, int op_errno, dict_t *xattr)
 {
     int i = 0;
     int ret = -1;
@@ -315,7 +315,7 @@ dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
     int disk_layout_len = 0;
     dht_conf_t *conf = this->private;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         err = op_errno;
     }
 
@@ -330,7 +330,7 @@ dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
         }
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         ret = 0;
         goto out;
     }

--- a/xlators/cluster/dht/src/dht-linkfile.c
+++ b/xlators/cluster/dht/src/dht-linkfile.c
@@ -13,7 +13,7 @@
 
 static int
 dht_linkfile_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, dict_t *xattr,
                         struct iatt *postparent)
 {
@@ -27,7 +27,7 @@ dht_linkfile_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     conf = this->private;
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         goto out;
 
     gf_uuid_unparse(local->loc.gfid, gfid);
@@ -45,7 +45,7 @@ out:
 
 static int
 dht_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, struct iatt *preparent,
                         struct iatt *postparent, dict_t *xdata)
 {
@@ -57,12 +57,12 @@ dht_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (!op_ret)
+    if (IS_SUCCESS(op_ret))
         local->linked = _gf_true;
 
     FRAME_SU_UNDO(frame, dht_local_t);
 
-    if (op_ret && (op_errno == EEXIST)) {
+    if (IS_ERROR(op_ret) && (op_errno == EEXIST)) {
         conf = this->private;
         subvol = cookie;
         if (!subvol)
@@ -156,8 +156,8 @@ dht_linkfile_create(call_frame_t *frame, fop_mknod_cbk_t linkfile_cbk,
 
     return 0;
 out:
-    local->linkfile.linkfile_cbk(frame, frame->this, frame->this, -1, ENOMEM,
-                                 loc->inode, NULL, NULL, NULL, NULL);
+    local->linkfile.linkfile_cbk(frame, frame->this, frame->this, gf_error,
+                                 ENOMEM, loc->inode, NULL, NULL, NULL, NULL);
 
     if (need_unref && dict)
         dict_unref(dict);
@@ -167,7 +167,7 @@ out:
 
 int
 dht_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         struct iatt *preparent, struct iatt *postparent,
                         dict_t *xdata)
 {
@@ -178,7 +178,7 @@ dht_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     subvol = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_UNLINK_FAILED,
                 "path=%s", local->loc.path, "gfid=%s", gfid, "subvolume=%s",
@@ -252,7 +252,7 @@ out:
 
 static int
 dht_linkfile_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, struct iatt *statpre,
+                         gf_return_t op_ret, int op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -261,7 +261,7 @@ dht_linkfile_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     loc = &local->loc;
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_SETATTR_FAILED,
                 "path=%s", (loc->path ? loc->path : "NULL"), "gfid=%s",
                 uuid_utoa(local->gfid), NULL);

--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -304,7 +304,7 @@ dht_entrylk_done(call_frame_t *lock_frame)
 
 static int32_t
 dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char gfid[GF_UUID_BUF_SIZE] = {0};
@@ -313,7 +313,7 @@ dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].ns.directory_ns.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "gfid=%s", gfid,
                 "DHT_LAYOUT_HEAL_DOMAIN", NULL);
@@ -325,7 +325,7 @@ dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 dht_unlock_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -337,7 +337,7 @@ dht_unlock_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     uuid_utoa_r(local->lock[0].ns.directory_ns.locks[lk_index]->loc.gfid, gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_UNLOCKING_FAILED,
                 "name=%s",
                 local->lock[0].ns.directory_ns.locks[lk_index]->xl->name,
@@ -360,6 +360,7 @@ dht_unlock_entrylk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 {
     dht_local_t *local = NULL;
     int ret = -1, i = 0;
+    gf_return_t op_ret = {0};
     call_frame_t *lock_frame = NULL;
     int call_cnt = 0;
 
@@ -424,7 +425,7 @@ done:
 
     /* no locks acquired, invoke entrylk_cbk */
     if (ret == 0)
-        entrylk_cbk(frame, NULL, frame->this, 0, 0, NULL);
+        entrylk_cbk(frame, NULL, frame->this, op_ret, 0, NULL);
 
     return ret;
 }
@@ -486,7 +487,7 @@ out:
 
 static int
 dht_entrylk_cleanup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_entrylk_done(frame);
     return 0;
@@ -517,7 +518,7 @@ dht_entrylk_cleanup(call_frame_t *lock_frame)
 
 static int32_t
 dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     int lk_index = 0;
     int i = 0;
@@ -526,7 +527,7 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         local->lock[0].ns.directory_ns.locks[lk_index]->locked = _gf_true;
     } else {
         switch (op_errno) {
@@ -535,13 +536,13 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 if (local->lock[0]
                         .ns.directory_ns.locks[lk_index]
                         ->do_on_failure != IGNORE_ENOENT_ESTALE) {
-                    local->lock[0].ns.directory_ns.op_ret = -1;
+                    local->lock[0].ns.directory_ns.op_ret = gf_error;
                     local->lock[0].ns.directory_ns.op_errno = op_errno;
                     goto cleanup;
                 }
                 break;
             default:
-                local->lock[0].ns.directory_ns.op_ret = -1;
+                local->lock[0].ns.directory_ns.op_ret = gf_error;
                 local->lock[0].ns.directory_ns.op_errno = op_errno;
                 goto cleanup;
         }
@@ -554,7 +555,7 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             ;
 
         if (i == local->lock[0].ns.directory_ns.lk_count) {
-            local->lock[0].ns.directory_ns.op_ret = -1;
+            local->lock[0].ns.directory_ns.op_ret = gf_error;
             local->lock[0].ns.directory_ns.op_errno = op_errno;
         }
 
@@ -683,7 +684,7 @@ dht_inodelk_done(call_frame_t *lock_frame)
 
 static int32_t
 dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -692,7 +693,7 @@ dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->lock[0].layout.my_layout.locks[lk_index]->loc.gfid,
                     gfid);
 
@@ -714,7 +715,7 @@ dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 dht_unlock_inodelk_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char gfid[GF_UUID_BUF_SIZE] = {0};
@@ -723,7 +724,7 @@ dht_unlock_inodelk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].layout.my_layout.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "DHT_LAYOUT_HEAL_DOMAIN gfid=%s",
                 gfid, NULL);
@@ -807,7 +808,7 @@ done:
 
     /* no locks acquired, invoke inodelk_cbk */
     if (ret == 0)
-        inodelk_cbk(frame, NULL, frame->this, 0, 0, NULL);
+        inodelk_cbk(frame, NULL, frame->this, gf_success, 0, NULL);
 
     return ret;
 }
@@ -869,7 +870,7 @@ out:
 
 static int
 dht_inodelk_cleanup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_inodelk_done(frame);
     return 0;
@@ -900,7 +901,7 @@ dht_inodelk_cleanup(call_frame_t *lock_frame)
 
 static int32_t
 dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -909,8 +910,8 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     lk_index = (long)cookie;
 
-    if (op_ret == -1) {
-        local->lock[0].layout.my_layout.op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->lock[0].layout.my_layout.op_ret = gf_error;
         local->lock[0].layout.my_layout.op_errno = op_errno;
 
         if (local && local->lock[0].layout.my_layout.locks[lk_index]) {
@@ -935,7 +936,7 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 out:
     call_cnt = dht_frame_return(frame);
     if (is_last_call(call_cnt)) {
-        if (local->lock[0].layout.my_layout.op_ret < 0) {
+        if (IS_ERROR(local->lock[0].layout.my_layout.op_ret)) {
             dht_inodelk_cleanup(frame);
             return 0;
         }
@@ -1000,7 +1001,7 @@ out:
 
 static int32_t
 dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     int lk_index = 0;
     int i = 0;
@@ -1013,7 +1014,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         local->lock[0].layout.my_layout.locks[lk_index]->locked = _gf_true;
     } else {
         switch (op_errno) {
@@ -1028,7 +1029,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                         .layout.my_layout.locks[lk_index]
                                         ->loc.gfid,
                                     gfid);
-                    local->lock[0].layout.my_layout.op_ret = -1;
+                    local->lock[0].layout.my_layout.op_ret = gf_error;
                     local->lock[0].layout.my_layout.op_errno = op_errno;
                     gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                             DHT_MSG_INODELK_FAILED, "subvol=%s",
@@ -1048,7 +1049,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                         .layout.my_layout.locks[lk_index]
                                         ->loc.gfid,
                                     gfid);
-                    local->lock[0].layout.my_layout.op_ret = -1;
+                    local->lock[0].layout.my_layout.op_ret = gf_error;
                     local->lock[0].layout.my_layout.op_errno = op_errno;
                     gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                             DHT_MSG_INODELK_FAILED, "subvol=%s",
@@ -1064,7 +1065,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 gf_uuid_unparse(
                     local->lock[0].layout.my_layout.locks[lk_index]->loc.gfid,
                     gfid);
-                local->lock[0].layout.my_layout.op_ret = -1;
+                local->lock[0].layout.my_layout.op_ret = gf_error;
                 local->lock[0].layout.my_layout.op_errno = op_errno;
                 gf_smsg(
                     this->name, GF_LOG_ERROR, op_errno, DHT_MSG_INODELK_FAILED,
@@ -1082,7 +1083,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             ;
 
         if (i == local->lock[0].layout.my_layout.lk_count) {
-            local->lock[0].layout.my_layout.op_ret = -1;
+            local->lock[0].layout.my_layout.op_ret = gf_error;
             local->lock[0].layout.my_layout.op_errno = op_errno;
         }
 
@@ -1185,12 +1186,12 @@ out:
 
 static int32_t
 dht_protect_namespace_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
     local = frame->local;
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         dht_unlock_inodelk_wrapper(frame, &local->current->ns.parent_layout);
 
     local->current->ns.ns_cbk(frame, cookie, this, op_ret, op_errno, xdata);
@@ -1199,7 +1200,7 @@ dht_protect_namespace_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1213,8 +1214,8 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     local = frame->local;
     entrylk = &local->current->ns.directory_ns;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -1222,7 +1223,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     loc = &entrylk->locks[0]->loc;
     gf_uuid_unparse(loc->gfid, pgfid);
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     lk_array = entrylk->locks;
     count = entrylk->lk_count;
 
@@ -1230,7 +1231,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
                                dht_protect_namespace_cbk);
 
     if (ret < 0) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EIO;
         gf_smsg(this->name, GF_LOG_WARNING, local->op_errno,
                 DHT_MSG_ENTRYLK_FAILED_AFT_INODELK, "fop=%s",

--- a/xlators/cluster/dht/src/dht-lock.h
+++ b/xlators/cluster/dht/src/dht-lock.h
@@ -73,12 +73,12 @@ dht_blocking_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 
 int32_t
 dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata);
 
 int32_t
 dht_blocking_entrylk_after_inodelk_rename(call_frame_t *frame, void *cookie,
-                                          xlator_t *this, int32_t op_ret,
+                                          xlator_t *this, gf_return_t op_ret,
                                           int32_t op_errno, dict_t *xdata);
 
 void

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2337,28 +2337,31 @@ rebalance_task(void *data)
 }
 
 static int
-rebalance_task_completion(int op_ret, call_frame_t *sync_frame, void *data)
+rebalance_task_completion(int ret, call_frame_t *sync_frame, void *data)
 {
     int32_t op_errno = EINVAL;
 
-    if (op_ret == -1) {
+    if (ret == -1) {
         /* Failure of migration process, mostly due to write process.
            as we can't preserve the exact errno, lets say there was
            no space to migrate-data
         */
         op_errno = ENOSPC;
-    } else if (op_ret == 1) {
+    } else if (ret == 1) {
         /* migration didn't happen, but is not a failure, let the user
            understand that he doesn't have permission to migrate the
            file.
         */
-        op_ret = -1;
+        ret = -1;
         op_errno = EPERM;
-    } else if (op_ret != 0) {
-        op_errno = -op_ret;
-        op_ret = -1;
+    } else if (ret != 0) {
+        op_errno = -ret;
+        ret = -1;
     }
 
+    /* */
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     DHT_STACK_UNWIND(setxattr, sync_frame, op_ret, op_errno, NULL);
     return 0;
 }

--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -907,15 +907,16 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
 {
     ec_fop_data_t *fop = dst->fop;
 
-    if (dst->op_ret != src->op_ret) {
+    if (GET_RET(dst->op_ret) != GET_RET(src->op_ret)) {
         gf_msg_debug(fop->xl->name, 0,
                      "Mismatching return code in "
                      "answers of '%s': %d <-> %d",
-                     ec_fop_name(fop->id), dst->op_ret, src->op_ret);
+                     ec_fop_name(fop->id), GET_RET(dst->op_ret),
+                     GET_RET(src->op_ret));
 
         return 0;
     }
-    if (dst->op_ret < 0) {
+    if (IS_ERROR(dst->op_ret)) {
         if (dst->op_errno != src->op_errno) {
             gf_msg_debug(fop->xl->name, 0,
                          "Mismatching errno code in "
@@ -935,7 +936,7 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
         return 0;
     }
 
-    if ((dst->op_ret >= 0) && (combine != NULL)) {
+    if (IS_SUCCESS(dst->op_ret) && (combine != NULL)) {
         return combine(fop, dst, src);
     }
 

--- a/xlators/cluster/ec/src/ec-common.h
+++ b/xlators/cluster/ec/src/ec-common.h
@@ -28,7 +28,7 @@ typedef enum { EC_DATA_TXN, EC_METADATA_TXN } ec_txn_t;
 #define QUORUM_CBK(fn, fop, frame, cookie, this, op_ret, op_errno, params...)  \
     do {                                                                       \
         ec_t *__ec = fop->xl->private;                                         \
-        int32_t __op_ret = 0;                                                  \
+        gf_return_t __op_ret;                                                  \
         int32_t __op_errno = 0;                                                \
         int32_t __success_count = gf_bits_count(fop->good);                    \
                                                                                \
@@ -37,8 +37,8 @@ typedef enum { EC_DATA_TXN, EC_METADATA_TXN } ec_txn_t;
         if (!fop->parent && frame &&                                           \
             (GF_CLIENT_PID_SELF_HEALD != frame->root->pid) &&                  \
             __ec->quorum_count && (__success_count < __ec->quorum_count) &&    \
-            op_ret >= 0) {                                                     \
-            __op_ret = -1;                                                     \
+            IS_SUCCESS(op_ret)) {                                              \
+            __op_ret = gf_error;                                               \
             __op_errno = EIO;                                                  \
             gf_msg(__ec->xl->name, GF_LOG_ERROR, 0,                            \
                    EC_MSG_CHILDS_INSUFFICIENT,                                 \
@@ -214,11 +214,11 @@ ec_get_heal_info(xlator_t *this, loc_t *loc, dict_t **dict);
 
 int32_t
 ec_lock_unlocked(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 void
 ec_update_fd_status(fd_t *fd, xlator_t *xl, int child_index,
-                    int32_t ret_status);
+                    gf_return_t ret_status);
 gf_boolean_t
 ec_is_entry_healing(ec_fop_data_t *fop);
 void

--- a/xlators/cluster/ec/src/ec-data.c
+++ b/xlators/cluster/ec/src/ec-data.c
@@ -15,7 +15,8 @@
 
 ec_cbk_data_t *
 ec_cbk_data_allocate(call_frame_t *frame, xlator_t *this, ec_fop_data_t *fop,
-                     int32_t id, int32_t idx, int32_t op_ret, int32_t op_errno)
+                     int32_t id, int32_t idx, gf_return_t op_ret,
+                     int32_t op_errno)
 {
     ec_cbk_data_t *cbk;
     ec_t *ec = this->private;

--- a/xlators/cluster/ec/src/ec-data.h
+++ b/xlators/cluster/ec/src/ec-data.h
@@ -15,7 +15,8 @@
 
 ec_cbk_data_t *
 ec_cbk_data_allocate(call_frame_t *frame, xlator_t *this, ec_fop_data_t *fop,
-                     int32_t id, int32_t idx, int32_t op_ret, int32_t op_errno);
+                     int32_t id, int32_t idx, gf_return_t op_ret,
+                     int32_t op_errno);
 ec_fop_data_t *
 ec_fop_data_allocate(call_frame_t *frame, xlator_t *this, int32_t id,
                      uint32_t flags, uintptr_t target, uint32_t fop_flags,

--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -17,10 +17,11 @@
 #include "ec-fops.h"
 
 int
-ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
-                 int op_errno, struct iatt *poststat, struct iatt *preparent,
-                 struct iatt *postparent, struct iatt *preparent2,
-                 struct iatt *postparent2, dict_t *xdata)
+ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
+                 gf_return_t op_ret, int op_errno, struct iatt *poststat,
+                 struct iatt *preparent, struct iatt *postparent,
+                 struct iatt *preparent2, struct iatt *postparent2,
+                 dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -36,7 +37,7 @@ ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
     idx = (long)cookie;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
@@ -46,7 +47,7 @@ ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
     if (xdata)
         cbk->xdata = dict_ref(xdata);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (poststat)
@@ -76,9 +77,10 @@ out:
 /* FOP: create */
 
 int32_t
-ec_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, fd_t *fd, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -231,8 +233,9 @@ ec_manager_create(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.create != NULL) {
-                fop->cbks.create(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.create(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL, NULL,
+                                 NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -318,16 +321,18 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL,
+             NULL);
     }
 }
 
 /* FOP: link */
 
 int32_t
-ec_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, inode_t *inode, struct iatt *buf,
-            struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+            struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+            dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -403,8 +408,8 @@ ec_manager_link(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.link != NULL) {
-                fop->cbks.link(fop->req_frame, fop, fop->xl, -1, fop->error,
-                               NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.link(fop->req_frame, fop, fop->xl, gf_error,
+                               fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -483,16 +488,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: mkdir */
 
 int32_t
-ec_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -584,8 +590,8 @@ ec_manager_mkdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.mkdir != NULL) {
-                fop->cbks.mkdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL, NULL,
+                fop->cbks.mkdir(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL, NULL,
                                 ((cbk) ? cbk->xdata : NULL));
             }
 
@@ -660,16 +666,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: mknod */
 
 int32_t
-ec_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -788,8 +795,8 @@ ec_manager_mknod(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.mknod != NULL) {
-                fop->cbks.mknod(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.mknod(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -864,17 +871,18 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: rename */
 
 int32_t
-ec_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, struct iatt *preoldparent,
-              struct iatt *postoldparent, struct iatt *prenewparent,
-              struct iatt *postnewparent, dict_t *xdata)
+ec_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              struct iatt *preoldparent, struct iatt *postoldparent,
+              struct iatt *prenewparent, struct iatt *postnewparent,
+              dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preoldparent, postoldparent, prenewparent,
@@ -947,8 +955,9 @@ ec_manager_rename(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.rename != NULL) {
-                fop->cbks.rename(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.rename(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL, NULL,
+                                 NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1028,16 +1037,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL,
+             NULL);
     }
 }
 
 /* FOP: rmdir */
 
 int32_t
-ec_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-             dict_t *xdata)
+ec_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, NULL,
                             preparent, postparent, NULL, NULL, xdata);
@@ -1098,8 +1108,8 @@ ec_manager_rmdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.rmdir != NULL) {
-                fop->cbks.rmdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL);
+                fop->cbks.rmdir(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1172,7 +1182,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1180,7 +1190,7 @@ out:
 
 int32_t
 ec_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1253,8 +1263,8 @@ ec_manager_symlink(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.symlink != NULL) {
-                fop->cbks.symlink(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                  NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.symlink(fop->req_frame, fop, fop->xl, gf_error,
+                                  fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1337,16 +1347,16 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: unlink */
 
 int32_t
-ec_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+ec_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, NULL,
                             preparent, postparent, NULL, NULL, xdata);
@@ -1407,8 +1417,8 @@ ec_manager_unlink(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.unlink != NULL) {
-                fop->cbks.unlink(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL);
+                fop->cbks.unlink(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1482,6 +1492,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-generic.c
+++ b/xlators/cluster/ec/src/ec-generic.c
@@ -20,8 +20,8 @@
 /* FOP: flush */
 
 int32_t
-ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -35,7 +35,7 @@ ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FLUSH, idx, op_ret,
                                op_errno);
@@ -121,8 +121,8 @@ ec_manager_flush(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.flush != NULL) {
-                fop->cbks.flush(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL);
+                fop->cbks.flush(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -238,7 +238,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -259,9 +259,9 @@ ec_combine_fsync(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-             dict_t *xdata)
+ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+             struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -275,12 +275,12 @@ ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSYNC, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (prebuf != NULL) {
                 cbk->iatt[0] = *prebuf;
             }
@@ -378,8 +378,8 @@ ec_manager_fsync(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fsync != NULL) {
-                fop->cbks.fsync(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL);
+                fop->cbks.fsync(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -466,7 +466,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -474,7 +474,7 @@ out:
 
 int32_t
 ec_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -488,7 +488,7 @@ ec_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSYNCDIR, idx, op_ret,
                                op_errno);
@@ -574,8 +574,8 @@ ec_manager_fsyncdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fsyncdir != NULL) {
-                fop->cbks.fsyncdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                   NULL);
+                fop->cbks.fsyncdir(fop->req_frame, fop, fop->xl, gf_error,
+                                   fop->error, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -653,7 +653,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -666,7 +666,7 @@ ec_lookup_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     uint64_t size = 0;
     int32_t have_size = 0, err;
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         return;
     }
 
@@ -718,9 +718,9 @@ ec_combine_lookup(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -735,12 +735,12 @@ ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_LOOKUP, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (inode != NULL) {
                 cbk->inode = inode_ref(inode);
                 if (cbk->inode == NULL) {
@@ -881,8 +881,8 @@ ec_manager_lookup(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.lookup != NULL) {
-                fop->cbks.lookup(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL);
+                fop->cbks.lookup(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_END;
@@ -939,7 +939,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL);
     }
 }
 
@@ -954,8 +954,9 @@ ec_combine_statfs(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+              dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -969,12 +970,12 @@ ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_STATFS, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->statvfs = *buf;
             }
@@ -1066,8 +1067,8 @@ ec_manager_statfs(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.statfs != NULL) {
-                fop->cbks.statfs(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL);
+                fop->cbks.statfs(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL);
             }
 
             return EC_STATE_END;
@@ -1127,7 +1128,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -1149,7 +1150,8 @@ ec_combine_xattrop(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 
 int32_t
 ec_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xattr, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+               dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_lock_link_t *link = NULL;
@@ -1167,14 +1169,14 @@ ec_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
     if (!cbk)
         goto out;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         cbk->dict = dict_ref(xattr);
 
         data = dict_get(cbk->dict, EC_XATTR_VERSION);
@@ -1285,12 +1287,12 @@ ec_manager_xattrop(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_XATTROP) {
                 if (fop->cbks.xattrop != NULL) {
-                    fop->cbks.xattrop(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.xattrop(fop->req_frame, fop, fop->xl, gf_error,
                                       fop->error, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.fxattrop != NULL) {
-                    fop->cbks.fxattrop(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.fxattrop(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL);
                 }
             }
@@ -1376,7 +1378,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -1453,15 +1455,15 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
 /* FOP: IPC */
 
 int32_t
-ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-           int32_t op_errno, dict_t *xdata)
+ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1475,7 +1477,7 @@ ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_IPC, idx, op_ret,
                                op_errno);
@@ -1541,8 +1543,8 @@ ec_manager_ipc(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.ipc != NULL) {
-                fop->cbks.ipc(fop->req_frame, fop, fop->xl, -1, fop->error,
-                              NULL);
+                fop->cbks.ipc(fop->req_frame, fop, fop->xl, gf_error,
+                              fop->error, NULL);
             }
 
             return EC_STATE_END;
@@ -1586,6 +1588,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-heald.c
+++ b/xlators/cluster/ec/src/ec-heald.c
@@ -575,14 +575,14 @@ int
 ec_heal_op(xlator_t *this, dict_t *output, gf_xl_afr_op_t op, int xl_id)
 {
     char key[64] = {0};
-    int op_ret = 0;
+    gf_return_t op_ret;
     ec_t *ec = NULL;
     int i = 0;
     GF_UNUSED int ret = 0;
 
     ec = this->private;
 
-    op_ret = -1;
+    op_ret = gf_error;
     for (i = 0; i < ec->nodes; i++) {
         snprintf(key, sizeof(key), "%d-%d-status", xl_id, i);
 
@@ -599,10 +599,10 @@ ec_heal_op(xlator_t *this, dict_t *output, gf_xl_afr_op_t op, int xl_id)
             } else if (op == GF_SHD_OP_HEAL_INDEX) {
                 ec_shd_index_healer_spawn(this, i);
             }
-            op_ret = 0;
+            op_ret = gf_success;
         }
     }
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -18,7 +18,7 @@
 
 int32_t
 ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
@@ -27,9 +27,9 @@ ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int i = 0;
 
     ec_trace("UPDATE_WRITEV_CBK", cookie, "ret=%d, errno=%d, parent-fop=%s",
-             op_ret, op_errno, ec_fop_name(parent->id));
+             GET_RET(op_ret), op_errno, ec_fop_name(parent->id));
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         ec_fop_set_error(parent, op_errno);
         goto out;
     }
@@ -109,7 +109,7 @@ out:
 
 int
 ec_inode_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
-                   int op_ret, int op_errno, struct iatt *prestat,
+                   gf_return_t op_ret, int op_errno, struct iatt *prestat,
                    struct iatt *poststat, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
@@ -126,14 +126,14 @@ ec_inode_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
     idx = (int32_t)(uintptr_t)cookie;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
     if (!cbk)
         goto out;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (xdata)
@@ -157,7 +157,7 @@ out:
 
 int32_t
 ec_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -174,8 +174,8 @@ ec_wind_removexattr(ec_t *ec, ec_fop_data_t *fop, int32_t idx)
 }
 
 void
-ec_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+ec_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     switch (fop->id) {
@@ -253,7 +253,8 @@ ec_manager_xattr(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_REPORT:
             GF_ASSERT(fop->error != 0);
 
-            ec_xattr_cbk(fop->req_frame, fop, fop->xl, -1, fop->error, NULL);
+            ec_xattr_cbk(fop->req_frame, fop, fop->xl, gf_error, fop->error,
+                         NULL);
 
             return EC_STATE_LOCK_REUSE;
 
@@ -333,7 +334,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -341,7 +342,7 @@ out:
 
 int32_t
 ec_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -417,7 +418,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -425,7 +426,7 @@ out:
 
 int32_t
 ec_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -513,12 +514,12 @@ ec_manager_setattr(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_SETATTR) {
                 if (fop->cbks.setattr != NULL) {
-                    fop->cbks.setattr(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.setattr(fop->req_frame, fop, fop->xl, gf_error,
                                       fop->error, NULL, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.fsetattr != NULL) {
-                    fop->cbks.fsetattr(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.fsetattr(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL, NULL);
                 }
             }
@@ -597,7 +598,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -605,7 +606,7 @@ out:
 
 int32_t
 ec_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                 struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -678,7 +679,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -686,7 +687,7 @@ out:
 
 int32_t
 ec_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -761,7 +762,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -769,7 +770,7 @@ out:
 
 int32_t
 ec_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -783,7 +784,7 @@ ec_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSETXATTR, idx, op_ret,
                                op_errno);
@@ -883,7 +884,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -895,7 +896,7 @@ out:
 
 int32_t
 ec_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prebuf,
@@ -1004,7 +1005,7 @@ ec_manager_fallocate(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fallocate != NULL) {
-                fop->cbks.fallocate(fop->req_frame, fop, fop->xl, -1,
+                fop->cbks.fallocate(fop->req_frame, fop, fop->xl, gf_error,
                                     fop->error, NULL, NULL, NULL);
             }
 
@@ -1083,7 +1084,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1147,7 +1148,7 @@ ec_discard_adjust_offset_size(ec_fop_data_t *fop)
 
 int32_t
 ec_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prebuf,
@@ -1215,7 +1216,7 @@ ec_manager_discard(ec_fop_data_t *fop, int32_t state)
         case EC_STATE_DELAYED_START:
 
             if (fop->size) {
-                if (fop->answer && fop->answer->op_ret == 0)
+                if (fop->answer && IS_SUCCESS(fop->answer->op_ret))
                     ec_update_discard_write(fop, fop->answer->mask);
             } else {
                 ec_update_discard_write(fop, fop->mask);
@@ -1258,8 +1259,8 @@ ec_manager_discard(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.discard != NULL) {
-                fop->cbks.discard(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                  NULL, NULL, NULL);
+                fop->cbks.discard(fop->req_frame, fop, fop->xl, gf_error,
+                                  fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1324,7 +1325,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1344,13 +1345,14 @@ ec_update_truncate_write(ec_fop_data_t *fop, uintptr_t mask)
 
 int32_t
 ec_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     int32_t err;
 
     fop->parent->good &= fop->good;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         fd_bind(fd);
         err = ec_update_truncate_write(fop->parent, fop->answer->mask);
         if (err != 0) {
@@ -1381,7 +1383,7 @@ ec_truncate_clean(ec_fop_data_t *fop)
 
 int32_t
 ec_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                 struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -1495,12 +1497,12 @@ ec_manager_truncate(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_TRUNCATE) {
                 if (fop->cbks.truncate != NULL) {
-                    fop->cbks.truncate(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.truncate(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.ftruncate != NULL) {
-                    fop->cbks.ftruncate(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.ftruncate(fop->req_frame, fop, fop->xl, gf_error,
                                         fop->error, NULL, NULL, NULL);
                 }
             }
@@ -1576,7 +1578,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1584,7 +1586,7 @@ out:
 
 int32_t
 ec_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                  struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -1654,7 +1656,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1732,7 +1734,7 @@ out:
 
 int32_t
 ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                     gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                      int32_t count, struct iatt *stbuf, struct iobref *iobref,
                      dict_t *xdata)
 {
@@ -1740,12 +1742,12 @@ ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base, tmp;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         tmp = 0;
         size = fop->size - fop->user_size - fop->head;
         base = ec->stripe_size - size;
-        if (op_ret > base) {
-            tmp = min(op_ret - base, size);
+        if (GET_RET(op_ret) > base) {
+            tmp = min(GET_RET(op_ret) - base, size);
             ec_iov_copy_to(fop->vector[0].iov_base + fop->size - size, vector,
                            count, base, tmp);
 
@@ -1765,7 +1767,7 @@ ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                     gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                      int32_t count, struct iatt *stbuf, struct iobref *iobref,
                      dict_t *xdata)
 {
@@ -1773,12 +1775,12 @@ ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         size = fop->head;
         base = 0;
 
-        if (op_ret > 0) {
-            base = min(op_ret, size);
+        if (GET_RET(op_ret) > 0) {
+            base = min(GET_RET(op_ret), size);
             ec_iov_copy_to(fop->vector[0].iov_base, vector, count, 0, base);
 
             size -= base;
@@ -1797,7 +1799,6 @@ ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
 
     return 0;
 }
-
 static int
 ec_make_internal_fop_xdata(dict_t **xdata)
 {
@@ -2087,15 +2088,16 @@ failed:
 }
 
 int32_t
-ec_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prestat, struct iatt *poststat,
-              dict_t *xdata)
+ec_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
+              struct iatt *poststat, dict_t *xdata)
 {
     ec_t *ec = NULL;
     if (this && this->private) {
         ec = this->private;
-        if ((op_ret > 0) && ((op_ret % ec->fragment_size) != 0)) {
-            op_ret = -1;
+        if ((GET_RET(op_ret) > 0) &&
+            ((GET_RET(op_ret) % ec->fragment_size) != 0)) {
+            op_ret = gf_error;
             op_errno = EIO;
         }
     }
@@ -2218,14 +2220,17 @@ ec_manager_writev(ec_fop_data_t *fop, int32_t state)
                 UNLOCK(&fop->fd->inode->lock);
 
                 if (fop->error == 0) {
-                    cbk->op_ret *= ec->fragments;
-                    if (cbk->op_ret < fop->head) {
-                        cbk->op_ret = 0;
+                    int32_t temp = GET_RET(cbk->op_ret);
+                    temp *= ec->fragments;
+                    if (temp < fop->head) {
+                        cbk->op_ret = gf_success;
+                        temp = 0;
                     } else {
-                        cbk->op_ret -= fop->head;
+                        temp -= fop->head;
+                        SET_RET(cbk->op_ret, temp);
                     }
-                    if (cbk->op_ret > fop->user_size) {
-                        cbk->op_ret = fop->user_size;
+                    if (temp > fop->user_size) {
+                        SET_RET(cbk->op_ret, fop->user_size);
                     }
                 }
             }
@@ -2261,8 +2266,8 @@ ec_manager_writev(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.writev != NULL) {
-                fop->cbks.writev(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL);
+                fop->cbks.writev(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -2364,6 +2369,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -189,12 +189,12 @@ struct _ec_inode {
     uint64_t bad_version;
 };
 
-typedef int32_t (*fop_heal_cbk_t)(call_frame_t *, void *, xlator_t *, int32_t,
-                                  int32_t, uintptr_t, uintptr_t, uintptr_t,
-                                  uint32_t, dict_t *);
-typedef int32_t (*fop_fheal_cbk_t)(call_frame_t *, void *, xlator_t *, int32_t,
-                                   int32_t, uintptr_t, uintptr_t, uintptr_t,
-                                   uint32_t, dict_t *);
+typedef int32_t (*fop_heal_cbk_t)(call_frame_t *, void *, xlator_t *,
+                                  gf_return_t, int32_t, uintptr_t, uintptr_t,
+                                  uintptr_t, uint32_t, dict_t *);
+typedef int32_t (*fop_fheal_cbk_t)(call_frame_t *, void *, xlator_t *,
+                                   gf_return_t, int32_t, uintptr_t, uintptr_t,
+                                   uintptr_t, uint32_t, dict_t *);
 
 union _ec_cbk {
     fop_access_cbk_t access;
@@ -399,7 +399,7 @@ struct _ec_cbk_data {
     ec_fop_data_t *fop;
     ec_cbk_data_t *next; /* next answer in the same group */
     uint32_t idx;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     int32_t count;
     uintptr_t mask;

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -1039,7 +1039,7 @@ ec_handle_heal_commands(call_frame_t *frame, xlator_t *this, loc_t *loc,
                         const char *name, dict_t *xdata)
 {
     dict_t *dict_rsp = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = {-1};
     int op_errno = ENOMEM;
 
     if (!name || strcmp(name, GF_HEAL_INFO))
@@ -1047,7 +1047,8 @@ ec_handle_heal_commands(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     op_errno = -ec_get_heal_info(this, loc, &dict_rsp);
     if (op_errno <= 0) {
-        op_errno = op_ret = 0;
+        op_errno = 0;
+        op_ret = gf_success;
     }
 
     STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict_rsp, NULL);
@@ -1086,7 +1087,7 @@ ec_gf_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 out:
     error = ENODATA;
-    STACK_UNWIND_STRICT(getxattr, frame, -1, error, NULL, NULL);
+    STACK_UNWIND_STRICT(getxattr, frame, gf_error, error, NULL, NULL);
     return 0;
 }
 
@@ -1103,7 +1104,7 @@ ec_gf_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
     return 0;
 out:
     error = ENODATA;
-    STACK_UNWIND_STRICT(fgetxattr, frame, -1, error, NULL, NULL);
+    STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, error, NULL, NULL);
     return 0;
 }
 
@@ -1262,7 +1263,7 @@ ec_gf_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(removexattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(removexattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1279,7 +1280,7 @@ ec_gf_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(fremovexattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1336,7 +1337,7 @@ ec_gf_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(setxattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(setxattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1353,7 +1354,7 @@ ec_gf_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(fsetxattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, error, NULL);
     return 0;
 }
 

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -293,8 +293,8 @@ error_gen_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_LOOKUP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(lookup, frame, -1, op_errno, NULL, NULL, NULL,
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
                             NULL);
         return 0;
     }
@@ -318,8 +318,8 @@ error_gen_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_STAT);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(stat, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(stat, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -343,8 +343,9 @@ error_gen_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_SETATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(setattr, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -368,8 +369,9 @@ error_gen_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FSETATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -393,8 +395,9 @@ error_gen_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_TRUNCATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(truncate, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -418,8 +421,9 @@ error_gen_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         op_errno = error_gen(this, GF_FOP_FTRUNCATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -443,8 +447,8 @@ error_gen_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
         op_errno = error_gen(this, GF_FOP_ACCESS);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(access, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(access, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -468,8 +472,9 @@ error_gen_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
         op_errno = error_gen(this, GF_FOP_READLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readlink, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -493,9 +498,9 @@ error_gen_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         op_errno = error_gen(this, GF_FOP_MKNOD);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -519,9 +524,9 @@ error_gen_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         op_errno = error_gen(this, GF_FOP_MKDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -545,8 +550,9 @@ error_gen_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
         op_errno = error_gen(this, GF_FOP_UNLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(unlink, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -570,8 +576,9 @@ error_gen_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         op_errno = error_gen(this, GF_FOP_RMDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(rmdir, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -595,9 +602,9 @@ error_gen_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
         op_errno = error_gen(this, GF_FOP_SYMLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(symlink, frame, -1, op_errno, NULL, NULL, NULL,
-                            NULL, NULL); /* pre & post parent attr */
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, op_errno, NULL, NULL,
+                            NULL, NULL, NULL); /* pre & post parent attr */
         return 0;
     }
 
@@ -621,9 +628,9 @@ error_gen_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
         op_errno = error_gen(this, GF_FOP_RENAME);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -647,9 +654,9 @@ error_gen_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
         op_errno = error_gen(this, GF_FOP_LINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -673,9 +680,9 @@ error_gen_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         op_errno = error_gen(this, GF_FOP_CREATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -699,8 +706,8 @@ error_gen_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         op_errno = error_gen(this, GF_FOP_OPEN);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(open, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(open, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -724,9 +731,9 @@ error_gen_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READ);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readv, frame, -1, op_errno, NULL, 0, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readv, frame, gf_error, op_errno, NULL, 0, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -762,8 +769,9 @@ error_gen_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
         count = 1;
         goto wind;
     } else if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(writev, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(writev, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 wind:
@@ -790,8 +798,8 @@ error_gen_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_FLUSH);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(flush, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(flush, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -815,8 +823,9 @@ error_gen_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
         op_errno = error_gen(this, GF_FOP_FSYNC);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsync, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -839,8 +848,8 @@ error_gen_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_FSTAT);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fstat, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -864,8 +873,8 @@ error_gen_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_OPENDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(opendir, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -889,8 +898,8 @@ error_gen_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
         op_errno = error_gen(this, GF_FOP_FSYNCDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -913,8 +922,8 @@ error_gen_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_STATFS);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(statfs, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -938,8 +947,8 @@ error_gen_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_SETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(setxattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -963,8 +972,8 @@ error_gen_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_GETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(getxattr, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -988,8 +997,8 @@ error_gen_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
         op_errno = error_gen(this, GF_FOP_FSETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1013,8 +1022,8 @@ error_gen_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FGETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1038,8 +1047,8 @@ error_gen_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_XATTROP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(xattrop, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1063,8 +1072,8 @@ error_gen_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FXATTROP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1088,8 +1097,8 @@ error_gen_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_REMOVEXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(removexattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1113,8 +1122,8 @@ error_gen_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FREMOVEXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1138,8 +1147,8 @@ error_gen_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
         op_errno = error_gen(this, GF_FOP_LK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(lk, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(lk, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1163,8 +1172,8 @@ error_gen_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_INODELK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(inodelk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1188,8 +1197,8 @@ error_gen_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_FINODELK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(finodelk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1214,8 +1223,8 @@ error_gen_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_ENTRYLK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(entrylk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1240,8 +1249,8 @@ error_gen_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_FENTRYLK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1265,8 +1274,8 @@ error_gen_getspec(call_frame_t *frame, xlator_t *this, const char *key,
         op_errno = error_gen(this, GF_FOP_GETSPEC);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(getspec, frame, -1, op_errno, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(getspec, frame, gf_error, op_errno, NULL);
         return 0;
     }
 
@@ -1290,8 +1299,8 @@ error_gen_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readdir, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1315,8 +1324,8 @@ error_gen_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READDIRP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readdirp, frame, -1, op_errno, NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, op_errno, NULL, NULL);
         return 0;
     }
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -293,7 +293,7 @@ is_fop_latency_started(call_frame_t *frame)
         end = &frame->end;                                                     \
                                                                                \
         elapsed = gf_tsdiff(begin, end) / 1000.0;                              \
-        throughput = op_ret / elapsed;                                         \
+        throughput = GET_RET(op_ret) / elapsed;                                \
                                                                                \
         conf = this->private;                                                  \
         gettimeofday(&tv, NULL);                                               \
@@ -1912,8 +1912,8 @@ out:
 
 int
 io_stats_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     struct ios_fd *iosfd = NULL;
@@ -1929,7 +1929,7 @@ io_stats_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -1967,7 +1967,7 @@ unwind:
 
 int
 io_stats_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct ios_fd *iosfd = NULL;
     char *path = NULL;
@@ -1982,7 +1982,7 @@ io_stats_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -2031,7 +2031,7 @@ unwind:
 
 int
 io_stats_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, STAT);
@@ -2041,7 +2041,7 @@ io_stats_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                   gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                    int32_t count, struct iatt *buf, struct iobref *iobref,
                    dict_t *xdata)
 {
@@ -2052,7 +2052,7 @@ io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fd = frame->local;
     frame->local = NULL;
 
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         len = iov_length(vector, count);
         ios_bump_read(this, fd, len);
     }
@@ -2073,7 +2073,7 @@ io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
@@ -2099,7 +2099,7 @@ io_stats_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata)
 {
@@ -2112,7 +2112,7 @@ io_stats_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                      gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                       dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
@@ -2135,7 +2135,7 @@ io_stats_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                      dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, READDIR);
@@ -2145,7 +2145,7 @@ io_stats_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSYNC);
@@ -2155,7 +2155,7 @@ io_stats_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preop,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *preop,
                      struct iatt *postop, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETATTR);
@@ -2165,8 +2165,9 @@ io_stats_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, UNLINK);
     STACK_UNWIND_STRICT(unlink, frame, op_ret, op_errno, preparent, postparent,
@@ -2176,7 +2177,7 @@ io_stats_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata)
@@ -2189,7 +2190,7 @@ io_stats_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, const char *buf,
+                      gf_return_t op_ret, int32_t op_errno, const char *buf,
                       struct iatt *sbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, READLINK);
@@ -2199,7 +2200,7 @@ io_stats_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     UPDATE_PROFILE_STATS(frame, LOOKUP);
@@ -2210,7 +2211,7 @@ io_stats_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
@@ -2222,7 +2223,7 @@ io_stats_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2234,7 +2235,7 @@ io_stats_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2244,7 +2245,7 @@ io_stats_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
 
     UPDATE_PROFILE_STATS(frame, MKDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     /* allocate a struct ios_stat and set the inode ctx */
@@ -2261,7 +2262,7 @@ unwind:
 
 int
 io_stats_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -2273,7 +2274,7 @@ io_stats_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FLUSH);
     STACK_UNWIND_STRICT(flush, frame, op_ret, op_errno, xdata);
@@ -2282,13 +2283,14 @@ io_stats_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
     int ret = -1;
 
     UPDATE_PROFILE_STATS(frame, OPENDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ios_fd_ctx_set(fd, this, 0);
@@ -2304,7 +2306,7 @@ unwind:
 
 int
 io_stats_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, RMDIR);
@@ -2316,7 +2318,7 @@ io_stats_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, TRUNCATE);
@@ -2327,7 +2329,7 @@ io_stats_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                     dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, STATFS);
@@ -2337,7 +2339,7 @@ io_stats_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETXATTR);
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
@@ -2346,7 +2348,7 @@ io_stats_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, GETXATTR);
@@ -2356,7 +2358,7 @@ io_stats_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, REMOVEXATTR);
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
@@ -2365,7 +2367,7 @@ io_stats_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSETXATTR);
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
@@ -2374,7 +2376,7 @@ io_stats_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FGETXATTR);
@@ -2384,7 +2386,7 @@ io_stats_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FREMOVEXATTR);
     STACK_UNWIND_STRICT(fremovexattr, frame, op_ret, op_errno, xdata);
@@ -2393,7 +2395,7 @@ io_stats_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSYNCDIR);
     STACK_UNWIND_STRICT(fsyncdir, frame, op_ret, op_errno, xdata);
@@ -2402,7 +2404,7 @@ io_stats_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ACCESS);
     STACK_UNWIND_STRICT(access, frame, op_ret, op_errno, xdata);
@@ -2411,8 +2413,8 @@ io_stats_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FTRUNCATE);
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -2422,7 +2424,7 @@ io_stats_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSTAT);
@@ -2432,8 +2434,8 @@ io_stats_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FALLOCATE);
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -2443,7 +2445,7 @@ io_stats_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, DISCARD);
@@ -2454,7 +2456,7 @@ io_stats_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ZEROFILL);
@@ -2465,7 +2467,7 @@ io_stats_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 io_stats_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, IPC);
     STACK_UNWIND_STRICT(ipc, frame, op_ret, op_errno, xdata);
@@ -2474,7 +2476,7 @@ io_stats_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                 dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, LK);
@@ -2484,7 +2486,7 @@ io_stats_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ENTRYLK);
     STACK_UNWIND_STRICT(entrylk, frame, op_ret, op_errno, xdata);
@@ -2493,7 +2495,7 @@ io_stats_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FENTRYLK);
     STACK_UNWIND_STRICT(fentrylk, frame, op_ret, op_errno, xdata);
@@ -2502,8 +2504,9 @@ io_stats_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, RCHECKSUM);
     STACK_UNWIND_STRICT(rchecksum, frame, op_ret, op_errno, weak_checksum,
@@ -2513,7 +2516,8 @@ io_stats_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, off_t offset,
+                  dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SEEK);
     STACK_UNWIND_STRICT(seek, frame, op_ret, op_errno, offset, xdata);
@@ -2522,7 +2526,7 @@ io_stats_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, LEASE);
@@ -2532,7 +2536,7 @@ io_stats_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *locklist, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, GETACTIVELK);
@@ -2542,7 +2546,7 @@ io_stats_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETACTIVELK);
     STACK_UNWIND_STRICT(setactivelk, frame, op_ret, op_errno, xdata);
@@ -2551,7 +2555,7 @@ io_stats_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_compound_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, void *data,
+                      gf_return_t op_ret, int32_t op_errno, void *data,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, COMPOUND);
@@ -2561,7 +2565,7 @@ io_stats_compound_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, XATTROP);
@@ -2571,7 +2575,7 @@ io_stats_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FXATTROP);
@@ -2581,7 +2585,7 @@ io_stats_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, INODELK);
     STACK_UNWIND_STRICT(inodelk, frame, op_ret, op_errno, xdata);
@@ -2628,7 +2632,7 @@ io_stats_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
 
 int
 io_stats_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FINODELK);
     STACK_UNWIND_STRICT(finodelk, frame, op_ret, op_errno, xdata);

--- a/xlators/debug/sink/src/sink.c
+++ b/xlators/debug/sink/src/sink.c
@@ -65,8 +65,8 @@ sink_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     /* the root of the volume always need to be a directory */
     stbuf.ia_type = IA_IFDIR;
 
-    STACK_UNWIND_STRICT(lookup, frame, 0, 0, loc ? loc->inode : NULL, &stbuf,
-                        xdata, &postparent);
+    STACK_UNWIND_STRICT(lookup, frame, gf_success, 0, loc ? loc->inode : NULL,
+                        &stbuf, xdata, &postparent);
 
     return 0;
 }

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -82,7 +82,7 @@ dump_history_trace(circular_buffer_t *cb, void *data)
 
 int
 trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -105,7 +105,7 @@ trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -115,15 +115,15 @@ trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d, fd=%p"
                      "*stbuf {%s}, *preparent {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret, fd,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), fd, statstr, preparentstr, postparentstr);
 
             /* for 'release' log */
             fd_ctx_set(fd, this, 0);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -135,7 +135,7 @@ out:
 
 int
 trace_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -151,15 +151,15 @@ trace_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d, "
                  "*fd=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 fd);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, fd);
 
         LOG_ELEMENT(conf, string);
     }
 
 out:
     /* for 'release' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(open, frame, op_ret, op_errno, fd, xdata);
@@ -168,7 +168,7 @@ out:
 
 int
 trace_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *buf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                dict_t *xdata)
 {
     char statstr[1024] = {
@@ -184,18 +184,19 @@ trace_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
-            (void)snprintf(
-                string, sizeof(string), "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
-                frame->root->unique, uuid_utoa(frame->local), op_ret, statstr);
+            (void)snprintf(string, sizeof(string),
+                           "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
+                           frame->root->unique, uuid_utoa(frame->local),
+                           GET_RET(op_ret), statstr);
         } else {
             (void)snprintf(string, sizeof(string),
                            "%" PRId64
                            ": gfid=%s op_ret=%d, "
                            "op_errno=%d)",
-                           frame->root->unique, uuid_utoa(frame->local), op_ret,
-                           op_errno);
+                           frame->root->unique, uuid_utoa(frame->local),
+                           GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -206,7 +207,7 @@ out:
 
 int
 trace_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                 int32_t count, struct iatt *buf, struct iobref *iobref,
                 dict_t *xdata)
 {
@@ -223,18 +224,19 @@ trace_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
-            snprintf(
-                string, sizeof(string), "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
-                frame->root->unique, uuid_utoa(frame->local), op_ret, statstr);
+            snprintf(string, sizeof(string),
+                     "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -246,7 +248,7 @@ out:
 
 int
 trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -265,7 +267,7 @@ trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -273,14 +275,14 @@ trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -291,7 +293,7 @@ out:
 
 int
 trace_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                  gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                   dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -306,7 +308,7 @@ trace_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 " : gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -319,7 +321,7 @@ out:
 
 int
 trace_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                    dict_t *xdata)
 {
     int count = 0;
@@ -339,12 +341,12 @@ trace_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (trace_fop_names[GF_FOP_READDIRP].enabled) {
         snprintf(string, sizeof(string),
                  "%" PRId64 " : gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
     }
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     list_for_each_entry(entry, &buf->list, list)
@@ -365,7 +367,7 @@ out:
 
 int
 trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -384,7 +386,7 @@ trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -392,14 +394,14 @@ trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s}",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -411,7 +413,7 @@ out:
 
 int
 trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                   struct iatt *statpost, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -430,7 +432,7 @@ trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(statpre, preopstr);
             TRACE_STAT_TO_STR(statpost, postopstr);
 
@@ -438,14 +440,14 @@ trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -457,7 +459,7 @@ out:
 
 int
 trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -476,7 +478,7 @@ trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(statpre, preopstr);
             TRACE_STAT_TO_STR(statpost, postopstr);
 
@@ -484,12 +486,12 @@ trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -501,7 +503,7 @@ out:
 
 int
 trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     char preparentstr[1024] = {
@@ -520,7 +522,7 @@ trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
 
@@ -529,15 +531,15 @@ trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s op_ret=%d, "
                      " *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -549,7 +551,7 @@ out:
 
 int
 trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  struct iatt *preoldparent, struct iatt *postoldparent,
                  struct iatt *prenewparent, struct iatt *postnewparent,
                  dict_t *xdata)
@@ -579,7 +581,7 @@ trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[6044] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preoldparent, preoldparentstr);
             TRACE_STAT_TO_STR(postoldparent, postoldparentstr);
@@ -593,15 +595,16 @@ trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      " *postoldparent = {%s}"
                      " *prenewparent = {%s}, "
                      "*postnewparent = {%s})",
-                     frame->root->unique, op_ret, statstr, preoldparentstr,
-                     postoldparentstr, prenewparentstr, postnewparentstr);
+                     frame->root->unique, GET_RET(op_ret), statstr,
+                     preoldparentstr, postoldparentstr, prenewparentstr,
+                     postnewparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -613,7 +616,7 @@ out:
 
 int
 trace_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, const char *buf,
+                   gf_return_t op_ret, int32_t op_errno, const char *buf,
                    struct iatt *stbuf, dict_t *xdata)
 {
     char statstr[1024] = {
@@ -629,20 +632,21 @@ trace_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(stbuf, statstr);
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": (op_ret=%d, op_errno=%d,"
                      "buf=%s, stbuf = { %s })",
-                     frame->root->unique, op_ret, op_errno, buf, statstr);
+                     frame->root->unique, GET_RET(op_ret), op_errno, buf,
+                     statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
 
         LOG_ELEMENT(conf, string);
@@ -654,7 +658,7 @@ out:
 
 int
 trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     char statstr[1024] = {
@@ -673,7 +677,7 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
             /* print buf->ia_gfid instead of inode->gfid,
@@ -685,8 +689,8 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s (op_ret=%d "
                      "*buf {%s}, *postparent {%s}",
-                     frame->root->unique, uuid_utoa(buf->ia_gfid), op_ret,
-                     statstr, postparentstr);
+                     frame->root->unique, uuid_utoa(buf->ia_gfid),
+                     GET_RET(op_ret), statstr, postparentstr);
 
             /* For 'forget' */
             inode_ctx_put(inode, this, 0);
@@ -695,8 +699,8 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -708,7 +712,7 @@ out:
 
 int
 trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -731,7 +735,7 @@ trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -741,12 +745,12 @@ trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      "*stbuf = {%s}, *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": op_ret=%d, op_errno=%d", frame->root->unique,
-                     op_ret, op_errno);
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -758,7 +762,7 @@ out:
 
 int
 trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -781,7 +785,7 @@ trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
     if (trace_fop_names[GF_FOP_MKNOD].enabled) {
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -791,12 +795,12 @@ trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      "*stbuf = {%s}, *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -808,7 +812,7 @@ out:
 
 int
 trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -831,7 +835,7 @@ trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -841,12 +845,12 @@ trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      ", *stbuf = {%s}, *prebuf = {%s}, "
                      "*postbuf = {%s} )",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -858,7 +862,7 @@ out:
 
 int
 trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -881,7 +885,7 @@ trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
     if (trace_fop_names[GF_FOP_LINK].enabled) {
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -891,15 +895,15 @@ trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": (op_ret=%d, "
                      "*stbuf = {%s},  *prebuf = {%s},"
                      " *postbuf = {%s})",
-                     frame->root->unique, op_ret, statstr, preparentstr,
-                     postparentstr);
+                     frame->root->unique, GET_RET(op_ret), statstr,
+                     preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -911,7 +915,7 @@ out:
 
 int
 trace_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -925,7 +929,7 @@ trace_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (trace_fop_names[GF_FOP_FLUSH].enabled) {
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -937,7 +941,7 @@ out:
 
 int
 trace_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -953,14 +957,14 @@ trace_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " fd=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 fd);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, fd);
 
         LOG_ELEMENT(conf, string);
     }
 out:
     /* for 'releasedir' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(opendir, frame, op_ret, op_errno, fd, xdata);
@@ -969,7 +973,7 @@ out:
 
 int
 trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     char preparentstr[1024] = {
@@ -988,7 +992,7 @@ trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
 
@@ -996,15 +1000,15 @@ trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "*prebuf={%s},  *postbuf={%s}",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1016,7 +1020,7 @@ out:
 
 int
 trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -1035,7 +1039,7 @@ trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -1043,14 +1047,14 @@ trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s} )",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1062,7 +1066,7 @@ out:
 
 int
 trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                  dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1075,7 +1079,7 @@ trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": ({f_bsize=%lu, "
@@ -1095,13 +1099,13 @@ trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      frame->root->unique, buf->f_bsize, buf->f_frsize,
                      buf->f_blocks, buf->f_bfree, buf->f_bavail, buf->f_files,
                      buf->f_ffree, buf->f_favail, buf->f_fsid, buf->f_flag,
-                     buf->f_namemax, op_ret);
+                     buf->f_namemax, GET_RET(op_ret));
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": (op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1112,7 +1116,7 @@ out:
 
 int
 trace_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1126,7 +1130,7 @@ trace_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1138,7 +1142,7 @@ out:
 
 int
 trace_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1155,8 +1159,8 @@ trace_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " dict=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 dict);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, dict);
 
         LOG_ELEMENT(conf, string);
     }
@@ -1168,7 +1172,7 @@ out:
 
 int
 trace_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1182,7 +1186,7 @@ trace_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1194,7 +1198,7 @@ out:
 
 int
 trace_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1211,8 +1215,8 @@ trace_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " dict=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 dict);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, dict);
 
         LOG_ELEMENT(conf, string);
     }
@@ -1224,7 +1228,7 @@ out:
 
 int
 trace_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1238,7 +1242,7 @@ trace_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1251,7 +1255,7 @@ out:
 
 int
 trace_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1265,7 +1269,7 @@ trace_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1277,7 +1281,7 @@ out:
 
 int
 trace_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1293,7 +1297,7 @@ trace_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, "
                  "op_errno=%d)",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1305,7 +1309,7 @@ out:
 
 int
 trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     char prebufstr[1024] = {
@@ -1324,7 +1328,7 @@ trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, prebufstr);
             TRACE_STAT_TO_STR(postbuf, postbufstr);
 
@@ -1332,14 +1336,15 @@ trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s} )",
-                     frame->root->unique, op_ret, prebufstr, postbufstr);
+                     frame->root->unique, GET_RET(op_ret), prebufstr,
+                     postbufstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1351,7 +1356,7 @@ out:
 
 int
 trace_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
 {
     char statstr[1024] = {
@@ -1365,21 +1370,21 @@ trace_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     if (trace_fop_names[GF_FOP_FSTAT].enabled) {
         char string[4096] = {0.};
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d "
                      "buf=%s",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     statstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1389,8 +1394,9 @@ out:
 }
 
 int
-trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+             dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1402,7 +1408,7 @@ trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
@@ -1410,16 +1416,16 @@ trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                      "l_start=%" PRId64
                      ", "
                      "l_len=%" PRId64 ", l_pid=%u})",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     lock->l_type, lock->l_whence, lock->l_start, lock->l_len,
-                     lock->l_pid);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), lock->l_type, lock->l_whence,
+                     lock->l_start, lock->l_len, lock->l_pid);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
 
         LOG_ELEMENT(conf, string);
@@ -1431,7 +1437,7 @@ out:
 
 int
 trace_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1445,7 +1451,7 @@ trace_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1457,7 +1463,7 @@ out:
 
 int
 trace_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1471,7 +1477,7 @@ trace_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1483,7 +1489,8 @@ out:
 
 int
 trace_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                  dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1497,7 +1504,7 @@ trace_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1509,7 +1516,7 @@ out:
 
 int
 trace_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1524,7 +1531,7 @@ trace_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1536,7 +1543,7 @@ out:
 
 int
 trace_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1550,7 +1557,7 @@ trace_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1562,7 +1569,7 @@ out:
 
 int
 trace_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1576,7 +1583,7 @@ trace_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1588,8 +1595,9 @@ out:
 
 int
 trace_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                    uint8_t *strong_checksum, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    uint32_t weak_checksum, uint8_t *strong_checksum,
+                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1603,7 +1611,7 @@ trace_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -2343,7 +2351,8 @@ out:
 
 static int
 trace_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, off_t offset,
+               dict_t *xdata)
 {
     trace_conf_t *conf = this->private;
 
@@ -2357,8 +2366,8 @@ trace_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d op_errno=%d, "
                  "offset=%" PRId64 "",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 offset);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, offset);
         LOG_ELEMENT(conf, string);
     }
 out:

--- a/xlators/features/arbiter/src/arbiter.c
+++ b/xlators/features/arbiter/src/arbiter.c
@@ -59,16 +59,16 @@ arbiter_inode_ctx_get(inode_t *inode, xlator_t *this)
 
 int32_t
 arbiter_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     arbiter_inode_ctx_t *ctx = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
     ctx = arbiter_inode_ctx_get(inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -94,12 +94,12 @@ arbiter_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(loc->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -116,12 +116,12 @@ arbiter_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -178,17 +178,17 @@ arbiter_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
     dict_t *rsp_xdata = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
     buf = &ctx->iattbuf;
-    op_ret = iov_length(vector, count);
+    SET_RET(op_ret, iov_length(vector, count));
     rsp_xdata = arbiter_fill_writev_xdata(fd, xdata, this);
 unwind:
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, buf, buf, rsp_xdata);
@@ -203,12 +203,12 @@ arbiter_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -224,12 +224,12 @@ arbiter_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -245,12 +245,12 @@ arbiter_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -264,7 +264,8 @@ static int32_t
 arbiter_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
               off_t offset, uint32_t flags, dict_t *xdata)
 {
-    STACK_UNWIND_STRICT(readv, frame, -1, ENOSYS, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, ENOSYS, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -272,7 +273,7 @@ static int32_t
 arbiter_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
              gf_seek_what_t what, dict_t *xdata)
 {
-    STACK_UNWIND_STRICT(seek, frame, -1, ENOSYS, 0, xdata);
+    STACK_UNWIND_STRICT(seek, frame, gf_error, ENOSYS, 0, xdata);
     return 0;
 }
 

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -41,7 +41,7 @@ barrier_local_free_gfid(call_frame_t *frame)
 
 int32_t
 barrier_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata)
 {
@@ -53,7 +53,7 @@ barrier_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *prebuf, struct iatt *postbuf,
                              dict_t *xdata)
 {
@@ -65,7 +65,7 @@ barrier_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
 {
@@ -77,7 +77,7 @@ barrier_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct iatt *preparent, struct iatt *postparent,
                          dict_t *xdata)
 {
@@ -89,10 +89,10 @@ barrier_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          struct iatt *preoldparent, struct iatt *postoldparent,
-                          struct iatt *prenewparent, struct iatt *postnewparent,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, struct iatt *preoldparent,
+                          struct iatt *postoldparent, struct iatt *prenewparent,
+                          struct iatt *postnewparent, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, buf, preoldparent,
@@ -102,8 +102,9 @@ barrier_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
@@ -113,8 +114,9 @@ barrier_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                         struct iatt *postbuf, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *prebuf, struct iatt *postbuf,
+                         dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(fsync, frame, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -123,8 +125,8 @@ barrier_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata)
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
@@ -133,7 +135,7 @@ barrier_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
 
 int32_t
 barrier_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
@@ -143,7 +145,7 @@ barrier_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
 
 int32_t
 barrier_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(writev, out, frame, this, op_ret, op_errno, prebuf, postbuf,
@@ -154,7 +156,7 @@ out:
 
 int32_t
 barrier_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     BARRIER_FOP_CBK(fremovexattr, out, frame, this, op_ret, op_errno, xdata);
 out:
@@ -163,7 +165,7 @@ out:
 
 int32_t
 barrier_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     BARRIER_FOP_CBK(removexattr, out, frame, this, op_ret, op_errno, xdata);
 out:
@@ -172,7 +174,7 @@ out:
 
 int32_t
 barrier_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(truncate, out, frame, this, op_ret, op_errno, prebuf,
@@ -183,7 +185,7 @@ out:
 
 int32_t
 barrier_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(ftruncate, out, frame, this, op_ret, op_errno, prebuf,
@@ -194,7 +196,7 @@ out:
 
 int32_t
 barrier_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -208,7 +210,7 @@ out:
 
 int32_t
 barrier_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     BARRIER_FOP_CBK(rmdir, out, frame, this, op_ret, op_errno, preparent,
@@ -219,7 +221,7 @@ out:
 
 int32_t
 barrier_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     BARRIER_FOP_CBK(unlink, out, frame, this, op_ret, op_errno, preparent,
@@ -230,7 +232,7 @@ out:
 
 int32_t
 barrier_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(fsync, out, frame, this, op_ret, op_errno, prebuf, postbuf,

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -352,7 +352,7 @@ br_stub_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     struct stat lstatbuf = {0};
     int ret = 0;
     int32_t op_errno = EINVAL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     struct iatt stbuf = {
         0,
     };
@@ -388,10 +388,11 @@ br_stub_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     iatt_from_stat(&stbuf, &lstatbuf);
     gf_uuid_copy(stbuf.ia_gfid, priv->bad_object_dir_gfid);
 
-    op_ret = op_errno = 0;
+    op_errno = 0;
+    op_ret = gf_success;
     xattr = dict_new();
     if (!xattr) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
     }
 
@@ -561,7 +562,7 @@ br_stub_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
     br_stub_fd_t *fctx = NULL;
     DIR *dir = NULL;
     int ret = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int count = 0;
     gf_dirent_t entries;
@@ -591,7 +592,7 @@ br_stub_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     /* pick ENOENT to indicate EOF */
     op_errno = errno;
-    op_ret = count;
+    SET_RET(op_ret, count);
 
     dict = xdata;
     (void)br_stub_bad_objects_path(this, fd, &entries, &dict);

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.h
@@ -69,8 +69,8 @@
             frame->local = NULL;                                               \
     } while (0)
 
-typedef int(br_stub_version_cbk)(call_frame_t *, void *, xlator_t *, int32_t,
-                                 int32_t, dict_t *);
+typedef int(br_stub_version_cbk)(call_frame_t *, void *, xlator_t *,
+                                 gf_return_t, int32_t, dict_t *);
 
 typedef struct br_stub_inode_ctx {
     int need_writeback;           /* does the inode need

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -52,8 +52,9 @@ changelog_init(xlator_t *this, changelog_priv_t *priv);
 
 int32_t
 changelog_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -61,7 +62,7 @@ changelog_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -173,8 +174,9 @@ out:
 
 int32_t
 changelog_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -182,7 +184,7 @@ changelog_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -321,7 +323,7 @@ out:
 
 int32_t
 changelog_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -331,7 +333,7 @@ changelog_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
     local = frame->local;
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 unwind:
     changelog_dec_fop_cnt(this, priv, local);
@@ -439,7 +441,7 @@ out:
 
 int32_t
 changelog_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -449,7 +451,7 @@ changelog_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -549,7 +551,7 @@ out:
 
 int32_t
 changelog_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -559,7 +561,7 @@ changelog_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -678,7 +680,7 @@ out:
 
 int32_t
 changelog_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -688,7 +690,7 @@ changelog_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -799,7 +801,7 @@ out:
 
 int32_t
 changelog_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -809,7 +811,7 @@ changelog_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -945,8 +947,8 @@ out:
 
 int32_t
 changelog_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                     struct iatt *buf, struct iatt *preparent,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
     int32_t ret = 0;
@@ -959,7 +961,7 @@ changelog_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     /* fill the event structure.. similar to open() */
     ev.ev_type = CHANGELOG_OP_TYPE_CREATE;
@@ -1105,7 +1107,7 @@ out:
 
 int32_t
 changelog_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                        dict_t *xdata)
 {
@@ -1115,7 +1117,7 @@ changelog_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1161,7 +1163,7 @@ wind:
 
 int32_t
 changelog_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno,
+                      gf_return_t op_ret, int32_t op_errno,
                       struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                       dict_t *xdata)
 {
@@ -1171,7 +1173,7 @@ changelog_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1230,7 +1232,7 @@ wind:
 
 int32_t
 changelog_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1238,7 +1240,7 @@ changelog_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1281,7 +1283,7 @@ wind:
 
 int32_t
 changelog_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1289,7 +1291,7 @@ changelog_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1334,7 +1336,7 @@ wind:
 
 int32_t
 changelog_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1342,7 +1344,7 @@ changelog_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1398,10 +1400,10 @@ changelog_handle_virtual_xattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         /* Assign local to prev_entry, so unwind will take
          * care of cleanup. */
         ((changelog_local_t *)(frame->local))->prev_entry = local;
-        CHANGELOG_STACK_UNWIND(setxattr, frame, 0, 0, NULL);
+        CHANGELOG_STACK_UNWIND(setxattr, frame, gf_success, 0, NULL);
         return;
     } else {
-        CHANGELOG_STACK_UNWIND(setxattr, frame, -1, ENOTSUP, NULL);
+        CHANGELOG_STACK_UNWIND(setxattr, frame, gf_error, ENOTSUP, NULL);
         return;
     }
 }
@@ -1447,7 +1449,7 @@ wind:
 
 int32_t
 changelog_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1455,7 +1457,7 @@ changelog_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1499,7 +1501,7 @@ wind:
 
 int32_t
 changelog_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                       dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1508,7 +1510,7 @@ changelog_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1556,7 +1558,7 @@ wind:
 
 int32_t
 changelog_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                        dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1565,7 +1567,7 @@ changelog_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1620,8 +1622,8 @@ wind:
 
 int32_t
 changelog_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1629,7 +1631,7 @@ changelog_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1668,8 +1670,9 @@ wind:
 
 int32_t
 changelog_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                        struct iatt *postbuf, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno,
+                        struct iatt *prebuf, struct iatt *postbuf,
+                        dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1677,7 +1680,7 @@ changelog_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1718,7 +1721,7 @@ wind:
 
 int32_t
 changelog_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1727,7 +1730,8 @@ changelog_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret <= 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(
+        priv, (IS_ERROR(op_ret) || (GET_RET(op_ret) == 0) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1774,7 +1778,7 @@ wind:
 
 int
 changelog_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int op_errno, fd_t *fd, dict_t *xdata)
 {
     int ret = 0;
     changelog_priv_t *priv = NULL;
@@ -1789,7 +1793,7 @@ changelog_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         logopen = _gf_true;
     }
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !logopen), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !logopen), unwind);
 
     /* fill the event structure */
     ev.ev_type = CHANGELOG_OP_TYPE_OPEN;
@@ -1862,7 +1866,7 @@ changelog_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     if (xdata)
         (void)dict_foreach(xdata, _changelog_generic_dispatcher, this);
 
-    STACK_UNWIND_STRICT(ipc, frame, 0, 0, NULL);
+    STACK_UNWIND_STRICT(ipc, frame, gf_success, 0, NULL);
     return 0;
 
 wind:
@@ -2105,7 +2109,7 @@ notify(xlator_t *this, int event, void *data, ...)
                         ret = -1;
                 }
                 UNLOCK(&priv->lock);
-                /* If ret = -1, then changelog barrier is already
+                /* If ret = gf_error, then changelog barrier is already
                  * disabled because of error or timeout.
                  */
                 if (ret == 0) {

--- a/xlators/features/cloudsync/src/cloudsync-common.h
+++ b/xlators/features/cloudsync/src/cloudsync-common.h
@@ -37,7 +37,7 @@ typedef struct cs_local {
     call_stub_t *stub;
     call_frame_t *main_frame;
     int op_errno;
-    int op_ret;
+    gf_return_t op_ret;
     fd_t *dlfd;
     off_t dloffset;
     struct iatt stbuf;

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -331,13 +331,13 @@ aws_sign_request(char *const str, char *awssekey)
 }
 
 int
-aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata)
+aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata)
 {
     aws_private_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, op_errno,
                "write failed "
                ". Aborting Download");
@@ -352,7 +352,7 @@ aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     CS_STACK_DESTROY(frame);
 
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 size_t

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
@@ -28,9 +28,9 @@ int
 aws_download_s3(call_frame_t *frame, void *config);
 
 int
-aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
+aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
 
 void *
 aws_init(xlator_t *this);

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
@@ -41,7 +41,7 @@ struct _cvlt_request {
     struct iobref *iobref;
     call_frame_t *frame;
     cvlt_op_t op_type;
-    int32_t op_ret;
+    int64_t op_ret;
     int32_t op_errno;
     xlator_t *this;
     sem_t sem;

--- a/xlators/features/cloudsync/src/cloudsync.h
+++ b/xlators/features/cloudsync/src/cloudsync.h
@@ -53,7 +53,7 @@ cs_resume_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 cs_inodelk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 size_t
 cs_write_callback(void *lcurlbuf, size_t size, size_t nitems, void *frame);
@@ -66,13 +66,13 @@ cs_is_file_remote(struct iatt *stbuf, dict_t *xattr);
 
 int32_t
 cs_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 int
 cs_build_loc(loc_t *loc, call_frame_t *frame);
 
 int
 cs_blocking_inodelk_cbk(call_frame_t *lock_frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 cs_read_authinfo(xlator_t *this);
@@ -97,16 +97,17 @@ cs_resume_postprocess(xlator_t *this, call_frame_t *frame, inode_t *inode);
 
 int32_t
 cs_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata);
 int32_t
 cs_resume_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc,
                    off_t offset, dict_t *xattr_req);
 
 int32_t
-cs_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iovec *vector, int32_t count,
-             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
+cs_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+             int32_t count, struct iatt *stbuf, struct iobref *iobref,
+             dict_t *xdata);
 int32_t
 cs_resume_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 off_t offset, uint32_t flags, dict_t *xdata);

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -17,7 +17,7 @@
 
 int32_t
 leases_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, fd, xdata);
 
@@ -85,14 +85,14 @@ err:
         GF_FREE(fd_ctx);
     }
 
-    STACK_UNWIND_STRICT(open, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                  dict_t *xdata)
+leases_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
@@ -135,14 +135,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(writev, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iovec *vector, int count,
-                 struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+leases_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iovec *vector,
+                 int count, struct iatt *stbuf, struct iobref *iobref,
+                 dict_t *xdata)
 {
     STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, vector, count, stbuf,
                         iobref, xdata);
@@ -183,13 +184,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(readv, frame, -1, errno, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, errno, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
-leases_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+leases_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     STACK_UNWIND_STRICT(lk, frame, op_ret, op_errno, lock, xdata);
 
@@ -228,7 +231,7 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(lk, frame, -1, errno, NULL, NULL);
+    STACK_UNWIND_STRICT(lk, frame, gf_error, errno, NULL, NULL);
     return 0;
 }
 
@@ -241,7 +244,7 @@ leases_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     struct gf_lease nullease = {
         0,
     };
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
 
     EXIT_IF_LEASES_OFF(this, out);
     EXIT_IF_INTERNAL_FOP(frame, xdata, out);
@@ -249,7 +252,7 @@ leases_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     ret = process_lease_req(frame, this, loc->inode, lease);
     if (ret < 0) {
         op_errno = -ret;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     goto unwind;
 
@@ -259,7 +262,7 @@ out:
            "You need to enable it for proper functioning of your "
            "application");
     op_errno = ENOSYS;
-    op_ret = -1;
+    op_ret = gf_error;
 
 unwind:
     STACK_UNWIND_STRICT(lease, frame, op_ret, op_errno,
@@ -269,7 +272,7 @@ unwind:
 
 int32_t
 leases_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -310,13 +313,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(truncate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(truncate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
@@ -357,13 +360,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(setattr, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -407,15 +410,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(rename, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+leases_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(unlink, frame, op_ret, op_errno, preparent, postparent,
                         xdata);
@@ -455,14 +458,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(unlink, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, inode_t *inode, struct iatt *stbuf,
-                struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+leases_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, inode_t *inode,
+                struct iatt *stbuf, struct iatt *preparent,
+                struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(link, frame, op_ret, op_errno, inode, stbuf, preparent,
                         postparent, xdata);
@@ -501,15 +505,16 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(link, frame, -1, errno, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
-leases_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-                  struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+leases_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+                  struct iatt *stbuf, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, stbuf,
                         preparent, postparent, xdata);
@@ -551,14 +556,14 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsync, frame, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -596,13 +601,13 @@ out:
                FIRST_CHILD(this)->fops->fsync, fd, flags, xdata);
     return 0;
 err:
-    STACK_UNWIND_STRICT(fsync, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsync, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -642,13 +647,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(ftruncate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(ftruncate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsetattr, frame, op_ret, op_errno, statpre, statpost,
@@ -688,13 +693,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(fsetattr, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsetattr, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, pre, post, xdata);
@@ -736,13 +741,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(fallocate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fallocate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                    struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(discard, frame, op_ret, op_errno, pre, post, xdata);
@@ -782,13 +787,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(discard, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(discard, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, pre, post, xdata);
@@ -828,13 +833,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(zerofill, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(zerofill, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int
 leases_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(flush, frame, op_ret, op_errno, xdata);
 
@@ -894,8 +899,8 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -181,9 +181,9 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
             if (plock->blocked) {
                 bcount++;
                 pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
-                             &plock->user_flock, -1, EINTR, NULL);
+                             &plock->user_flock, gf_error, EINTR, NULL);
 
-                STACK_UNWIND_STRICT(lk, plock->frame, -1, EINTR,
+                STACK_UNWIND_STRICT(lk, plock->frame, gf_error, EINTR,
                                     &plock->user_flock, NULL);
 
             } else {
@@ -265,8 +265,8 @@ blkd:
         {
             list_del_init(&ilock->blocked_locks);
             pl_trace_out(this, ilock->frame, NULL, NULL, F_SETLKW,
-                         &ilock->user_flock, -1, EAGAIN, ilock->volume);
-            STACK_UNWIND_STRICT(inodelk, ilock->frame, -1, EAGAIN, NULL);
+                         &ilock->user_flock, gf_error, EAGAIN, ilock->volume);
+            STACK_UNWIND_STRICT(inodelk, ilock->frame, gf_error, EAGAIN, NULL);
             // No need to take lock as the locks are only in one list
             __pl_inodelk_unref(ilock);
         }
@@ -370,9 +370,9 @@ blkd:
         {
             list_del_init(&elock->blocked_locks);
             entrylk_trace_out(this, elock->frame, elock->volume, NULL, NULL,
-                              elock->basename, ENTRYLK_LOCK, elock->type, -1,
-                              EAGAIN);
-            STACK_UNWIND_STRICT(entrylk, elock->frame, -1, EAGAIN, NULL);
+                              elock->basename, ENTRYLK_LOCK, elock->type,
+                              gf_error, EAGAIN);
+            STACK_UNWIND_STRICT(entrylk, elock->frame, gf_error, EAGAIN, NULL);
 
             __pl_entrylk_unref(elock);
         }

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -140,7 +140,7 @@ pl_trace_in(xlator_t *this, call_frame_t *frame, fd_t *fd, loc_t *loc, int cmd,
 
 void
 pl_trace_out(xlator_t *this, call_frame_t *frame, fd_t *fd, loc_t *loc, int cmd,
-             struct gf_flock *flock, int op_ret, int op_errno,
+             struct gf_flock *flock, gf_return_t op_ret, int op_errno,
              const char *domain);
 
 void
@@ -158,7 +158,7 @@ entrylk_trace_in(xlator_t *this, call_frame_t *frame, const char *volume,
 void
 entrylk_trace_out(xlator_t *this, call_frame_t *frame, const char *volume,
                   fd_t *fd, loc_t *loc, const char *basename, entrylk_cmd cmd,
-                  entrylk_type type, int op_ret, int op_errno);
+                  entrylk_type type, gf_return_t op_ret, int op_errno);
 
 void
 entrylk_trace_block(xlator_t *this, call_frame_t *frame, const char *volume,
@@ -166,7 +166,7 @@ entrylk_trace_block(xlator_t *this, call_frame_t *frame, const char *volume,
                     entrylk_type type);
 
 void
-pl_print_verdict(char *str, int size, int op_ret, int op_errno);
+pl_print_verdict(char *str, int size, int32_t op_ret, int op_errno);
 
 void
 pl_print_lockee(char *str, int size, fd_t *fd, loc_t *loc);

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -245,7 +245,8 @@ grant_blocked_reserve_locks(xlator_t *this, pl_inode_t *pl_inode)
                lkowner_utoa(&lock->owner), lock->user_flock.l_start,
                lock->user_flock.l_len);
 
-        STACK_UNWIND_STRICT(lk, lock->frame, 0, 0, &lock->user_flock, NULL);
+        STACK_UNWIND_STRICT(lk, lock->frame, gf_success, 0, &lock->user_flock,
+                            NULL);
     }
 }
 
@@ -316,9 +317,9 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
             } else {
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
                 pl_trace_out(this, lock->frame, fd, NULL, cmd,
-                             &lock->user_flock, -1, EAGAIN, NULL);
+                             &lock->user_flock, gf_error, EAGAIN, NULL);
                 pl_update_refkeeper(this, fd->inode);
-                STACK_UNWIND_STRICT(lk, lock->frame, -1, EAGAIN,
+                STACK_UNWIND_STRICT(lk, lock->frame, gf_error, EAGAIN,
                                     &lock->user_flock, NULL);
                 __destroy_lock(lock);
             }

--- a/xlators/features/metadisp/src/gen-fops.py
+++ b/xlators/features/metadisp/src/gen-fops.py
@@ -64,7 +64,7 @@ metadisp_@NAME@ (call_frame_t *frame, xlator_t *this,
   return 0;
 
 unwind:
-  STACK_UNWIND_STRICT(lookup, frame, -1, EINVAL, NULL, NULL, NULL, NULL);
+  STACK_UNWIND_STRICT(lookup, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL);
   return 0;
 }
 """

--- a/xlators/features/metadisp/src/metadisp-create.c
+++ b/xlators/features/metadisp/src/metadisp-create.c
@@ -10,7 +10,7 @@
 
 int32_t
 metadisp_create_dentry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            inode_t *inode, struct iatt *buf,
                            struct iatt *preparent, struct iatt *postparent,
                            dict_t *xdata)
@@ -34,13 +34,13 @@ metadisp_create_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 metadisp_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = cookie;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, buf,
                             preparent, postparent, xdata);
         return 0;
@@ -59,8 +59,8 @@ metadisp_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(create, frame, -1, EINVAL, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -93,8 +93,8 @@ metadisp_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(create, frame, -1, EINVAL, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 out:
     return -1;

--- a/xlators/features/metadisp/src/metadisp-fsync.c
+++ b/xlators/features/metadisp/src/metadisp-fsync.c
@@ -13,7 +13,7 @@ metadisp_fsync_resume(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
 int32_t
 metadisp_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -21,7 +21,7 @@ metadisp_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 

--- a/xlators/features/metadisp/src/metadisp-lookup.c
+++ b/xlators/features/metadisp/src/metadisp-lookup.c
@@ -8,14 +8,14 @@
 
 int32_t
 metadisp_backend_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, dict_t *xdata,
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf, dict_t *xdata,
                             struct iatt *postparent)
 {
     METADISP_TRACE("backend_lookup_cbk");
     if (op_errno == ENOENT) {
         op_errno = ENODATA;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xdata,
                         postparent);
@@ -39,20 +39,21 @@ metadisp_backend_lookup_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(lookup, frame, -1, EINVAL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, EINVAL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
 metadisp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = NULL;
     stub = cookie;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -69,7 +70,7 @@ metadisp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     call_resume(stub);
     return 0;
 unwind:
-    METADISP_TRACE("unwinding %d %d", op_ret, op_errno);
+    METADISP_TRACE("unwinding %d %d", GET_RET(op_ret), op_errno);
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xdata,
                         postparent);
     if (stub) {

--- a/xlators/features/metadisp/src/metadisp-open.c
+++ b/xlators/features/metadisp/src/metadisp-open.c
@@ -3,16 +3,16 @@
 
 int32_t
 metadisp_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
-    METADISP_TRACE("got open results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got open results %d %d", GET_RET(op_ret), op_errno);
 
     call_stub_t *stub = NULL;
     if (cookie) {
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -65,6 +65,6 @@ metadisp_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                       METADATA_CHILD(this)->fops->open, loc, flags, fd, xdata);
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(open, frame, -1, EINVAL, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }

--- a/xlators/features/metadisp/src/metadisp-setattr.c
+++ b/xlators/features/metadisp/src/metadisp-setattr.c
@@ -3,7 +3,7 @@
 
 int32_t
 metadisp_backend_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *statpre, struct iatt *statpost,
                              dict_t *xdata)
 
@@ -11,7 +11,7 @@ metadisp_backend_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     METADISP_TRACE("backend_setattr_cbk");
     if (op_errno == ENOENT) {
         op_errno = ENODATA;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
@@ -38,20 +38,20 @@ metadisp_backend_setattr_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(setattr, frame, -1, EINVAL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 metadisp_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = NULL;
     stub = cookie;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -66,7 +66,7 @@ metadisp_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     call_resume(stub);
     return 0;
 unwind:
-    METADISP_TRACE("unwinding %d %d", op_ret, op_errno);
+    METADISP_TRACE("unwinding %d %d", GET_RET(op_ret), op_errno);
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
     if (stub) {

--- a/xlators/features/metadisp/src/metadisp-stat.c
+++ b/xlators/features/metadisp/src/metadisp-stat.c
@@ -18,12 +18,12 @@
 
 int32_t
 metadisp_stat_backend_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, dict_t *xdata)
 {
-    METADISP_TRACE("got backend stat results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got backend stat results %d %d", GET_RET(op_ret), op_errno);
     if (op_errno == ENOENT) {
-        STACK_UNWIND_STRICT(open, frame, -1, ENODATA, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENODATA, NULL, NULL);
         return 0;
     }
     STACK_UNWIND_STRICT(stat, frame, op_ret, op_errno, buf, xdata);
@@ -37,7 +37,7 @@ metadisp_stat_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     METADISP_TRACE("winding stat to path %s", loc->path);
     if (gf_uuid_is_null(loc->gfid)) {
         METADISP_TRACE("bad object, sending EUCLEAN");
-        STACK_UNWIND_STRICT(open, frame, -1, EUCLEAN, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, EUCLEAN, NULL, NULL);
         return 0;
     }
 
@@ -48,18 +48,18 @@ metadisp_stat_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 metadisp_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
-    METADISP_TRACE("got stat results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got stat results %d %d", GET_RET(op_ret), op_errno);
 
     if (cookie) {
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -119,6 +119,6 @@ metadisp_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
                       METADATA_CHILD(this)->fops->stat, loc, xdata);
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(stat, frame, -1, EINVAL, NULL, NULL);
+    STACK_UNWIND_STRICT(stat, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }

--- a/xlators/features/namespace/src/namespace.c
+++ b/xlators/features/namespace/src/namespace.c
@@ -195,7 +195,7 @@ out:
  * once we've gotten the namespace hash. */
 int32_t
 get_path_resume_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     path_parse_result_t ret = PATH_PARSE_RESULT_NO_PATH;
@@ -224,7 +224,8 @@ get_path_resume_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* If we get a value back for the GET_ANCESTRY_PATH_KEY, then we
      * try to access it and parse it like a path. */
-    if (!op_ret && !dict_get_str(dict, GET_ANCESTRY_PATH_KEY, &path)) {
+    if (IS_SUCCESS(op_ret) &&
+        !dict_get_str(dict, GET_ANCESTRY_PATH_KEY, &path)) {
         gf_log(this->name, GF_LOG_DEBUG, "G>P %s retrieved path %s",
                uuid_utoa(local->loc.gfid), path);
         /* Now let's parse a path, finally. */

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -119,11 +119,11 @@ out:
 
 int32_t
 gf_quiesce_failover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     quiesce_priv_t *priv = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* Failure here doesn't mean the failover to another host didn't
          * succeed, we will know if failover succeeds or not by the
          * CHILD_UP/CHILD_DOWN event. A failure here indicates something
@@ -309,7 +309,7 @@ gf_quiesce_enqueue(xlator_t *this, call_stub_t *stub)
 
 int32_t
 quiesce_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *dict, struct iatt *postparent)
 {
     call_stub_t *stub = NULL;
@@ -317,13 +317,13 @@ quiesce_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_lookup_stub(frame, default_lookup_resume, &local->loc,
                                local->dict);
         if (!stub) {
-            STACK_UNWIND_STRICT(lookup, frame, -1, ENOMEM, NULL, NULL, NULL,
-                                NULL);
+            STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL, NULL);
             goto out;
         }
 
@@ -341,7 +341,7 @@ out:
 
 int32_t
 quiesce_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -349,11 +349,11 @@ quiesce_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_stat_stub(frame, default_stat_resume, &local->loc, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(stat, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(stat, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -370,19 +370,19 @@ out:
 
 int32_t
 quiesce_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_access_stub(frame, default_access_resume, &local->loc,
                                local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(access, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(access, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -399,7 +399,7 @@ out:
 
 int32_t
 quiesce_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -407,12 +407,13 @@ quiesce_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readlink_stub(frame, default_readlink_resume, &local->loc,
                                  local->size, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+            STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL);
             goto out;
         }
 
@@ -429,19 +430,19 @@ out:
 
 int32_t
 quiesce_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_open_stub(frame, default_open_resume, &local->loc,
                              local->flag, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -458,7 +459,7 @@ out:
 
 int32_t
 quiesce_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -467,14 +468,14 @@ quiesce_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readv_stub(frame, default_readv_resume, local->fd,
                               local->size, local->offset, local->io_flag,
                               xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readv, frame, -1, ENOMEM, NULL, 0, NULL, NULL,
-                                NULL);
+            STACK_UNWIND_STRICT(readv, frame, gf_error, ENOMEM, NULL, 0, NULL,
+                                NULL, NULL);
             goto out;
         }
 
@@ -492,18 +493,18 @@ out:
 
 int32_t
 quiesce_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_flush_stub(frame, default_flush_resume, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(flush, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(flush, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -520,7 +521,7 @@ out:
 
 int32_t
 quiesce_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -528,12 +529,13 @@ quiesce_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsync_stub(frame, default_fsync_resume, local->fd,
                               local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fsync, frame, -1, ENOMEM, NULL, NULL, NULL);
+            STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL);
             goto out;
         }
 
@@ -550,7 +552,7 @@ out:
 
 int32_t
 quiesce_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -558,11 +560,11 @@ quiesce_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fstat_stub(frame, default_fstat_resume, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fstat, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -579,19 +581,20 @@ out:
 
 int32_t
 quiesce_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_opendir_stub(frame, default_opendir_resume, &local->loc,
                                 local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(opendir, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -608,19 +611,19 @@ out:
 
 int32_t
 quiesce_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsyncdir_stub(frame, default_fsyncdir_resume, local->fd,
                                  local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -637,7 +640,7 @@ out:
 
 int32_t
 quiesce_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -645,12 +648,12 @@ quiesce_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_statfs_stub(frame, default_statfs_resume, &local->loc,
                                xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(statfs, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -667,7 +670,7 @@ out:
 
 int32_t
 quiesce_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -675,12 +678,12 @@ quiesce_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fgetxattr_stub(frame, default_fgetxattr_resume, local->fd,
                                   local->name, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -697,7 +700,7 @@ out:
 
 int32_t
 quiesce_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -705,12 +708,12 @@ quiesce_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_getxattr_stub(frame, default_getxattr_resume, &local->loc,
                                  local->name, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(getxattr, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -727,20 +730,22 @@ out:
 
 int32_t
 quiesce_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_rchecksum_stub(frame, default_rchecksum_resume, local->fd,
                                   local->offset, local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOMEM, 0, NULL, NULL);
+            STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOMEM, 0, NULL,
+                                NULL);
             goto out;
         }
 
@@ -758,7 +763,7 @@ out:
 
 int32_t
 quiesce_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -766,12 +771,12 @@ quiesce_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdir_stub(frame, default_readdir_resume, local->fd,
                                 local->size, local->offset, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readdir, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -788,7 +793,7 @@ out:
 
 int32_t
 quiesce_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -796,12 +801,12 @@ quiesce_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdirp_stub(frame, default_readdirp_resume, local->fd,
                                  local->size, local->offset, local->dict);
         if (!stub) {
-            STACK_UNWIND_STRICT(readdirp, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -820,7 +825,7 @@ out:
 
 int32_t
 quiesce_writev_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -831,14 +836,14 @@ quiesce_writev_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_writev_stub (frame, default_writev_resume,
                                         local->fd, local->vector, local->flag,
                                         local->offset, local->io_flags,
                                         local->iobref, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (writev, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (writev, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -856,7 +861,7 @@ out:
 
 int32_t
 quiesce_xattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -866,13 +871,13 @@ quiesce_xattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_xattrop_stub (frame, default_xattrop_resume,
                                          &local->loc, local->xattrop_flags,
                                          local->dict, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (xattrop, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (xattrop, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -890,7 +895,7 @@ out:
 
 int32_t
 quiesce_fxattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -900,13 +905,13 @@ quiesce_fxattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fxattrop_stub (frame, default_fxattrop_resume,
                                           local->fd, local->xattrop_flags,
                                           local->dict, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fxattrop, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (fxattrop, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -924,7 +929,7 @@ out:
 
 int32_t
 quiesce_lk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -934,12 +939,12 @@ quiesce_lk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_lk_stub (frame, default_lk_resume,
                                     local->fd, local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (lk, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (lk, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -957,7 +962,7 @@ out:
 
 int32_t
 quiesce_inodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -967,13 +972,13 @@ quiesce_inodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_inodelk_stub (frame, default_inodelk_resume,
                                          local->volname, &local->loc,
                                          local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (inodelk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (inodelk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -991,7 +996,7 @@ out:
 
 int32_t
 quiesce_finodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1001,13 +1006,13 @@ quiesce_finodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_finodelk_stub (frame, default_finodelk_resume,
                                          local->volname, local->fd,
                                          local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (finodelk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (finodelk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1024,7 +1029,7 @@ out:
 
 int32_t
 quiesce_entrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1034,13 +1039,13 @@ quiesce_entrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_entrylk_stub (frame, default_entrylk_resume,
                                          local->volname, &local->loc,
                                          local->name, local->cmd, local->type, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (entrylk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (entrylk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1057,7 +1062,7 @@ out:
 
 int32_t
 quiesce_fentrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1067,13 +1072,13 @@ quiesce_fentrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fentrylk_stub (frame, default_fentrylk_resume,
                                           local->volname, local->fd,
                                           local->name, local->cmd, local->type, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fentrylk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (fentrylk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1090,7 +1095,7 @@ out:
 
 int32_t
 quiesce_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -1101,12 +1106,12 @@ quiesce_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_setattr_stub (frame, default_setattr_resume,
                                          &local->loc, &local->stbuf, local->flag, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (setattr, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (setattr, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -1125,7 +1130,7 @@ out:
 
 int32_t
 quiesce_fsetattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                       struct iatt *statpost, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -1137,12 +1142,12 @@ quiesce_fsetattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
         local = frame->local;
         frame->local = NULL;
 
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fsetattr_stub (frame, default_fsetattr_resume,
                                           local->fd, &local->stbuf, local->flag, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fsetattr, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (fsetattr, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -1183,7 +1188,7 @@ quiesce_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_removexattr_stub(frame, default_removexattr_resume, loc, name,
                                 xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(removexattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1210,7 +1215,7 @@ quiesce_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fremovexattr_stub(frame, default_fremovexattr_resume, fd, name,
                                  xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1237,7 +1242,8 @@ quiesce_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     stub = fop_truncate_stub(frame, default_truncate_resume, loc, offset,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1264,7 +1270,7 @@ quiesce_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     stub = fop_fsetxattr_stub(frame, default_fsetxattr_resume, fd, dict, flags,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1291,7 +1297,7 @@ quiesce_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     stub = fop_setxattr_stub(frame, default_setxattr_resume, loc, dict, flags,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(setxattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1321,8 +1327,8 @@ quiesce_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     stub = fop_create_stub(frame, default_create_resume, loc,
                            (flags & ~O_APPEND), mode, umask, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(create, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(create, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -1348,8 +1354,8 @@ quiesce_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     stub = fop_link_stub(frame, default_link_resume, oldloc, newloc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(link, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(link, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1375,8 +1381,8 @@ quiesce_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     stub = fop_rename_stub(frame, default_rename_resume, oldloc, newloc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rename, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -1404,8 +1410,8 @@ quiesce_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     stub = fop_symlink_stub(frame, default_symlink_resume, linkpath, loc, umask,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(symlink, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1431,7 +1437,7 @@ quiesce_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     stub = fop_rmdir_stub(frame, default_rmdir_resume, loc, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rmdir, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1457,7 +1463,7 @@ quiesce_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     stub = fop_unlink_stub(frame, default_unlink_resume, loc, xflag, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(unlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1483,8 +1489,8 @@ quiesce_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     stub = fop_mkdir_stub(frame, default_mkdir_resume, loc, mode, umask, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(mkdir, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1512,8 +1518,8 @@ quiesce_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     stub = fop_mknod_stub(frame, default_mknod_resume, loc, mode, rdev, umask,
                           xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(mknod, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1540,7 +1546,8 @@ quiesce_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     stub = fop_ftruncate_stub(frame, default_ftruncate_resume, fd, offset,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1574,7 +1581,8 @@ quiesce_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 
     stub = fop_readlink_stub(frame, default_readlink_resume, loc, size, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1606,7 +1614,7 @@ quiesce_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
 
     stub = fop_access_stub(frame, default_access_resume, loc, mask, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(access, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(access, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1640,7 +1648,7 @@ quiesce_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     stub = fop_fgetxattr_stub(frame, default_fgetxattr_resume, fd, name, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1670,7 +1678,7 @@ quiesce_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     stub = fop_statfs_stub(frame, default_statfs_resume, loc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(statfs, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1702,7 +1710,7 @@ quiesce_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
 
     stub = fop_fsyncdir_stub(frame, default_fsyncdir_resume, fd, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1734,7 +1742,7 @@ quiesce_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 
     stub = fop_opendir_stub(frame, default_opendir_resume, loc, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(opendir, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1764,7 +1772,7 @@ quiesce_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     stub = fop_fstat_stub(frame, default_fstat_resume, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fstat, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1796,7 +1804,7 @@ quiesce_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
 
     stub = fop_fsync_stub(frame, default_fsync_resume, fd, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsync, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1826,7 +1834,7 @@ quiesce_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     stub = fop_flush_stub(frame, default_flush_resume, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(flush, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(flush, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1855,7 +1863,7 @@ quiesce_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_writev_stub(frame, default_writev_resume, fd, vector, count, off,
                            flags, iobref, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(writev, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1891,7 +1899,7 @@ quiesce_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readv_stub(frame, default_readv_resume, fd, size, offset, flags,
                           xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readv, frame, -1, ENOMEM, NULL, 0, NULL, NULL,
+        STACK_UNWIND_STRICT(readv, frame, gf_error, ENOMEM, NULL, 0, NULL, NULL,
                             NULL);
         return 0;
     }
@@ -1930,7 +1938,7 @@ quiesce_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     stub = fop_open_stub(frame, default_open_resume, loc, (flags & ~O_APPEND),
                          fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1964,7 +1972,7 @@ quiesce_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     stub = fop_getxattr_stub(frame, default_getxattr_resume, loc, name, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(getxattr, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1991,7 +1999,7 @@ quiesce_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_xattrop_stub(frame, default_xattrop_resume, loc, flags, dict,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(xattrop, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2018,7 +2026,7 @@ quiesce_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fxattrop_stub(frame, default_fxattrop_resume, fd, flags, dict,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2044,7 +2052,7 @@ quiesce_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     stub = fop_lk_stub(frame, default_lk_resume, fd, cmd, lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2072,7 +2080,7 @@ quiesce_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_inodelk_stub(frame, default_inodelk_resume, volume, loc, cmd,
                             lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(inodelk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2100,7 +2108,7 @@ quiesce_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_finodelk_stub(frame, default_finodelk_resume, volume, fd, cmd,
                              lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(finodelk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2129,7 +2137,7 @@ quiesce_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_entrylk_stub(frame, default_entrylk_resume, volume, loc,
                             basename, cmd, type, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(entrylk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2158,7 +2166,7 @@ quiesce_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_fentrylk_stub(frame, default_fentrylk_resume, volume, fd,
                              basename, cmd, type, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2192,7 +2200,7 @@ quiesce_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     stub = fop_rchecksum_stub(frame, default_rchecksum_resume, fd, offset, len,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOMEM, 0, NULL, NULL);
+        STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOMEM, 0, NULL, NULL);
         return 0;
     }
 
@@ -2226,7 +2234,7 @@ quiesce_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readdir_stub(frame, default_readdir_resume, fd, size, off,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readdir, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2261,7 +2269,7 @@ quiesce_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readdirp_stub(frame, default_readdirp_resume, fd, size, off,
                              dict);
     if (!stub) {
-        STACK_UNWIND_STRICT(readdirp, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2288,7 +2296,7 @@ quiesce_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_setattr_stub(frame, default_setattr_resume, loc, stbuf, valid,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(setattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -2318,7 +2326,7 @@ quiesce_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     stub = fop_stat_stub(frame, default_stat_resume, loc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(stat, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(stat, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2350,7 +2358,8 @@ quiesce_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     stub = fop_lookup_stub(frame, default_lookup_resume, loc, xattr_req);
     if (!stub) {
-        STACK_UNWIND_STRICT(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2377,7 +2386,8 @@ quiesce_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fsetattr_stub(frame, default_fsetattr_resume, fd, stbuf, valid,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2405,7 +2415,8 @@ quiesce_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     stub = fop_fallocate_stub(frame, default_fallocate_resume, fd, mode, offset,
                               len, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fallocate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2416,19 +2427,20 @@ quiesce_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
 int
 quiesce_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, off_t offset,
+                 dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_seek_stub(frame, default_seek_resume, local->fd,
                              local->offset, local->what, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(seek, frame, -1, ENOMEM, 0, NULL);
+            STACK_UNWIND_STRICT(seek, frame, gf_error, ENOMEM, 0, NULL);
             goto out;
         }
 
@@ -2468,7 +2480,7 @@ quiesce_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     stub = fop_seek_stub(frame, default_seek_resume, fd, offset, what, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(seek, frame, -1, ENOMEM, 0, NULL);
+        STACK_UNWIND_STRICT(seek, frame, gf_error, ENOMEM, 0, NULL);
         return 0;
     }
 

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -161,7 +161,7 @@ struct quota_inode_ctx {
 typedef struct quota_inode_ctx quota_inode_ctx_t;
 
 typedef void (*quota_ancestry_built_t)(struct list_head *parents,
-                                       inode_t *inode, int32_t op_ret,
+                                       inode_t *inode, gf_return_t op_ret,
                                        int32_t op_errno, void *data);
 
 typedef void (*quota_fop_continue_t)(call_frame_t *frame);
@@ -175,7 +175,7 @@ struct quota_local {
     loc_t validate_loc;
     int64_t delta;
     int8_t object_delta;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     int64_t size;
     char just_validated;

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -139,7 +139,7 @@ quotad_aggregator_getlimit_cbk(xlator_t *this, call_frame_t *frame,
     int ret = -1;
     int type = 0;
 
-    if (!rsp || (rsp->op_ret == -1))
+    if (!rsp || (rsp->op_ret < 0))
         goto reply;
 
     GF_PROTOCOL_DICT_UNSERIALIZE(frame->this, xdata, (rsp->xdata.xdata_val),

--- a/xlators/features/quota/src/quotad.c
+++ b/xlators/features/quota/src/quotad.c
@@ -43,9 +43,9 @@ mem_acct_init(xlator_t *this)
 }
 
 int32_t
-qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     quotad_aggregator_lookup_cbk_t lookup_cbk = NULL;
     gfs3_lookup_rsp rsp = {
@@ -54,7 +54,7 @@ qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     lookup_cbk = cookie;
 
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = op_errno;
 
     gf_stat_from_iatt(&rsp.postparent, postparent);

--- a/xlators/features/read-only/src/read-only-common.c
+++ b/xlators/features/read-only/src/read-only-common.c
@@ -50,7 +50,7 @@ ro_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
         allzero = _gf_true;
 
     if (is_readonly_or_worm_enabled(frame, this) && !allzero)
-        STACK_UNWIND_STRICT(xattrop, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, EROFS, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->xattrop, loc, flags, dict,
@@ -70,7 +70,7 @@ ro_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
         allzero = _gf_true;
 
     if (is_readonly_or_worm_enabled(frame, this) && !allzero)
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, EROFS, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fxattrop, fd, flags, dict,
@@ -136,7 +136,7 @@ ro_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
            int32_t valid, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(setattr, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->setattr, loc, stbuf, valid,
@@ -150,7 +150,8 @@ ro_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
             int32_t valid, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsetattr, fd, stbuf, valid,
@@ -164,7 +165,8 @@ ro_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
             dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(truncate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
@@ -177,7 +179,8 @@ ro_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
              dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
@@ -190,7 +193,8 @@ ro_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
              off_t offset, size_t len, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fallocate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fallocate, fd, mode, offset,
@@ -203,8 +207,8 @@ ro_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
          dev_t rdev, mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(mknod, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->mknod, loc, mode, rdev, umask,
@@ -218,8 +222,8 @@ ro_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
          mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(mkdir, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->mkdir, loc, mode, umask,
@@ -233,7 +237,7 @@ ro_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(unlink, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->unlink, loc, xflag, xdata);
@@ -246,7 +250,7 @@ ro_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
          dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(rmdir, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
@@ -259,8 +263,8 @@ ro_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
            loc_t *loc, mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(symlink, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->symlink, linkpath, loc, umask,
@@ -274,8 +278,8 @@ ro_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(rename, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            NULL, xdata);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rename, oldloc, newloc, xdata);
@@ -288,8 +292,8 @@ ro_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(link, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(link, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this), FIRST_CHILD(this)->fops->link,
                         oldloc, newloc, xdata);
@@ -302,8 +306,8 @@ ro_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
           mode_t mode, mode_t umask, fd_t *fd, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(create, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            NULL, xdata);
+        STACK_UNWIND_STRICT(create, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->create, loc, flags, mode,
@@ -313,8 +317,8 @@ ro_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 }
 
 static int32_t
-ro_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+ro_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, fd, xdata);
     return 0;
@@ -327,7 +331,7 @@ ro_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     if (is_readonly_or_worm_enabled(frame, this) &&
         (((flags & O_ACCMODE) == O_WRONLY) ||
          ((flags & O_ACCMODE) == O_RDWR))) {
-        STACK_UNWIND_STRICT(open, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(open, frame, gf_error, EROFS, NULL, xdata);
         return 0;
     }
 
@@ -341,7 +345,7 @@ ro_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
              int32_t flags, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsetxattr, fd, dict, flags,
@@ -355,7 +359,7 @@ ro_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
             dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsyncdir, fd, flags, xdata);
@@ -369,7 +373,7 @@ ro_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(writev, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->writev, fd, vector, count, off,
@@ -383,7 +387,7 @@ ro_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
             int32_t flags, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(setxattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->setxattr, loc, dict, flags,
@@ -397,7 +401,7 @@ ro_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                const char *name, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(removexattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);

--- a/xlators/features/sdfs/src/sdfs.c
+++ b/xlators/features/sdfs/src/sdfs.c
@@ -209,7 +209,7 @@ err:
 
 int
 sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     call_stub_t *stub = NULL;
@@ -224,7 +224,7 @@ sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "Unlocking entry lock failed for %s", local->loc.name);
 
@@ -236,7 +236,7 @@ sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 sdfs_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -266,7 +266,7 @@ sdfs_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -280,8 +280,8 @@ sdfs_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mkdir, local->main_frame, -1, op_errno, NULL, NULL,
-                        NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mkdir, local->main_frame, gf_error, op_errno, NULL,
+                        NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -318,8 +318,8 @@ sdfs_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -329,7 +329,7 @@ err:
 
 int
 sdfs_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -357,7 +357,7 @@ sdfs_rmdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -370,8 +370,8 @@ sdfs_rmdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(rmdir, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -407,7 +407,7 @@ sdfs_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -417,7 +417,7 @@ err:
 
 int
 sdfs_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                 struct iatt *stbuf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -447,7 +447,7 @@ sdfs_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -461,8 +461,8 @@ sdfs_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(create, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(create, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -499,8 +499,8 @@ sdfs_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -510,7 +510,7 @@ err:
 
 int
 sdfs_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -538,7 +538,7 @@ sdfs_unlink_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -551,8 +551,8 @@ sdfs_unlink_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(unlink, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -588,7 +588,7 @@ sdfs_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -598,7 +598,7 @@ err:
 
 int
 sdfs_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -627,7 +627,7 @@ sdfs_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -640,8 +640,8 @@ sdfs_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -678,7 +678,7 @@ sdfs_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     if (new_frame)
@@ -689,7 +689,7 @@ err:
 
 int
 sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -701,7 +701,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     locks = local->lock;
     lk_index = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     } else {
@@ -721,7 +721,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "unlocking entry lock failed ");
         SDFS_STACK_DESTROY(frame);
@@ -731,9 +731,10 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
-sdfs_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *stbuf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+sdfs_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *stbuf, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     sdfs_lock_t *lock = NULL;
@@ -772,7 +773,7 @@ sdfs_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     locks = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed");
         goto err;
@@ -783,8 +784,8 @@ sdfs_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     for (i = 0; i < locks->lock_count && locks->entrylk->locked[i]; i++) {
@@ -921,7 +922,7 @@ sdfs_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 err:
 
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     if (new_frame)
@@ -932,7 +933,7 @@ err:
 
 int
 sdfs_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -961,7 +962,7 @@ sdfs_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -974,8 +975,8 @@ sdfs_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mknod, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mknod, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -1012,8 +1013,8 @@ sdfs_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1023,7 +1024,7 @@ err:
 
 int
 sdfs_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                 struct iatt *preoldparent, struct iatt *postoldparent,
                 struct iatt *prenewparent, struct iatt *postnewparent,
                 dict_t *xdata)
@@ -1068,7 +1069,7 @@ sdfs_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     lock = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed ");
         goto err;
@@ -1080,8 +1081,8 @@ sdfs_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(rename, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rename, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     for (i = 0; i < lock->lock_count && lock->entrylk->locked[i]; i++) {
@@ -1185,8 +1186,8 @@ sdfs_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 err:
 
-    STACK_UNWIND_STRICT(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1196,7 +1197,7 @@ err:
 
 int
 sdfs_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     sdfs_local_t *local = NULL;
@@ -1232,7 +1233,7 @@ sdfs_lookup_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1245,8 +1246,8 @@ sdfs_lookup_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(lookup, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL);
     local->main_frame = NULL;
 
     SDFS_STACK_DESTROY(frame);
@@ -1294,7 +1295,8 @@ sdfs_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1304,7 +1306,7 @@ err:
 
 int32_t
 sdfs_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                  gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                   dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -1331,7 +1333,7 @@ sdfs_readdirp_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     gf_uuid_unparse(fd->inode->gfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1344,8 +1346,8 @@ sdfs_readdirp_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(readdirp, local->main_frame, -1, local->op_errno, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(readdirp, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL);
 
     local->main_frame = NULL;
 
@@ -1384,7 +1386,7 @@ sdfs_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(readdirp, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(readdirp, frame, gf_error, op_errno, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);

--- a/xlators/features/sdfs/src/sdfs.h
+++ b/xlators/features/sdfs/src/sdfs.h
@@ -32,7 +32,7 @@ struct sdfs_local {
     loc_t parent_loc;
     call_stub_t *stub;
     sdfs_lock_t *lock;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     gf_atomic_t call_cnt;
 };

--- a/xlators/features/selinux/src/selinux.c
+++ b/xlators/features/selinux/src/selinux.c
@@ -17,7 +17,8 @@
 
 static int
 selinux_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *dict,
+                      dict_t *xdata)
 {
     int ret = 0;
     char *name = cookie;
@@ -40,7 +41,7 @@ selinux_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                   const char *name, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     char *xattr_name = (char *)name;
 
@@ -68,7 +69,8 @@ err:
 
 static int
 selinux_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *dict,
+                     dict_t *xdata)
 {
     int ret = 0;
     char *name = cookie;
@@ -92,7 +94,7 @@ selinux_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                  const char *name, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     char *xattr_name = (char *)name;
 
@@ -119,7 +121,7 @@ err:
 
 static int
 selinux_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -130,7 +132,7 @@ selinux_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                   int flags, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     int32_t ret = -1;
 
@@ -157,7 +159,7 @@ err:
 
 static int
 selinux_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -168,7 +170,7 @@ selinux_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                  int flags, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     int32_t ret = -1;
 

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -156,7 +156,7 @@ shard_unlock_entrylk(call_frame_t *frame, xlator_t *this);
                                                                                \
         __ret = dict_set_uint64(dict, GF_XATTR_SHARD_FILE_SIZE, 8 * 4);        \
         if (__ret) {                                                           \
-            local->op_ret = -1;                                                \
+            local->op_ret = gf_error;                                          \
             local->op_errno = ENOMEM;                                          \
             gf_msg(this->name, GF_LOG_WARNING, 0, SHARD_MSG_DICT_OP_FAILED,    \
                    "Failed to set dict value:"                                 \
@@ -252,7 +252,7 @@ typedef int32_t (*shard_post_update_size_fop_handler_t)(call_frame_t *frame,
                                                         xlator_t *this);
 
 typedef struct shard_local {
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     uint64_t first_block;
     uint64_t last_block;

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -283,7 +283,7 @@ out:
 
 static int32_t
 gf_svc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     svc_local_t *local = NULL;
@@ -316,7 +316,7 @@ gf_svc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
        is lost. In this case if nameless lookup fails with ESTALE,
        then send the lookup to the 2nd child of svc.
     */
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (subvolume == FIRST_CHILD(this)) {
             gf_smsg(this->name,
                     (op_errno == ENOENT || op_errno == ESTALE) ? GF_LOG_DEBUG
@@ -377,7 +377,7 @@ gf_svc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     int32_t ret = -1;
     svc_local_t *local = NULL;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     inode_t *parent = NULL;
     dict_t *new_xdata = NULL;
@@ -407,7 +407,7 @@ gf_svc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     local = mem_get0(this->local_pool);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_NO_MEMORY, NULL);
         goto out;
@@ -501,7 +501,7 @@ gf_svc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     xlator_t *subvolume = NULL;
     int32_t ret = -1;
     int inode_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_private_t *priv = NULL;
@@ -564,7 +564,7 @@ out:
 
 static int32_t
 gf_svc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
 {
     /* TODO: FIX ME
@@ -600,7 +600,7 @@ gf_svc_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -629,7 +629,7 @@ gf_svc_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -654,7 +654,8 @@ out:
 
 static int32_t
 gf_svc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     svc_fd_t *svc_fd = NULL;
     svc_local_t *local = NULL;
@@ -667,7 +668,7 @@ gf_svc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, this->private, out);
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         goto out;
 
     priv = this->private;
@@ -725,7 +726,7 @@ gf_svc_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_local_t *local = NULL;
@@ -769,7 +770,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -780,7 +781,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "path=%s", loc->path,
@@ -793,7 +794,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                         FIRST_CHILD(this)->fops->setattr, loc, stbuf, valid,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -814,7 +815,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
 {
         int32_t      ret        = -1;
         int          inode_type = -1;
-        int          op_ret     = -1;
+        gf_return_t  op_ret     = gf_error;
         int          op_errno   = EINVAL;
         gf_boolean_t wind       = _gf_false;
 
@@ -825,7 +826,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
 
         ret = svc_inode_ctx_get (this, fd->inode, &inode_type);
         if (ret < 0) {
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = EINVAL;
                 gf_msg (this->name, GF_LOG_ERROR, op_errno,
                         SVC_MSG_GET_INODE_CONTEXT_FAILED, "failed to "
@@ -839,7 +840,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
                                  FIRST_CHILD (this)->fops->fsetattr, fd, stbuf,
                                  valid, xdata);
         } else {
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = EROFS;
                 goto out;
         }
@@ -861,7 +862,7 @@ gf_svc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_private_t *priv = NULL;
@@ -915,7 +916,7 @@ gf_svc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
             }
 
             op_errno = 0;
-            op_ret = strlen(entry_point) + 1;
+            SET_RET(op_ret, (strlen(entry_point) + 1));
             /* We should return from here */
             goto out;
         }
@@ -949,7 +950,7 @@ gf_svc_fgetxattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
         int           inode_type = -1;
         xlator_t     *subvolume  = NULL;
         gf_boolean_t  wind       = _gf_false;
-        int           op_ret     = -1;
+        gf_return_t   op_ret     = gf_error;
         int           op_errno   = EINVAL;
 
         GF_VALIDATE_OR_GOTO ("svc", this, out);
@@ -979,7 +980,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -990,7 +991,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "name=%s", loc->name,
@@ -1003,7 +1004,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                         FIRST_CHILD(this)->fops->setxattr, loc, dict, flags,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1023,7 +1024,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1034,7 +1035,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1047,7 +1048,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                         FIRST_CHILD(this)->fops->fsetxattr, fd, dict, flags,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1067,7 +1068,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 {
     int inode_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1078,7 +1079,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "name=%s", loc->name,
@@ -1090,7 +1091,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1105,14 +1106,14 @@ out:
 
 static int32_t
 gf_svc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1133,7 +1134,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1147,7 +1148,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1165,7 +1166,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         STACK_WIND(frame, gf_svc_mkdir_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->mkdir, loc, mode, umask, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1181,14 +1182,14 @@ out:
 
 static int32_t
 gf_svc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1209,7 +1210,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1223,7 +1224,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1242,7 +1243,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                    FIRST_CHILD(this)->fops->mknod, loc, mode, rdev, umask,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1266,7 +1267,7 @@ gf_svc_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 {
     xlator_t *subvolume = NULL;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1286,7 +1287,7 @@ gf_svc_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     if (((flags & O_ACCMODE) == O_WRONLY) || ((flags & O_ACCMODE) == O_RDWR)) {
         if (subvolume != FIRST_CHILD(this)) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EINVAL;
             goto out;
         }
@@ -1305,14 +1306,14 @@ out:
 
 static int32_t
 gf_svc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *stbuf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1334,7 +1335,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1349,7 +1350,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1368,7 +1369,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                    FIRST_CHILD(this)->fops->create, loc, flags, mode, umask, fd,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1384,14 +1385,14 @@ out:
 
 static int32_t
 gf_svc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1412,7 +1413,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
                loc_t *loc, mode_t umask, dict_t *xdata)
 {
     int parent_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1427,7 +1428,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1446,7 +1447,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
                    FIRST_CHILD(this)->fops->symlink, linkpath, loc, umask,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1465,7 +1466,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
               dict_t *xdata)
 {
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1477,7 +1478,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1489,7 +1490,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->unlink, loc, flags, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1509,7 +1510,7 @@ gf_svc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     int inode_type = -1;
     xlator_t *subvolume = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1540,7 +1541,7 @@ gf_svc_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     int inode_type = -1;
     xlator_t *subvolume = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1571,7 +1572,7 @@ gf_svc_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     int ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1597,7 +1598,7 @@ out:
 
 int32_t
 gf_svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -1607,7 +1608,7 @@ gf_svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
@@ -1653,7 +1654,7 @@ gf_svc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     xlator_t *subvolume = NULL;
     svc_local_t *local = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_fd_t *svc_fd = NULL;
@@ -1672,7 +1673,7 @@ gf_svc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);
     else {
         if (svc_fd->entry_point_handled && off == svc_fd->last_offset) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = ENOENT;
             goto out;
         }
@@ -1730,7 +1731,7 @@ out:
 
 static int32_t
 gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, inode_t *inode,
+                           gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                            struct iatt *buf, dict_t *xdata,
                            struct iatt *postparent)
 {
@@ -1750,7 +1751,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ESTALE && !local->revalidate) {
             local->revalidate = 1;
             ret = gf_svc_special_dir_revalidate_lookup(frame, this, xdata);
@@ -1758,7 +1759,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if (!ret)
                 return 0;
         }
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1767,7 +1768,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!svc_fd) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_GET_FD_CONTEXT_FAILED,
                 "gfid=%s", uuid_utoa(local->fd->inode->gfid), NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1775,7 +1776,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (gf_svc_get_entry_point(this, entry_point, sizeof(entry_point))) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, SVC_MSG_COPY_ENTRY_POINT_FAILED,
                 NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1784,7 +1785,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!entry) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_NO_MEMORY,
                 "entry-point=%s", entry_point, NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOMEM;
         goto out;
     }
@@ -1801,7 +1802,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 "entry-name=%s", entry->d_name, NULL);
 
     list_add_tail(&entry->list, &entries.list);
-    op_ret = 1;
+    SET_RET(op_ret, 1);
     svc_fd->last_offset = entry->d_off;
     svc_fd->entry_point_handled = _gf_true;
 
@@ -1896,7 +1897,7 @@ out:
 
 static gf_boolean_t
 gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
-                              int32_t op_ret, int32_t op_errno,
+                              gf_return_t op_ret, int32_t op_errno,
                               gf_dirent_t *entries, dict_t *xdata)
 {
     svc_local_t *local = NULL;
@@ -1938,7 +1939,7 @@ gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!private->show_entry_point)
         goto out;
 
-    if (op_ret == 0 && op_errno == ENOENT && private->special_dir &&
+    if (IS_SUCCESS(op_ret) && op_errno == ENOENT && private->special_dir &&
         strcmp(private->special_dir, "") && svc_fd->special_dir &&
         local->subvolume == FIRST_CHILD(this)) {
         if (gf_svc_get_entry_point(this, entry_point, sizeof(entry_point))) {
@@ -2009,7 +2010,7 @@ out:
 
 static int32_t
 gf_svc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -2023,7 +2024,7 @@ gf_svc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
@@ -2095,7 +2096,7 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     xlator_t *subvolume = NULL;
     svc_local_t *local = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_fd_t *svc_fd = NULL;
@@ -2130,7 +2131,7 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);
     else {
         if (svc_fd->entry_point_handled && off == svc_fd->last_offset) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = ENOENT;
             goto out;
         }
@@ -2167,7 +2168,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     int src_inode_type = -1;
     int dst_inode_type = -1;
     int dst_parent_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int32_t ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -2180,7 +2181,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, oldloc->inode, &src_inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -2189,7 +2190,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     if (src_inode_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_RENAME_SNAPSHOT_ENTRY, "name=%s", oldloc->name, NULL);
@@ -2199,7 +2200,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     if (newloc->inode) {
         ret = svc_inode_ctx_get(this, newloc->inode, &dst_inode_type);
         if (!ret && dst_inode_type == VIRTUAL_INODE) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EROFS;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                     SVC_MSG_RENAME_SNAPSHOT_ENTRY, "oldloc-name=%s",
@@ -2211,7 +2212,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     if (dst_inode_type < 0) {
         ret = svc_inode_ctx_get(this, newloc->parent, &dst_parent_type);
         if (!ret && dst_parent_type == VIRTUAL_INODE) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EROFS;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                     SVC_MSG_RENAME_SNAPSHOT_ENTRY, "oldloc-name=%s",
@@ -2242,7 +2243,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 {
     int src_inode_type = -1;
     int dst_parent_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int32_t ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -2255,7 +2256,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, oldloc->inode, &src_inode_type);
     if (!ret && src_inode_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_LINK_SNAPSHOT_ENTRY,
                 "oldloc-name=%s", oldloc->name, NULL);
@@ -2264,7 +2265,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, newloc->parent, &dst_parent_type);
     if (!ret && dst_parent_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_LINK_SNAPSHOT_ENTRY,
                 "oldloc-name=%s", oldloc->name, "newloc-name=%s", newloc->name,
@@ -2290,7 +2291,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     int ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -2301,7 +2302,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "path=%s", loc->path,
@@ -2313,7 +2314,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -2333,7 +2334,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 {
     int inode_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -2344,7 +2345,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -2356,7 +2357,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsync, fd, datasync, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -2373,7 +2374,7 @@ out:
 static int32_t
 gf_svc_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int ret = -1;
     int inode_type = -1;

--- a/xlators/features/snapview-client/src/snapview-client.h
+++ b/xlators/features/snapview-client/src/snapview-client.h
@@ -47,7 +47,7 @@ typedef struct __svc_local svc_local_t;
             if (!new_xdata) {                                                  \
                 gf_log(this->name, GF_LOG_ERROR,                               \
                        "failed to allocate new dict");                         \
-                op_ret = -1;                                                   \
+                op_ret = gf_error;                                             \
                 op_errno = ENOMEM;                                             \
                 goto label;                                                    \
             }                                                                  \
@@ -55,7 +55,7 @@ typedef struct __svc_local svc_local_t;
         ret = dict_set_str(xdata, "entry-point", "true");                      \
         if (ret) {                                                             \
             gf_log(this->name, GF_LOG_ERROR, "failed to set dict");            \
-            op_ret = -1;                                                       \
+            op_ret = gf_error;                                                 \
             op_errno = ENOMEM;                                                 \
             goto label;                                                        \
         }                                                                      \
@@ -69,7 +69,7 @@ typedef struct __svc_local svc_local_t;
             gf_log(this->name, GF_LOG_ERROR,                                   \
                    "inode context not found for gfid %s",                      \
                    uuid_utoa(inode->gfid));                                    \
-            op_ret = -1;                                                       \
+            op_ret = gf_error;                                                 \
             op_errno = EINVAL;                                                 \
             goto label;                                                        \
         }                                                                      \

--- a/xlators/features/snapview-server/src/snapview-server-mgmt.c
+++ b/xlators/features/snapview-server/src/snapview-server-mgmt.c
@@ -279,7 +279,7 @@ mgmt_get_snapinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (rsp.op_ret < 0) {
         errno = rsp.op_errno;
         ret = -1;
         goto out;

--- a/xlators/features/snapview-server/src/snapview-server.h
+++ b/xlators/features/snapview-server/src/snapview-server.h
@@ -100,7 +100,7 @@
                        "failed to get the handle for %s "                      \
                        "(gfid: %s)",                                           \
                        loc->path, uuid_utoa_r(loc->inode->gfid, tmp_uuid));    \
-                ret = -1;                                                      \
+                ret = gf_error;                                                \
                 goto label;                                                    \
             }                                                                  \
                                                                                \

--- a/xlators/features/thin-arbiter/src/thin-arbiter.c
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.c
@@ -92,7 +92,7 @@ ta_release_fop(ta_fop_t *fop)
 
 int32_t
 ta_set_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     TA_STACK_UNWIND(xattrop, frame, op_ret, op_errno, dict, xdata);
@@ -130,14 +130,14 @@ ta_verify_on_disk_source(ta_fop_t *fop, dict_t *dict)
 
 int32_t
 ta_get_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     ta_fop_t *fop = NULL;
     int ret = 0;
 
     fop = frame->local;
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -160,7 +160,7 @@ ta_get_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
     return -1;
 }
 
@@ -226,7 +226,7 @@ ta_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, -ret, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, -ret, NULL, NULL);
     return 0;
 }
 
@@ -250,7 +250,7 @@ ta_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, -ret, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, -ret, NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/thin-arbiter/src/thin-arbiter.h
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.h
@@ -29,7 +29,7 @@
 #define TA_STACK_UNWIND(fop, frame, op_ret, op_errno, params...)               \
     do {                                                                       \
         ta_fop_t *__local = NULL;                                              \
-        int32_t __op_ret = 0;                                                  \
+        gf_return_t __op_ret = gf_success;                                     \
         int32_t __op_errno = 0;                                                \
                                                                                \
         __local = frame->local;                                                \

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -20,18 +20,19 @@
 
 int32_t
 trash_truncate_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata);
 
 int32_t
 trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *stbuf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata);
@@ -296,7 +297,7 @@ wipe_eliminate_path(trash_elim_path **trav)
  */
 int32_t
 trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -308,7 +309,7 @@ trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "rename trash directory "
                "failed: %s",
@@ -320,7 +321,7 @@ trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv->oldtrash_dir = gf_strdup(priv->newtrash_dir);
     if (!priv->oldtrash_dir) {
-        op_ret = ENOMEM;
+        SET_RET(op_ret, ENOMEM);
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
     }
 
@@ -328,7 +329,7 @@ out:
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int
@@ -415,14 +416,15 @@ out:
 
 int32_t
 trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, struct iatt *preparent,
-                            struct iatt *postparent, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf,
+                            struct iatt *preparent, struct iatt *postparent,
+                            dict_t *xdata)
 {
     trash_local_t *local = NULL;
     local = frame->local;
 
-    if (op_ret != 0 && !(op_errno == EEXIST))
+    if (IS_ERROR(op_ret) && !(op_errno == EEXIST))
         gf_log(this->name, GF_LOG_ERROR,
                "mkdir failed for "
                "internal op directory : %s",
@@ -431,7 +433,7 @@ trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -443,7 +445,7 @@ trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -454,13 +456,13 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         priv->oldtrash_dir = gf_strdup(priv->newtrash_dir);
         if (!priv->oldtrash_dir) {
             gf_log(this->name, GF_LOG_ERROR, "out of memory");
-            op_ret = ENOMEM;
+            SET_RET(op_ret, ENOMEM);
         }
-    } else if (op_ret != 0 && errno != EEXIST)
+    } else if (IS_ERROR(op_ret) && errno != EEXIST)
         gf_log(this->name, GF_LOG_ERROR,
                "mkdir failed for trash"
                " directory : %s",
@@ -469,7 +471,7 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -478,7 +480,7 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_dir_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     data_t *data = NULL;
@@ -531,7 +533,7 @@ out:
  */
 int32_t
 trash_internalop_dir_lookup_cbk(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, inode_t *inode,
                                 struct iatt *buf, dict_t *xdata,
                                 struct iatt *postparent)
@@ -552,7 +554,7 @@ trash_internalop_dir_lookup_cbk(call_frame_t *frame, void *cookie,
     GF_VALIDATE_OR_GOTO("trash", priv, out);
 
     local = frame->local;
-    if (op_ret != 0 && op_errno == ENOENT) {
+    if (IS_ERROR(op_ret) && op_errno == ENOENT) {
         loc_wipe(&local->loc);
         gfid_ptr = GF_MALLOC(sizeof(uuid_t), gf_common_mt_uuid_t);
         if (!gfid_ptr) {
@@ -607,7 +609,7 @@ out:
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -617,7 +619,7 @@ out:
  */
 int32_t
 trash_dir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     trash_private_t *priv = NULL;
@@ -635,7 +637,7 @@ trash_dir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
 
     loc_wipe(&local->loc);
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "inode found with gfid %s",
                uuid_utoa(buf->ia_gfid));
 
@@ -801,7 +803,7 @@ out:
 
 int32_t
 trash_common_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *buf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata)
 {
@@ -812,7 +814,7 @@ trash_common_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_common_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata)
@@ -824,8 +826,9 @@ trash_common_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_common_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                       struct iatt *postparent, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *preparent, struct iatt *postparent,
+                       dict_t *xdata)
 {
     STACK_UNWIND_STRICT(rmdir, frame, op_ret, op_errno, preparent, postparent,
                         xdata);
@@ -837,7 +840,7 @@ trash_common_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_common_unwind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         struct iatt *preparent, struct iatt *postparent,
                         dict_t *xdata)
 {
@@ -853,7 +856,7 @@ trash_common_unwind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *stbuf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata)
 {
@@ -892,7 +895,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     loop_count = local->loop_count;
 
     /* The directory is not present , need to create it */
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -944,7 +947,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* Given path is created , comparing to the required path */
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         dir_name = dirname(tmp_str);
         if (strcmp((char *)cookie, dir_name) == 0) {
             /* File path exists we can rename it*/
@@ -957,7 +960,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR((op_ret)) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore unlinking %s without moving to trash "
@@ -1037,7 +1040,7 @@ out:
  */
 int32_t
 trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata)
@@ -1063,7 +1066,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         /* the file path does not exist we want to create path
          * for the file
          */
@@ -1106,7 +1109,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOTDIR)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTDIR)) {
         /* if entry is already present in trash directory,
          * new one is not copied*/
         gf_log(this->name, GF_LOG_DEBUG,
@@ -1119,7 +1122,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == EISDIR)) {
+    if (IS_ERROR((op_ret)) && (op_errno == EISDIR)) {
         /* if entry is directory,we remove directly */
         gf_log(this->name, GF_LOG_DEBUG,
                "target(%s) exists as directory, cannot keep copy, "
@@ -1172,14 +1175,14 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        " GF_RESPONSE_LINK_COUNT_XDATA");
             }
         ctr_out:
-            TRASH_STACK_UNWIND(unlink, frame, 0, op_errno, preoldparent,
-                               postoldparent, new_xdata);
+            TRASH_STACK_UNWIND(unlink, frame, gf_success, op_errno,
+                               preoldparent, postoldparent, new_xdata);
             goto out;
         }
     }
     /* All other cases, unlink should return success */
-    TRASH_STACK_UNWIND(unlink, frame, 0, op_errno, preoldparent, postoldparent,
-                       xdata);
+    TRASH_STACK_UNWIND(unlink, frame, gf_success, op_errno, preoldparent,
+                       postoldparent, xdata);
 out:
 
     if (tmp_str)
@@ -1197,7 +1200,7 @@ out:
  */
 int32_t
 trash_common_unwind_buf_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata)
 {
@@ -1208,7 +1211,7 @@ trash_common_unwind_buf_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_unlink_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                       dict_t *xdata)
 {
     trash_private_t *priv = NULL;
@@ -1224,7 +1227,7 @@ trash_unlink_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "%s: %s", local->loc.path,
                strerror(op_errno));
         TRASH_STACK_UNWIND(unlink, frame, op_ret, op_errno, buf, NULL, xdata);
@@ -1346,7 +1349,7 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(unlink, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(unlink, frame, gf_error, ENOMEM, NULL, NULL, xdata);
         ret = ENOMEM;
         goto out;
     }
@@ -1390,7 +1393,7 @@ out:
  */
 int32_t
 trash_truncate_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
 {
@@ -1399,7 +1402,7 @@ trash_truncate_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "deleting the newly created file: %s",
                strerror(op_errno));
     }
@@ -1416,16 +1419,17 @@ out:
  */
 int32_t
 trash_truncate_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                         int32_t count, struct iatt *stbuf,
-                         struct iobref *iobuf, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iovec *vector, int32_t count,
+                         struct iatt *stbuf, struct iobref *iobuf,
+                         dict_t *xdata)
 {
     trash_local_t *local = NULL;
 
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG,
                "readv on the existing file failed: %s", strerror(op_errno));
 
@@ -1448,15 +1452,16 @@ out:
  */
 int32_t
 trash_truncate_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata)
 {
     trash_local_t *local = NULL;
 
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG,
                "writev on the existing file failed: %s", strerror(op_errno));
@@ -1489,7 +1494,7 @@ out:
  */
 int32_t
 trash_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, fd_t *fd,
+                        gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                         dict_t *xdata)
 {
     trash_local_t *local = NULL;
@@ -1497,7 +1502,7 @@ trash_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG, "open on the existing file failed: %s",
                strerror(op_errno));
@@ -1525,7 +1530,7 @@ out:
  */
 int32_t
 trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, fd_t *fd,
+                          gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                           inode_t *inode, struct iatt *buf,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
@@ -1554,7 +1559,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* Checks whether path is present in trash directory or not */
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         /* Creating the directory structure here. */
         tmp_str = gf_strdup(local->newpath);
         if (!tmp_str) {
@@ -1591,7 +1596,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved.
          * Deleting the newly created copy.
          */
@@ -1631,7 +1636,7 @@ out:
  */
 int32_t
 trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *stbuf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata)
 {
@@ -1671,7 +1676,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -1721,7 +1726,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         dir_name = dirname(tmp_str);
         if (strcmp((char *)cookie, dir_name) == 0) {
             flags = O_CREAT | O_EXCL | O_WRONLY;
@@ -1741,7 +1746,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR((op_ret)) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore truncating %s without moving the "
@@ -1815,7 +1820,7 @@ out:
 
 int32_t
 trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         dict_t *xdata)
 {
     trash_private_t *priv = NULL;
@@ -1842,7 +1847,7 @@ trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     pthread_mutex_unlock(&table->lock);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "fstat on the file failed: %s",
                strerror(op_errno));
 
@@ -2007,7 +2012,8 @@ trash_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(truncate, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(truncate, frame, gf_error, ENOMEM, NULL, NULL,
+                           xdata);
         ret = ENOMEM;
         goto out;
     }
@@ -2095,7 +2101,8 @@ trash_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(ftruncate, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(ftruncate, frame, gf_error, ENOMEM, NULL, NULL,
+                           xdata);
         ret = -1;
         goto out;
     }
@@ -2129,7 +2136,7 @@ int32_t
 trash_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
             mode_t umask, dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2141,7 +2148,7 @@ trash_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                "mkdir issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(mkdir, frame, op_ret, op_errno, NULL, NULL, NULL,
                             NULL, xdata);
@@ -2162,7 +2169,7 @@ int
 trash_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
              dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2174,7 +2181,7 @@ trash_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
                "rename issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, NULL, NULL, NULL,
                             NULL, NULL, xdata);
@@ -2195,7 +2202,7 @@ int32_t
 trash_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
             dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2207,7 +2214,7 @@ trash_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
                "rmdir issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(rmdir, frame, op_ret, op_errno, NULL, NULL, xdata);
     } else {

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -28,8 +28,8 @@
 #include <glusterfs/defaults.h>
 
 static int32_t
-up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -40,7 +40,7 @@ up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -74,15 +74,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -91,7 +91,7 @@ up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -128,15 +128,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, struct iovec *vector, int count, struct iatt *stbuf,
-             struct iobref *iobref, dict_t *xdata)
+up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, struct iovec *vector, int count,
+             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -147,7 +147,7 @@ up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -182,13 +182,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 static int32_t
-up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -200,7 +201,7 @@ up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -233,15 +234,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                dict_t *xdata)
+up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                struct iatt *postbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -252,7 +253,7 @@ up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -287,15 +288,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *statpre, struct iatt *statpost,
-               dict_t *xdata)
+up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *statpre,
+               struct iatt *statpost, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -306,7 +307,7 @@ up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     /* XXX: setattr -> UP_SIZE or UP_OWN or UP_MODE or UP_TIMES
@@ -355,16 +356,17 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *stbuf, struct iatt *preoldparent,
-              struct iatt *postoldparent, struct iatt *prenewparent,
-              struct iatt *postnewparent, dict_t *xdata)
+up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
+              struct iatt *preoldparent, struct iatt *postoldparent,
+              struct iatt *prenewparent, struct iatt *postnewparent,
+              dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -375,7 +377,7 @@ up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_RENAME_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -423,16 +425,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    UPCALL_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -443,7 +445,7 @@ up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -482,15 +484,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-            int op_errno, inode_t *inode, struct iatt *stbuf,
-            struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int op_errno, inode_t *inode,
+            struct iatt *stbuf, struct iatt *preparent, struct iatt *postparent,
+            dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -501,7 +504,7 @@ up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -540,16 +543,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    UPCALL_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     return 0;
 }
 
 static int32_t
-up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, struct iatt *preparent, struct iatt *postparent,
-             dict_t *xdata)
+up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -560,7 +563,7 @@ up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -600,15 +603,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, inode_t *inode, struct iatt *stbuf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, inode_t *inode,
+             struct iatt *stbuf, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -619,7 +623,7 @@ up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -660,16 +664,17 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+              struct iatt *stbuf, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -680,7 +685,7 @@ up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -724,16 +729,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    UPCALL_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, inode_t *inode, struct iatt *stbuf, dict_t *xattr,
-              struct iatt *postparent)
+up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, inode_t *inode,
+              struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -744,7 +749,7 @@ up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -778,14 +783,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 static int32_t
-up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, struct iatt *buf, dict_t *xdata)
+up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+            dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -796,7 +803,7 @@ up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -829,7 +836,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -854,7 +861,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -880,14 +887,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, dict_t *xdata)
+up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -898,7 +905,7 @@ up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -932,15 +939,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
-up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, const char *path, struct iatt *stbuf,
-                dict_t *xdata)
+up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, const char *path,
+                struct iatt *stbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -951,7 +958,7 @@ up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -985,15 +992,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1004,7 +1012,7 @@ up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1045,15 +1053,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1066,7 +1074,7 @@ up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1107,15 +1115,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1126,7 +1134,7 @@ up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1160,14 +1168,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+              dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1178,7 +1187,7 @@ up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1211,14 +1220,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+               gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1230,7 +1239,7 @@ up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1264,14 +1273,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                 dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1284,7 +1293,7 @@ up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1327,7 +1336,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -1353,14 +1362,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                  struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1372,7 +1381,7 @@ up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1407,14 +1416,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *pre,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1426,7 +1435,7 @@ up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1460,14 +1469,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                 struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1479,7 +1488,7 @@ up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1513,14 +1522,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-            int op_errno, off_t offset, dict_t *xdata)
+up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int op_errno, off_t offset, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1531,7 +1540,7 @@ up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1565,14 +1574,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(seek, frame, -1, op_errno, 0, NULL);
+    UPCALL_STACK_UNWIND(seek, frame, gf_error, op_errno, 0, NULL);
 
     return 0;
 }
 
 static int32_t
 up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1591,7 +1600,7 @@ up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1599,7 +1608,7 @@ up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1639,14 +1648,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1665,7 +1674,7 @@ up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1673,7 +1682,7 @@ up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1713,14 +1722,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1739,14 +1748,14 @@ up_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1796,14 +1805,14 @@ err:
     if (xattr)
         dict_unref(xattr);
 
-    UPCALL_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1822,14 +1831,14 @@ up_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1879,14 +1888,15 @@ err:
     if (xattr)
         dict_unref(xattr);
 
-    UPCALL_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                 dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1897,7 +1907,7 @@ up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1929,13 +1939,14 @@ out:
                FIRST_CHILD(this)->fops->fgetxattr, fd, name, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
 static int32_t
 up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1946,7 +1957,7 @@ up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1978,7 +1989,7 @@ out:
                FIRST_CHILD(this)->fops->getxattr, loc, name, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(getxattr, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2011,7 +2022,8 @@ err:
  */
 static int32_t
 up_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+               dict_t *xdata)
 {
     client_t *client = NULL;
     upcall_local_t *local = NULL;
@@ -2021,7 +2033,7 @@ up_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -2071,7 +2083,7 @@ out:
                FIRST_CHILD(this)->fops->xattrop, loc, optype, xattr, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2105,7 +2117,7 @@ out:
                FIRST_CHILD(this)->fops->fxattrop, fd, optype, xattr, xdata);
     return 0;
 err:
-    STACK_UNWIND_STRICT(fxattrop, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(fxattrop, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2188,6 +2200,7 @@ up_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
 {
     upcall_private_t *priv = NULL;
     int ret = 0;
+    gf_return_t op_ret;
 
     priv = this->private;
     GF_VALIDATE_OR_GOTO(this->name, priv, out);
@@ -2205,7 +2218,8 @@ up_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     }
 
 out:
-    STACK_UNWIND_STRICT(ipc, frame, ret, 0, NULL);
+    SET_RET(op_ret, ret);
+    STACK_UNWIND_STRICT(ipc, frame, op_ret, 0, NULL);
     return 0;
 
 wind:

--- a/xlators/features/utime/src/utime-gen-fops-c.py
+++ b/xlators/features/utime/src/utime-gen-fops-c.py
@@ -26,7 +26,7 @@ gf_utime_@NAME@ (call_frame_t *frame, xlator_t *this,
 FOPS_CBK_COMMON_TEMPLATE = """
 int32_t
 gf_utime_@NAME@_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno,
+                     gf_return_t op_ret, int32_t op_errno,
                     @LONG_ARGS@)
 {
         STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno, @SHORT_ARGS@);

--- a/xlators/lib/src/libxlator.h
+++ b/xlators/lib/src/libxlator.h
@@ -27,9 +27,9 @@
 #define MARKER_UUID_TYPE 1
 #define MARKER_XTIME_TYPE 2
 
-typedef int32_t (*xlator_specf_unwind_t)(call_frame_t *frame, int op_ret,
-                                         int op_errno, dict_t *dict,
-                                         dict_t *xdata);
+typedef int32_t (*xlator_specf_unwind_t)(call_frame_t *frame,
+                                         gf_return_t op_ret, int op_errno,
+                                         dict_t *dict, dict_t *xdata);
 
 struct volume_mark {
     uint8_t major;
@@ -122,11 +122,13 @@ typedef struct marker_str xl_marker_local_t;
 
 int32_t
 cluster_markerxtime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, dict_t *dict, dict_t *xdata);
+                        gf_return_t op_ret, int op_errno, dict_t *dict,
+                        dict_t *xdata);
 
 int32_t
 cluster_markeruuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *dict, dict_t *xdata);
+                       gf_return_t op_ret, int op_errno, dict_t *dict,
+                       dict_t *xdata);
 
 int
 cluster_handle_marker_getxattr(call_frame_t *frame, loc_t *loc,

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -241,7 +241,7 @@ meta_inode_discover(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     meta_iatt_fill(&iatt, loc->inode, loc->inode->ia_type);
 
-    META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
+    META_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &iatt, xdata,
                       &postparent);
     return 0;
 }

--- a/xlators/meta/src/meta.c
+++ b/xlators/meta/src/meta.c
@@ -30,8 +30,8 @@ meta_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         meta_iatt_fill(&iatt, loc->inode, IA_IFDIR);
         gf_uuid_parse(META_ROOT_GFID, iatt.ia_gfid);
 
-        META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
-                          &parent);
+        META_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &iatt,
+                          xdata, &parent);
         return 0;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5409,7 +5409,7 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     GD_SYNCOP(rpc, (&args), NULL, gd_syncop_brick_op_cbk, brick_req,
               &gd_brick_prog, brick_req->op, xdr_gd1_mgmt_brick_op_req);
 
-    if (args.op_ret)
+    if (IS_ERROR(args.op_ret))
         goto out;
 
     ret = dict_get_int32n(args.dict, "clientcount", SLEN("clientcount"),

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -49,7 +49,7 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
     GF_ASSERT(uuid);
 
     if (op_ret) {
-        args->op_ret = op_ret;
+        SET_RET(args->op_ret, op_ret);
         args->op_errno = op_errno;
 
         RCU_READ_LOCK;
@@ -754,7 +754,7 @@ glusterd_mgmt_v3_initiate_lockdown(glusterd_op_t op, dict_t *dict,
     if (args.errstr)
         *op_errstr = gf_strdup(args.errstr);
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -1108,7 +1108,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PRE_VALIDATION_FAIL,
                "Pre Validation failed on peers");
 
@@ -1116,7 +1116,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -1461,7 +1461,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BRICK_OP_FAIL,
                "Brick ops failed on peers");
 
@@ -1469,7 +1469,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent brick op req for %s "
@@ -1745,7 +1745,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMIT_OP_FAIL,
                "Commit failed on peers");
 
@@ -1753,7 +1753,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -2013,7 +2013,7 @@ glusterd_mgmt_v3_post_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_COMMIT_OP_FAIL,
                "Post commit failed on peers");
 
@@ -2021,7 +2021,7 @@ glusterd_mgmt_v3_post_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -2242,7 +2242,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_VALIDATION_FAIL,
                "Post Validation failed on peers");
 
@@ -2250,7 +2250,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent post valaidation req for %s "
@@ -2431,7 +2431,7 @@ glusterd_mgmt_v3_release_peer_locks(glusterd_op_t op, dict_t *dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
                "Unlock failed on peers");
 
@@ -2439,7 +2439,7 @@ glusterd_mgmt_v3_release_peer_locks(glusterd_op_t op, dict_t *dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent unlock op req for %s "

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -6502,7 +6502,7 @@ glusterd_take_brick_snapshot_cbk(int ret, call_frame_t *frame, void *opaque)
     args = snap_args->args;
 
     if (ret)
-        args->op_ret = ret;
+        SET_RET(args->op_ret, ret);
 
     GF_FREE(opaque);
     synctask_barrier_wake(args);
@@ -6616,11 +6616,11 @@ glusterd_schedule_brick_snapshot(dict_t *dict, dict_t *rsp_dict,
     synctask_barrier_wait((&args), taskcount);
     taskcount = 0;
 
-    if (args.op_ret)
+    if (IS_ERROR(args.op_ret))
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_CREATION_FAIL,
                "Failed to create snapshot");
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 out:
     if (ret && taskcount)
         synctask_barrier_wait((&args), taskcount);

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -2663,7 +2663,7 @@ static volgen_brick_xlator_t server_graph_table[] = {
     {brick_graph_add_posix, "posix"},
 };
 
-static glusterd_server_xlator_t
+static gf_xlator_list_t
 get_server_xlator(char *xlator)
 {
     int i = 0;

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.h
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.h
@@ -115,21 +115,6 @@ typedef enum gd_volopt_flags_ {
     VOLOPT_FLAG_NEVER_RESET = 0x08, /* option which should not be reset */
 } gd_volopt_flags_t;
 
-typedef enum {
-    GF_XLATOR_POSIX = 0,
-    GF_XLATOR_ACL,
-    GF_XLATOR_LOCKS,
-    GF_XLATOR_LEASES,
-    GF_XLATOR_UPCALL,
-    GF_XLATOR_IOT,
-    GF_XLATOR_INDEX,
-    GF_XLATOR_MARKER,
-    GF_XLATOR_IO_STATS,
-    GF_XLATOR_BD,
-    GF_XLATOR_SERVER,
-    GF_XLATOR_NONE,
-} glusterd_server_xlator_t;
-
 /* As of now debug xlators can be loaded only below fuse in the client
  * graph via cli. More xlators can be added below when the cli option
  * for adding debug xlators anywhere in the client graph has to be made

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -371,14 +371,14 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
                 gf_log_eh(                                                     \
                     "op_ret: %d, op_errno: %d, "                               \
                     "%" PRIu64 ", %s () => %p, gfid: %s",                      \
-                    op_ret, op_errno, frame->root->unique,                     \
+                    GET_RET(op_ret), op_errno, frame->root->unique,            \
                     gf_fop_list[frame->root->op], state->fd,                   \
                     uuid_utoa(state->fd->inode->gfid));                        \
             else                                                               \
                 gf_log_eh(                                                     \
                     "op_ret: %d, op_errno: %d, "                               \
                     "%" PRIu64 ", %s () => %s, gfid: %s",                      \
-                    op_ret, op_errno, frame->root->unique,                     \
+                    GET_RET(op_ret), op_errno, frame->root->unique,            \
                     gf_fop_list[frame->root->op], state->loc.path,             \
                     uuid_utoa(state->loc.gfid));                               \
         }                                                                      \
@@ -418,7 +418,7 @@ typedef struct {
     inode_t *hint;
     u_char pargfid[16];
     inode_t *parhint;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     loc_t resolve_loc;
 } fuse_resolve_t;

--- a/xlators/nfs/server/src/acl3.c
+++ b/xlators/nfs/server/src/acl3.c
@@ -257,7 +257,8 @@ acl3_setacl_reply(rpcsvc_request_t *req, setaclreply *reply)
  */
 int
 acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
     nfs3_call_state_t *cs = NULL;
@@ -273,7 +274,7 @@ acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR(op_ret) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -321,7 +322,7 @@ err:
  */
 int
 acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *dict,
+                        gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
@@ -342,7 +343,7 @@ acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR(op_ret) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -389,8 +390,9 @@ err:
 }
 
 int
-acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
     nfs3_call_state_t *cs = NULL;
@@ -410,7 +412,7 @@ acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     }
@@ -538,11 +540,11 @@ rpcerr:
 
 int
 acl3_setacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     nfs3_call_state_t *cs = NULL;
     cs = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         nfsstat3 status = nfs3_cbk_errno_status(op_ret, op_errno);
         cs->args.setaclreply.status = status;
     }

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -265,7 +265,7 @@ err:
 #define nfs_fop_restore_root_ino(locl, fopret, preattr, postattr, prepar,      \
                                  postpar)                                      \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
         if ((locl)->rootinode) {                                               \
             if ((preattr)) {                                                   \
@@ -302,7 +302,7 @@ err:
 #define nfs_fop_newloc_restore_root_ino(locl, fopret, preattr, postattr,       \
                                         prepar, postpar)                       \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
                                                                                \
         if ((locl)->newrootinode) {                                            \
@@ -397,13 +397,13 @@ nfs_gfid_dict(inode_t *inode)
 
 int32_t
 nfs_fop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xattr, struct iatt *postparent)
 {
     struct nfs_fop_local *local = NULL;
     fop_lookup_cbk_t progcbk;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -449,7 +449,7 @@ err:
 
 int32_t
 nfs_fop_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_access_cbk_t progcbk = NULL;
@@ -494,7 +494,7 @@ err:
 
 int32_t
 nfs_fop_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -539,7 +539,7 @@ err:
 
 int32_t
 nfs_fop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -585,7 +585,8 @@ err:
 
 int32_t
 nfs_fop_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_opendir_cbk_t progcbk = NULL;
@@ -627,7 +628,7 @@ err:
 
 int
 nfs_fop_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_flush_cbk_t progcbk = NULL;
@@ -668,7 +669,7 @@ err:
 
 int32_t
 nfs_fop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -714,7 +715,7 @@ err:
 
 int32_t
 nfs_fop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -757,14 +758,14 @@ err:
 
 int32_t
 nfs_fop_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_create_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -811,7 +812,7 @@ err:
 
 int32_t
 nfs_fop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -856,14 +857,14 @@ err:
 
 int32_t
 nfs_fop_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_mkdir_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -907,14 +908,14 @@ err:
 
 int32_t
 nfs_fop_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_symlink_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -958,7 +959,7 @@ err:
 
 int32_t
 nfs_fop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1002,14 +1003,14 @@ err:
 
 int32_t
 nfs_fop_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_mknod_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -1053,7 +1054,7 @@ err:
 
 int32_t
 nfs_fop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
@@ -1098,7 +1099,7 @@ err:
 
 int32_t
 nfs_fop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
@@ -1143,14 +1144,14 @@ err:
 
 int32_t
 nfs_fop_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_link_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -1194,7 +1195,7 @@ err:
 
 int32_t
 nfs_fop_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -1249,7 +1250,7 @@ err:
 
 int32_t
 nfs_fop_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
@@ -1291,7 +1292,7 @@ err:
 
 int32_t
 nfs_fop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1360,7 +1361,7 @@ err:
 
 int32_t
 nfs_fop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1404,7 +1405,7 @@ err:
 
 int32_t
 nfs_fop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -1450,7 +1451,7 @@ err:
 
 int32_t
 nfs_fop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1458,7 +1459,7 @@ nfs_fop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl_to_prog_data(nfl, progcbk, frame);
 
-    if (!op_ret)
+    if (IS_SUCCESS(op_ret))
         fd_lk_insert_and_merge(nfl->fd, nfl->cmd, &nfl->flock);
 
     fd_unref(nfl->fd);
@@ -1502,7 +1503,7 @@ err:
 
 int32_t
 nfs_fop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1545,7 +1546,7 @@ err:
 
 int32_t
 nfs_fop_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_setxattr_cbk_t progcbk = NULL;
@@ -1588,7 +1589,7 @@ err:
 
 int32_t
 nfs_fop_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -52,15 +52,15 @@ nfl_inodes_init(struct nfs_fop_local *nfl, inode_t *inode, inode_t *parent,
 
 int32_t
 nfs_inode_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                     struct iatt *buf, struct iatt *preparent,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
     fop_create_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -122,7 +122,7 @@ err:
 
 int32_t
 nfs_inode_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -130,7 +130,7 @@ nfs_inode_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_mkdir_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -172,12 +172,13 @@ err:
 
 int32_t
 nfs_inode_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if ((op_ret == -1) && (fd))
+    if ((IS_ERROR(op_ret)) && (fd))
         fd_unref(fd);
     /* Not needed here since the fd is cached in higher layers and the bind
      * must happen atomically when the fd gets added to the fd LRU.
@@ -229,7 +230,7 @@ err:
 
 int32_t
 nfs_inode_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -238,7 +239,7 @@ nfs_inode_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_rename_cbk_t progcbk = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     inode_rename(this->itable, nfl->parent, nfl->path, nfl->newparent,
@@ -277,7 +278,7 @@ err:
 
 int32_t
 nfs_inode_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -285,7 +286,7 @@ nfs_inode_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_link_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     nfl = frame->local;
@@ -328,15 +329,16 @@ err:
 
 int32_t
 nfs_inode_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_unlink_cbk_t progcbk = NULL;
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -374,15 +376,16 @@ err:
 
 int32_t
 nfs_inode_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_rmdir_cbk_t progcbk = NULL;
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -421,7 +424,7 @@ err:
 
 int32_t
 nfs_inode_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -431,7 +434,7 @@ nfs_inode_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -476,7 +479,7 @@ err:
 
 int32_t
 nfs_inode_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -485,7 +488,7 @@ nfs_inode_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode_t *linked_inode = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -529,12 +532,13 @@ err:
 
 int32_t
 nfs_inode_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if (op_ret != -1)
+    if (IS_SUCCESS(op_ret))
         fd_bind(fd);
 
     inodes_nfl_to_prog_data(nfl, progcbk, frame);

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -469,11 +469,11 @@ unlock:
 
 int32_t
 nfs_start_subvol_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, dict_t *xattr,
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf, dict_t *xattr,
                             struct iatt *postparent)
 {
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Failed to lookup root: %s", strerror(op_errno));
         goto err;

--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -251,9 +251,9 @@ nfs3_errno_to_nfsstat3(int errnum)
  * happens by any means, then set NFS3 status to NFS3ERR_SERVERFAULT.
  */
 nfsstat3
-nfs3_cbk_errno_status(int32_t op_ret, int32_t op_errno)
+nfs3_cbk_errno_status(gf_return_t op_ret, int32_t op_errno)
 {
-    if ((op_ret == -1) && (op_errno == 0)) {
+    if (IS_ERROR(op_ret) && (op_errno == 0)) {
         return NFS3ERR_SERVERFAULT;
     }
 
@@ -3522,7 +3522,7 @@ err:
 
 int32_t
 nfs3_fh_resolve_entry_lookup_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, dict_t *xattr,
                                  struct iatt *postparent)
@@ -3531,10 +3531,10 @@ nfs3_fh_resolve_entry_lookup_cbk(call_frame_t *frame, void *cookie,
     inode_t *linked_inode = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3570,7 +3570,7 @@ err:
 
 int32_t
 nfs3_fh_resolve_inode_lookup_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, dict_t *xattr,
                                  struct iatt *postparent)
@@ -3579,10 +3579,10 @@ nfs3_fh_resolve_inode_lookup_cbk(call_frame_t *frame, void *cookie,
     inode_t *linked_inode = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3778,7 +3778,7 @@ err_resume_call:
 
 int32_t
 nfs3_fh_resolve_root_lookup_cbk(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, inode_t *inode,
                                 struct iatt *buf, dict_t *xattr,
                                 struct iatt *postparent)
@@ -3786,10 +3786,10 @@ nfs3_fh_resolve_root_lookup_cbk(call_frame_t *frame, void *cookie,
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Root lookup failed: %s", strerror(op_errno));
         goto err;

--- a/xlators/nfs/server/src/nfs3-helpers.h
+++ b/xlators/nfs/server/src/nfs3-helpers.h
@@ -30,7 +30,7 @@ nfs3_extract_lookup_name(lookup3args *args);
 extern nfsstat3
 nfs3_errno_to_nfsstat3(int errnum);
 
-extern nfsstat3 nfs3_cbk_errno_status(int32_t, int32_t);
+extern nfsstat3 nfs3_cbk_errno_status(gf_return_t, int32_t);
 
 extern void
 nfs3_fill_lookup3res(lookup3res *res, nfsstat3 stat, struct nfs3_fh *newfh,

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -523,13 +523,14 @@ typedef int (*nlm4_resume_fn_t)(void *cs);
 
 int32_t
 nlm4_file_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     nfs3_call_state_t *cs = frame->local;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         fd_bind(cs->fd);
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resume_fn(cs);
 
     frame->local = NULL;
@@ -779,14 +780,14 @@ nlm4_test_reply(nfs3_call_state_t *cs, nlm4_stats stat, struct gf_flock *flock)
 
 int
 nlm4svc_test_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                  dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else if (flock->l_type == F_UNLCK)
@@ -1391,7 +1392,7 @@ ret:
 
 int
 nlm4svc_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                  dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
@@ -1405,7 +1406,7 @@ nlm4svc_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     caller_name = cs->args.nlm4_lockargs.alock.caller_name;
     transit_cnt = nlm_dec_transit_count(cs->fd, caller_name);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (transit_cnt == 0)
             nlm_search_and_delete(cs->fd, &cs->args.nlm4_lockargs.alock);
         stat = nlm4_errno_to_nlm4stat(op_errno);
@@ -1595,14 +1596,14 @@ nlm4svc_nm_lock(rpcsvc_request_t *req)
 
 int
 nlm4svc_cancel_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                    dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {
@@ -1754,14 +1755,14 @@ rpcerr:
 
 int
 nlm4svc_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                    dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = GF_REF_GET((nfs3_call_state_t *)frame->local);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {

--- a/xlators/performance/io-cache/src/io-cache.h
+++ b/xlators/performance/io-cache/src/io-cache.h
@@ -70,7 +70,7 @@ struct ioc_local {
     loc_t file_loc;
     off_t offset;
     size_t size;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     struct list_head fill_list; /* list of ioc_fill structures */
     off_t pending_offset;       /*
@@ -178,9 +178,9 @@ ptr_to_str(void *ptr);
 
 int32_t
 ioc_readv_disabled_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                       int32_t count, struct iatt *stbuf, struct iobref *iobref,
-                       dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iovec *vector, int32_t count, struct iatt *stbuf,
+                       struct iobref *iobref, dict_t *xdata);
 
 ioc_page_t *
 __ioc_page_get(ioc_inode_t *ioc_inode, off_t offset);
@@ -202,7 +202,7 @@ void
 ioc_page_flush(ioc_page_t *page);
 
 ioc_waitq_t *
-__ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno);
+__ioc_page_error(ioc_page_t *page, gf_return_t op_ret, int32_t op_errno);
 
 void
 ioc_frame_return(call_frame_t *frame);

--- a/xlators/performance/io-cache/src/ioc-inode.c
+++ b/xlators/performance/io-cache/src/ioc-inode.c
@@ -73,7 +73,7 @@ ioc_inode_wakeup(call_frame_t *frame, ioc_inode_t *ioc_inode,
     GF_VALIDATE_OR_GOTO(frame->this->name, local, out);
 
     if (ioc_inode == NULL) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EINVAL;
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0, IO_CACHE_MSG_INODE_NULL,
                 NULL);

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -609,7 +609,7 @@ iot_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
     iot_conf_t *conf = NULL;
     dict_t *depths = NULL;
     int i = 0;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = {0};
     int32_t op_errno = 0;
 
     conf = this->private;
@@ -621,7 +621,7 @@ iot_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
          */
         depths = dict_new();
         if (!depths) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind_special_getxattr;
         }

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -1132,7 +1132,7 @@ mdc_prepare_request(xlator_t *this, mdc_local_t *local, dict_t *xdata)
 
 int
 mdc_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+               gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                dict_t *xdata)
 {
     struct mdc_conf *conf = this->private;
@@ -1142,7 +1142,7 @@ mdc_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         }
@@ -1163,14 +1163,15 @@ out:
 int
 mdc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
-    int ret = 0, op_ret = 0, op_errno = 0;
+    int ret = 0, op_errno = 0;
+    gf_return_t op_ret = {0};
     struct statvfs *buf = NULL;
     mdc_local_t *local = NULL;
     struct mdc_conf *conf = this->private;
 
     local = mdc_local_get(frame, loc->inode);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto out;
     }
@@ -1187,7 +1188,6 @@ mdc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     ret = mdc_load_statfs_info_from_cache(this, &buf);
     if (ret == 0 && buf) {
-        op_ret = 0;
         op_errno = 0;
         goto out;
     }
@@ -1204,7 +1204,7 @@ out:
 
 int
 mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, dict_t *dict, struct iatt *postparent)
 {
     mdc_local_t *local = NULL;
@@ -1215,7 +1215,7 @@ mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT)
             GF_ATOMIC_INC(conf->mdc_counter.negative_lookup);
 
@@ -1301,8 +1301,8 @@ mdc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &stbuf, xattr_rsp,
-                     &postparent);
+    MDC_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &stbuf,
+                     xattr_rsp, &postparent);
 
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -1326,8 +1326,9 @@ uncached:
 }
 
 int
-mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *buf, dict_t *xdata)
+mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+             dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1335,7 +1336,7 @@ mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         }
@@ -1378,7 +1379,7 @@ mdc_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         goto uncached;
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(stat, frame, 0, 0, &stbuf, xdata);
+    MDC_STACK_UNWIND(stat, frame, gf_success, 0, &stbuf, xdata);
 
     return 0;
 
@@ -1397,8 +1398,9 @@ uncached:
 }
 
 int
-mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1406,7 +1408,7 @@ mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         }
@@ -1444,7 +1446,7 @@ mdc_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         goto uncached;
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(fstat, frame, 0, 0, &stbuf, xdata);
+    MDC_STACK_UNWIND(fstat, frame, gf_success, 0, &stbuf, xdata);
 
     return 0;
 
@@ -1464,7 +1466,7 @@ uncached:
 
 int
 mdc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1474,7 +1476,7 @@ mdc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
 
@@ -1508,7 +1510,7 @@ mdc_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 int
 mdc_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1518,7 +1520,7 @@ mdc_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
 
@@ -1552,9 +1554,10 @@ mdc_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 }
 
 int
-mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1563,7 +1566,7 @@ mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1603,9 +1606,10 @@ mdc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 }
 
 int
-mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1614,7 +1618,7 @@ mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1655,7 +1659,7 @@ mdc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 int
 mdc_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1665,7 +1669,7 @@ mdc_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         /* if errno is ESTALE, parent is not present, which implies even
          * child is not present. Also, man 2 unlink states unlink can
          * return ENOENT if a component in pathname does not
@@ -1713,9 +1717,9 @@ mdc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t xflag,
 }
 
 int
-mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1724,7 +1728,7 @@ mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         /* if errno is ESTALE, parent is not present, which implies even
          * child is not present. Also, man 2 rmdir states rmdir can
          * return ENOENT if a directory component in pathname does not
@@ -1769,7 +1773,7 @@ mdc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
 
 int
 mdc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -1780,7 +1784,7 @@ mdc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1830,7 +1834,7 @@ wind:
 
 int
 mdc_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *buf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                struct iatt *preoldparent, struct iatt *postoldparent,
                struct iatt *prenewparent, struct iatt *postnewparent,
                dict_t *xdata)
@@ -1841,7 +1845,7 @@ mdc_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
             mdc_inode_iatt_invalidate(this, local->loc2.parent);
@@ -1891,9 +1895,10 @@ mdc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1902,7 +1907,7 @@ mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
             mdc_inode_iatt_invalidate(this, local->loc2.parent);
@@ -1944,7 +1949,7 @@ mdc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 int
 mdc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1955,7 +1960,7 @@ mdc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1996,8 +2001,8 @@ mdc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 }
 
 static int
-mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, fd_t *fd, dict_t *xdata)
+mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2006,7 +2011,7 @@ mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2045,9 +2050,10 @@ out:
 }
 
 int
-mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iovec *vector, int32_t count,
-              struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+              int32_t count, struct iatt *stbuf, struct iobref *iobref,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2055,7 +2061,7 @@ mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2088,7 +2094,7 @@ mdc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int
 mdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2097,7 +2103,7 @@ mdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2132,7 +2138,7 @@ mdc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
 int
 mdc_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2141,7 +2147,7 @@ mdc_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         mdc_inode_iatt_set(this, local->loc.inode, NULL, local->incident_time);
         goto out;
     }
@@ -2207,7 +2213,7 @@ wind:
 
 int
 mdc_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2216,7 +2222,7 @@ mdc_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2282,9 +2288,9 @@ wind:
 }
 
 int
-mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2292,7 +2298,7 @@ mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2325,7 +2331,7 @@ mdc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
 int
 mdc_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2340,7 +2346,7 @@ mdc_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2384,7 +2390,7 @@ mdc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr,
 
 int
 mdc_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2399,7 +2405,7 @@ mdc_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2443,7 +2449,8 @@ mdc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xattr,
 
 int
 mdc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xattr, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+                 dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2451,7 +2458,7 @@ mdc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2478,6 +2485,7 @@ mdc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
              dict_t *xdata)
 {
     int ret;
+    gf_return_t op_ret;
     int op_errno = ENODATA;
     mdc_local_t *local = NULL;
     dict_t *xattr = NULL;
@@ -2506,7 +2514,8 @@ mdc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.xattr_hit);
-    MDC_STACK_UNWIND(getxattr, frame, ret, op_errno, xattr, xdata);
+    SET_RET(op_ret, ret);
+    MDC_STACK_UNWIND(getxattr, frame, op_ret, op_errno, xattr, xdata);
 
     if (xattr)
         dict_unref(xattr);
@@ -2531,7 +2540,7 @@ uncached:
 
 int
 mdc_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                   dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2540,7 +2549,7 @@ mdc_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2567,6 +2576,7 @@ mdc_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
               dict_t *xdata)
 {
     int ret;
+    gf_return_t op_ret;
     mdc_local_t *local = NULL;
     dict_t *xattr = NULL;
     int op_errno = ENODATA;
@@ -2594,7 +2604,8 @@ mdc_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.xattr_hit);
-    MDC_STACK_UNWIND(fgetxattr, frame, ret, op_errno, xattr, xdata);
+    SET_RET(op_ret, ret);
+    MDC_STACK_UNWIND(fgetxattr, frame, op_ret, op_errno, xattr, xdata);
 
     if (xattr)
         dict_unref(xattr);
@@ -2619,7 +2630,7 @@ uncached:
 
 int
 mdc_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2634,7 +2645,7 @@ mdc_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2698,7 +2709,7 @@ mdc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         ret = -1;
         op_errno = ENODATA;
 
-        MDC_STACK_UNWIND(removexattr, frame, ret, op_errno, xdata);
+        MDC_STACK_UNWIND(removexattr, frame, gf_error, op_errno, xdata);
     } else {
         STACK_WIND(frame, mdc_removexattr_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
@@ -2718,7 +2729,7 @@ uncached:
 
 int
 mdc_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2733,7 +2744,7 @@ mdc_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2798,7 +2809,7 @@ mdc_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         ret = -1;
         op_errno = ENODATA;
 
-        MDC_STACK_UNWIND(fremovexattr, frame, ret, op_errno, xdata);
+        MDC_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, xdata);
     } else {
         STACK_WIND(frame, mdc_fremovexattr_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->fremovexattr, fd, name, xdata);
@@ -2818,7 +2829,7 @@ uncached:
 
 int32_t
 mdc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2826,7 +2837,7 @@ mdc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -2863,8 +2874,9 @@ mdc_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 }
 
 int
-mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, gf_dirent_t *entries, dict_t *xdata)
+mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                 dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     mdc_local_t *local = NULL;
@@ -2873,8 +2885,8 @@ mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (!local)
         goto unwind;
 
-    if (op_ret <= 0) {
-        if ((op_ret == -1) && ((op_errno == ENOENT) || (op_errno == ESTALE)))
+    if (GET_RET(op_ret) <= 0) {
+        if (IS_ERROR(op_ret) && ((op_errno == ENOENT) || (op_errno == ESTALE)))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto unwind;
     }
@@ -2918,13 +2930,14 @@ mdc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 out:
-    MDC_STACK_UNWIND(readdirp, frame, -1, ENOMEM, NULL, NULL);
+    MDC_STACK_UNWIND(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
 int
-mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, gf_dirent_t *entries, dict_t *xdata)
+mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2932,7 +2945,7 @@ mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -2972,13 +2985,13 @@ mdc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 unwind:
-    MDC_STACK_UNWIND(readdir, frame, -1, ENOMEM, NULL, NULL);
+    MDC_STACK_UNWIND(readdir, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
 int
 mdc_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2987,7 +3000,7 @@ mdc_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3023,7 +3036,7 @@ mdc_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
 int
 mdc_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3032,7 +3045,7 @@ mdc_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3066,7 +3079,7 @@ mdc_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int
 mdc_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3075,7 +3088,7 @@ mdc_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3109,7 +3122,7 @@ mdc_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int32_t
 mdc_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, const char *path,
+                 gf_return_t op_ret, int32_t op_errno, const char *path,
                  struct iatt *buf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3118,7 +3131,7 @@ mdc_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ENOENT) || (op_errno == ESTALE))
@@ -3146,13 +3159,13 @@ mdc_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MDC_STACK_UNWIND(readlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 mdc_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -3160,7 +3173,7 @@ mdc_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -3188,13 +3201,13 @@ mdc_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(fsyncdir, frame, -1, ENOMEM, NULL);
+    MDC_STACK_UNWIND(fsyncdir, frame, gf_error, ENOMEM, NULL);
     return 0;
 }
 
 int32_t
 mdc_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -3202,7 +3215,7 @@ mdc_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -3230,7 +3243,7 @@ mdc_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(access, frame, -1, ENOMEM, NULL);
+    MDC_STACK_UNWIND(access, frame, gf_error, ENOMEM, NULL);
     return 0;
 }
 

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -151,7 +151,7 @@ typedef struct ob_inode {
             _xl, _fd, 0, true, false, &__ob_inode, &__first_fd);               \
         switch (__ob_state) {                                                  \
             case OB_STATE_OPEN_PENDING:                                        \
-                default_flush_cbk(_frame, NULL, _xl, 0, 0, NULL);              \
+                default_flush_cbk(_frame, NULL, _xl, gf_success, 0, NULL);     \
                 break;                                                         \
                 OB_POST_COMMON(flush, _xl, _frame, __first_fd, ##_args);       \
         }                                                                      \
@@ -387,14 +387,14 @@ ob_resume_pending(struct list_head *list)
 }
 
 static void
-ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd, int32_t op_ret,
-                  int32_t op_errno)
+ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd,
+                  gf_return_t op_ret, int32_t op_errno)
 {
     struct list_head list;
 
     INIT_LIST_HEAD(&list);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         fd_ctx_set(fd, xl, op_errno <= 0 ? EIO : op_errno);
     }
 
@@ -417,7 +417,7 @@ ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd, int32_t op_ret,
 }
 
 static int32_t
-ob_open_cbk(call_frame_t *frame, void *cookie, xlator_t *xl, int32_t op_ret,
+ob_open_cbk(call_frame_t *frame, void *cookie, xlator_t *xl, gf_return_t op_ret,
             int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     ob_inode_t *ob_inode;
@@ -486,7 +486,7 @@ ob_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags, fd_t *fd,
                  *       probably this doesn't make sense since it won't contain
                  *       any requested data. I think it would be better to pass
                  *       NULL for xdata. */
-                default_open_cbk(frame, NULL, this, 0, 0, fd, xdata);
+                default_open_cbk(frame, NULL, this, gf_success, 0, fd, xdata);
 
                 return ob_open_dispatch(this, ob_inode, first_fd, stub);
             }
@@ -496,7 +496,7 @@ ob_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags, fd_t *fd,
 
         /* In case of error, simulate a regular completion but with an error
          * code. */
-        ob_open_completed(this, ob_inode, first_fd, -1, ENOMEM);
+        ob_open_completed(this, ob_inode, first_fd, gf_error, ENOMEM);
 
         state = -ENOMEM;
     }

--- a/xlators/performance/read-ahead/src/read-ahead.h
+++ b/xlators/performance/read-ahead/src/read-ahead.h
@@ -44,7 +44,7 @@ struct ra_local {
     struct ra_fill fill;
     off_t offset;
     size_t size;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     off_t pending_offset;
     size_t pending_size;
@@ -120,7 +120,7 @@ void
 ra_page_flush(ra_page_t *page);
 
 ra_waitq_t *
-ra_page_error(ra_page_t *page, int32_t op_ret, int32_t op_errno);
+ra_page_error(ra_page_t *page, gf_return_t op_ret, int32_t op_errno);
 void
 ra_page_purge(ra_page_t *page);
 

--- a/xlators/playground/rot-13/src/rot-13.c
+++ b/xlators/playground/rot-13/src/rot-13.c
@@ -46,7 +46,7 @@ rot13_iovec(struct iovec *vector, int count)
 
 int32_t
 rot13_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                 int32_t count, struct iatt *stbuf, struct iobref *iobref,
                 dict_t *xdata)
 {
@@ -71,7 +71,7 @@ rot13_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int32_t
 rot13_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -30,7 +30,7 @@ extern rpc_clnt_prog_t clnt_pmap_prog;
 int32_t
 client3_getspec(call_frame_t *frame, xlator_t *this, void *data)
 {
-    CLIENT_STACK_UNWIND(getspec, frame, -1, ENOSYS, NULL);
+    CLIENT_STACK_UNWIND(getspec, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -697,7 +697,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    int32_t op_ret = 0;
+    int op_ret = 0;
     int32_t op_errno = 0;
     gf_boolean_t auth_fail = _gf_false;
     glusterfs_ctx_t *ctx = NULL;

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -92,7 +92,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(symlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(symlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf,
                         &preparent, &postparent, xdata);
 
@@ -161,9 +163,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mknod, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mknod, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -229,9 +232,10 @@ out:
                 "Path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mkdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mkdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -367,8 +371,10 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(open, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(open, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -425,8 +431,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(stat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &iatt, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(stat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &iatt, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -484,7 +492,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.path, &iatt,
                         xdata);
 
@@ -551,9 +561,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(unlink, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(unlink, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -608,9 +619,10 @@ out:
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
-    CLIENT_STACK_UNWIND(rmdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rmdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -663,7 +675,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(truncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -715,8 +729,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &statfs, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(statfs, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &statfs, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -776,9 +792,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(writev, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -836,8 +853,10 @@ out:
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(flush, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(flush, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -893,9 +912,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsync, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -955,7 +975,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(setxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setxattr, frame, fin_ret, op_errno, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1025,7 +1047,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(getxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, xdata);
 
     /* don't use GF_FREE, this memory was allocated by libc */
     free(rsp.dict.dict_val);
@@ -1091,7 +1115,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fgetxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, fin_ret, op_errno, dict, xdata);
 
     free(rsp.dict.dict_val);
 
@@ -1155,7 +1181,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(removexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(removexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1203,7 +1231,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1251,7 +1281,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1299,8 +1331,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(access, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1353,7 +1387,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ftruncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1405,8 +1441,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stat, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fstat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1453,7 +1491,9 @@ out:
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(inodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(inodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1505,7 +1545,9 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(finodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(finodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1554,7 +1596,9 @@ out:
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(entrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(entrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1603,7 +1647,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(fentrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fentrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1662,7 +1708,9 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(xattrop, frame, rsp.op_ret, gf_error_to_errno(op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(xattrop, frame, fin_ret, gf_error_to_errno(op_errno),
                         dict, xdata);
 
     free(rsp.dict.dict_val);
@@ -1728,8 +1776,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(fxattrop, frame, rsp.op_ret,
-                        gf_error_to_errno(op_errno), dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fxattrop, frame, fin_ret, gf_error_to_errno(op_errno),
+                        dict, xdata);
 
     free(rsp.dict.dict_val);
 
@@ -1791,7 +1841,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fsetxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, fin_ret, op_errno, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1843,7 +1895,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1903,7 +1957,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fallocate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1958,7 +2014,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(discard, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2012,7 +2070,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(zerofill, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2060,7 +2120,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ipc, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2108,8 +2170,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), rsp.offset, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(seek, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        rsp.offset, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2163,7 +2227,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2241,9 +2307,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, "Path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(create, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(create, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2291,7 +2358,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rchecksum, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rchecksum, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.weak_checksum,
                         (uint8_t *)rsp.strong_checksum.strong_checksum_val,
                         xdata);
@@ -2354,8 +2423,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lease, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &lease, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lease, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &lease, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2425,7 +2496,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lk, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lk, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         &lock, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2481,7 +2554,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
-    CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2540,7 +2615,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdirp, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2610,9 +2687,11 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stbuf, &preoldparent,
-                        &postoldparent, &prenewparent, &postnewparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rename, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stbuf, &preoldparent, &postoldparent, &prenewparent,
+                        &postnewparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2677,9 +2756,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(link, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(link, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2744,7 +2824,9 @@ out:
                 "Path=%s", local->loc.path, "gfid=%s",
                 loc_gfid_utoa(&local->loc), NULL);
     }
-    CLIENT_STACK_UNWIND(opendir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(opendir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), fd, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2843,7 +2925,9 @@ out:
                          "node");
     }
 
-    CLIENT_STACK_UNWIND(lookup, frame, rsp.op_ret, rsp.op_errno, inode, &stbuf,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lookup, frame, fin_ret, rsp.op_errno, inode, &stbuf,
                         xdata, &postparent);
 
     if (xdata)
@@ -2906,9 +2990,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), vector, rspcount,
-                        &stat, iobref, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readv, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        vector, rspcount, &stat, iobref, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2986,7 +3071,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(getactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &locklist, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -3039,7 +3126,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -3228,7 +3317,8 @@ client3_3_lookup(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3273,7 +3363,7 @@ client3_3_stat(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3315,7 +3405,7 @@ client3_3_truncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3357,7 +3447,7 @@ client3_3_ftruncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3399,7 +3489,7 @@ client3_3_access(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3487,7 +3577,7 @@ unwind:
         iobref_unref(rsp_iobref);
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3528,7 +3618,7 @@ client3_3_unlink(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3569,7 +3659,7 @@ client3_3_rmdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3629,8 +3719,8 @@ client3_3_symlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3673,8 +3763,8 @@ client3_3_rename(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3731,7 +3821,7 @@ client3_3_link(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    CLIENT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
     GF_FREE(req.xdata.xdata_val);
 
@@ -3784,8 +3874,8 @@ client3_3_mknod(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3850,8 +3940,8 @@ client3_3_mkdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3908,8 +3998,8 @@ client3_3_create(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3968,7 +4058,7 @@ client3_3_open(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -4067,7 +4157,8 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4128,7 +4219,7 @@ client3_3_writev(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4189,7 +4280,7 @@ client3_3_flush(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4231,7 +4322,7 @@ client3_3_fsync(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsync, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsync, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4275,7 +4366,7 @@ client3_3_fstat(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4329,7 +4420,7 @@ client3_3_opendir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -4372,7 +4463,7 @@ client3_3_fsyncdir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4415,7 +4506,7 @@ client3_3_statfs(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4458,7 +4549,7 @@ client3_3_setxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.dict_val);
 
     GF_FREE(req.xdata.xdata_val);
@@ -4504,7 +4595,7 @@ client3_3_fsetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.dict_val);
 
     GF_FREE(req.xdata.xdata_val);
@@ -4592,7 +4683,7 @@ client3_3_fgetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
@@ -4614,7 +4705,7 @@ client3_3_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     };
     dict_t *dict = NULL;
     int ret = 0;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int op_errno = ESTALE;
     int count = 0;
     clnt_local_t *local = NULL;
@@ -4720,7 +4811,9 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, NULL);
 
     if (dict) {
         dict_unref(dict);
@@ -4819,7 +4912,7 @@ client3_3_xattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.dict_val);
 
@@ -4913,7 +5006,7 @@ client3_3_fxattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fxattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fxattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.dict_val);
 
@@ -4961,7 +5054,7 @@ client3_3_removexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5004,7 +5097,7 @@ client3_3_fremovexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5046,7 +5139,7 @@ client3_3_lease(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5116,7 +5209,7 @@ client3_3_lk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5158,7 +5251,7 @@ client3_3_inodelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(inodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(inodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5206,7 +5299,7 @@ client3_3_finodelk(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.xdata_val);
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(finodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(finodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5251,7 +5344,7 @@ client3_3_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(entrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5294,7 +5387,7 @@ client3_3_fentrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fentrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5334,7 +5427,7 @@ client3_3_rchecksum(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rchecksum, frame, -1, op_errno, 0, NULL, NULL);
+    CLIENT_STACK_UNWIND(rchecksum, frame, gf_error, op_errno, 0, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5439,7 +5532,7 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5543,7 +5636,7 @@ unwind:
 
     GF_FREE(req.dict.dict_val);
 
-    CLIENT_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -5585,7 +5678,7 @@ client3_3_setattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5626,7 +5719,7 @@ client3_3_fsetattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5667,7 +5760,7 @@ client3_3_fallocate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5707,7 +5800,7 @@ client3_3_discard(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5749,7 +5842,7 @@ client3_3_zerofill(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5791,7 +5884,7 @@ client3_3_ipc(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5835,7 +5928,7 @@ client3_3_seek(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5885,7 +5978,7 @@ client3_3_getactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(getactivelk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(getactivelk, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -5945,7 +6038,7 @@ client3_3_setactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
 unwind:
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setactivelk, frame, gf_error, op_errno, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -81,7 +81,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(symlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(symlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf,
                         &preparent, &postparent, xdata);
 
@@ -148,9 +150,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mknod, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mknod, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -214,9 +217,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mkdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mkdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -279,8 +283,10 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(open, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(open, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -335,8 +341,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(stat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &iatt, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(stat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &iatt, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -392,7 +400,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.path, &iatt,
                         xdata);
 
@@ -457,9 +467,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(unlink, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(unlink, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -512,9 +523,10 @@ out:
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
-    CLIENT_STACK_UNWIND(rmdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rmdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -565,7 +577,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(truncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -617,8 +631,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &statfs, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(statfs, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &statfs, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -676,9 +692,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(writev, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -733,8 +750,10 @@ out:
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(flush, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(flush, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -788,9 +807,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsync, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
     if (xdata)
         dict_unref(xdata);
 
@@ -844,7 +864,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(setxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setxattr, frame, fin_ret, op_errno, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -918,7 +940,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(getxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -985,7 +1009,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(fgetxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, fin_ret, op_errno, dict, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1045,7 +1071,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(removexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(removexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1091,7 +1119,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1137,7 +1167,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1183,8 +1215,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(access, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1235,7 +1269,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ftruncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1285,8 +1321,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stat, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fstat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stat, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1331,7 +1369,9 @@ out:
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(inodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(inodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1381,7 +1421,9 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(finodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(finodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1428,7 +1470,9 @@ out:
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(entrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(entrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1475,7 +1519,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(fentrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fentrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1538,7 +1584,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(xattrop, frame, rsp.op_ret, gf_error_to_errno(op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(xattrop, frame, fin_ret, gf_error_to_errno(op_errno),
                         dict, xdata);
 
     if (xdata)
@@ -1607,8 +1655,10 @@ out:
             client_attempt_reopen(local->fd, this);
     }
 
-    CLIENT_STACK_UNWIND(fxattrop, frame, rsp.op_ret,
-                        gf_error_to_errno(op_errno), dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fxattrop, frame, fin_ret, gf_error_to_errno(op_errno),
+                        dict, xdata);
     if (xdata)
         dict_unref(xdata);
 
@@ -1665,7 +1715,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fsetxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, fin_ret, op_errno, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1718,7 +1770,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fallocate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1771,7 +1825,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(discard, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
     if (xdata)
@@ -1822,7 +1878,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(zerofill, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1868,7 +1926,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ipc, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         xdata);
 
     if (xdata)
@@ -1913,8 +1973,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), rsp.offset, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(seek, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        rsp.offset, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1966,7 +2028,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2020,7 +2084,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2097,9 +2163,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(create, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(create, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2151,8 +2218,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lease, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &lease, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lease, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &lease, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2220,7 +2289,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lk, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lk, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         &lock, xdata);
 
     free(rsp.flock.lk_owner.lk_owner_val);
@@ -2274,7 +2345,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
-    CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2331,7 +2404,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdirp, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2399,9 +2474,11 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stbuf, &preoldparent,
-                        &postoldparent, &prenewparent, &postnewparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rename, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stbuf, &preoldparent, &postoldparent, &prenewparent,
+                        &postnewparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2465,9 +2542,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(link, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(link, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2532,7 +2610,9 @@ out:
                 "path=%s", local->loc.path, "gfid=%s",
                 loc_gfid_utoa(&local->loc), NULL);
     }
-    CLIENT_STACK_UNWIND(opendir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(opendir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), fd, xdata);
 
     if (xdata)
@@ -2624,12 +2704,12 @@ out:
                     PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path,
                     "gfid=%s", loc_gfid_utoa(&local->loc), NULL);
         else
-            gf_msg_trace(this->name, 0,
-                         "not found on remote "
-                         "node");
+            gf_msg_trace(this->name, 0, "not found on remote node");
     }
 
-    CLIENT_STACK_UNWIND(lookup, frame, rsp.op_ret, rsp.op_errno, inode, &stbuf,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lookup, frame, fin_ret, rsp.op_errno, inode, &stbuf,
                         xdata, &postparent);
 
     if (xdata)
@@ -2690,9 +2770,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), vector, rspcount,
-                        &stat, iobref, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readv, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        vector, rspcount, &stat, iobref, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2767,7 +2848,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(getactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &locklist, xdata);
     if (xdata)
         dict_unref(xdata);
@@ -2815,7 +2898,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -2880,7 +2965,9 @@ out:
         if (local->attempt_reopen_out)
             client_attempt_reopen(local->fd_out, this);
     }
-    CLIENT_STACK_UNWIND(copy_file_range, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(copy_file_range, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &stbuf, &prestat,
                         &poststat, xdata);
 
@@ -3069,7 +3156,8 @@ client4_0_lookup(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3114,7 +3202,7 @@ client4_0_stat(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3157,7 +3245,7 @@ client4_0_truncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3200,7 +3288,7 @@ client4_0_ftruncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3242,7 +3330,7 @@ client4_0_access(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3296,7 +3384,7 @@ client4_0_readlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3337,7 +3425,7 @@ client4_0_unlink(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3378,7 +3466,7 @@ client4_0_rmdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3438,8 +3526,8 @@ client4_0_symlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3482,8 +3570,8 @@ client4_0_rename(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3541,7 +3629,7 @@ client4_0_link(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    CLIENT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3594,8 +3682,8 @@ client4_0_mknod(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3660,8 +3748,8 @@ client4_0_mkdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3718,8 +3806,8 @@ client4_0_create(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3778,7 +3866,7 @@ client4_0_open(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3872,7 +3960,8 @@ unwind:
     if (rsp_iobuf)
         iobuf_unref(rsp_iobuf);
 
-    CLIENT_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3934,7 +4023,7 @@ client4_0_writev(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3994,7 +4083,7 @@ client4_0_flush(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4036,7 +4125,7 @@ client4_0_fsync(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsync, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsync, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4080,7 +4169,7 @@ client4_0_fstat(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4134,7 +4223,7 @@ client4_0_opendir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4178,7 +4267,7 @@ client4_0_fsyncdir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4221,7 +4310,7 @@ client4_0_statfs(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4264,7 +4353,7 @@ client4_0_setxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.pairs.pairs_val);
 
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4309,7 +4398,7 @@ client4_0_fsetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4360,7 +4449,7 @@ client4_0_fgetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4379,9 +4468,10 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     };
     dict_t *dict = NULL;
     int ret = 0;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int op_errno = ESTALE;
     clnt_local_t *local = NULL;
+    gf_return_t fin_ret;
 
     if (!frame || !this || !data) {
         op_errno = 0;
@@ -4445,8 +4535,11 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
+
 unwind:
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
+
+    SET_RET(fin_ret, op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, NULL);
 
     if (dict) {
         dict_unref(dict);
@@ -4508,7 +4601,7 @@ client4_0_xattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4559,7 +4652,7 @@ client4_0_fxattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fxattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fxattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4603,7 +4696,7 @@ client4_0_removexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4646,7 +4739,7 @@ client4_0_fremovexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4688,7 +4781,7 @@ client4_0_lease(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4758,7 +4851,7 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4800,7 +4893,7 @@ client4_0_inodelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(inodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(inodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4848,7 +4941,7 @@ client4_0_finodelk(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.pairs.pairs_val);
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(finodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(finodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4893,7 +4986,7 @@ client4_0_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(entrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4936,7 +5029,7 @@ client4_0_fentrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fentrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5042,7 +5135,7 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5147,7 +5240,7 @@ unwind:
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
-    CLIENT_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -5189,7 +5282,7 @@ client4_0_setattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5230,7 +5323,7 @@ client4_0_fallocate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5270,7 +5363,7 @@ client4_0_discard(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5312,7 +5405,7 @@ client4_0_zerofill(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5354,7 +5447,7 @@ client4_0_ipc(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5398,7 +5491,7 @@ client4_0_seek(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5447,7 +5540,7 @@ client4_0_getactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(getactivelk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(getactivelk, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -5505,7 +5598,7 @@ client4_0_setactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
 unwind:
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setactivelk, frame, gf_error, op_errno, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -5552,7 +5645,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(rchecksum, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rchecksum, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.weak_checksum,
                         (uint8_t *)rsp.strong_checksum.strong_checksum_val,
                         xdata);
@@ -5580,6 +5675,7 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     struct iatt postbuf = {
         0,
     };
+    gf_return_t fin_ret;
     dict_t *xdata = NULL;
     call_frame_t *frame = NULL;
     gfx_common_2iatt_rsp rsp = {
@@ -5608,7 +5704,9 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    CLIENT_STACK_UNWIND(namelink, frame, rsp.op_ret,
+
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(namelink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prebuf, &postbuf,
                         xdata);
     if (xdata)
@@ -5626,6 +5724,7 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     struct iatt stbuf = {
         0,
     };
+    gf_return_t fin_ret;
     dict_t *xdata = NULL;
     call_frame_t *frame = NULL;
     gfx_common_iatt_rsp rsp = {
@@ -5655,7 +5754,9 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    CLIENT_STACK_UNWIND(icreate, frame, rsp.op_ret,
+
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(icreate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf, xdata);
     if (xdata)
         dict_unref(xdata);
@@ -5718,7 +5819,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(put, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(put, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
@@ -5771,7 +5874,7 @@ client4_0_namelink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(namelink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(namelink, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -5822,7 +5925,7 @@ client4_0_icreate(call_frame_t *frame, xlator_t *this, void *data)
 free_reqdata:
     GF_FREE(req.xdata.pairs.pairs_val);
 unwind:
-    CLIENT_STACK_UNWIND(icreate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(icreate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -5886,7 +5989,8 @@ client4_0_put(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(put, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(put, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -5956,8 +6060,8 @@ client4_0_copy_file_range(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(copy_file_range, frame, -1, op_errno, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(copy_file_range, frame, gf_error, op_errno, NULL, NULL,
+                        NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5997,7 +6101,7 @@ client4_0_fsetattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -6042,7 +6146,7 @@ client4_0_rchecksum(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rchecksum, frame, -1, op_errno, 0, NULL, NULL);
+    CLIENT_STACK_UNWIND(rchecksum, frame, gf_error, op_errno, 0, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -379,7 +379,7 @@ client_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 out:
     /* think of avoiding a missing frame */
     if (ret)
-        STACK_UNWIND_STRICT(lookup, frame, -1, ENOTCONN, NULL, NULL, NULL,
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
                             NULL);
 
     return 0;
@@ -407,7 +407,7 @@ client_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(stat, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(stat, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -436,7 +436,8 @@ client_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(truncate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -465,7 +466,8 @@ client_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -494,7 +496,7 @@ client_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(access, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(access, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -523,7 +525,8 @@ client_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readlink, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -554,8 +557,8 @@ client_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(mknod, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -585,8 +588,8 @@ client_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(mkdir, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -615,7 +618,8 @@ client_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(unlink, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -645,7 +649,7 @@ client_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 out:
     /* think of avoiding a missing frame */
     if (ret)
-        STACK_UNWIND_STRICT(rmdir, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, ENOTCONN, NULL, NULL, NULL);
 
     return 0;
 }
@@ -675,8 +679,8 @@ client_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(symlink, frame, -1, ENOTCONN, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -705,8 +709,8 @@ client_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(rename, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -735,8 +739,8 @@ client_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(link, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(link, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -769,8 +773,8 @@ client_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(create, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(create, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -801,7 +805,7 @@ client_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(open, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -834,8 +838,8 @@ client_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readv, frame, -1, ENOTCONN, NULL, 0, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(readv, frame, gf_error, ENOTCONN, NULL, 0, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -871,7 +875,8 @@ client_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(writev, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -898,7 +903,7 @@ client_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(flush, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(flush, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -927,7 +932,7 @@ client_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsync, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOTCONN, NULL, NULL, NULL);
 
     return 0;
 }
@@ -954,7 +959,7 @@ client_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fstat, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -983,7 +988,7 @@ client_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(opendir, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1012,7 +1017,7 @@ client_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1039,7 +1044,7 @@ client_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(statfs, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1073,8 +1078,8 @@ client_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(copy_file_range, frame, -1, ENOTCONN, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(copy_file_range, frame, gf_error, ENOTCONN, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -1198,6 +1203,7 @@ client_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     int op_ret = -1;
     int op_errno = ENOTCONN;
     int need_unwind = 0;
+    gf_return_t fin_ret;
     clnt_conf_t *conf = NULL;
     rpc_clnt_procedure_t *proc = NULL;
     clnt_args_t args = {
@@ -1247,8 +1253,10 @@ client_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         }
     }
 out:
-    if (need_unwind)
-        STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, NULL);
+    if (need_unwind) {
+        SET_RET(fin_ret, op_ret);
+        STACK_UNWIND_STRICT(setxattr, frame, fin_ret, op_errno, NULL);
+    }
 
     return 0;
 }
@@ -1278,7 +1286,7 @@ client_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1307,7 +1315,7 @@ client_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1336,7 +1344,7 @@ client_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getxattr, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1366,7 +1374,7 @@ client_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(xattrop, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1396,7 +1404,7 @@ client_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1425,7 +1433,7 @@ client_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(removexattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1454,7 +1462,7 @@ client_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1483,7 +1491,7 @@ client_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1513,7 +1521,7 @@ client_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1544,7 +1552,7 @@ client_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(inodelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1575,7 +1583,7 @@ client_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(finodelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1608,7 +1616,7 @@ client_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(entrylk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1641,7 +1649,7 @@ client_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1671,7 +1679,8 @@ client_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOTCONN, 0, NULL, NULL);
+        STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOTCONN, 0, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1704,7 +1713,7 @@ client_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readdir, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1737,7 +1746,7 @@ client_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readdirp, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1767,7 +1776,8 @@ client_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(setattr, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1797,7 +1807,8 @@ client_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1828,7 +1839,8 @@ client_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fallocate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1858,7 +1870,8 @@ client_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(discard, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(discard, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1888,7 +1901,8 @@ client_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(zerofill, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(zerofill, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1915,7 +1929,7 @@ client_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(ipc, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(ipc, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1945,7 +1959,7 @@ client_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(seek, frame, -1, ENOTCONN, 0, NULL);
+        STACK_UNWIND_STRICT(seek, frame, gf_error, ENOTCONN, 0, NULL);
 
     return 0;
 }
@@ -1973,7 +1987,7 @@ client_getactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getactivelk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(getactivelk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -2002,7 +2016,7 @@ client_setactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(setactivelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(setactivelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -2032,7 +2046,7 @@ client_getspec(call_frame_t *frame, xlator_t *this, const char *key,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getspec, frame, -1, EINVAL, NULL);
+        STACK_UNWIND_STRICT(getspec, frame, gf_error, EINVAL, NULL);
 
     return 0;
 }
@@ -2056,7 +2070,7 @@ client_compound(call_frame_t *frame, xlator_t *this, void *data, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(compound, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(compound, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -2083,7 +2097,8 @@ client_namelink(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(namelink, frame, -1, EINVAL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(namelink, frame, gf_error, EINVAL, NULL, NULL,
+                            NULL);
     return 0;
 }
 
@@ -2111,7 +2126,7 @@ client_icreate(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(icreate, frame, -1, EINVAL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(icreate, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -2150,8 +2165,8 @@ client_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(put, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(put, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -2633,7 +2648,7 @@ init(xlator_t *this)
 
     this->private = conf;
 
-    /* If it returns -1, then its a failure, if it returns +1 we need
+    /* If it returns gf_error, then its a failure, if it returns +1 we need
        have to understand that 'this' is subvolume of a xlator which,
        will set the remote host and remote subvolume in a setxattr
        call.

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -353,10 +353,10 @@ server_post_open(call_frame_t *frame, xlator_t *this, gfs3_open_rsp *rsp,
 }
 
 void
-server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, int op_ret)
+server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret)
 {
     gf_stat_from_iatt(&rsp->stat, stbuf);
-    rsp->size = op_ret;
+    rsp->size = GET_RET(op_ret);
 }
 
 int
@@ -716,10 +716,10 @@ server4_post_open(call_frame_t *frame, xlator_t *this, gfx_open_rsp *rsp,
 }
 
 void
-server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, int op_ret)
+server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret)
 {
     gfx_stat_from_iattx(&rsp->stat, stbuf);
-    rsp->size = op_ret;
+    rsp->size = GET_RET(op_ret);
 }
 
 int

--- a/xlators/protocol/server/src/server-common.h
+++ b/xlators/protocol/server/src/server-common.h
@@ -107,7 +107,7 @@ int
 server_post_open(call_frame_t *frame, xlator_t *this, gfs3_open_rsp *rsp,
                  fd_t *fd);
 void
-server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, int op_ret);
+server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret);
 
 int
 server_post_opendir(call_frame_t *frame, xlator_t *this, gfs3_opendir_rsp *rsp,
@@ -160,7 +160,7 @@ int
 server4_post_open(call_frame_t *frame, xlator_t *this, gfx_open_rsp *rsp,
                   fd_t *fd);
 void
-server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, int op_ret);
+server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret);
 
 int
 server4_post_create(call_frame_t *frame, gfx_create_rsp *rsp,

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -238,7 +238,7 @@ server_setvolume(rpcsvc_request_t *req)
     char *msg = NULL;
     xlator_t *this = NULL;
     int32_t ret = -1;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     uint32_t opversion = 0;
     rpc_transport_t *xprt = NULL;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -224,7 +224,7 @@ free_state(server_state_t *state)
 
 static int
 server_connection_cleanup_flush_cbk(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, dict_t *xdata)
 {
     int32_t ret = -1;
@@ -783,7 +783,7 @@ server_resolve_is_empty(server_resolve_t *resolve)
 }
 
 void
-server_print_reply(call_frame_t *frame, int op_ret, int op_errno)
+server_print_reply(call_frame_t *frame, gf_return_t op_ret, int op_errno)
 {
     server_conf_t *conf = NULL;
     server_state_t *state = NULL;

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -57,7 +57,7 @@ set_resolve_gfid(client_t *client, uuid_t resolve_gfid, char *on_wire_gfid)
 /* Callback function section */
 int
 server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                   dict_t *xdata)
 {
     gfs3_statfs_rsp rsp = {
@@ -68,7 +68,7 @@ server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, PS_MSG_STATFS,
                "%" PRId64 ": STATFS, client: %s, error-xlator: %s",
                frame->root->unique, STACK_CLIENT_NAME(frame->root),
@@ -79,7 +79,7 @@ server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_statfs(&rsp, buf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -93,7 +93,7 @@ out:
 
 int
 server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     rpcsvc_request_t *req = NULL;
@@ -107,7 +107,7 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (state->is_revalidate == 1 && op_ret == -1) {
+    if (state->is_revalidate == 1 && IS_ERROR(op_ret)) {
         state->is_revalidate = 2;
         loc_copy(&fresh_loc, &state->loc);
         inode_unref(fresh_loc.inode);
@@ -126,7 +126,7 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->is_revalidate && op_errno == ENOENT) {
             if (!__is_root_gfid(state->resolve.gfid)) {
                 inode_unlink(state->loc.inode, state->loc.parent,
@@ -155,10 +155,10 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_lookup(&rsp, frame, state, inode, stbuf, postparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->resolve.bname) {
             gf_msg(this->name, fop_log_level(GF_FOP_LOOKUP, op_errno), op_errno,
                    PS_MSG_LOOKUP_INFO,
@@ -193,7 +193,7 @@ out:
 
 int
 server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                  dict_t *xdata)
 {
     gfs3_lease_rsp rsp = {
@@ -205,7 +205,7 @@ server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_LEASE, op_errno), op_errno,
                PS_MSG_LK_INFO,
@@ -218,7 +218,7 @@ server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_lease(&rsp, lease);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -231,8 +231,9 @@ out:
 }
 
 int
-server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     gfs3_lk_rsp rsp = {
         0,
@@ -243,7 +244,7 @@ server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_LK, op_errno), op_errno,
                PS_MSG_LK_INFO,
@@ -258,7 +259,7 @@ server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     server_post_lk(this, &rsp, lock);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -272,7 +273,7 @@ out:
 
 int
 server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -285,7 +286,7 @@ server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_INODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64
@@ -298,7 +299,7 @@ server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -312,7 +313,7 @@ out:
 
 int
 server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -325,7 +326,7 @@ server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FINODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64 ": FINODELK %" PRId64
@@ -338,7 +339,7 @@ server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -352,7 +353,7 @@ out:
 
 int
 server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -365,7 +366,7 @@ server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_ENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64
@@ -378,7 +379,7 @@ server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -392,7 +393,7 @@ out:
 
 int
 server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -405,7 +406,7 @@ server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64 ": FENTRYLK %" PRId64
@@ -418,7 +419,7 @@ server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -432,7 +433,7 @@ out:
 
 int
 server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -443,7 +444,7 @@ server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_ACCESS_INFO,
                "%" PRId64
@@ -456,7 +457,7 @@ server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -470,7 +471,7 @@ out:
 
 int
 server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     gfs3_rmdir_rsp rsp = {
@@ -484,7 +485,7 @@ server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_DIR_INFO,
                "%" PRId64
                ": RMDIR %s (%s/%s), client: %s, "
@@ -498,7 +499,7 @@ server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_rmdir(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -512,7 +513,7 @@ out:
 
 int
 server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -527,7 +528,7 @@ server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
                "%" PRId64
@@ -541,7 +542,7 @@ server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_mkdir(state, &rsp, inode, stbuf, preparent, postparent, xdata);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -555,7 +556,7 @@ out:
 
 int
 server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -570,7 +571,7 @@ server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKNOD, op_errno), op_errno,
                PS_MSG_MKNOD_INFO,
                "%" PRId64
@@ -584,7 +585,7 @@ server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_mknod(state, &rsp, stbuf, preparent, postparent, inode);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -598,7 +599,7 @@ out:
 
 int
 server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -609,7 +610,7 @@ server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNCDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -623,7 +624,7 @@ server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -637,7 +638,7 @@ out:
 
 int
 server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     gfs3_readdir_rsp rsp = {
@@ -650,7 +651,7 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -664,17 +665,17 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (GET_RET(op_ret) > 0) {
         ret = server_post_readdir(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -690,8 +691,10 @@ out:
 
 int
 server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfs3_opendir_rsp rsp = {
@@ -702,7 +705,7 @@ server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPENDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -715,13 +718,15 @@ server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server_post_opendir(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server_post_opendir(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    if (op_ret)
+    if (IS_SUCCESS(op_ret))
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -735,7 +740,7 @@ out:
 
 int
 server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -746,14 +751,14 @@ server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (ENODATA == op_errno || ENOATTR == op_errno)
             loglevel = GF_LOG_DEBUG;
@@ -771,7 +776,7 @@ server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -785,7 +790,7 @@ out:
 
 int
 server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -795,14 +800,14 @@ server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FREMOVEXATTR, op_errno),
                op_errno, PS_MSG_REMOVEXATTR_INFO,
@@ -816,7 +821,7 @@ server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -830,7 +835,7 @@ out:
 
 int
 server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     gfs3_getxattr_rsp rsp = {
@@ -842,7 +847,7 @@ server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_GETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -859,7 +864,7 @@ server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -875,7 +880,7 @@ out:
 
 int
 server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     gfs3_fgetxattr_rsp rsp = {
@@ -887,7 +892,7 @@ server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FGETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -905,7 +910,7 @@ server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 out:
 
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -940,7 +945,7 @@ _gf_server_log_setxattr_failure(dict_t *d, char *k, data_t *v, void *tmp)
 
 int
 server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -950,14 +955,14 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -975,7 +980,7 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1010,7 +1015,7 @@ _gf_server_log_fsetxattr_failure(dict_t *d, char *k, data_t *v, void *tmp)
 
 int
 server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -1020,14 +1025,14 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP) {
             dict_foreach(state->dict, _gf_server_log_fsetxattr_failure, frame);
@@ -1045,7 +1050,7 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1059,7 +1064,7 @@ out:
 
 int
 server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -1081,7 +1086,7 @@ server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.pargfid, oldpar_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_RENAME_INFO,
@@ -1098,7 +1103,7 @@ server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_rename(frame, state, &rsp, stbuf, preoldparent, postoldparent,
                        prenewparent, postnewparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1112,7 +1117,7 @@ out:
 
 int
 server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     gfs3_unlink_rsp rsp = {
@@ -1123,7 +1128,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
@@ -1132,7 +1137,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_UNLINK, op_errno), op_errno,
                PS_MSG_LINK_INFO,
                "%" PRId64
@@ -1154,7 +1159,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_unlink(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1168,7 +1173,7 @@ out:
 
 int
 server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *stbuf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -1183,7 +1188,7 @@ server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
                ": SYMLINK %s (%s/%s), client: %s, "
@@ -1198,7 +1203,7 @@ server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                         xdata);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1212,7 +1217,7 @@ out:
 
 int
 server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stbuf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -1233,7 +1238,7 @@ server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.gfid, gfid_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
 
@@ -1250,7 +1255,7 @@ server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_link(state, &rsp, inode, stbuf, preparent, postparent, xdata);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1264,7 +1269,7 @@ out:
 
 int
 server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_truncate_rsp rsp = {
@@ -1276,7 +1281,7 @@ server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_TRUNCATE_INFO,
                "%" PRId64
@@ -1291,7 +1296,7 @@ server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_truncate(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1305,7 +1310,7 @@ out:
 
 int
 server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                  dict_t *xdata)
 {
     gfs3_fstat_rsp rsp = {
@@ -1318,7 +1323,7 @@ server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.xdata.xdata_len, op_errno, out);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FSTAT, op_errno), op_errno,
                PS_MSG_STAT_INFO,
                "%" PRId64 ": FSTAT %" PRId64
@@ -1333,7 +1338,7 @@ server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fstat(state, &rsp, stbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1347,7 +1352,7 @@ out:
 
 int
 server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_ftruncate_rsp rsp = {0};
@@ -1357,7 +1362,7 @@ server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FTRUNCATE, op_errno), op_errno,
                PS_MSG_TRUNCATE_INFO,
@@ -1373,7 +1378,7 @@ server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_ftruncate(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1387,7 +1392,7 @@ out:
 
 int
 server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -1398,7 +1403,7 @@ server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FLUSH, op_errno), op_errno,
                PS_MSG_FLUSH_INFO,
@@ -1412,7 +1417,7 @@ server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1426,7 +1431,7 @@ out:
 
 int
 server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_fsync_rsp rsp = {
@@ -1438,7 +1443,7 @@ server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNC, op_errno), op_errno,
                PS_MSG_SYNC_INFO,
@@ -1454,7 +1459,7 @@ server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fsync(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1468,7 +1473,7 @@ out:
 
 int
 server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_write_rsp rsp = {
@@ -1480,7 +1485,7 @@ server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_WRITE, op_errno), op_errno,
                PS_MSG_WRITE_INFO,
@@ -1496,7 +1501,7 @@ server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_writev(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1510,7 +1515,7 @@ out:
 
 int
 server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                 gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                  int32_t count, struct iatt *stbuf, struct iobref *iobref,
                  dict_t *xdata)
 {
@@ -1533,7 +1538,7 @@ server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READ, op_errno), op_errno,
                PS_MSG_READ_INFO,
@@ -1549,7 +1554,7 @@ server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_readv(&rsp, stbuf, op_ret);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1563,8 +1568,9 @@ out:
 
 int
 server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                     uint8_t *strong_checksum, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     uint32_t weak_checksum, uint8_t *strong_checksum,
+                     dict_t *xdata)
 {
     gfs3_rchecksum_rsp rsp = {
         0,
@@ -1575,7 +1581,7 @@ server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_RCHECKSUM, op_errno), op_errno,
                PS_MSG_CHKSUM_INFO,
@@ -1590,7 +1596,7 @@ server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_rchecksum(&rsp, weak_checksum, strong_checksum);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1604,8 +1610,9 @@ out:
 
 int
 server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfs3_open_rsp rsp = {
@@ -1615,7 +1622,7 @@ server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPEN, op_errno), op_errno,
                PS_MSG_OPEN_INFO,
@@ -1626,11 +1633,13 @@ server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server_post_open(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server_post_open(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1643,10 +1652,11 @@ out:
 
 int
 server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *stbuf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     uint64_t fd_no = 0;
@@ -1659,7 +1669,7 @@ server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
                "%" PRId64
                ": CREATE %s (%s/%s), client: %s, "
@@ -1678,18 +1688,18 @@ server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  frame->root->unique, state->loc.name,
                  uuid_utoa(stbuf->ia_gfid));
 
-    op_ret = server_post_create(frame, &rsp, state, this, fd, inode, stbuf,
-                                preparent, postparent);
-    if (op_ret) {
-        op_errno = -op_ret;
-        op_ret = -1;
+    ret = server_post_create(frame, &rsp, state, this, fd, inode, stbuf,
+                             preparent, postparent);
+    if (ret < 0) {
+        op_errno = -ret;
+        op_ret = gf_error;
         goto out;
     }
 
 out:
-    if (op_ret)
+    if (IS_SUCCESS(op_ret))
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1703,7 +1713,7 @@ out:
 
 int
 server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, const char *buf,
+                    gf_return_t op_ret, int32_t op_errno, const char *buf,
                     struct iatt *stbuf, dict_t *xdata)
 {
     gfs3_readlink_rsp rsp = {
@@ -1715,7 +1725,7 @@ server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
@@ -1729,7 +1739,7 @@ server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_readlink(&rsp, stbuf, buf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
     if (!rsp.path)
         rsp.path = "";
@@ -1745,7 +1755,7 @@ out:
 
 int
 server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                 dict_t *xdata)
 {
     gfs3_stat_rsp rsp = {
@@ -1758,7 +1768,7 @@ server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.xdata.xdata_len, op_errno, out);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_STAT, op_errno), op_errno,
                PS_MSG_STAT_INFO,
                "%" PRId64 ": STAT %s (%s), client: %s, error-xlator: %s",
@@ -1770,7 +1780,7 @@ server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_stat(state, &rsp, stbuf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1784,7 +1794,7 @@ out:
 
 int
 server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     gfs3_setattr_rsp rsp = {
@@ -1796,7 +1806,7 @@ server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SETATTR_INFO,
                "%" PRId64
@@ -1811,7 +1821,7 @@ server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_setattr(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1825,7 +1835,7 @@ out:
 
 int
 server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfs3_fsetattr_rsp rsp = {
@@ -1837,7 +1847,7 @@ server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSETATTR, op_errno), op_errno,
                PS_MSG_SETATTR_INFO,
@@ -1853,7 +1863,7 @@ server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fsetattr(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1867,7 +1877,7 @@ out:
 
 int
 server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     gfs3_xattrop_rsp rsp = {
@@ -1879,7 +1889,7 @@ server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1896,7 +1906,7 @@ server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1912,7 +1922,7 @@ out:
 
 int
 server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     gfs3_xattrop_rsp rsp = {
@@ -1924,7 +1934,7 @@ server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FXATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1941,7 +1951,7 @@ server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1957,7 +1967,7 @@ out:
 
 int
 server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gfs3_readdirp_rsp rsp = {
@@ -1972,7 +1982,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIRP, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -1986,10 +1996,10 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (GET_RET(op_ret) > 0) {
         ret = server_post_readdirp(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
@@ -1998,7 +2008,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_link_inodes_from_dirent(this, state->fd->inode, entries);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2014,7 +2024,7 @@ out:
 
 int
 server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     gfs3_fallocate_rsp rsp = {
@@ -2026,7 +2036,7 @@ server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FALLOCATE, op_errno), op_errno,
                PS_MSG_ALLOC_INFO,
@@ -2042,7 +2052,7 @@ server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fallocate(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2056,7 +2066,7 @@ out:
 
 int
 server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     gfs3_discard_rsp rsp = {
@@ -2068,7 +2078,7 @@ server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_DISCARD, op_errno), op_errno,
                PS_MSG_DISCARD_INFO,
@@ -2084,7 +2094,7 @@ server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_discard(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2098,7 +2108,7 @@ out:
 
 int
 server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfs3_zerofill_rsp rsp = {
@@ -2113,7 +2123,7 @@ server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_ZEROFILL, op_errno), op_errno,
                PS_MSG_ZEROFILL_INFO,
                "%" PRId64 ": ZEROFILL%" PRId64
@@ -2128,7 +2138,7 @@ server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_zerofill(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2141,7 +2151,7 @@ out:
 
 int
 server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -2155,7 +2165,7 @@ server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SERVER_IPC_INFO,
                "%" PRId64 ": IPC%" PRId64
                " (%s), client: %s, "
@@ -2167,7 +2177,7 @@ server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2180,7 +2190,8 @@ out:
 
 int
 server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, off_t offset,
+                dict_t *xdata)
 {
     struct gfs3_seek_rsp rsp = {
         0,
@@ -2194,7 +2205,7 @@ server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_SEEK, op_errno), op_errno,
                PS_MSG_SEEK_INFO,
                "%" PRId64 ": SEEK%" PRId64
@@ -2208,7 +2219,7 @@ server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_seek(&rsp, offset);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2221,7 +2232,7 @@ out:
 
 static int
 server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfs3_setactivelk_rsp rsp = {
         0,
@@ -2234,7 +2245,7 @@ server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
                "%" PRId64
@@ -2247,7 +2258,7 @@ server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2266,12 +2277,12 @@ int
 server_rchecksum_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = EINVAL;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
@@ -2295,7 +2306,7 @@ server_lease_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_lease_cbk, bound_xl, bound_xl->fops->lease,
@@ -2316,7 +2327,7 @@ server_lk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_lk_cbk, bound_xl, bound_xl->fops->lk, state->fd,
@@ -2334,18 +2345,18 @@ int
 server_rename_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2364,18 +2375,18 @@ int
 server_link_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2400,7 +2411,7 @@ server_symlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2422,7 +2433,7 @@ server_access_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_access_cbk, bound_xl, bound_xl->fops->access,
@@ -2442,7 +2453,7 @@ server_fentrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2471,7 +2482,7 @@ server_entrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2501,7 +2512,7 @@ server_finodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2533,7 +2544,7 @@ server_inodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2560,7 +2571,7 @@ server_rmdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_rmdir_cbk, bound_xl, bound_xl->fops->rmdir,
@@ -2580,7 +2591,7 @@ server_mkdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2602,7 +2613,7 @@ server_mknod_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2625,7 +2636,7 @@ server_fsyncdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsyncdir_cbk, bound_xl, bound_xl->fops->fsyncdir,
@@ -2645,7 +2656,7 @@ server_readdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     GF_ASSERT(state->fd);
@@ -2667,7 +2678,7 @@ server_readdirp_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readdirp_cbk, bound_xl, bound_xl->fops->readdirp,
@@ -2687,7 +2698,7 @@ server_opendir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -2713,7 +2724,7 @@ server_statfs_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_statfs_cbk, bound_xl, bound_xl->fops->statfs,
@@ -2733,7 +2744,7 @@ server_removexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_removexattr_cbk, bound_xl,
@@ -2753,7 +2764,7 @@ server_fremovexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fremovexattr_cbk, bound_xl,
@@ -2773,7 +2784,7 @@ server_fgetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fgetxattr_cbk, bound_xl, bound_xl->fops->fgetxattr,
@@ -2792,7 +2803,7 @@ server_xattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_xattrop_cbk, bound_xl, bound_xl->fops->xattrop,
@@ -2811,7 +2822,7 @@ server_fxattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fxattrop_cbk, bound_xl, bound_xl->fops->fxattrop,
@@ -2830,7 +2841,7 @@ server_fsetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setxattr_cbk, bound_xl, bound_xl->fops->fsetxattr,
@@ -2850,7 +2861,7 @@ server_unlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_unlink_cbk, bound_xl, bound_xl->fops->unlink,
@@ -2869,7 +2880,7 @@ server_truncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_truncate_cbk, bound_xl, bound_xl->fops->truncate,
@@ -2888,7 +2899,7 @@ server_fstat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fstat_cbk, bound_xl, bound_xl->fops->fstat,
@@ -2907,7 +2918,7 @@ server_setxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setxattr_cbk, bound_xl, bound_xl->fops->setxattr,
@@ -2927,7 +2938,7 @@ server_getxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_getxattr_cbk, bound_xl, bound_xl->fops->getxattr,
@@ -2946,7 +2957,7 @@ server_ftruncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_ftruncate_cbk, bound_xl, bound_xl->fops->ftruncate,
@@ -2966,7 +2977,7 @@ server_flush_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_flush_cbk, bound_xl, bound_xl->fops->flush,
@@ -2986,7 +2997,7 @@ server_fsync_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsync_cbk, bound_xl, bound_xl->fops->fsync,
@@ -3006,7 +3017,7 @@ server_writev_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_writev_cbk, bound_xl, bound_xl->fops->writev,
@@ -3027,7 +3038,7 @@ server_readv_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readv_cbk, bound_xl, bound_xl->fops->readv,
@@ -3048,7 +3059,7 @@ server_create_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -3058,7 +3069,7 @@ server_create_resume(call_frame_t *frame, xlator_t *bound_xl)
         gf_msg("server", GF_LOG_ERROR, 0, PS_MSG_FD_CREATE_FAILED,
                "fd creation for the inode %s failed",
                state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : NULL);
-        state->resolve.op_ret = -1;
+        state->resolve.op_ret = gf_error;
         state->resolve.op_errno = ENOMEM;
         goto err;
     }
@@ -3083,7 +3094,7 @@ server_open_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -3106,7 +3117,7 @@ server_readlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readlink_cbk, bound_xl, bound_xl->fops->readlink,
@@ -3125,7 +3136,7 @@ server_fsetattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsetattr_cbk, bound_xl, bound_xl->fops->fsetattr,
@@ -3145,7 +3156,7 @@ server_setattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setattr_cbk, bound_xl, bound_xl->fops->setattr,
@@ -3165,7 +3176,7 @@ server_stat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_stat_cbk, bound_xl, bound_xl->fops->stat,
@@ -3184,7 +3195,7 @@ server_lookup_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->loc.inode)
@@ -3210,7 +3221,7 @@ server_fallocate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fallocate_cbk, bound_xl, bound_xl->fops->fallocate,
@@ -3231,7 +3242,7 @@ server_discard_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_discard_cbk, bound_xl, bound_xl->fops->discard,
@@ -3251,7 +3262,7 @@ server_zerofill_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_zerofill_cbk, bound_xl, bound_xl->fops->zerofill,
@@ -3271,7 +3282,7 @@ server_seek_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_seek_cbk, bound_xl, bound_xl->fops->seek,
@@ -3286,7 +3297,7 @@ err:
 
 static int
 server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        lock_migration_info_t *locklist, dict_t *xdata)
 {
     gfs3_getactivelk_rsp rsp = {
@@ -3301,7 +3312,7 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
@@ -3316,17 +3327,17 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) means there are no locks on the file*/
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         ret = serialize_rsp_locklist(locklist, &rsp);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -3348,7 +3359,7 @@ server_getactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_getactivelk_cbk, bound_xl,
@@ -3367,7 +3378,7 @@ server_setactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setactivelk_cbk, bound_xl,
@@ -5824,8 +5835,8 @@ out:
     free(args.bname);
     free(args.xdata.xdata_val);
 
-    server_lookup_cbk(frame, NULL, frame->this, -1, EINVAL, NULL, NULL, NULL,
-                      NULL);
+    server_lookup_cbk(frame, NULL, frame->this, gf_error, EINVAL, NULL, NULL,
+                      NULL, NULL);
     ret = 0;
 
 err:

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -45,7 +45,7 @@ rpc_receive_common(rpcsvc_request_t *req, call_frame_t **fr,
 /* Callback function section */
 int
 server4_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     gfx_statfs_rsp rsp = {
@@ -55,7 +55,7 @@ server4_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno, PS_MSG_STATFS,
                 "frame=%" PRId64, frame->root->unique, "client=%s",
                 STACK_CLIENT_NAME(frame->root), "error-xlator=%s",
@@ -66,7 +66,7 @@ server4_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_statfs(&rsp, buf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -80,7 +80,7 @@ out:
 
 int
 server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     rpcsvc_request_t *req = NULL;
@@ -94,7 +94,7 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (state->is_revalidate == 1 && op_ret == -1) {
+    if (state->is_revalidate == 1 && IS_ERROR(op_ret)) {
         state->is_revalidate = 2;
         loc_copy(&fresh_loc, &state->loc);
         inode_unref(fresh_loc.inode);
@@ -112,7 +112,7 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->is_revalidate && op_errno == ENOENT) {
             if (!__is_root_gfid(state->resolve.gfid)) {
                 inode_unlink(state->loc.inode, state->loc.parent,
@@ -141,10 +141,10 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_lookup(&rsp, frame, state, inode, stbuf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->resolve.bname) {
             gf_smsg(this->name, fop_log_level(GF_FOP_LOOKUP, op_errno),
                     op_errno, PS_MSG_LOOKUP_INFO, "frame=%" PRId64,
@@ -174,7 +174,7 @@ out:
 
 int
 server4_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                   dict_t *xdata)
 {
     gfx_lease_rsp rsp = {
@@ -185,7 +185,7 @@ server4_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_LEASE, op_errno), op_errno,
                 PS_MSG_LK_INFO, "frame=%" PRId64, frame->root->unique,
@@ -196,7 +196,7 @@ server4_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     server4_post_lease(&rsp, lease);
 
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -210,7 +210,7 @@ server4_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 server4_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata)
 {
     gfx_lk_rsp rsp = {
@@ -221,7 +221,7 @@ server4_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_LK, op_errno), op_errno,
                 PS_MSG_LK_INFO, "frame=%" PRId64, frame->root->unique,
@@ -234,7 +234,7 @@ server4_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_lk(this, &rsp, lock);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -248,7 +248,7 @@ out:
 
 int
 server4_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -260,7 +260,7 @@ server4_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_INODELK, op_errno), op_errno,
                 PS_MSG_INODELK_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuuid_utoa=%s",
@@ -271,7 +271,7 @@ server4_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -285,7 +285,7 @@ out:
 
 int
 server4_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -297,7 +297,7 @@ server4_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_FINODELK, op_errno), op_errno,
                 PS_MSG_INODELK_INFO, "frame=%" PRId64, frame->root->unique,
                 "FINODELK_fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -308,7 +308,7 @@ server4_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -322,7 +322,7 @@ out:
 
 int
 server4_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -334,7 +334,7 @@ server4_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_ENTRYLK, op_errno), op_errno,
                 PS_MSG_ENTRYLK_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuid_utoa=%s",
@@ -345,7 +345,7 @@ server4_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -359,7 +359,7 @@ out:
 
 int
 server4_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -371,7 +371,7 @@ server4_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_FENTRYLK, op_errno), op_errno,
                 PS_MSG_ENTRYLK_INFO, "frame=%" PRId64, frame->root->unique,
                 "FENTRYLK_fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -382,7 +382,7 @@ server4_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -396,7 +396,7 @@ out:
 
 int
 server4_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -406,7 +406,7 @@ server4_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_ACCESS_INFO,
                 "frame=%" PRId64, frame->root->unique, "path=%s",
@@ -418,7 +418,7 @@ server4_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -432,7 +432,7 @@ out:
 
 int
 server4_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -445,7 +445,7 @@ server4_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_DIR_INFO,
                 "frame=%" PRId64, frame->root->unique, "RMDIR_pat=%s",
                 (state->loc.path) ? state->loc.path : "", "uuid_utoa=%s",
@@ -459,7 +459,7 @@ server4_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_entry_remove(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -473,7 +473,7 @@ out:
 
 int
 server4_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -487,7 +487,7 @@ server4_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_MKDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
                 "MKDIR_path=%s", (state->loc.path) ? state->loc.path : "",
@@ -500,7 +500,7 @@ server4_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_common_3iatt(state, &rsp, inode, stbuf, preparent, postparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -514,7 +514,7 @@ out:
 
 int
 server4_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -528,7 +528,7 @@ server4_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_MKNOD, op_errno), op_errno,
                 PS_MSG_MKNOD_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuid_utoa=%s",
@@ -541,7 +541,7 @@ server4_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_common_3iatt(state, &rsp, inode, stbuf, preparent, postparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -555,7 +555,7 @@ out:
 
 int
 server4_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -565,7 +565,7 @@ server4_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FSYNCDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -577,7 +577,7 @@ server4_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -591,7 +591,7 @@ out:
 
 int
 server4_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gfx_readdir_rsp rsp = {
@@ -603,7 +603,7 @@ server4_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -615,17 +615,17 @@ server4_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (GET_RET(op_ret) > 0) {
         ret = server4_post_readdir(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -641,8 +641,10 @@ out:
 
 int
 server4_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfx_open_rsp rsp = {
@@ -652,7 +654,7 @@ server4_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_OPENDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -663,13 +665,16 @@ server4_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server4_post_open(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server4_post_open(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    if (op_ret)
+    if (GET_RET(op_ret)) {
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    }
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -683,7 +688,7 @@ out:
 
 int
 server4_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -694,7 +699,7 @@ server4_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (ENODATA == op_errno || ENOATTR == op_errno)
             loglevel = GF_LOG_DEBUG;
@@ -711,7 +716,7 @@ server4_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -725,7 +730,7 @@ out:
 
 int
 server4_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -735,7 +740,7 @@ server4_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FREMOVEXATTR, op_errno),
                 op_errno, PS_MSG_REMOVEXATTR_INFO, "frame=%" PRId64,
@@ -748,7 +753,7 @@ server4_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -762,7 +767,7 @@ out:
 
 int
 server4_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     gfx_common_dict_rsp rsp = {
@@ -773,7 +778,7 @@ server4_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_GETXATTR, op_errno), op_errno,
                 PS_MSG_GETXATTR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -786,7 +791,7 @@ server4_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(dict, &rsp.dict);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -802,7 +807,7 @@ out:
 
 int
 server4_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     gfx_common_dict_rsp rsp = {
@@ -813,7 +818,7 @@ server4_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FGETXATTR, op_errno), op_errno,
                 PS_MSG_GETXATTR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -826,7 +831,7 @@ server4_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(dict, &rsp.dict);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -842,7 +847,7 @@ out:
 
 int
 server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -852,7 +857,7 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -868,7 +873,7 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -882,7 +887,7 @@ out:
 
 int
 server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -892,7 +897,7 @@ server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP) {
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -908,7 +913,7 @@ server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -922,7 +927,7 @@ out:
 
 int
 server4_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -943,7 +948,7 @@ server4_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.pargfid, oldpar_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_RENAME_INFO,
@@ -960,7 +965,7 @@ server4_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_rename(frame, state, &rsp, stbuf, preoldparent, postoldparent,
                         prenewparent, postnewparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -974,7 +979,7 @@ out:
 
 int
 server4_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -987,7 +992,7 @@ server4_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_UNLINK, op_errno), op_errno,
                 PS_MSG_LINK_INFO, "frame=%" PRId64, frame->root->unique,
                 "UNLINK_path=%s", state->loc.path, "uuid_utoa=%s",
@@ -1008,7 +1013,7 @@ server4_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_entry_remove(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1022,7 +1027,7 @@ out:
 
 int
 server4_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -1036,7 +1041,7 @@ server4_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                 "frame=%" PRId64, frame->root->unique, "SYMLINK_path= %s",
                 (state->loc.path) ? state->loc.path : "", "uuid_utoa=%s",
@@ -1050,7 +1055,7 @@ server4_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_3iatt(state, &rsp, inode, stbuf, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1064,7 +1069,7 @@ out:
 
 int
 server4_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -1084,7 +1089,7 @@ server4_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.gfid, gfid_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
 
@@ -1100,7 +1105,7 @@ server4_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_link(state, &rsp, inode, stbuf, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1114,7 +1119,7 @@ out:
 
 int
 server4_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1125,7 +1130,7 @@ server4_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_TRUNCATE_INFO,
                 "frame=%" PRId64, frame->root->unique, "TRUNCATE_path=%s",
@@ -1138,7 +1143,7 @@ server4_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1152,7 +1157,7 @@ out:
 
 int
 server4_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                   dict_t *xdata)
 {
     gfx_common_iatt_rsp rsp = {
@@ -1164,7 +1169,7 @@ server4_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_to_xdr(xdata, &rsp.xdata);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_FSTAT, op_errno), op_errno,
                 PS_MSG_STAT_INFO, "frame=%" PRId64, frame->root->unique,
                 "FSTAT_fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -1177,7 +1182,7 @@ server4_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_iatt(state, &rsp, stbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1191,7 +1196,7 @@ out:
 
 int
 server4_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {0};
@@ -1200,7 +1205,7 @@ server4_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FTRUNCATE, op_errno), op_errno,
                 PS_MSG_TRUNCATE_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1214,7 +1219,7 @@ server4_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1228,7 +1233,7 @@ out:
 
 int
 server4_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -1238,7 +1243,7 @@ server4_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FLUSH, op_errno), op_errno,
                 PS_MSG_FLUSH_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1250,7 +1255,7 @@ server4_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1264,7 +1269,7 @@ out:
 
 int
 server4_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1275,7 +1280,7 @@ server4_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FSYNC, op_errno), op_errno,
                 PS_MSG_SYNC_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1289,7 +1294,7 @@ server4_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1303,7 +1308,7 @@ out:
 
 int
 server4_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1314,7 +1319,7 @@ server4_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_WRITE, op_errno), op_errno,
                 PS_MSG_WRITE_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1328,7 +1333,7 @@ server4_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1342,7 +1347,7 @@ out:
 
 int
 server4_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -1364,7 +1369,7 @@ server4_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 #endif
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READ, op_errno), op_errno,
                 PS_MSG_READ_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1378,7 +1383,7 @@ server4_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_readv(&rsp, stbuf, op_ret);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1392,8 +1397,9 @@ out:
 
 int
 server4_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata)
 {
     gfx_rchecksum_rsp rsp = {
         0,
@@ -1403,7 +1409,7 @@ server4_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_RCHECKSUM, op_errno), op_errno,
                 PS_MSG_CHKSUM_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1416,7 +1422,7 @@ server4_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_rchecksum(&rsp, weak_checksum, strong_checksum);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1430,8 +1436,9 @@ out:
 
 int
 server4_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfx_open_rsp rsp = {
@@ -1440,7 +1447,7 @@ server4_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_OPEN, op_errno), op_errno,
                 PS_MSG_OPEN_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1451,11 +1458,13 @@ server4_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server4_post_open(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server4_post_open(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1468,10 +1477,11 @@ out:
 
 int
 server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *stbuf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     uint64_t fd_no = 0;
@@ -1483,7 +1493,7 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(
             this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
             "frame=%" PRId64, frame->root->unique, "path=%s", state->loc.path,
@@ -1495,24 +1505,22 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* TODO: log gfid too */
     gf_msg_trace(frame->root->client->bound_xl->name, 0,
-                 "%" PRId64
-                 ": "
-                 "CREATE %s (%s)",
-                 frame->root->unique, state->loc.name,
-                 uuid_utoa(stbuf->ia_gfid));
+                 "%" PRId64 ": CREATE %s (%s)", frame->root->unique,
+                 state->loc.name, uuid_utoa(stbuf->ia_gfid));
 
-    op_ret = server4_post_create(frame, &rsp, state, this, fd, inode, stbuf,
-                                 preparent, postparent);
-    if (op_ret) {
-        op_errno = -op_ret;
-        op_ret = -1;
+    ret = server4_post_create(frame, &rsp, state, this, fd, inode, stbuf,
+                              preparent, postparent);
+    if (ret < 0) {
+        op_errno = -ret;
+        op_ret = gf_error;
         goto out;
     }
 
 out:
-    if (op_ret)
+    if (GET_RET(op_ret)) {
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    }
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1526,7 +1534,7 @@ out:
 
 int
 server4_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *buf,
+                     gf_return_t op_ret, int32_t op_errno, const char *buf,
                      struct iatt *stbuf, dict_t *xdata)
 {
     gfx_readlink_rsp rsp = {
@@ -1537,7 +1545,7 @@ server4_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                 "frame=%" PRId64, frame->root->unique, "READLINK_path=%s",
@@ -1549,7 +1557,7 @@ server4_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_readlink(&rsp, stbuf, buf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
     if (!rsp.path)
         rsp.path = "";
@@ -1565,7 +1573,7 @@ out:
 
 int
 server4_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                  dict_t *xdata)
 {
     gfx_common_iatt_rsp rsp = {
@@ -1577,7 +1585,7 @@ server4_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_to_xdr(xdata, &rsp.xdata);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_STAT, op_errno), op_errno,
                 PS_MSG_STAT_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", (state->loc.path) ? state->loc.path : "",
@@ -1589,7 +1597,7 @@ server4_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_common_iatt(state, &rsp, stbuf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1603,7 +1611,7 @@ out:
 
 int
 server4_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1614,7 +1622,7 @@ server4_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SETATTR_INFO,
                 "frame=%" PRId64, frame->root->unique, "path=%s",
@@ -1628,7 +1636,7 @@ server4_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1642,7 +1650,7 @@ out:
 
 int
 server4_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1653,7 +1661,7 @@ server4_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FSETATTR, op_errno), op_errno,
                 PS_MSG_SETATTR_INFO, "frame=%" PRId64,
@@ -1667,7 +1675,7 @@ server4_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1681,7 +1689,7 @@ out:
 
 int
 server4_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     gfx_common_dict_rsp rsp = {
@@ -1692,7 +1700,7 @@ server4_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno), op_errno,
                 PS_MSG_XATTROP_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1705,7 +1713,7 @@ server4_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(dict, &rsp.dict);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1721,7 +1729,7 @@ out:
 
 int
 server4_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     gfx_common_dict_rsp rsp = {
@@ -1732,7 +1740,7 @@ server4_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FXATTROP, op_errno), op_errno,
                 PS_MSG_XATTROP_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1746,7 +1754,7 @@ server4_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_to_xdr(dict, &rsp.dict);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1762,7 +1770,7 @@ out:
 
 int
 server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     gfx_readdirp_rsp rsp = {
@@ -1776,7 +1784,7 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READDIRP, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1788,10 +1796,10 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (GET_RET(op_ret) > 0) {
         ret = server4_post_readdirp(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
@@ -1800,7 +1808,7 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_link_inodes_from_dirent(this, state->fd->inode, entries);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1816,8 +1824,9 @@ out:
 
 int
 server4_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
         0,
@@ -1827,7 +1836,7 @@ server4_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FALLOCATE, op_errno), op_errno,
                 PS_MSG_ALLOC_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1841,7 +1850,7 @@ server4_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1855,7 +1864,7 @@ out:
 
 int
 server4_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1866,7 +1875,7 @@ server4_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_DISCARD, op_errno), op_errno,
                 PS_MSG_DISCARD_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1880,7 +1889,7 @@ server4_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1894,7 +1903,7 @@ out:
 
 int
 server4_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -1908,7 +1917,7 @@ server4_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_ZEROFILL, op_errno), op_errno,
                 PS_MSG_ZEROFILL_INFO, "frame=%" PRId64, frame->root->unique,
                 "fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -1921,7 +1930,7 @@ server4_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_2iatt(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -1934,7 +1943,7 @@ out:
 
 int
 server4_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -1947,7 +1956,7 @@ server4_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SERVER_IPC_INFO,
                 "frame=%" PRId64, frame->root->unique, "IPC=%" PRId64,
                 state->resolve.fd_no, "uuid_utoa=%s",
@@ -1958,7 +1967,7 @@ server4_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -1971,7 +1980,8 @@ out:
 
 int
 server4_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, off_t offset,
+                 dict_t *xdata)
 {
     struct gfx_seek_rsp rsp = {
         0,
@@ -1984,7 +1994,7 @@ server4_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_SEEK, op_errno), op_errno,
                 PS_MSG_SEEK_INFO, "frame=%" PRId64, frame->root->unique,
                 "fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -1996,7 +2006,7 @@ server4_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server4_post_seek(&rsp, offset);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2009,7 +2019,7 @@ out:
 
 static int
 server4_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfx_common_rsp rsp = {
         0,
@@ -2021,7 +2031,7 @@ server4_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SETACTIVELK_INFO,
                 "frame=%" PRId64, frame->root->unique, "path==%s",
@@ -2032,7 +2042,7 @@ server4_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2047,7 +2057,7 @@ out:
 
 int
 server4_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     gfx_common_2iatt_rsp rsp = {
@@ -2056,7 +2066,7 @@ server4_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     rpcsvc_request_t *req = NULL;
 
     dict_to_xdr(xdata, &rsp.xdata);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     gfx_stat_from_iattx(&rsp.prestat, prebuf);
@@ -2068,7 +2078,7 @@ server4_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
      */
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2082,7 +2092,7 @@ out:
 
 int
 server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *stbuf, dict_t *xdata)
 {
     server_state_t *state = NULL;
@@ -2095,7 +2105,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_to_xdr(xdata, &rsp.xdata);
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
                 "frame=%" PRId64, uuid_utoa(state->resolve.gfid),
                 "ICREATE_gfid=%s", uuid_utoa(state->resolve.gfid),
@@ -2112,7 +2122,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
 
     if (!link_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOENT;
         goto out;
     }
@@ -2123,7 +2133,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gfx_stat_from_iattx(&rsp.stat, stbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2137,7 +2147,7 @@ out:
 
 int
 server4_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stbuf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -2151,7 +2161,7 @@ server4_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(
             this->name, GF_LOG_INFO, op_errno, PS_MSG_PUT_INFO,
             "frame=%" PRId64, frame->root->unique, "path=%s", state->loc.path,
@@ -2171,7 +2181,7 @@ server4_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_3iatt(state, &rsp, inode, stbuf, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2185,7 +2195,7 @@ out:
 
 int
 server4_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *stbuf, struct iatt *prebuf_dst,
                             struct iatt *postbuf_dst, dict_t *xdata)
 {
@@ -2199,7 +2209,7 @@ server4_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         uuid_utoa_r(state->resolve.gfid, in_gfid);
@@ -2228,7 +2238,7 @@ server4_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server4_post_common_3iatt_noinode(&rsp, stbuf, prebuf_dst, postbuf_dst);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2246,12 +2256,13 @@ int
 server4_rchecksum_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret;
+    ;
     int op_errno = EINVAL;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
@@ -2276,7 +2287,7 @@ server4_lease_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_lease_cbk, bound_xl, bound_xl->fops->lease,
@@ -2297,7 +2308,7 @@ server4_put_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2321,7 +2332,7 @@ server4_lk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_lk_cbk, bound_xl, bound_xl->fops->lk, state->fd,
@@ -2339,18 +2350,18 @@ int
 server4_rename_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2369,18 +2380,18 @@ int
 server4_link_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2405,7 +2416,7 @@ server4_symlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2427,7 +2438,7 @@ server4_access_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_access_cbk, bound_xl, bound_xl->fops->access,
@@ -2447,7 +2458,7 @@ server4_fentrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2476,7 +2487,7 @@ server4_entrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2506,7 +2517,7 @@ server4_finodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2538,7 +2549,7 @@ server4_inodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2565,7 +2576,7 @@ server4_rmdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_rmdir_cbk, bound_xl, bound_xl->fops->rmdir,
@@ -2585,7 +2596,7 @@ server4_mkdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2607,7 +2618,7 @@ server4_mknod_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2630,7 +2641,7 @@ server4_fsyncdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fsyncdir_cbk, bound_xl, bound_xl->fops->fsyncdir,
@@ -2650,7 +2661,7 @@ server4_readdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     GF_ASSERT(state->fd);
@@ -2672,7 +2683,7 @@ server4_readdirp_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_readdirp_cbk, bound_xl, bound_xl->fops->readdirp,
@@ -2692,7 +2703,7 @@ server4_opendir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -2717,7 +2728,7 @@ server4_statfs_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_statfs_cbk, bound_xl, bound_xl->fops->statfs,
@@ -2737,7 +2748,7 @@ server4_removexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_removexattr_cbk, bound_xl,
@@ -2757,7 +2768,7 @@ server4_fremovexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fremovexattr_cbk, bound_xl,
@@ -2777,7 +2788,7 @@ server4_fgetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fgetxattr_cbk, bound_xl,
@@ -2796,7 +2807,7 @@ server4_xattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_xattrop_cbk, bound_xl, bound_xl->fops->xattrop,
@@ -2815,7 +2826,7 @@ server4_fxattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fxattrop_cbk, bound_xl, bound_xl->fops->fxattrop,
@@ -2834,7 +2845,7 @@ server4_fsetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_setxattr_cbk, bound_xl, bound_xl->fops->fsetxattr,
@@ -2854,7 +2865,7 @@ server4_unlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_unlink_cbk, bound_xl, bound_xl->fops->unlink,
@@ -2873,7 +2884,7 @@ server4_truncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_truncate_cbk, bound_xl, bound_xl->fops->truncate,
@@ -2892,7 +2903,7 @@ server4_fstat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fstat_cbk, bound_xl, bound_xl->fops->fstat,
@@ -2911,7 +2922,7 @@ server4_setxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_setxattr_cbk, bound_xl, bound_xl->fops->setxattr,
@@ -2931,7 +2942,7 @@ server4_getxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_getxattr_cbk, bound_xl, bound_xl->fops->getxattr,
@@ -2950,7 +2961,7 @@ server4_ftruncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_ftruncate_cbk, bound_xl,
@@ -2971,7 +2982,7 @@ server4_flush_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_flush_cbk, bound_xl, bound_xl->fops->flush,
@@ -2991,7 +3002,7 @@ server4_fsync_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fsync_cbk, bound_xl, bound_xl->fops->fsync,
@@ -3011,7 +3022,7 @@ server4_writev_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_writev_cbk, bound_xl, bound_xl->fops->writev,
@@ -3032,7 +3043,7 @@ server4_readv_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_readv_cbk, bound_xl, bound_xl->fops->readv,
@@ -3053,7 +3064,7 @@ server4_create_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -3063,7 +3074,7 @@ server4_create_resume(call_frame_t *frame, xlator_t *bound_xl)
         gf_smsg("server", GF_LOG_ERROR, 0, PS_MSG_FD_CREATE_FAILED, "inode=%s",
                 state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : NULL,
                 NULL);
-        state->resolve.op_ret = -1;
+        state->resolve.op_ret = gf_error;
         state->resolve.op_errno = ENOMEM;
         goto err;
     }
@@ -3088,7 +3099,7 @@ server4_open_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -3111,7 +3122,7 @@ server4_readlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_readlink_cbk, bound_xl, bound_xl->fops->readlink,
@@ -3130,7 +3141,7 @@ server4_fsetattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fsetattr_cbk, bound_xl, bound_xl->fops->fsetattr,
@@ -3150,7 +3161,7 @@ server4_setattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_setattr_cbk, bound_xl, bound_xl->fops->setattr,
@@ -3170,7 +3181,7 @@ server4_stat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_stat_cbk, bound_xl, bound_xl->fops->stat,
@@ -3189,7 +3200,7 @@ server4_lookup_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->loc.inode)
@@ -3215,7 +3226,7 @@ server4_fallocate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_fallocate_cbk, bound_xl,
@@ -3236,7 +3247,7 @@ server4_discard_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_discard_cbk, bound_xl, bound_xl->fops->discard,
@@ -3256,7 +3267,7 @@ server4_zerofill_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_zerofill_cbk, bound_xl, bound_xl->fops->zerofill,
@@ -3276,7 +3287,7 @@ server4_seek_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_seek_cbk, bound_xl, bound_xl->fops->seek,
@@ -3291,7 +3302,7 @@ err:
 
 static int
 server4_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         lock_migration_info_t *locklist, dict_t *xdata)
 {
     gfx_getactivelk_rsp rsp = {
@@ -3305,7 +3316,7 @@ server4_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_GETACTIVELK_INFO,
@@ -3318,17 +3329,17 @@ server4_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) means there are no locks on the file*/
-    if (op_ret > 0) {
+    if (GET_RET(op_ret) > 0) {
         ret = serialize_rsp_locklist_v2(locklist, &rsp);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -3350,7 +3361,7 @@ server4_getactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_getactivelk_cbk, bound_xl,
@@ -3369,7 +3380,7 @@ server4_setactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_setactivelk_cbk, bound_xl,
@@ -3388,7 +3399,7 @@ server4_namelink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -3410,7 +3421,7 @@ server4_icreate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -3432,7 +3443,7 @@ server4_copy_file_range_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server4_copy_file_range_cbk, bound_xl,

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -104,7 +104,7 @@ typedef struct {
     u_char pargfid[16];
     char *path;
     char *bname;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     loc_t resolve_loc;
 } server_resolve_t;

--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -76,7 +76,7 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
         0,
     };
     int _fd = -1;
-    int op_ret = -1;
+    gf_return_t op_ret;
     int op_errno = 0;
     struct iovec iov;
     struct iobref *iobref = NULL;
@@ -94,7 +94,7 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
     offset = paiocb->offset;
 
     if (res < 0) {
-        op_ret = -1;
+        ret = -1;
         op_errno = -res;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_READV_FAILED,
                "readv(async) failed fd=%d,size=%lu,offset=%llu (%d)", _fd,
@@ -105,19 +105,18 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
 
     ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
     if (ret != 0) {
-        op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
                "fstat failed on fd=%d", _fd);
         goto out;
     }
 
-    op_ret = res;
+    ret = res;
     op_errno = 0;
 
     iobref = iobref_new();
     if (!iobref) {
-        op_ret = -1;
+        ret = -1;
         op_errno = ENOMEM;
         goto out;
     }
@@ -125,15 +124,16 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
     iobref_add(iobref, iobuf);
 
     iov.iov_base = iobuf_ptr(iobuf);
-    iov.iov_len = op_ret;
+    iov.iov_len = ret;
 
     /* Hack to notify higher layers of EOF. */
     if (!postbuf.ia_size || (offset + iov.iov_len) >= postbuf.ia_size)
         op_errno = ENOENT;
 
-    GF_ATOMIC_ADD(priv->read_value, op_ret);
+    GF_ATOMIC_ADD(priv->read_value, ret);
 
 out:
+    SET_RET(op_ret, ret);
     STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, &iov, 1, &postbuf,
                         iobref, NULL);
     if (iobuf)
@@ -229,7 +229,7 @@ posix_aio_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(readv, frame, -1, op_errno, 0, 0, 0, 0, 0);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, op_errno, 0, 0, 0, 0, 0);
     if (iobuf)
         iobuf_unref(iobuf);
 
@@ -254,14 +254,14 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
         0,
     };
     int _fd = -1;
-    int op_ret = -1;
+    gf_return_t op_ret;
     int op_errno = 0;
     int ret = 0;
     struct posix_private *priv = NULL;
     fd_t *fd = NULL;
 
     if (!paiocb) {
-        op_ret = -1;
+        ret = -1;
         op_errno = EINVAL;
         goto out;
     }
@@ -274,7 +274,7 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
     _fd = paiocb->_fd;
 
     if (res < 0) {
-        op_ret = -1;
+        ret = -1;
         op_errno = -res;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_WRITEV_FAILED,
                "writev(async) failed fd=%d,offset=%llu (%d)", _fd,
@@ -285,19 +285,19 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
 
     ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
     if (ret != 0) {
-        op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
                "fstat failed on fd=%d", _fd);
         goto out;
     }
 
-    op_ret = res;
+    ret = res;
     op_errno = 0;
 
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
+    GF_ATOMIC_ADD(priv->write_value, ret);
 
 out:
+    SET_RET(op_ret, ret);
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, &prebuf, &postbuf,
                         NULL);
 
@@ -389,7 +389,7 @@ posix_aio_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(writev, frame, -1, op_errno, 0, 0, 0);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, op_errno, 0, 0, 0);
 
     if (paiocb) {
         if (paiocb->iobref)

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 
 #include <glusterfs/defaults.h>
+#include <glusterfs/globals.h>
 
 #include "posix-acl.h"
 #include "posix-acl-xattr.h"
@@ -939,8 +940,8 @@ out:
 
 int
 posix_acl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xattr, struct iatt *postparent)
+                     gf_return_t op_ret, int op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xattr, struct iatt *postparent)
 {
     struct posix_acl *acl_access = NULL;
     struct posix_acl *acl_default = NULL;
@@ -951,12 +952,12 @@ posix_acl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = 0;
     dict_t *my_xattr = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ctx = posix_acl_ctx_new(inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -1051,8 +1052,11 @@ green:
     STACK_WIND(frame, posix_acl_lookup_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->lookup, loc, my_xattr);
     return 0;
+
 red:
-    STACK_UNWIND_STRICT(lookup, frame, -1, EACCES, NULL, NULL, NULL, NULL);
+
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, EACCES, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
@@ -1061,7 +1065,7 @@ int
 posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
                  dict_t *xdata)
 {
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int perm = 0;
     int mode = 0;
@@ -1079,7 +1083,7 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
         goto unwind;
     }
     if (!perm) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto unwind;
     }
@@ -1087,10 +1091,10 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
     if (is_fuse_call) {
         mode = acl_permits(frame, loc->inode, perm);
         if (mode) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = 0;
         } else {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EACCES;
         }
     } else {
@@ -1111,10 +1115,12 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
     }
 
 unwind:
-    if (is_fuse_call)
+    if (is_fuse_call) {
         STACK_UNWIND_STRICT(access, frame, op_ret, op_errno, NULL);
-    else
-        STACK_UNWIND_STRICT(access, frame, 0, mode, NULL);
+    } else {
+        op_ret = gf_success;
+        STACK_UNWIND_STRICT(access, frame, op_ret, mode, NULL);
+    }
     return 0;
 }
 
@@ -1137,7 +1143,7 @@ posix_acl_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t off,
     }
 
     /* fail by default */
-    STACK_UNWIND_STRICT(truncate, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(truncate, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 
 green:
@@ -1183,7 +1189,7 @@ green:
                FIRST_CHILD(this)->fops->open, loc, flags, fd, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(open, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, EACCES, NULL, NULL);
     return 0;
 }
 
@@ -1204,7 +1210,8 @@ green:
                FIRST_CHILD(this)->fops->readv, fd, size, offset, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readv, frame, -1, EACCES, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, EACCES, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -1227,7 +1234,7 @@ green:
                flags, iobref, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(writev, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1248,7 +1255,7 @@ green:
                FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(ftruncate, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(ftruncate, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1265,17 +1272,17 @@ green:
                FIRST_CHILD(this)->fops->opendir, loc, fd, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(opendir, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(opendir, frame, gf_error, EACCES, NULL, NULL);
     return 0;
 }
 
 int
 posix_acl_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                    struct iatt *preparent, struct iatt *postparent,
-                    dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, inode_t *inode,
+                    struct iatt *buf, struct iatt *preparent,
+                    struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_MKDIR);
@@ -1304,17 +1311,18 @@ green:
                FIRST_CHILD(this)->fops->mkdir, loc, newmode, umask, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(mkdir, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mkdir, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int
 posix_acl_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                    struct iatt *preparent, struct iatt *postparent,
-                    dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, inode_t *inode,
+                    struct iatt *buf, struct iatt *preparent,
+                    struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_MKNOD);
@@ -1344,17 +1352,18 @@ green:
                xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(mknod, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mknod, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int
 posix_acl_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, fd_t *fd, inode_t *inode,
+                     gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
                      struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_CREATE);
@@ -1384,18 +1393,18 @@ green:
                xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(create, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int
 posix_acl_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, inode_t *inode,
+                      gf_return_t op_ret, int op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_SYMLINK);
@@ -1419,8 +1428,8 @@ green:
                FIRST_CHILD(this)->fops->symlink, linkname, loc, umask, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(symlink, frame, -1, EACCES, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(symlink, frame, gf_error, EACCES, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -1440,7 +1449,7 @@ green:
                FIRST_CHILD(this)->fops->unlink, loc, xflag, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(unlink, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1460,7 +1469,7 @@ green:
                FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(rmdir, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1486,8 +1495,8 @@ posix_acl_rename(call_frame_t *frame, xlator_t *this, loc_t *old, loc_t *new,
                FIRST_CHILD(this)->fops->rename, old, new, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(rename, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -1518,7 +1527,7 @@ posix_acl_link(call_frame_t *frame, xlator_t *this, loc_t *old, loc_t *new,
                FIRST_CHILD(this)->fops->link, old, new, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     return 0;
@@ -1537,14 +1546,14 @@ green:
                FIRST_CHILD(this)->fops->readdir, fd, size, offset, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readdir, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(readdir, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
 
 int
 posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, gf_dirent_t *entries,
+                       gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                        dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -1554,7 +1563,11 @@ posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     data_t *data = NULL;
     int ret = 0;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
+        goto unwind;
+
+    /* generally means no entries found */
+    if (GET_RET(op_ret) == 0)
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -1565,7 +1578,7 @@ posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         ctx = posix_acl_ctx_new(entry->inode, this);
         if (!ctx) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -1652,7 +1665,7 @@ green:
         dict_unref(alloc_dict);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readdirp, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(readdirp, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -1718,7 +1731,7 @@ setattr_scrutiny(call_frame_t *frame, inode_t *inode, struct iatt *buf,
 
 int
 posix_acl_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     inode_t *inode = NULL;
@@ -1726,7 +1739,7 @@ posix_acl_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode = frame->local;
     frame->local = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, postbuf, GF_FOP_SETATTR);
@@ -1754,14 +1767,14 @@ posix_acl_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                FIRST_CHILD(this)->fops->setattr, loc, buf, valid, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
 posix_acl_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *prebuf,
+                       gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
 {
     inode_t *inode = NULL;
@@ -1769,7 +1782,7 @@ posix_acl_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode = frame->local;
     frame->local = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, postbuf, GF_FOP_FSETATTR);
@@ -1797,7 +1810,7 @@ posix_acl_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                FIRST_CHILD(this)->fops->fsetattr, fd, buf, valid, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fsetattr, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsetattr, frame, gf_error, EACCES, NULL, NULL, NULL);
 
     return 0;
 }
@@ -1946,7 +1959,7 @@ out:
 }
 int
 posix_acl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     /*
      * Update the context of posix_acl_translator, if any of
@@ -1983,7 +1996,7 @@ posix_acl_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                       xattr, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(setxattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -2007,7 +2020,7 @@ posix_acl_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                FIRST_CHILD(this)->fops->fsetxattr, fd, xattr, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fsetxattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -2030,7 +2043,7 @@ green:
     return 0;
 
 red:
-    STACK_UNWIND_STRICT(getxattr, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(getxattr, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -2051,7 +2064,7 @@ green:
                FIRST_CHILD(this)->fops->fgetxattr, fd, name, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fgetxattr, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -2088,7 +2101,7 @@ green:
                FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(removexattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(removexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }


### PR DESCRIPTION
* return signature of all 'fops' callback changed to `gf_return_t`.

* provide IS_ERROR()/IS_SUCCESS() macros to check only this type of argument.

* provide 2 global variables `gf_success` and `gf_error` introduced, which
  can used instead of -1 and 0 return used largely today.

Change-Id: Ib91216afaa89d7e4509757b50dd8a7d60a6bf0a9
Updates: #280
Signed-off-by: Amar Tumballi <amar@kadalu.io>

