### PR TITLE
Update maintainer list of DHT

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -96,7 +96,10 @@ S: Maintained
 F: xlators/features/changelog/
 
 Distributed Hashing Table (DHT)
-P: Susant Palai <spalai@redhat.com>
+M: Mohit Agrawal <moagrawa@redhat.com>
+M: Barak Sason Rofman <bsasonro@redhat.com>
+M: Tamar Shacked <tshacked@redhat.com>
+P: Csaba Henk <chenk@redhat.com>
 S: Maintained
 F: xlators/cluster/dht/
 
@@ -508,3 +511,4 @@ M: Ira Cooper
 M: Shwetha Panduranga
 M: Nithya Balachandran
 M: Raghavendra Gowdappa
+M: Susant Palai


### PR DESCRIPTION
Update maintainers list to reflect current status of DHT.

fixes: #1550
Change-Id: Ie5ddd0255a53da1ac2b4dd1b210d69e78ca6c85a
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

