### PR TITLE
trash: Create inode_table only while feature is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,12 @@ if test "x$with_ipv6_default" = "xyes" ; then
    GF_CFLAGS="$GF_CFLAGS -DIPV6_DEFAULT"
 fi
 
+USE_BRICKMUX="no"
+if test "x$enable_brickmux" = "xyes" ; then
+   USE_BRICKMUX="yes"
+   AC_DEFINE(GF_ENABLE_BRICKMUX, 1, [Enable Brick Mux.])
+fi
+
 dnl check for gcc -Werror=format-security
 saved_CFLAGS=$CFLAGS
 CFLAGS="-Wformat -Werror=format-security"
@@ -1706,6 +1712,7 @@ echo "With Python          : ${PYTHON_VERSION}"
 echo "Cloudsync            : $BUILD_CLOUDSYNC"
 echo "Metadata dispersal   : $BUILD_METADISP"
 echo "Link with TCMALLOC   : $BUILD_TCMALLOC"
+echo "Enable Brick Mux     : $USE_BRICKMUX"
 echo
 
 # dnl Note: ${X^^} capitalization assumes bash >= 4.x

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -2246,6 +2246,9 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("trash", priv->state, options, bool, out);
 
     if (priv->state) {
+        if (!priv->trash_itable)
+            priv->trash_itable = inode_table_new(0, this);
+
         ret = create_or_rename_trash_directory(this);
 
         if (tmp)
@@ -2501,7 +2504,8 @@ init(xlator_t *this)
         goto out;
     }
 
-    priv->trash_itable = inode_table_new(0, this);
+    if (priv->state)
+        priv->trash_itable = inode_table_new(0, this);
     gf_log(this->name, GF_LOG_DEBUG, "brick path is%s", priv->brick_path);
 
     this->private = (void *)priv;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -139,6 +139,17 @@ is_brick_mx_enabled(void)
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
+    /* GF_ENABLE_BRICKMUX set as a compile time build option, if the
+       option is set and brick_mux key is not configured then consider
+       brick_mux option is enabled
+    */
+    #if defined(GF_ENABLE_BRICKMUX)
+        if (ret) {
+            ret = _gf_false;
+            enabled = _gf_true;
+        }
+    #endif
+
     return ret ? _gf_false : enabled;
 }
 


### PR DESCRIPTION
Currently trash xlator create a inode table(1M) even if
feature is not enabled.In brick_mux environment while 250
bricks are attached with a single brick process and feature
is not enable brick process increase RSS size unnecessarily.

Solution: Create inode_table only while a feature is enabled.
          The patch reduces 250M RSS size per brick process
          if trash feature is not enabled.

Change-Id: I11a6fd2b8419fe2988f398be6ec30fb4f3b99a5d
Fixes: #1543
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

