### PR TITLE
gfapi: give appropriate error when size exceeds

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1534,6 +1534,14 @@ glfs_pwritev_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
 
     GF_REF_GET(glfd);
 
+    if (iovec->iov_len >= GF_UNIT_GB) {
+        ret = -1;
+        errno = EINVAL;
+        gf_smsg(THIS->name, GF_LOG_ERROR, errno, API_MSG_INVALID_ARG,
+                "size >= %llu is not allowed", GF_UNIT_GB, NULL);
+        goto out;
+    }
+
     subvol = glfs_active_subvol(glfd->fs);
     if (!subvol) {
         ret = -1;


### PR DESCRIPTION
This patch help generate appropriate error message
when the gfapi tries to write data equal to or
greater than 1 Gb due to the limitation at the
socket layer.

fixes: #1518

Change-Id: I1234a0b5a6e675a0b20c6b1afe0f4390fd721f6f
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

