### PR TITLE
afr: fixing null dereference reported by coverity

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -2803,7 +2803,7 @@ afr_anon_inode_create(xlator_t *this, int child, inode_t **linked_inode)
     }
 
     frame = afr_frame_create(this, &op_errno);
-    if (op_errno) {
+    if (!frame) {
         goto out;
     }
     local = frame->local;


### PR DESCRIPTION
Added a null check to avoid a null pointer dereference

CID: 1433222
Updates: #1060
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

