### PR TITLE
configure.ac: Add --enable-brickmux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,12 @@ if test "x$with_ipv6_default" = "xyes" ; then
    GF_CFLAGS="$GF_CFLAGS -DIPV6_DEFAULT"
 fi
 
+USE_BRICKMUX="no"
+if test "x$enable_brickmux" = "xyes" ; then
+   USE_BRICKMUX="yes"
+   AC_DEFINE(GF_ENABLE_BRICKMUX, 1, [Enable Brick Mux.])
+fi
+
 dnl check for gcc -Werror=format-security
 saved_CFLAGS=$CFLAGS
 CFLAGS="-Wformat -Werror=format-security"
@@ -1706,6 +1712,7 @@ echo "With Python          : ${PYTHON_VERSION}"
 echo "Cloudsync            : $BUILD_CLOUDSYNC"
 echo "Metadata dispersal   : $BUILD_METADISP"
 echo "Link with TCMALLOC   : $BUILD_TCMALLOC"
+echo "Enable Brick Mux     : $USE_BRICKMUX"
 echo
 
 # dnl Note: ${X^^} capitalization assumes bash >= 4.x

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -139,6 +139,17 @@ is_brick_mx_enabled(void)
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
+    /* GF_ENABLE_BRICKMUX set as a compile time build option, if the
+       option is set and brick_mux key is not configured then consider
+       brick_mux option is enabled
+    */
+    #if defined(GF_ENABLE_BRICKMUX)
+        if (ret) {
+            ret = _gf_false;
+            enabled = _gf_true;
+        }
+    #endif
+
     return ret ? _gf_false : enabled;
 }
 


### PR DESCRIPTION
Introduce an --enable-brickmux configure option to
enable brick_mux as a default option.

Fixes: gluster#1569
Change-Id: Id0c61ee3500630889e2cb2b5816cd40f68d47c94
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

