### PR TITLE
posix: Attach a posix_spawn_disk_thread with glusterfs_ctx

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1688,9 +1688,13 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
     INIT_LIST_HEAD(&cmd_args->xlator_options);
     INIT_LIST_HEAD(&cmd_args->volfile_servers);
     ctx->pxl_count = 0;
+    ctx->diskxl_count = 0;
     pthread_mutex_init(&ctx->fd_lock, NULL);
     pthread_cond_init(&ctx->fd_cond, NULL);
     INIT_LIST_HEAD(&ctx->janitor_fds);
+    pthread_mutex_init(&ctx->xl_lock, NULL);
+    pthread_cond_init(&ctx->xl_cond, NULL);
+    INIT_LIST_HEAD(&ctx->diskth_xl);
 
     lim.rlim_cur = RLIM_INFINITY;
     lim.rlim_max = RLIM_INFINITY;

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -740,7 +740,13 @@ struct _glusterfs_ctx {
     pthread_t janitor;
     /* The variable is use to save total posix xlator count */
     uint32_t pxl_count;
+    uint32_t diskxl_count;
 
+    /* List of posix xlator use by disk thread*/
+    struct list_head diskth_xl;
+    pthread_mutex_t xl_lock;
+    pthread_cond_t xl_cond;
+    pthread_t disk_space_check;
     char volume_id[GF_UUID_BUF_SIZE]; /* Used only in protocol/client */
 };
 typedef struct _glusterfs_ctx glusterfs_ctx_t;

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -217,5 +217,5 @@ int
 posix_check_internal_writes(xlator_t *this, fd_t *fd, int sysfd, dict_t *xdata);
 
 void
-posix_disk_space_check(xlator_t *this);
+posix_disk_space_check(struct posix_private *priv);
 #endif /* !_POSIX_HANDLE_H */

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2301,9 +2301,8 @@ unlock:
 }
 
 void
-posix_disk_space_check(xlator_t *this)
+posix_disk_space_check(struct posix_private *priv)
 {
-    struct posix_private *priv = NULL;
     char *subvol_path = NULL;
     int op_ret = 0;
     double size = 0;
@@ -2312,16 +2311,14 @@ posix_disk_space_check(xlator_t *this)
     double totsz = 0;
     double freesz = 0;
 
-    GF_VALIDATE_OR_GOTO("posix-helpers", this, out);
-    priv = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, priv, out);
+    GF_VALIDATE_OR_GOTO("posix-helpers", priv, out);
 
     subvol_path = priv->base_path;
 
     op_ret = sys_statvfs(subvol_path, &buf);
 
     if (op_ret == -1) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_STATVFS_FAILED,
+        gf_msg("posix-disk", GF_LOG_ERROR, errno, P_MSG_STATVFS_FAILED,
                "statvfs failed on %s", subvol_path);
         goto out;
     }
@@ -2345,78 +2342,106 @@ out:
 }
 
 static void *
-posix_disk_space_check_thread_proc(void *data)
+posix_ctx_disk_thread_proc(void *data)
 {
-    xlator_t *this = NULL;
     struct posix_private *priv = NULL;
+    glusterfs_ctx_t *ctx = NULL;
     uint32_t interval = 0;
-    int ret = -1;
+    struct posix_diskxl *pthis = NULL;
+    struct posix_diskxl *tmp = NULL;
+    xlator_t *this = NULL;
+    struct timespec sleep_till = {
+        0,
+    };
 
-    this = data;
-    priv = this->private;
-
+    ctx = data;
     interval = 5;
-    gf_msg_debug(this->name, 0,
-                 "disk-space thread started, "
+
+    gf_msg_debug("glusterfs_ctx", 0,
+                 "Ctx disk-space thread started, "
                  "interval = %d seconds",
                  interval);
     while (1) {
-        /* aborting sleep() is a request to exit this thread, sleep()
-         * will normally not return when cancelled */
-        ret = sleep(interval);
-        if (ret > 0)
-            break;
-        /* prevent thread errors while doing the health-check(s) */
-        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+        pthread_mutex_lock(&ctx->xl_lock);
+        {
+            if (!ctx->diskxl_count) {
+                pthread_mutex_unlock(&ctx->xl_lock);
+                break;
+            }
 
-        /* Do the disk-check.*/
-        posix_disk_space_check(this);
-        if (!priv->disk_space_check_active)
-            goto out;
-        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+            list_for_each_entry_safe(pthis, tmp, &ctx->diskth_xl, list)
+            {
+                pthis->is_use = _gf_true;
+                pthread_mutex_unlock(&ctx->xl_lock);
+
+                THIS = this = pthis->xl;
+                priv = this->private;
+
+                posix_disk_space_check(priv);
+
+                pthread_mutex_lock(&ctx->xl_lock);
+                {
+                    pthis->is_use = _gf_false;
+                    /* Send a signal to posix_notify function */
+                    if (pthis->detach_notify)
+                        pthread_cond_signal(&pthis->cond);
+                }
+            }
+
+            timespec_now_realtime(&sleep_till);
+            sleep_till.tv_sec += 5;
+            (void)pthread_cond_timedwait(&ctx->xl_cond, &ctx->xl_lock,
+                                         &sleep_till);
+        }
+        pthread_mutex_unlock(&ctx->xl_lock);
     }
 
 out:
-    gf_msg_debug(this->name, 0, "disk space check thread exiting");
-    LOCK(&priv->lock);
-    {
-        priv->disk_space_check_active = _gf_false;
-    }
-    UNLOCK(&priv->lock);
-
     return NULL;
 }
 
 int
-posix_spawn_disk_space_check_thread(xlator_t *xl)
+posix_spawn_disk_space_check_thread(xlator_t *this)
 {
-    struct posix_private *priv = NULL;
-    int ret = -1;
+    int ret = 0;
+    glusterfs_ctx_t *ctx = NULL;
+    struct posix_diskxl *pxl = NULL;
+    struct posix_private *priv = this->private;
 
-    priv = xl->private;
+    ctx = this->ctx;
 
-    LOCK(&priv->lock);
+    pthread_mutex_lock(&ctx->xl_lock);
     {
-        /* cancel the running thread  */
-        if (priv->disk_space_check_active == _gf_true) {
-            pthread_cancel(priv->disk_space_check);
-            priv->disk_space_check_active = _gf_false;
-        }
+        if (ctx->diskxl_count++ == 0) {
+            ret = gf_thread_create(&ctx->disk_space_check, NULL,
+                                   posix_ctx_disk_thread_proc, ctx,
+                                   "posixctxres");
 
-        ret = gf_thread_create(&priv->disk_space_check, NULL,
-                               posix_disk_space_check_thread_proc, xl,
-                               "posixrsv");
-        if (ret) {
-            priv->disk_space_check_active = _gf_false;
-            gf_msg(xl->name, GF_LOG_ERROR, errno, P_MSG_DISK_SPACE_CHECK_FAILED,
-                   "unable to setup disk space check thread");
-            goto unlock;
+            if (ret) {
+                gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_THREAD_FAILED,
+                       "spawning disk space check thread failed");
+                ctx->diskxl_count--;
+                pthread_mutex_unlock(&ctx->xl_lock);
+                goto out;
+            }
         }
-
-        priv->disk_space_check_active = _gf_true;
+        pxl = calloc(1, sizeof(*pxl));
+        if (!pxl) {
+            ret = ENOMEM;
+            gf_log(this->name, GF_LOG_ERROR,
+                   "Calloc is failed to allocate "
+                   "memory for diskxl object");
+            pthread_mutex_unlock(&ctx->xl_lock);
+            goto out;
+        }
+        pthread_cond_init(&pxl->cond, NULL);
+        pxl->xl = this;
+        priv->pxl = (void *)pxl;
+        list_add_tail(&pxl->list, &ctx->diskth_xl);
     }
-unlock:
-    UNLOCK(&priv->lock);
+    pthread_mutex_unlock(&ctx->xl_lock);
+
+out:
     return ret;
 }
 

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -719,7 +719,7 @@ posix_do_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
        option behaviour
     */
     if (priv->disk_reserve)
-        posix_disk_space_check(this);
+        posix_disk_space_check(priv);
 
     DISK_SPACE_CHECK_AND_GOTO(frame, priv, xdata, ret, ret, unlock);
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -129,6 +129,14 @@ struct posix_fd {
     char _pad[4]; /* manual padding */
 };
 
+struct posix_diskxl {
+    pthread_cond_t cond;
+    struct list_head list;
+    xlator_t *xl;
+    gf_boolean_t detach_notify;
+    gf_boolean_t is_use;
+};
+
 struct posix_private {
     char *base_path;
     int32_t base_path_length;
@@ -167,6 +175,7 @@ struct posix_private {
     pthread_mutex_t janitor_mutex;
     pthread_cond_t janitor_cond;
     pthread_cond_t fd_cond;
+    pthread_cond_t disk_cond;
     int fsync_queue_count;
     int32_t janitor_sleep_duration;
 
@@ -221,7 +230,6 @@ struct posix_private {
     gf_boolean_t ctime;
     gf_boolean_t janitor_task_stop;
 
-    gf_boolean_t disk_space_check_active;
     char disk_unit;
     gf_boolean_t health_check_active;
     gf_boolean_t update_pgfid_nlinks;
@@ -252,6 +260,7 @@ struct posix_private {
     gf_boolean_t aio_init_done;
     gf_boolean_t aio_capable;
     uint32_t rel_fdcount;
+    void *pxl;
 };
 
 typedef struct {


### PR DESCRIPTION
Currently posix xlator spawns posix_disk_space_threads per brick and in
case of brick_mux environment while glusterd attached bricks at maximum
level(250) with a single brick process in that case 250 threads are
spawned for all bricks and brick process memory size also increased.

Solution: Attach a posix_disk_space thread with glusterfs_ctx to
      spawn a thread per process basis instead of spawning a per brick

Fixes: #1482
Change-Id: I8dd88f252a950495b71742e2a7588bd5bb019ec7
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

