### PR TITLE
io-stats: Configure ios_sample_buf_size based on sample_interval value

### DIFF
--- a/tests/bugs/glusterd/daemon-log-level-option.t
+++ b/tests/bugs/glusterd/daemon-log-level-option.t
@@ -61,8 +61,8 @@ rm -f /var/log/glusterfs/glustershd.log
 TEST $CLI volume set all cluster.daemon-log-level WARNING
 TEST $CLI volume start $V0
 
-# log should not have any info messages
-EXPECT 0 Info_messages_count "/var/log/glusterfs/glustershd.log"
+# log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
+EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
 
 # log should not have any debug messages
 EXPECT 0 Debug_messages_count "/var/log/glusterfs/glustershd.log"
@@ -78,8 +78,8 @@ rm -f /var/log/glusterfs/glustershd.log
 TEST $CLI volume set all cluster.daemon-log-level ERROR
 TEST $CLI volume start $V0
 
-# log should not have any info messages
-EXPECT 0 Info_messages_count "/var/log/glusterfs/glustershd.log"
+# log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
+EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
 
 # log should not have any warning messages
 EXPECT 0 Warning_messages_count "/var/log/glusterfs/glustershd.log"

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3699,6 +3699,15 @@ xlator_set_loglevel(xlator_t *this, int log_level)
     }
 }
 
+void
+ios_sample_buf_size_configure(char *name, struct ios_conf *conf)
+{
+    conf->ios_sample_buf_size = 1024;
+    gf_log(name, GF_LOG_INFO,
+           "Configure ios_sample_buf "
+           " size is 1024 because ios_sample_interval is 0");
+}
+
 int
 reconfigure(xlator_t *this, dict_t *options)
 {
@@ -3755,8 +3764,13 @@ reconfigure(xlator_t *this, dict_t *options)
                      int32, out);
     GF_OPTION_RECONF("ios-dump-format", dump_format_str, options, str, out);
     ios_set_log_format_code(conf, dump_format_str);
-    GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
-                     int32, out);
+    if (conf->ios_sample_interval) {
+        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
+                         int32, out);
+    } else {
+        ios_sample_buf_size_configure (this->name, conf);
+    }
+
     GF_OPTION_RECONF("sys-log-level", sys_log_str, options, str, out);
     if (sys_log_str) {
         sys_log_level = glusterd_check_log_level(sys_log_str);
@@ -3933,8 +3947,12 @@ init(xlator_t *this)
     GF_OPTION_INIT("ios-dump-format", dump_format_str, str, out);
     ios_set_log_format_code(conf, dump_format_str);
 
-    GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
-                   out);
+    if (conf->ios_sample_interval) {
+        GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
+                       out);
+    } else {
+        ios_sample_buf_size_configure (this->name, conf);
+    }
 
     ret = ios_init_sample_buf(conf);
     if (ret) {


### PR DESCRIPTION
io-stats xlator declares a ios_sample_buf_size 64k object(10M) per xlator
but in case of sample_interval is 0 this big buffer is not required so
declare the default value only while sample_interval is not 0.The new
change would be helpful to reduce RSS size for a brick and shd process
while the number of volumes are huge.

Change-Id: I3e82cca92e40549355edfac32580169f3ce51af8
Fixes: #1542
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

