### PR TITLE
trash: Create inode_table only while feature is enabled

### DIFF
--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -2246,6 +2246,9 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("trash", priv->state, options, bool, out);
 
     if (priv->state) {
+        if (!priv->trash_itable)
+            priv->trash_itable = inode_table_new(0, this);
+
         ret = create_or_rename_trash_directory(this);
 
         if (tmp)
@@ -2501,7 +2504,8 @@ init(xlator_t *this)
         goto out;
     }
 
-    priv->trash_itable = inode_table_new(0, this);
+    if (priv->state)
+        priv->trash_itable = inode_table_new(0, this);
     gf_log(this->name, GF_LOG_DEBUG, "brick path is%s", priv->brick_path);
 
     this->private = (void *)priv;


### PR DESCRIPTION
Currently trash xlator create a inode table(1M) even if
feature is not enabled.In brick_mux environment while 250
bricks are attached with a single brick process and feature
is not enable brick process increase RSS size unnecessarily.

Solution: Create inode_table only while a feature is enabled.
          The patch reduces 250M RSS size per brick process
          if trash feature is not enabled.

Change-Id: I11a6fd2b8419fe2988f398be6ec30fb4f3b99a5d
Fixes: #1543
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

