### PR TITLE
core: configure optimum inode table hash_size for shd

### DIFF
--- a/api/src/glfs-master.c
+++ b/api/src/glfs-master.c
@@ -39,7 +39,7 @@ graph_setup(struct glfs *fs, glusterfs_graph_t *graph)
         }
 
         if (!new_subvol->itable) {
-            itable = inode_table_new(131072, new_subvol);
+            itable = inode_table_new(131072, new_subvol, 0, 0);
             if (!itable) {
                 errno = ENOMEM;
                 ret = -1;

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -35,11 +35,12 @@ typedef struct _dentry dentry_t;
 
 struct _inode_table {
     pthread_mutex_t lock;
-    size_t hashsize;    /* bucket size of inode hash and dentry hash */
-    char *name;         /* name of the inode table, just for gf_log() */
-    inode_t *root;      /* root directory inode, with number 1 */
-    xlator_t *xl;       /* xlator to be called to do purge */
-    uint32_t lru_limit; /* maximum LRU cache size */
+    size_t dentry_hashsize; /* Number of buckets for dentry hash*/
+    size_t inode_hashsize;  /* Size of inode hash table */
+    char *name;             /* name of the inode table, just for gf_log() */
+    inode_t *root;          /* root directory inode, with number 1 */
+    xlator_t *xl;           /* xlator to be called to do purge */
+    uint32_t lru_limit;     /* maximum LRU cache size */
     struct list_head *inode_hash; /* buckets for inode hash table */
     struct list_head *name_hash;  /* buckets for dentry hash table */
     struct list_head active; /* list of inodes currently active (in an fop) */
@@ -120,12 +121,14 @@ struct _inode {
 #define GFID_STR_PFX_LEN (sizeof(GFID_STR_PFX) - 1)
 
 inode_table_t *
-inode_table_new(uint32_t lru_limit, xlator_t *xl);
+inode_table_new(uint32_t lru_limit, xlator_t *xl, uint32_t dhash_size,
+                uint32_t inodehash_size);
 
 inode_table_t *
 inode_table_with_invalidator(uint32_t lru_limit, xlator_t *xl,
                              int32_t (*invalidator_fn)(xlator_t *, inode_t *),
-                             xlator_t *invalidator_xl);
+                             xlator_t *invalidator_xl, uint32_t dentry_hashsize,
+                             uint32_t inode_hashsize);
 
 void
 inode_table_destroy_all(glusterfs_ctx_t *ctx);

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -633,7 +633,15 @@ init(xlator_t *this)
         goto out;
     }
 
-    this->itable = inode_table_new(SHD_INODE_LRU_LIMIT, this);
+    if (priv->shd.iamshd) {
+        /* Number of hash bucket should be prime number so declare 131
+           total dentry hash buckets
+        */
+        this->itable = inode_table_new(SHD_INODE_LRU_LIMIT, this, 131, 128);
+    } else {
+        this->itable = inode_table_new(SHD_INODE_LRU_LIMIT, this, 0, 0);
+    }
+
     if (!this->itable) {
         ret = -ENOMEM;
         goto out;

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2405,7 +2405,7 @@ dht_build_root_inode(xlator_t *this, inode_t **inode)
     inode_table_t *itable = NULL;
     static uuid_t root_gfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
-    itable = inode_table_new(0, this);
+    itable = inode_table_new(0, this, 0, 0);
     if (!itable)
         return;
 

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -875,7 +875,7 @@ init(xlator_t *this)
     if (ec_assign_read_mask(ec, read_mask_str))
         goto failed;
 
-    this->itable = inode_table_new(EC_SHD_INODE_LRU_LIMIT, this);
+    this->itable = inode_table_new(EC_SHD_INODE_LRU_LIMIT, this, 0, 0);
     if (!this->itable)
         goto failed;
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1634,7 +1634,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
                 child->child_up = 1;
                 child->xl = subvol;
                 if (!child->table)
-                    child->table = inode_table_new(4096, subvol);
+                    child->table = inode_table_new(4096, subvol, 0, 0);
 
                 _br_qchild_event(this, child, br_brick_connect);
                 pthread_cond_signal(&priv->cond);

--- a/xlators/features/quota/src/quotad-helpers.c
+++ b/xlators/features/quota/src/quotad-helpers.c
@@ -32,7 +32,7 @@ get_quotad_aggregator_state(xlator_t *this, rpcsvc_request_t *req)
     UNLOCK(&priv->lock);
 
     if (active_subvol->itable == NULL)
-        active_subvol->itable = inode_table_new(4096, active_subvol);
+        active_subvol->itable = inode_table_new(4096, active_subvol, 0, 0);
 
     state->itable = active_subvol->itable;
 

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -2501,7 +2501,7 @@ init(xlator_t *this)
         goto out;
     }
 
-    priv->trash_itable = inode_table_new(0, this);
+    priv->trash_itable = inode_table_new(0, this, 0, 0);
     gf_log(this->name, GF_LOG_DEBUG, "brick path is%s", priv->brick_path);
 
     this->private = (void *)priv;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6358,10 +6358,10 @@ fuse_graph_setup(xlator_t *this, glusterfs_graph_t *graph)
         }
 
 #if FUSE_KERNEL_MINOR_VERSION >= 11
-        itable = inode_table_with_invalidator(priv->lru_limit, graph->top,
-                                              fuse_inode_invalidate_fn, this);
+        itable = inode_table_with_invalidator(
+            priv->lru_limit, graph->top, fuse_inode_invalidate_fn, this, 0, 0);
 #else
-        itable = inode_table_new(0, graph->top);
+        itable = inode_table_new(0, graph->top, 0, 0);
 #endif
         if (!itable) {
             ret = -1;

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -565,7 +565,7 @@ nfs_init_subvolume(struct nfs_state *nfs, xlator_t *xl)
         return -1;
 
     lrusize = nfs->memfactor * GF_NFS_INODE_LRU_MULT;
-    xl->itable = inode_table_new(lrusize, xl);
+    xl->itable = inode_table_new(lrusize, xl, 0, 0);
     if (!xl->itable) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to allocate inode table");

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -637,7 +637,7 @@ server_setvolume(rpcsvc_request_t *req)
 
             /* TODO: what is this ? */
             client->bound_xl->itable = inode_table_new(conf->inode_lru_limit,
-                                                       client->bound_xl);
+                                                       client->bound_xl, 0, 0);
         }
     }
     UNLOCK(&conf->itable_lock);


### PR DESCRIPTION
In brick_mux environment a shd process consume high memory.
After print the statedump i have found it allocates 1M per afr xlator
for all bricks.In case of configure 4k volumes it consumes almost total
6G RSS size in which 4G consumes by inode_tables

[cluster/replicate.test1-replicate-0 - usage-type gf_common_mt_list_head memusage]
size=1273488
num_allocs=2
max_size=1273488
max_num_allocs=2
total_allocs=2

inode_new_table function allocates memory(1M) for a list of inode and dentry hash.
For shd lru_limit size is 1 so we don't need to create a big hash table so to reduce
RSS size for shd process pass optimum bucket count at the time of creating inode_table.

Change-Id: I039716d42321a232fdee1ee8fd50295e638715bb
Fixes: #1538
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

