### PR TITLE
cli-rpc: conditional init of global quota rpc

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -843,9 +843,18 @@ main(int argc, char *argv[])
     if (!global_rpc)
         goto out;
 
-    global_quotad_rpc = cli_quotad_clnt_rpc_init();
-    if (!global_quotad_rpc)
-        goto out;
+    /*
+     * Now, one doesn't need to initialize global rpc
+     * for quota unless and until quota is enabled.
+     * So why not put a check to save all the rpc related
+     * ops here.
+     */
+    ret = sys_access(QUOTAD_PID_PATH, F_OK);
+    if (!ret) {
+        global_quotad_rpc = cli_quotad_clnt_rpc_init();
+        if (!global_quotad_rpc)
+            goto out;
+    }
 
     ret = cli_cmds_register(&state);
     if (ret)

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -31,6 +31,9 @@
 #define CLI_TAB_LENGTH 8
 #define CLI_BRICK_STATUS_LINE_LEN 78
 
+// Quotad pid path.
+#define QUOTAD_PID_PATH "/var/run/gluster/quotad/quotad.pid"
+
 /* Geo-rep command positional arguments' index  */
 #define GEO_REP_CMD_INDEX 1
 #define GEO_REP_CMD_CONFIG_INDEX 4


### PR DESCRIPTION
Issue: It is seem that the initialization of rpc to
connect with quotad is done in every glusterfs cli command,
irrespective of whether the quota feature is enabled or disabled.
This seems to be an overkill.

Code change: The file /var/run/quotad/quotad.pid is present
signals that quotad is enabled. Hence we can put a conditional
check for seeing when this file exists and if it doesn't we
just skip over the initialization of the global quotad rpc.

This will go on to reduce the extra rpc calls and operations
being performed in the kernel space.

Fixes: #1577
Change-Id: Icb69d35330f76ce95626f59af75a12726eb620ff
Signed-off-by: srijan-sivakumar <ssivakumar@redhat.com>

