### PR TITLE
fix fedora smoke warning for rdma

### DIFF
--- a/rpc/rpc-transport/rdma/src/Makefile.am
+++ b/rpc/rpc-transport/rdma/src/Makefile.am
@@ -19,6 +19,6 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) \
 	-I$(top_srcdir)/rpc/xdr/src \
 	-I$(top_builddir)/rpc/xdr/src
 
-AM_CFLAGS = -Wall $(GF_CFLAGS)
+AM_CFLAGS = -Wall -Wno-address-of-packed-member $(GF_CFLAGS)
 
 CLEANFILES = *~


### PR DESCRIPTION
Warning:
rpc/rpc-transport/rdma/src/rdma.c:2008:16: error: taking address of packed member of ‘union <anonymous>’ may result in an unaligned pointer value [-Werror=address-of-packed-member]
chunkptr = &hdr->rm_body.rm_chunks[0];

Fix:
Use Wno-address-of-packed-member for now since rdma is removed from devel
branch.

Change-Id: I8586c2d0d21d7c8c2c3274d3391e6600c089ac8f
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

