### PR TITLE
geo-rep: Enable rsync verbose logging for debugging

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -1482,7 +1482,13 @@ class SSH(object):
 
         log_rsync_performance = gconf.getr("log-rsync-performance", False)
 
-        if log_rsync_performance:
+        rsync_verbose = False
+        for item in argv:
+            if item == "--verbose" or item.startswith("-v"):
+                rsync_verbose = True
+                break
+
+        if log_rsync_performance or rsync_verbose:
             # use stdout=PIPE only when log_rsync_performance enabled
             # Else rsync will write to stdout and nobody is there
             # to consume. If PIPE is full rsync hangs.
@@ -1519,6 +1525,9 @@ class SSH(object):
                     rsync_msg.append(line)
             logging.info(lf("rsync performance",
                             data=", ".join(rsync_msg)))
+
+        if rsync_verbose:
+            logging.info(lf("rsync verbose", data=repr(stdout)))
 
         return po
 


### PR DESCRIPTION
By default rsync command is run without --verbose argument.
The rsync command takes "--verbose" or "-vv" which prints
verbal output which helps in debugging rsync errors. The
verbose argument can be passed by setting geo-rep config
option "rsync_options" to required verbose string. If set,
this patch logs rsync verbose output in the geo-rep log file.

Fixes: #1587
Change-Id: I0b7e1e813eb7e90f1c2ba885b42fd52dbd44386a
Signed-off-by: Kotresh HR <khiremat@redhat.com>

