### PR TITLE
glusterd: enhancement around port mapper

### DIFF
--- a/rpc/rpc-lib/src/protocol-common.h
+++ b/rpc/rpc-lib/src/protocol-common.h
@@ -109,7 +109,8 @@ enum gf_aggregator_procnum {
 enum gf_pmap_port_type {
     GF_PMAP_PORT_FREE = 0,
     GF_PMAP_PORT_FOREIGN, /* it actually means, not sure who is using it, but it
-                             is in-use */
+                             is in-use  with release-9 onwards, we will not use
+                             this type*/
     GF_PMAP_PORT_LEASED,
     GF_PMAP_PORT_ANY,
     GF_PMAP_PORT_BRICKSERVER, /* port used by brick process */


### PR DESCRIPTION
pmap_registry_new() tests bind() for all ports from base_port
to max_port for pmap registry initialization. The initialized
data will be stale when we want to use the ports, so we avoid
keeping any entry of free ports at the beginning and check the
port if its free or not only before using it.

pmap_registry_alloc() searches for a free port from the base_port
for every volume. Instead, we can start from last_alloc port and
if we don't find a free port between last_alloc port max_port, we
search from base_port to last_alloc port.

Fixes: #786

Signed-off-by: nik-redhat <nladha@redhat.com>

