### PR TITLE
afr/heal: Implement outcast logic in metadata heal

### DIFF
--- a/tests/basic/afr/afr-metadata-outcast.t
+++ b/tests/basic/afr/afr-metadata-outcast.t
@@ -1,0 +1,70 @@
+#!/bin/bash
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST useradd tmpuser
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1}
+TEST $CLI volume set $V0 cluster.favorite-child-policy mtime
+TEST $CLI volume set $V0 cluster.self-heal-daemon off
+TEST $CLI volume set $V0 cluster.metadata-self-heal off
+TEST $CLI volume set $V0 cluster.entry-self-heal on
+TEST $CLI volume set $V0 cluster.data-self-heal off
+
+TEST $CLI volume start $V0
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "^2$" online_brick_count
+
+TEST glusterfs --volfile-id=$V0 --acl --volfile-server=$H0 --entry-timeout=0 $M0;
+
+TEST kill_brick $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN ${PROCESS_DOWN_TIMEOUT} "^1$" online_brick_count
+
+TEST mkdir -p $M0/tmp1/new
+TEST chown tmpuser:tmpuser $M0/tmp1/
+TEST chown tmpuser:tmpuser $M0/tmp1/new
+TEST chmod o-rx $M0/tmp1/
+TEST chmod o-rx $M0/tmp1/new
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "^2$" online_brick_count
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0;
+TEST glusterfs --volfile-id=$V0 --acl --volfile-server=$H0 --entry-timeout=0 $M0;
+TEST ls $M0/tmp1
+
+#At this point, we have completed entry-heal but not meta-data heal
+OrigUserid=$(id -u tmpuser)
+FileUserid=$(id -u `stat -c '%U' $B0/${V0}1/tmp1`)
+EXPECT "^$OrigUserid$" echo $FileUserid
+
+OrigUserid=$(id -u tmpuser)
+FileUserid=$(id -u `stat -c '%U' $B0/${V0}0/tmp1`)
+EXPECT_NOT "^$OrigUserid$" echo $FileUserid
+
+
+TEST kill_brick $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN ${PROCESS_DOWN_TIMEOUT} "^1$" online_brick_count
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0;
+TEST glusterfs --volfile-id=$V0 --acl --volfile-server=$H0 --entry-timeout=0 $M0;
+
+#With this lookup from mount-point, the dht will trigger a setxattr which will force afr to do an xattrop
+#So there will be a split-brain now,
+TEST ls $M0/tmp1
+TEST $CLI volume heal $V0 disable
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "^2$" online_brick_count
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "^2$" afr_get_split_brain_count $V0
+TEST $CLI volume set $V0 cluster.self-heal-daemon on
+TEST $CLI volume heal $V0 enable
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+
+OrigUserid=$(id -u tmpuser)
+FileUserid=$(id -u `stat -c '%U' $B0/${V0}0/tmp1`)
+EXPECT "^$OrigUserid$" echo $FileUserid
+
+userdel --force tmpuser
+cleanup

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -7890,8 +7890,12 @@ afr_is_outcast_set(dict_t *xdata, int type)
         if (pending_raw) {
             pending_int = pending_raw;
 
-            if (ntoh32(pending_int[idx]))
+            if (pending_int[idx]) {
+                /* We are not using ntoh32 here since it is just a non-zero
+                 * check
+                 */
                 return _gf_true;
+            }
         }
     }
     return _gf_false;
@@ -7908,12 +7912,21 @@ afr_is_any_outcast_set(dict_t *xdata)
     type = AFR_METADATA_TRANSACTION;
     idx = afr_index_for_transaction_type(type);
 
+    /* TODO
+     * Currently outcast logic is only implemeted for meta-data transactions,
+     * When we do the outcase for all the fop this has to be changed to a loop
+     * to check for all types of fops.
+     */
     if (dict_get_ptr(xdata, AFR_OUTCAST_DEFAULT, &pending_raw) == 0) {
         if (pending_raw) {
             pending_int = pending_raw;
 
-            if (ntoh32(pending_int[idx]))
+            if (pending_int[idx]) {
+                /* We are not using ntoh32 here since it is just a non-zero
+                 * check
+                 */
                 return _gf_true;
+            }
         }
     }
     /*

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -7876,3 +7876,49 @@ afr_ta_dict_contains_pending_xattr(dict_t *dict, afr_private_t *priv, int child)
 
     return _gf_false;
 }
+
+gf_boolean_t
+afr_is_outcast_set(dict_t *xdata, int type)
+{
+    int idx = -1;
+    void *pending_raw = NULL;
+    int *pending_int = NULL;
+
+    idx = afr_index_for_transaction_type(type);
+
+    if (dict_get_ptr(xdata, AFR_OUTCAST_DEFAULT, &pending_raw) == 0) {
+        if (pending_raw) {
+            pending_int = pending_raw;
+
+            if (ntoh32(pending_int[idx]))
+                return _gf_true;
+        }
+    }
+    return _gf_false;
+}
+
+gf_boolean_t
+afr_is_any_outcast_set(dict_t *xdata)
+{
+    int idx = -1;
+    void *pending_raw = NULL;
+    int *pending_int = NULL;
+    afr_transaction_type type;
+
+    type = AFR_METADATA_TRANSACTION;
+    idx = afr_index_for_transaction_type(type);
+
+    if (dict_get_ptr(xdata, AFR_OUTCAST_DEFAULT, &pending_raw) == 0) {
+        if (pending_raw) {
+            pending_int = pending_raw;
+
+            if (ntoh32(pending_int[idx]))
+                return _gf_true;
+        }
+    }
+    /*
+     * At the moment, outcast for AFR_METADATA_TRANSACTION is
+     * implemented
+     */
+    return _gf_false;
+}

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -285,6 +285,10 @@ afr_selfheal_recreate_entry(call_frame_t *frame, int dst, int source,
 
     mode = st_mode_from_ia(iatt->ia_prot, iatt->ia_type);
 
+    /*
+     * The entry is created with this fop, Hence no need to take metadata lock
+     * to perform this operation
+     */
     ret = afr_set_heal_outcast(xdata, outcast, AFR_METADATA_TRANSACTION, 1);
     if (ret)
         goto out;

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -42,6 +42,9 @@ __afr_selfheal_metadata_do(call_frame_t *frame, xlator_t *this, inode_t *inode,
     dict_t *old_xattr = NULL;
     afr_private_t *priv = NULL;
     int i = 0;
+    int outcast[AFR_NUM_CHANGE_LOGS] = {
+        0,
+    };
 
     priv = this->private;
 
@@ -85,6 +88,9 @@ __afr_selfheal_metadata_do(call_frame_t *frame, xlator_t *this, inode_t *inode,
                 healed_sinks[i] = 0;
         }
 
+        ret = afr_set_heal_outcast(xattr, outcast, AFR_METADATA_TRANSACTION, 0);
+        if (ret)
+            goto out;
         ret = syncop_setxattr(priv->children[i], &loc, xattr, 0, NULL, NULL);
         if (ret)
             healed_sinks[i] = 0;

--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -374,4 +374,8 @@ afr_selfheal_entry_delete(xlator_t *this, inode_t *dir, const char *name,
                           inode_t *inode, int child, struct afr_reply *replies);
 int
 afr_anon_inode_create(xlator_t *this, int child, inode_t **linked_inode);
+
+int
+afr_set_heal_outcast(dict_t *xdata, int *outcast, afr_transaction_type type,
+                     int val);
 #endif /* !_AFR_SELFHEAL_H */

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -28,6 +28,7 @@
 #define AFR_SH_DATA_DOMAIN_FMT "%s:self-heal"
 #define AFR_DIRTY_DEFAULT AFR_XATTR_PREFIX ".dirty"
 #define AFR_DIRTY (((afr_private_t *)(THIS->private))->afr_dirty)
+#define AFR_OUTCAST_DEFAULT AFR_XATTR_PREFIX ".outcast"
 
 #define AFR_LOCKEE_COUNT_MAX 3
 #define AFR_DOM_COUNT_MAX 3
@@ -1420,4 +1421,9 @@ afr_fill_success_replies(afr_local_t *local, afr_private_t *priv,
 gf_boolean_t
 afr_is_private_directory(afr_private_t *priv, uuid_t pargfid, const char *name,
                          pid_t pid);
+gf_boolean_t
+afr_is_outcast_set(dict_t *xdata, int type);
+
+gf_boolean_t
+afr_is_any_outcast_set(dict_t *xdata);
 #endif /* __AFR_H__ */


### PR DESCRIPTION
When an entry heal is happening, the entry is created with
root:root permissions and none of the xattrs are set on the
entry till the meta-data heal is completed. Which means we
can say for sure that the entry is not usable till the
meta-data heal is completed. This causes problems when there
is a split-brain and favourite-child-pplicy is set. There is
a chance that the entry with wrong meta-data information
might get picked, and it's meta-data information like permissions
will be synced.

So this patch implement a way to identify the entry that
has not completed the initial meta-data heal, hence it
restricts such entries being chosen as source for the heal.

TODO:
CUrrently this logic is only implemented for the initial
meta-data heal, we could implement for data-heal as well
as ongoing modification for a better way of identifying the
source

Change-Id: Ife84bcd49e3dd99ca08f64110060edafbc9f07a5
Updates: #1546
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

