### PR TITLE
dict: add dict_set_bool function

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -474,7 +474,7 @@ set_fuse_mount_options(glusterfs_ctx_t *ctx, dict_t *options)
     }
 
     if (!cmd_args->no_daemon_mode) {
-        DICT_SET_VAL(dict_set_static_ptr, options, "sync-to-mount", "enable",
+        DICT_SET_VAL(dict_set_bool, options, "sync-to-mount", _gf_true,
                      glusterfsd_msg_3);
     }
 

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -1004,6 +1004,22 @@ data_from_ptr_common(void *value, gf_boolean_t is_static)
 }
 
 data_t *
+data_from_bool(bool value)
+{
+    data_t *data = get_new_data();
+
+    if (!data) {
+        return NULL;
+    }
+
+    data->data = value ? "1" : "0";
+    data->len = 2;
+    data->data_type = GF_DATA_TYPE_BOOL;
+
+    return data;
+}
+
+data_t *
 str_to_data(char *value)
 {
     if (!value) {
@@ -1104,6 +1120,7 @@ static char *data_type_name[GF_DATA_TYPE_MAX] = {
     [GF_DATA_TYPE_GFUUID] = "gf-uuid",
     [GF_DATA_TYPE_IATT] = "iatt",
     [GF_DATA_TYPE_MDATA] = "mdata",
+    [GF_DATA_TYPE_BOOL] = "bool",
 };
 
 int64_t
@@ -2779,6 +2796,26 @@ err:
     if (data)
         data_unref(data);
 
+    return ret;
+}
+
+int
+dict_set_bool(dict_t *this, char *key, bool val)
+{
+    data_t *data = NULL;
+    int ret = 0;
+
+    data = data_from_bool(val);
+    if (!data) {
+        ret = -EINVAL;
+        goto err;
+    }
+
+    ret = dict_set(this, key, data);
+    if (ret < 0)
+        data_destroy(data);
+
+err:
     return ret;
 }
 

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -230,6 +230,9 @@ data_from_uint32(uint32_t value);
 data_t *
 data_from_uint16(uint16_t value);
 
+data_t *
+data_from_bool(bool value);
+
 char *
 data_to_str(data_t *data);
 void *
@@ -370,7 +373,10 @@ GF_MUST_CHECK int
 dict_get_strn(dict_t *this, char *key, const int keylen, char **str);
 
 GF_MUST_CHECK int
+dict_set_bool(dict_t *this, char *key, bool val);
+GF_MUST_CHECK int
 dict_get_str_boolean(dict_t *this, char *key, int default_val);
+
 GF_MUST_CHECK int
 dict_rename_key(dict_t *this, char *key, char *replace_key);
 GF_MUST_CHECK int

--- a/libglusterfs/src/glusterfs/glusterfs-fops.h
+++ b/libglusterfs/src/glusterfs/glusterfs-fops.h
@@ -234,7 +234,8 @@ enum gf_dict_data_type_t {
     GF_DATA_TYPE_GFUUID = 7,
     GF_DATA_TYPE_IATT = 8,
     GF_DATA_TYPE_MDATA = 9,
-    GF_DATA_TYPE_MAX = 10,
+    GF_DATA_TYPE_BOOL = 10,
+    GF_DATA_TYPE_MAX = 11,
 };
 typedef enum gf_dict_data_type_t gf_dict_data_type_t;
 

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -427,6 +427,7 @@ dict_setn_nstrn
 dict_set_nstrn
 dict_set_uint32
 dict_set_uint64
+dict_set_bool
 dict_set_flag
 dict_clear_flag
 dict_check_flag

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6816,12 +6816,7 @@ init(xlator_t *this_xl)
         priv->fuse_dump_fd = ret;
     }
 
-    sync_to_mount = _gf_false;
-    ret = dict_get_str(options, "sync-to-mount", &value_string);
-    if (ret == 0) {
-        ret = gf_string2boolean(value_string, &sync_to_mount);
-        GF_ASSERT(ret == 0);
-    }
+    sync_to_mount = dict_get_str_boolean(options, "sync-to-mount", _gf_false);
 
     priv->fopen_keep_cache = 2;
     if (dict_get(options, "fopen-keep-cache")) {


### PR DESCRIPTION
For setting boolean, different methods are used across the code,
like dynamic pointer or unsigned int or string

This fix now corrects for only one key - sync-to-mount,
which expects a boolean value

This is 1st part of fix, 2nd part will handle protocol related
changes

Fixes: #985
Change-Id: Ifae0f359bea36d639927871655ed5f606cdc929d
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>

