### PR TITLE
mount/fuse: Fix graph-switch when reader-thread-count is set

### DIFF
--- a/tests/basic/fuse/active-io-graph-switch.t
+++ b/tests/basic/fuse/active-io-graph-switch.t
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+TESTS_EXPECTED_IN_LOOP=12
+
+function perform_io_on_mount {
+    local m="$1"
+    local f="$2"
+    local lockfile="$3"
+    while [ -f "$m/$lockfile" ];
+    do
+        dd if=/dev/zero of=$m/$f bs=1M count=1
+    done
+}
+
+function perform_graph_switch {
+    for i in {1..3}
+    do
+        TEST_IN_LOOP $CLI volume set $V0 performance.stat-prefetch off
+        sleep 3
+        TEST_IN_LOOP $CLI volume set $V0 performance.stat-prefetch on
+        sleep 3
+    done
+}
+
+function count_files {
+    ls $M0 | wc -l
+}
+
+cleanup;
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume set $V0 flush-behind off
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+TEST touch $M0/lock
+for i in {1..100}; do perform_io_on_mount $M0 $i lock & done
+EXPECT_WITHIN 5 "101" count_files
+
+perform_graph_switch
+TEST rm -f $M0/lock
+wait
+EXPECT "100" count_files
+TEST rm -f $M0/{1..100}
+EXPECT "0" count_files
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+#Repeat the tests with reader-thread-count
+TEST $GFS --reader-thread-count=10 --volfile-id=/$V0 --volfile-server=$H0 $M0
+TEST touch $M0/lock
+for i in {1..100}; do perform_io_on_mount $M0 $i lock & done
+EXPECT_WITHIN 5 "101" count_files
+
+perform_graph_switch
+TEST rm -f $M0/lock
+wait
+EXPECT "100" count_files
+TEST rm -f $M0/{1..100}
+EXPECT "0" count_files
+
+cleanup

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -5874,7 +5874,9 @@ fuse_graph_sync(xlator_t *this)
         new_graph_id = priv->next_graph->id;
         priv->next_graph = NULL;
         need_first_lookup = 1;
-        priv->handle_graph_switch = _gf_true;
+        if (old_subvol) {
+            priv->handle_graph_switch = _gf_true;
+        }
 
         while (!priv->event_recvd) {
             ret = pthread_cond_wait(&priv->sync_cond, &priv->sync_mutex);
@@ -5910,13 +5912,6 @@ unlock:
         if (winds_on_old_subvol == 0) {
             xlator_notify(old_subvol, GF_EVENT_PARENT_DOWN, old_subvol, NULL);
         }
-    } else {
-        pthread_mutex_lock(&priv->sync_mutex);
-        {
-            priv->handle_graph_switch = _gf_false;
-            pthread_cond_broadcast(&priv->migrate_cond);
-        }
-        pthread_mutex_unlock(&priv->sync_mutex);
     }
 
     return 0;


### PR DESCRIPTION
Problem:
The current graph-switch code sets priv->handle_graph_switch to false even
when graph-switch is in progress which leads to crashes in some cases

Fix:
priv->handle_graph_switch should be set to false only when graph-switch
completes.

fixes: #1539
Change-Id: I5b04f7220a0a6e65c5f5afa3e28d1afe9efcdc31
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

