### PR TITLE
DHT - Simulate Global Layout in Rebalance

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -264,11 +264,13 @@ Geo Replication
 M: Aravinda Vishwanathapura <aravinda@kadalu.io>
 M: Kotresh HR <khiremat@redhat.com>
 M: Sunny Kumar <sunkumar@redhat.com>
+P: Shwetha Acharya <sacharya@redhat.com>
 S: Maintained
 F: geo-replication/
 
 Glusterfind
 M: Aravinda Vishwanathapura <aravinda@kadalu.io>
+P: Shwetha Acharya <sacharya@redhat.com>
 S: Maintained
 F: tools/glusterfind/
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -305,6 +305,7 @@ Management Daemon - glusterd
 M: Atin Mukherjee <amukherj@redhat.com>
 M: Mohit Agrawal <moagrawa@redhat.com>
 M: Sanju Rakonde <srakonde@redhat.com>
+P: Srijan Sivakumar <ssivakum@redhat.com>
 S: Maintained
 F: cli/
 F: xlators/mgmt/glusterd/

--- a/libglusterfs/src/glusterfs/store.h
+++ b/libglusterfs/src/glusterfs/store.h
@@ -60,7 +60,8 @@ gf_store_unlink_tmppath(gf_store_handle_t *shandle);
 
 int
 gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
-                           gf_store_op_errno_t *store_errno);
+                           gf_store_op_errno_t *store_errno, char *str,
+                           size_t buf_size);
 
 int32_t
 gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value);

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -184,7 +184,8 @@ out:
 
 int
 gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
-                           gf_store_op_errno_t *store_errno)
+                           gf_store_op_errno_t *store_errno, char *str,
+                           size_t buf_size)
 {
     int32_t ret = -1;
     char *savetok = NULL;
@@ -192,7 +193,6 @@ gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
     char *value = NULL;
     char *temp = NULL;
     size_t str_len = 0;
-    char str[8192];
 
     GF_ASSERT(file);
     GF_ASSERT(iter_key);
@@ -200,7 +200,7 @@ gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
     GF_ASSERT(store_errno);
 
 retry:
-    temp = fgets(str, 8192, file);
+    temp = fgets(str, buf_size, file);
     if (temp == NULL || feof(file)) {
         ret = -1;
         *store_errno = GD_STORE_EOF;
@@ -274,8 +274,9 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
         fseek(handle->read, 0, SEEK_SET);
     }
     do {
+        char buf[8192];
         ret = gf_store_read_and_tokenize(handle->read, &iter_key, &iter_val,
-                                         &store_errno);
+                                         &store_errno, buf, 8192);
         if (ret < 0) {
             gf_msg_trace("", 0,
                          "error while reading key '%s': "
@@ -579,6 +580,8 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     int32_t ret = -1;
     char *iter_key = NULL;
     char *iter_val = NULL;
+    char buf[8192];
+
     gf_store_op_errno_t store_errno = GD_STORE_SUCCESS;
 
     GF_ASSERT(iter);
@@ -586,7 +589,7 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     GF_ASSERT(value);
 
     ret = gf_store_read_and_tokenize(iter->file, &iter_key, &iter_val,
-                                     &store_errno);
+                                     &store_errno, buf, 8192);
     if (ret < 0) {
         goto out;
     }

--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -5,7 +5,7 @@
 . $(dirname $0)/../geo-rep.rc
 . $(dirname $0)/../env.rc
 
-SCRIPT_TIMEOUT=600
+SCRIPT_TIMEOUT=900
 
 ### Basic Non-root geo-rep setup test with Distribute Replicate volumes
 

--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -33,6 +33,10 @@ slave_url=$usr@$slave
 slave_vol=$GSV0
 ssh_url=$usr@$SH0
 
+#Cleanup stale keys
+sed -i '/^command=.*SSH_ORIGINAL_COMMAND#.*/d' /home/$usr/.ssh/authorized_keys
+sed -i '/^command=.*gsyncd.*/d' /home/$usr/.ssh/authorized_keys
+
 ############################################################
 #SETUP VOLUMES AND VARIABLES
 

--- a/tests/bugs/bug-1064147.t
+++ b/tests/bugs/bug-1064147.t
@@ -25,6 +25,9 @@ EXPECT 'Started' volinfo_field $V0 'Status';
 TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 --entry-timeout=0 $M0;
 #------------------------------------------------------------
 
+#Run lookup to create a layout
+TEST ls $M0/
+
 # Test case 1 - Subvolume down + Healing
 #------------------------------------------------------------
 # Kill 2nd brick process

--- a/tests/bugs/glusterd/daemon-log-level-option.t
+++ b/tests/bugs/glusterd/daemon-log-level-option.t
@@ -61,8 +61,8 @@ rm -f /var/log/glusterfs/glustershd.log
 TEST $CLI volume set all cluster.daemon-log-level WARNING
 TEST $CLI volume start $V0
 
-# log should not have any info messages
-EXPECT 0 Info_messages_count "/var/log/glusterfs/glustershd.log"
+# log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
+EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
 
 # log should not have any debug messages
 EXPECT 0 Debug_messages_count "/var/log/glusterfs/glustershd.log"
@@ -78,8 +78,8 @@ rm -f /var/log/glusterfs/glustershd.log
 TEST $CLI volume set all cluster.daemon-log-level ERROR
 TEST $CLI volume start $V0
 
-# log should not have any info messages
-EXPECT 0 Info_messages_count "/var/log/glusterfs/glustershd.log"
+# log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
+EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
 
 # log should not have any warning messages
 EXPECT 0 Warning_messages_count "/var/log/glusterfs/glustershd.log"

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -499,6 +499,8 @@ struct gf_defrag_info_ {
     gf_boolean_t stats;
     /* lock migration flag */
     gf_boolean_t lock_migration_enabled;
+
+    dht_layout_t *root_layout;
 };
 
 typedef struct gf_defrag_info_ gf_defrag_info_t;
@@ -818,6 +820,9 @@ xlator_t *
 dht_subvol_get_hashed(xlator_t *this, loc_t *loc);
 xlator_t *
 dht_subvol_get_cached(xlator_t *this, inode_t *inode);
+xlator_t *
+dht_subvol_get_hashed_root_layout(xlator_t *this, loc_t *loc,
+                                  dht_layout_t *root_layout);
 xlator_t *
 dht_subvol_next(xlator_t *this, xlator_t *prev);
 xlator_t *

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -956,6 +956,44 @@ out:
     return subvol;
 }
 
+/* Get the layout of the root dir.
+ * This method does not unref the layout - this needs to be done externally */
+xlator_t *
+dht_subvol_get_hashed_root_layout(xlator_t *this, loc_t *loc,
+                                  dht_layout_t *root_layout)
+{
+    xlator_t *subvol = NULL;
+    dht_conf_t *conf = NULL;
+    dht_methods_t *methods = NULL;
+
+    GF_VALIDATE_OR_GOTO("dht", this, out);
+    GF_VALIDATE_OR_GOTO(this->name, loc, out);
+
+    conf = this->private;
+    GF_VALIDATE_OR_GOTO(this->name, conf, out);
+
+    methods = &(conf->methods);
+
+    if (__is_root_gfid(loc->gfid)) {
+        subvol = dht_first_up_subvol(this);
+        goto out;
+    }
+
+    GF_VALIDATE_OR_GOTO(this->name, loc->parent, out);
+    GF_VALIDATE_OR_GOTO(this->name, loc->name, out);
+
+    subvol = methods->layout_search(this, root_layout, loc->name);
+
+    if (!subvol) {
+        gf_msg_debug(this->name, 0, "No hashed subvolume for path=%s",
+                     loc->path);
+        goto out;
+    }
+
+out:
+    return subvol;
+}
+
 xlator_t *
 dht_subvol_get_cached(xlator_t *this, inode_t *inode)
 {

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4183,11 +4183,8 @@ gf_defrag_start_crawl(void *data)
     };
     int thread_index = 0;
     pthread_t *tid = NULL;
-    /* All Commenting-out in the method are not part of the patch and are
-     * due to the issue mentioned at:
-     * https://github.com/gluster/glusterfs/issues/1507 */
-    //    pthread_t filecnt_thread;
-    //    gf_boolean_t fc_thread_started = _gf_false;
+    pthread_t filecnt_thread;
+    gf_boolean_t fc_thread_started = _gf_false;
 
     this = data;
     if (!this)
@@ -4342,13 +4339,13 @@ gf_defrag_start_crawl(void *data)
             goto out;
         }
 
-        //        ret = gf_defrag_estimates_init(this, &loc, &filecnt_thread);
-        //        if (ret) {
-        //            /* Not a fatal error. Allow the rebalance to proceed*/
-        //            ret = 0;
-        //        } else {
-        //            fc_thread_started = _gf_true;
-        //        }
+        ret = gf_defrag_estimates_init(this, &loc, &filecnt_thread);
+        if (ret) {
+            /* Not a fatal error. Allow the rebalance to proceed*/
+            ret = 0;
+        } else {
+            fc_thread_started = _gf_true;
+        }
     }
 
     ret = gf_defrag_scan_dir(this, defrag, &loc, rebal_dict, migrate_data);
@@ -4382,9 +4379,9 @@ out:
         defrag->defrag_status = GF_DEFRAG_STATUS_COMPLETE;
     }
 
-    //    if (fc_thread_started) {
-    //        gf_defrag_estimates_cleanup(this, defrag, filecnt_thread);
-    //    }
+    if (fc_thread_started) {
+        gf_defrag_estimates_cleanup(this, defrag, filecnt_thread);
+    }
 
     dht_send_rebalance_event(this, defrag->cmd, defrag->defrag_status);
 

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2734,7 +2734,8 @@ gf_defrag_migrate_single_file(void *opaque)
 
     iatt_ptr = &iatt;
 
-    hashed_subvol = dht_subvol_get_hashed(this, &entry_loc);
+    hashed_subvol = dht_subvol_get_hashed_root_layout(this, &entry_loc,
+                                                      defrag->root_layout);
     if (!hashed_subvol) {
         gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_HASHED_SUBVOL_GET_FAILED,
                "Failed to get hashed subvol for %s", entry_loc.path);
@@ -3504,7 +3505,7 @@ out:
 
 int
 gf_defrag_settle_hash(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
-                      dict_t *fix_layout)
+                      dict_t *rebal_dict)
 {
     int ret;
     dht_conf_t *conf = NULL;
@@ -3535,14 +3536,14 @@ gf_defrag_settle_hash(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
         return 0;
     }
 
-    ret = dict_set_uint32(fix_layout, "new-commit-hash",
+    ret = dict_set_uint32(rebal_dict, "new-commit-hash",
                           defrag->new_commit_hash);
     if (ret) {
         gf_log(this->name, GF_LOG_ERROR, "Failed to set new-commit-hash");
         return -1;
     }
 
-    ret = syncop_setxattr(this, loc, fix_layout, 0, NULL, NULL);
+    ret = syncop_setxattr(this, loc, rebal_dict, 0, NULL, NULL);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_LAYOUT_FIX_FAILED,
                "fix layout on %s failed", loc->path);
@@ -3556,14 +3557,14 @@ gf_defrag_settle_hash(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
     }
 
     /* TBD: find more efficient solution than adding/deleting every time */
-    dict_del(fix_layout, "new-commit-hash");
+    dict_del(rebal_dict, "new-commit-hash");
 
     return 0;
 }
 
 int
-gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
-                     dict_t *fix_layout, dict_t *migrate_data)
+gf_defrag_scan_dir(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
+                   dict_t *rebal_dict, dict_t *migrate_data)
 {
     int ret = -1;
     loc_t entry_loc = {
@@ -3658,7 +3659,7 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
 
             gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_READDIR_ERROR,
                    "readdirp failed for "
-                   "path %s. Aborting fix-layout",
+                   "path %s. Aborting dir scan",
                    loc->path);
 
             ret = -1;
@@ -3769,8 +3770,8 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
              * lookup of a dir failed. Hence, don't commit hash
              * for the current directory*/
 
-            ret = gf_defrag_fix_layout(this, defrag, &entry_loc, fix_layout,
-                                       migrate_data);
+            ret = gf_defrag_scan_dir(this, defrag, &entry_loc, rebal_dict,
+                                     migrate_data);
 
             if (defrag->defrag_status == GF_DEFRAG_STATUS_STOPPED ||
                 defrag->defrag_status == GF_DEFRAG_STATUS_FAILED) {
@@ -3789,7 +3790,7 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
                     goto out;
                 } else {
                     /* Let's not commit-hash if
-                     * gf_defrag_fix_layout failed*/
+                     * gf_defrag_scan_dir failed*/
                     continue;
                 }
             }
@@ -3798,50 +3799,6 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
         gf_dirent_free(&entries);
         free_entries = _gf_false;
         INIT_LIST_HEAD(&entries.list);
-    }
-
-    /* A directory layout is fixed only after its subdirs are healed to
-     * any newly added bricks. If the layout is fixed before subdirs are
-     * healed, the newly added brick will get a non-null layout.
-     * Any subdirs which hash to that layout will no longer show up
-     * in a directory listing until they are healed.
-     */
-
-    ret = syncop_setxattr(this, loc, fix_layout, 0, NULL, NULL);
-
-    /* In case of a race where the directory is deleted just before
-     * layout setxattr, the errors are updated in the layout structure.
-     * We can use this information to make a decision whether the directory
-     * is deleted entirely.
-     */
-    if (ret == 0) {
-        ret = dht_dir_layout_error_check(this, loc->inode);
-        ret = -ret;
-    }
-
-    if (ret) {
-        if (-ret == ENOENT || -ret == ESTALE) {
-            gf_msg(this->name, GF_LOG_INFO, -ret, DHT_MSG_LAYOUT_FIX_FAILED,
-                   "Setxattr failed. Dir %s "
-                   "renamed or removed",
-                   loc->path);
-            if (conf->decommission_subvols_cnt) {
-                defrag->total_failures++;
-            }
-            ret = 0;
-            goto out;
-        } else {
-            gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_LAYOUT_FIX_FAILED,
-                   "Setxattr failed for %s", loc->path);
-
-            defrag->total_failures++;
-
-            if (conf->decommission_in_progress) {
-                defrag->defrag_status = GF_DEFRAG_STATUS_FAILED;
-                ret = -1;
-                goto out;
-            }
-        }
     }
 
     if (defrag->cmd != GF_DEFRAG_CMD_START_LAYOUT_FIX) {
@@ -3864,22 +3821,6 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
                     goto out;
                 }
             }
-        }
-    }
-
-    gf_msg_trace(this->name, 0, "fix layout called on %s", loc->path);
-
-    if (gf_defrag_settle_hash(this, defrag, loc, fix_layout) != 0) {
-        defrag->total_failures++;
-
-        gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_SETTLE_HASH_FAILED,
-               "Settle hash failed for %s", loc->path);
-
-        ret = -1;
-
-        if (conf->decommission_in_progress) {
-            defrag->defrag_status = GF_DEFRAG_STATUS_FAILED;
-            goto out;
         }
     }
 
@@ -4176,7 +4117,7 @@ out:
 }
 
 int
-gf_defrag_parallel_migration_cleanup(gf_defrag_info_t *defrag,
+gf_defrag_parallel_migration_cleanup(xlator_t *this, gf_defrag_info_t *defrag,
                                      pthread_t *tid_array, int thread_index)
 {
     int ret = -1;
@@ -4210,6 +4151,9 @@ gf_defrag_parallel_migration_cleanup(gf_defrag_info_t *defrag,
 
     GF_FREE(defrag->queue);
 
+    /* Unref root layout after 'refing' it during init stage */
+    dht_layout_unref(this, defrag->root_layout);
+
     ret = 0;
 out:
     return ret;
@@ -4221,7 +4165,7 @@ gf_defrag_start_crawl(void *data)
     xlator_t *this = NULL;
     dht_conf_t *conf = NULL;
     gf_defrag_info_t *defrag = NULL;
-    dict_t *fix_layout = NULL;
+    dict_t *rebal_dict = NULL;
     dict_t *migrate_data = NULL;
     dict_t *status = NULL;
     glusterfs_ctx_t *ctx = NULL;
@@ -4239,8 +4183,11 @@ gf_defrag_start_crawl(void *data)
     };
     int thread_index = 0;
     pthread_t *tid = NULL;
-    pthread_t filecnt_thread;
-    gf_boolean_t fc_thread_started = _gf_false;
+    /* All Commenting-out in the method are not part of the patch and are
+     * due to the issue mentioned at:
+     * https://github.com/gluster/glusterfs/issues/1507 */
+    //    pthread_t filecnt_thread;
+    //    gf_boolean_t fc_thread_started = _gf_false;
 
     this = data;
     if (!this)
@@ -4292,8 +4239,8 @@ gf_defrag_start_crawl(void *data)
     dht_get_du_info(statfs_frame, this, &loc);
     THIS = old_THIS;
 
-    fix_layout = dict_new();
-    if (!fix_layout) {
+    rebal_dict = dict_new();
+    if (!rebal_dict) {
         ret = -1;
         goto out;
     }
@@ -4307,7 +4254,7 @@ gf_defrag_start_crawl(void *data)
     gf_log(this->name, GF_LOG_INFO, "%s using commit hash %u", __func__,
            conf->vol_commit_hash);
 
-    ret = dict_set_uint32(fix_layout, conf->commithash_xattr_name,
+    ret = dict_set_uint32(rebal_dict, conf->commithash_xattr_name,
                           conf->vol_commit_hash);
     if (ret) {
         gf_log(this->name, GF_LOG_ERROR, "Failed to set %s",
@@ -4317,7 +4264,7 @@ gf_defrag_start_crawl(void *data)
         goto out;
     }
 
-    ret = syncop_setxattr(this, &loc, fix_layout, 0, NULL, NULL);
+    ret = syncop_setxattr(this, &loc, rebal_dict, 0, NULL, NULL);
     if (ret) {
         gf_log(this->name, GF_LOG_ERROR,
                "Failed to set commit hash on %s. "
@@ -4330,7 +4277,7 @@ gf_defrag_start_crawl(void *data)
 
     /* We now return to our regularly scheduled program. */
 
-    ret = dict_set_str(fix_layout, GF_XATTR_FIX_LAYOUT_KEY, "yes");
+    ret = dict_set_str(rebal_dict, GF_XATTR_FIX_LAYOUT_KEY, "yes");
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_REBALANCE_START_FAILED,
                "Failed to start rebalance:"
@@ -4343,7 +4290,7 @@ gf_defrag_start_crawl(void *data)
 
     defrag->new_commit_hash = conf->vol_commit_hash;
 
-    ret = syncop_setxattr(this, &loc, fix_layout, 0, NULL, NULL);
+    ret = syncop_setxattr(this, &loc, rebal_dict, 0, NULL, NULL);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_REBALANCE_FAILED,
                "fix layout on %s failed", loc.path);
@@ -4376,6 +4323,17 @@ gf_defrag_start_crawl(void *data)
             goto out;
         }
 
+        /* Get the layout of the root dir and decide whether or not to migrate
+         * file by comparing file's current location with it */
+        defrag->root_layout = dht_layout_get(this, defrag->root_inode);
+        if (!defrag->root_layout) {
+            gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_REBALANCE_FAILED,
+                   "dailed to get layout of root dir");
+            defrag->total_failures++;
+            ret = -1;
+            goto out;
+        }
+
         /* Initialise the structures required for parallel migration */
         ret = gf_defrag_parallel_migration_init(this, defrag, &tid,
                                                 &thread_index);
@@ -4384,23 +4342,23 @@ gf_defrag_start_crawl(void *data)
             goto out;
         }
 
-        ret = gf_defrag_estimates_init(this, &loc, &filecnt_thread);
-        if (ret) {
-            /* Not a fatal error. Allow the rebalance to proceed*/
-            ret = 0;
-        } else {
-            fc_thread_started = _gf_true;
-        }
+        //        ret = gf_defrag_estimates_init(this, &loc, &filecnt_thread);
+        //        if (ret) {
+        //            /* Not a fatal error. Allow the rebalance to proceed*/
+        //            ret = 0;
+        //        } else {
+        //            fc_thread_started = _gf_true;
+        //        }
     }
 
-    ret = gf_defrag_fix_layout(this, defrag, &loc, fix_layout, migrate_data);
+    ret = gf_defrag_scan_dir(this, defrag, &loc, rebal_dict, migrate_data);
     if (ret) {
         defrag->total_failures++;
         ret = -1;
         goto out;
     }
 
-    if (gf_defrag_settle_hash(this, defrag, &loc, fix_layout) != 0) {
+    if (gf_defrag_settle_hash(this, defrag, &loc, rebal_dict) != 0) {
         defrag->total_failures++;
         ret = -1;
         goto out;
@@ -4417,16 +4375,16 @@ out:
         defrag->defrag_status = GF_DEFRAG_STATUS_FAILED;
     }
 
-    gf_defrag_parallel_migration_cleanup(defrag, tid, thread_index);
+    gf_defrag_parallel_migration_cleanup(this, defrag, tid, thread_index);
 
     if ((defrag->defrag_status != GF_DEFRAG_STATUS_STOPPED) &&
         (defrag->defrag_status != GF_DEFRAG_STATUS_FAILED)) {
         defrag->defrag_status = GF_DEFRAG_STATUS_COMPLETE;
     }
 
-    if (fc_thread_started) {
-        gf_defrag_estimates_cleanup(this, defrag, filecnt_thread);
-    }
+    //    if (fc_thread_started) {
+    //        gf_defrag_estimates_cleanup(this, defrag, filecnt_thread);
+    //    }
 
     dht_send_rebalance_event(this, defrag->cmd, defrag->defrag_status);
 

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4020,7 +4020,7 @@ dht_file_counter_thread(void *args)
     dht_build_root_loc(defrag->root_inode, &root_loc);
 
     while (defrag->defrag_status == GF_DEFRAG_STATUS_STARTED) {
-        timespec_now(&time_to_wait);
+        timespec_now_realtime(&time_to_wait);
         time_to_wait.tv_sec += 600;
 
         pthread_mutex_lock(&defrag->fc_mutex);

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3699,6 +3699,15 @@ xlator_set_loglevel(xlator_t *this, int log_level)
     }
 }
 
+void
+ios_sample_buf_size_configure(char *name, struct ios_conf *conf)
+{
+    conf->ios_sample_buf_size = 1024;
+    gf_log(name, GF_LOG_INFO,
+           "Configure ios_sample_buf "
+           " size is 1024 because ios_sample_interval is 0");
+}
+
 int
 reconfigure(xlator_t *this, dict_t *options)
 {
@@ -3755,8 +3764,13 @@ reconfigure(xlator_t *this, dict_t *options)
                      int32, out);
     GF_OPTION_RECONF("ios-dump-format", dump_format_str, options, str, out);
     ios_set_log_format_code(conf, dump_format_str);
-    GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
-                     int32, out);
+    if (conf->ios_sample_interval) {
+        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
+                         int32, out);
+    } else {
+        ios_sample_buf_size_configure (this->name, conf);
+    }
+
     GF_OPTION_RECONF("sys-log-level", sys_log_str, options, str, out);
     if (sys_log_str) {
         sys_log_level = glusterd_check_log_level(sys_log_str);
@@ -3933,8 +3947,12 @@ init(xlator_t *this)
     GF_OPTION_INIT("ios-dump-format", dump_format_str, str, out);
     ios_set_log_format_code(conf, dump_format_str);
 
-    GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
-                   out);
+    if (conf->ios_sample_interval) {
+        GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
+                       out);
+    } else {
+        ios_sample_buf_size_configure (this->name, conf);
+    }
 
     ret = ios_init_sample_buf(conf);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4020,8 +4020,9 @@ glusterd_store_retrieve_missed_snaps_list(xlator_t *this)
     }
 
     do {
+        char buf[8192];
         ret = gf_store_read_and_tokenize(fp, &missed_node_info, &value,
-                                         &store_errno);
+                                         &store_errno, buf, 8192);
         if (ret) {
             if (store_errno == GD_STORE_EOF) {
                 gf_msg_debug(this->name, 0, "EOF for missed_snap_list");

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -139,16 +139,16 @@ is_brick_mx_enabled(void)
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
-    /* GF_ENABLE_BRICKMUX set as a compile time build option, if the
-       option is set and brick_mux key is not configured then consider
-       brick_mux option is enabled
-    */
-    #if defined(GF_ENABLE_BRICKMUX)
-        if (ret) {
-            ret = _gf_false;
-            enabled = _gf_true;
-        }
-    #endif
+/* GF_ENABLE_BRICKMUX set as a compile time build option, if the
+   option is set and brick_mux key is not configured then consider
+   brick_mux option is enabled
+*/
+#if defined(GF_ENABLE_BRICKMUX)
+    if (ret) {
+        ret = _gf_false;
+        enabled = _gf_true;
+    }
+#endif
 
     return ret ? _gf_false : enabled;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -6717,14 +6717,14 @@ glusterd_brick_start(glusterd_volinfo_t *volinfo,
         goto out;
     }
 
-    if (strncmp(uuid_utoa(volinfo->volume_id), uuid_utoa(volid),
-                GF_UUID_BUF_SIZE)) {
+    if (gf_uuid_compare(volinfo->volume_id, volid)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Mismatching %s extended attribute on brick root (%s),"
                " brick is deemed not to be a part of the volume (%s)",
                GF_XATTR_VOL_ID_KEY, brickinfo->path, volinfo->volname);
         goto out;
     }
+
     is_service_running = gf_is_service_running(pidfile, &pid);
     if (is_service_running) {
         if (is_brick_mx_enabled()) {


### PR DESCRIPTION
This patch simulates the conditions of Global Layout for testing
purposes of rebalance.
In the per-directory model, the decision-making mechanism in rebalance
determines whether or not to migrate a file based on comparing the
file's
current location to the layout of its parent directory (by referencing
the parent dir's layout using parent inode). In order to simulate
the conditions of Global Layout (in which a layout will exist only
for the root dir) this mechanism has been modified to take into
account only the layout of the root dir and decide whether to migare
or not by comparing the file's current location with this layout.

In this patch the fix-layout operation is completely removed from
rebalance, apart for the root dir (hence effectively ignoring the
per-directory layout and only caring about root layout).

Notes:
1 - This patch, in combination with other patches that will
follow, will be used to test rebalance is a simulated
Global Layout environment.
2 - This patch will *FAIL* CI and cannot be expected
to pass regression. Regression tests (especially DHT and
rebalance rests) expects files to be present in certain locations.
As we simulate a different distribution mechanism, this patch
will fail regression until tests are modified as well.
3 - In order to verify the validity of this work (as current
regression is not relevant until changed), a number of files
were created in the root dir. In addition to these files, a
number of sub-dirs were created and in each of these sub-dirs
files were created with the same amount and names of the files
in the root dir itself. When triggering rebalance, it was
verified that all the files in the sub-dirs migrate in the
exact same manner as the files in the root dir (for the files
in the root dir it does not matter of distribution is per-dir
or Global Layout).

updates: #1433

Change-Id: Ie8bb34a87f1af5688aa42a170bc8ab261d88bff1
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

