### PR TITLE
glusterd[brick_mux]: Optimize friend handshake code to avoid call_bail

### DIFF
--- a/libglusterfs/src/ctx.c
+++ b/libglusterfs/src/ctx.c
@@ -14,6 +14,7 @@
 #include "glusterfs/glusterfs.h"
 #include "timer-wheel.h"
 
+glusterfs_ctx_t *global_ctx = NULL;
 glusterfs_ctx_t *
 glusterfs_ctx_new()
 {
@@ -55,6 +56,9 @@ glusterfs_ctx_new()
     GF_ATOMIC_INIT(ctx->stats.max_dict_pairs, 0);
     GF_ATOMIC_INIT(ctx->stats.total_pairs_used, 0);
     GF_ATOMIC_INIT(ctx->stats.total_dicts_used, 0);
+
+    if (!global_ctx)
+        global_ctx = ctx;
 out:
     return ctx;
 }

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -30,8 +30,6 @@ struct dict_cmp {
     gf_boolean_t (*value_ignore)(char *k);
 };
 
-static glusterfs_ctx_t *global_ctx = NULL;
-
 #define VALIDATE_DATA_AND_LOG(data, type, key, ret_val)                        \
     do {                                                                       \
         if (!data || !data->data) {                                            \
@@ -108,7 +106,6 @@ get_new_dict_full(int size_hint)
     dict->free_pair.key = NULL;
     dict->totkvlen = 0;
     LOCK_INIT(&dict->lock);
-    global_ctx = THIS->ctx;
 
     return dict;
 }

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -91,7 +91,6 @@ const char *gf_upcall_list[GF_UPCALL_FLAGS_MAXVALUE] = {
 /* This global ctx is a bad hack to prevent some of the libgfapi crashes.
  * This should be removed once the patch on resource pool is accepted
  */
-glusterfs_ctx_t *global_ctx = NULL;
 pthread_mutex_t global_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
 xlator_t global_xlator;
 static int gf_global_mem_acct_enable = 1;
@@ -231,7 +230,6 @@ __glusterfs_this_location()
     if (*this_location == NULL) {
         thread_xlator = &global_xlator;
     }
-
     return this_location;
 }
 

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -154,6 +154,9 @@ dict_deln(dict_t *this, char *key, const int keylen);
 int
 dict_reset(dict_t *dict);
 
+data_t *
+get_new_data_from_pool(glusterfs_ctx_t *ctx);
+
 int
 dict_key_count(dict_t *this);
 
@@ -417,4 +420,8 @@ dict_has_key_from_array(dict_t *dict, char **strings, gf_boolean_t *result);
 
 int
 dict_serialized_length_lk(dict_t *this);
+
+int32_t
+dict_unserialize_specific_keys(char *orig_buf, int32_t size, dict_t **fill,
+                               char **specific_key_arr, dict_t **specific_dict);
 #endif

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -154,9 +154,6 @@ dict_deln(dict_t *this, char *key, const int keylen);
 int
 dict_reset(dict_t *dict);
 
-data_t *
-get_new_data_from_pool(glusterfs_ctx_t *ctx);
-
 int
 dict_key_count(dict_t *this);
 
@@ -423,5 +420,6 @@ dict_serialized_length_lk(dict_t *this);
 
 int32_t
 dict_unserialize_specific_keys(char *orig_buf, int32_t size, dict_t **fill,
-                               char **specific_key_arr, dict_t **specific_dict);
+                               char **specific_key_arr, dict_t **specific_dict,
+                               int totkeycount);
 #endif

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -185,4 +185,5 @@ int
 gf_global_mem_acct_enable_get(void);
 int
 gf_global_mem_acct_enable_set(int val);
+
 #endif /* !_GLOBALS_H */

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -186,4 +186,5 @@ gf_global_mem_acct_enable_get(void);
 int
 gf_global_mem_acct_enable_set(int val);
 
+extern glusterfs_ctx_t *global_ctx;
 #endif /* !_GLOBALS_H */

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -432,6 +432,7 @@ dict_clear_flag
 dict_check_flag
 dict_unref
 dict_unserialize
+dict_unserialize_specific_keys
 drop_token
 eh_destroy
 eh_dump

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -82,7 +82,7 @@ glusterd_big_locked_handler(rpcsvc_request_t *req, rpcsvc_actor actor_fn)
     return ret;
 }
 
-static char *specific_key_suffix[] = {".quota-cksum", ".cksum", ".version",
+static char *specific_key_suffix[] = {".quota-cksum", ".ckusm", ".version",
                                       ".quota-version", ".name"};
 
 static int

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -106,6 +106,8 @@ glusterd_destroy_friend_req_ctx(glusterd_friend_req_ctx_t *ctx)
 
     if (ctx->vols)
         dict_unref(ctx->vols);
+    if (ctx->peer_ver)
+        dict_unref(ctx->peer_ver);
     GF_FREE(ctx->hostname);
     GF_FREE(ctx);
 }
@@ -995,8 +997,8 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
     // Build comparison logic here.
     pthread_mutex_lock(&conf->import_volumes);
     {
-        ret = glusterd_compare_friend_data(ev_ctx->vols, &status,
-                                           event->peername);
+        ret = glusterd_compare_friend_data(ev_ctx->vols, ev_ctx->peer_ver,
+                                           &status, event->peername);
         if (ret) {
             pthread_mutex_unlock(&conf->import_volumes);
             goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -171,6 +171,7 @@ typedef struct glusterd_friend_req_ctx_ {
     rpcsvc_request_t *req;
     int port;
     dict_t *vols;
+    dict_t *peer_ver;  // Dictionary to save peer ver data
 } glusterd_friend_req_ctx_t;
 
 typedef struct glusterd_friend_update_ctx_ {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5229,7 +5229,7 @@ glusterd_import_friend_volumes_synctask(void *opaque)
 {
     int32_t ret = -1;
     int32_t count = 0;
-    int i = 0; /* Always start from 0 to access correct bitmap */
+    int i = 1;
     xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     dict_t *peer_data = NULL;
@@ -5269,10 +5269,10 @@ glusterd_import_friend_volumes_synctask(void *opaque)
     while (i <= count) {
         bm = arg->status_arr[i / 64];
         while (bm != 0) {
-            mask = bm &
-                   (-bm); /* mask will contain the lowest bit set from bm. */
+            /* mask will contain the lowest bit set from bm. */
+            mask = bm & (-bm);
             bm ^= mask;
-            ret = glusterd_import_friend_volume(peer_data, 0 + ffsll(mask) - 1,
+            ret = glusterd_import_friend_volume(peer_data, i + ffsll(mask) - 2,
                                                 arg);
             if (ret < 0) {
                 break;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -241,7 +241,7 @@ glusterd_add_volumes_to_export_dict(dict_t *peer_data, char **buf,
                                     u_int *length);
 
 int32_t
-glusterd_compare_friend_data(dict_t *peer_data, int32_t *status,
+glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
                              char *hostname);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -248,8 +248,8 @@ typedef struct glusterd_add_dict_args {
 
 typedef struct glusterd_friend_synctask_args {
     dict_t *peer_data;
-    dict_t *peer_ver_data;          // Dictionary to save peer version data
-    uint64_t status_arr[256];       // Array to save volume update status
+    dict_t *peer_ver_data;  // Dictionary to save peer version data
+    uint64_t *status_arr;   // Array to save volume update status
 } glusterd_friend_synctask_args_t;
 
 typedef enum gf_brick_status {

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -247,8 +247,9 @@ typedef struct glusterd_add_dict_args {
 } glusterd_add_dict_args_t;
 
 typedef struct glusterd_friend_synctask_args {
-    char *dict_buf;
-    u_int dictlen;
+    dict_t *peer_data;
+    dict_t *peer_ver_data;          // Dictionary to save peer version data
+    uint64_t status_arr[256];       // Array to save volume update status
 } glusterd_friend_synctask_args_t;
 
 typedef enum gf_brick_status {

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -248,8 +248,11 @@ typedef struct glusterd_add_dict_args {
 
 typedef struct glusterd_friend_synctask_args {
     dict_t *peer_data;
-    dict_t *peer_ver_data;   // Dictionary to save peer version data
-    uint64_t status_arr[1];  // Array to save volume update status
+    dict_t *peer_ver_data;  // Dictionary to save peer version data
+    /* This status_arr[1] is not a real size, real size of the array
+       is dynamically allocated
+    */
+    uint64_t status_arr[1];
 } glusterd_friend_synctask_args_t;
 
 typedef enum gf_brick_status {

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -248,8 +248,8 @@ typedef struct glusterd_add_dict_args {
 
 typedef struct glusterd_friend_synctask_args {
     dict_t *peer_data;
-    dict_t *peer_ver_data;  // Dictionary to save peer version data
-    uint64_t *status_arr;   // Array to save volume update status
+    dict_t *peer_ver_data;   // Dictionary to save peer version data
+    uint64_t status_arr[1];  // Array to save volume update status
 } glusterd_friend_synctask_args_t;
 
 typedef enum gf_brick_status {


### PR DESCRIPTION
During glusterd handshake glusterd received a volume dictionary
from peer end to compare the own volume dictionary data.If the options
are differ it sets the key to recognize volume options are changed
and call import syntask to delete/start the volume.In brick_mux
environment while number of volumes are high(5k) the dict api in function
glusterd_compare_friend_volume takes time because the function
glusterd_handle_friend_req saves all peer volume data in a single dictionary.
Due to time taken by the function glusterd_handle_friend RPC requests receives
a call_bail from a peer end gluster(CLI) won't be able to show volume status.

Solution: To optimize the code done below changes
1) Populate a new specific dictionary to save the peer end version specific
   data so that function won't take much time to take the decision about the
   peer end has some volume updates.
2) In case of volume has differ version set the key in status_arr instead
   of saving in a dictionary to make the operation is faster.

Note: To validate the changes followed below procedure
1) Setup 5100 distributed volumes 3x1
2) Enable brick_mux
3) Start all the volumes
4) Kill all gluster processes on 3rd node
5) Run a loop to update volume option on a 1st node
   for i in {1..5100}; do gluster v set vol$i performance.open-behind off; done
6) Start the glusterd process on the 3rd node
7) Wait to finish handshake and check there should not be any call_bail message
   in the logs

Change-Id: Ibad7c23988539cc369ecc39dea2ea6985470bee1
Fixes: #1613
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

