### PR TITLE
glusted: Optimize glusterd_volinfo_find function

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -6802,6 +6802,8 @@ glusterd_snapshot_clone_commit(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
+    snap_vol->volname_hash = gf_dm_hashfn(snap_vol->volname,
+                                          strlen(snap_vol->volname));
     glusterd_list_add_order(&snap_vol->vol_list, &priv->volumes,
                             glusterd_compare_volume_name);
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -3342,6 +3342,8 @@ glusterd_store_retrieve_volume(char *volname, glusterd_snap_t *snap)
         goto out;
 
     if (!snap) {
+        volinfo->volname_hash = gf_dm_hashfn(volinfo->volname,
+                                             strlen(volinfo->volname));
         glusterd_list_add_order(&volinfo->vol_list, &priv->volumes,
                                 glusterd_compare_volume_name);
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -1693,6 +1693,7 @@ glusterd_volinfo_find(const char *volname, glusterd_volinfo_t **volinfo)
     int32_t ret = -1;
     xlator_t *this = NULL;
     glusterd_conf_t *priv = NULL;
+    uint32_t hash = 0;
 
     GF_ASSERT(volname);
     this = THIS;
@@ -1701,9 +1702,10 @@ glusterd_volinfo_find(const char *volname, glusterd_volinfo_t **volinfo)
     priv = this->private;
     GF_ASSERT(priv);
 
+    hash = gf_dm_hashfn(volname, strlen(volname));
     cds_list_for_each_entry(tmp_volinfo, &priv->volumes, vol_list)
     {
-        if (!strcmp(tmp_volinfo->volname, volname)) {
+        if (tmp_volinfo->volname_hash == hash) {
             gf_msg_debug(this->name, 0, "Volume %s found", volname);
             ret = 0;
             *volinfo = tmp_volinfo;
@@ -1722,6 +1724,7 @@ glusterd_volume_exists(const char *volname)
     gf_boolean_t volume_found = _gf_false;
     xlator_t *this = NULL;
     glusterd_conf_t *priv = NULL;
+    uint32_t hash = 0;
 
     GF_ASSERT(volname);
     this = THIS;
@@ -1730,9 +1733,10 @@ glusterd_volume_exists(const char *volname)
     priv = this->private;
     GF_ASSERT(priv);
 
+    hash = gf_dm_hashfn(volname, strlen(volname));
     cds_list_for_each_entry(tmp_volinfo, &priv->volumes, vol_list)
     {
-        if (!strcmp(tmp_volinfo->volname, volname)) {
+        if (tmp_volinfo->volname_hash == hash) {
             gf_msg_debug(this->name, 0, "Volume %s found", volname);
             volume_found = _gf_true;
             break;
@@ -5107,6 +5111,8 @@ glusterd_import_friend_volume(dict_t *peer_data, int count)
     if (ret)
         goto out;
 
+    new_volinfo->volname_hash = gf_dm_hashfn(new_volinfo->volname,
+                                             strlen(new_volinfo->volname));
     glusterd_list_add_order(&new_volinfo->vol_list, &priv->volumes,
                             glusterd_compare_volume_name);
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -18,6 +18,7 @@
 #include <glusterfs/logging.h>
 #include <glusterfs/call-stub.h>
 #include <glusterfs/byte-order.h>
+#include <glusterfs/hashfn.h>
 #include "glusterd.h"
 #include "rpc-clnt.h"
 #include "protocol-common.h"

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -2272,6 +2272,8 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
     }
 
     volinfo->rebal.defrag_status = 0;
+    volinfo->volname_hash = gf_dm_hashfn(volinfo->volname,
+                                         strlen(volinfo->volname));
     glusterd_list_add_order(&volinfo->vol_list, &priv->volumes,
                             glusterd_compare_volume_name);
     vol_added = _gf_true;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -517,6 +517,7 @@ struct glusterd_volinfo_ {
     /* Flag to check about volume has received updates
        from peer
     */
+    uint32_t volname_hash;
 };
 
 typedef enum gd_snap_status_ {


### PR DESCRIPTION
The function(glusterd_volinfo_find) is use by multiple places to fetch
volinfo object from a volumes list. In case of brick_mux environment
while too many volumes are configured it is not good to compare everytime volume
based on volname.Instead of comparing again and again based on volname by
strcmp save hash of volname in volinfo object and compare the hash values.

Fixes: #1615
Change-Id: Idbe59a62d66ceb97181e050a1ee3961d014564d3
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

