### PR TITLE
tests/00-geo-rep: 00-georep-verify-non-root-setup.t fails on devel br…

### DIFF
--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -33,6 +33,10 @@ slave_url=$usr@$slave
 slave_vol=$GSV0
 ssh_url=$usr@$SH0
 
+#Cleanup stale keys
+sed -i '/^command=.*SSH_ORIGINAL_COMMAND#.*/d' /home/$usr/.ssh/authorized_keys
+sed -i '/^command=.*gsyncd.*/d' /home/$usr/.ssh/authorized_keys
+
 ############################################################
 #SETUP VOLUMES AND VARIABLES
 


### PR DESCRIPTION
tests/00-geo-rep: 00-georep-verify-non-root-setup.t fails on devel branch

ssh -oPasswordAuthentication=no -oStrictHostKeyChecking=no -i
/var/lib/glusterd/geo-replication/secret.pem -p 22 nroot@127.0.0.1
/build/install/sbin/gluster --xml --remote-host=localhost volume info
slave failes with error 255.

Adding ssh key clean up code at the beginning of the test, inorder to
clean any stale entries

Updates: #1594
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

