### PR TITLE
glusterd: Resolve clang format issue

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -139,16 +139,16 @@ is_brick_mx_enabled(void)
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
-    /* GF_ENABLE_BRICKMUX set as a compile time build option, if the
-       option is set and brick_mux key is not configured then consider
-       brick_mux option is enabled
-    */
-    #if defined(GF_ENABLE_BRICKMUX)
-        if (ret) {
-            ret = _gf_false;
-            enabled = _gf_true;
-        }
-    #endif
+/* GF_ENABLE_BRICKMUX set as a compile time build option, if the
+   option is set and brick_mux key is not configured then consider
+   brick_mux option is enabled
+*/
+#if defined(GF_ENABLE_BRICKMUX)
+    if (ret) {
+        ret = _gf_false;
+        enabled = _gf_true;
+    }
+#endif
 
     return ret ? _gf_false : enabled;
 }


### PR DESCRIPTION
In the commit 8d54899724a31f29848e1461f68ce2cf40585056 clang
format issue was introduced in patch but clang check was not
complained at the time of running regression.

Fixes: #1569
Change-Id: Ib1fb039ebe3c77f39b8c686eb4699327256ac494
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

