### PR TITLE
DHT - Fixing rebalance failure on issuing stop command

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3061,12 +3061,10 @@ int static gf_defrag_get_entry(xlator_t *this, int i,
     struct dht_container *tmp_container = NULL;
 
     if (defrag->defrag_status != GF_DEFRAG_STATUS_STARTED) {
-        ret = -1;
         goto out;
     }
 
     if (dir_dfmeta->offset_var[i].readdir_done == 1) {
-        ret = 0;
         goto out;
     }
 
@@ -3083,7 +3081,6 @@ int static gf_defrag_get_entry(xlator_t *this, int i,
                               &(dir_dfmeta->equeue[i]), xattr_req, NULL);
         if (ret == 0) {
             dir_dfmeta->offset_var[i].readdir_done = 1;
-            ret = 0;
             goto out;
         }
 
@@ -3109,7 +3106,6 @@ int static gf_defrag_get_entry(xlator_t *this, int i,
 
     while (1) {
         if (defrag->defrag_status != GF_DEFRAG_STATUS_STARTED) {
-            ret = -1;
             goto out;
         }
 
@@ -3221,12 +3217,14 @@ int static gf_defrag_get_entry(xlator_t *this, int i,
     }
 
 out:
-    if (ret == 0) {
-        *container = tmp_container;
-    } else {
-        if (tmp_container) {
+    if (defrag->defrag_status == GF_DEFRAG_STATUS_STARTED) {
+        if (ret == 0) {
+            *container = tmp_container;
+        } else {
             gf_defrag_free_container(tmp_container);
         }
+    } else {
+        gf_defrag_free_container(tmp_container);
     }
 
     return ret;
@@ -3439,7 +3437,7 @@ gf_defrag_process_dir(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
                                       migrate_data, dir_dfmeta, xattr_req,
                                       perrno);
 
-            if (defrag->defrag_status == GF_DEFRAG_STATUS_STOPPED) {
+            if (defrag->defrag_status != GF_DEFRAG_STATUS_STARTED) {
                 goto out;
             }
 
@@ -3772,8 +3770,7 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
             ret = gf_defrag_fix_layout(this, defrag, &entry_loc, fix_layout,
                                        migrate_data);
 
-            if (defrag->defrag_status == GF_DEFRAG_STATUS_STOPPED ||
-                defrag->defrag_status == GF_DEFRAG_STATUS_FAILED) {
+            if (defrag->defrag_status != GF_DEFRAG_STATUS_STARTED) {
                 goto out;
             }
 
@@ -3846,6 +3843,10 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
 
     if (defrag->cmd != GF_DEFRAG_CMD_START_LAYOUT_FIX) {
         ret = gf_defrag_process_dir(this, defrag, loc, migrate_data, &perrno);
+
+        if (defrag->defrag_status != GF_DEFRAG_STATUS_STARTED) {
+            goto out;
+        }
 
         if (ret) {
             if (perrno == ENOENT || perrno == ESTALE) {


### PR DESCRIPTION
Issuing a stop command for an ongoing rebalance process results in an
error.
This issue was brought up in
https://bugzilla.redhat.com/show_bug.cgi?id=1286171 and a patch
(https://review.gluster.org/#/c/glusterfs/+/24103/) was submitted to
resolve the issue. However the submitted patch resolved only part of the
problem by reducing the number of log messages that were printed (since
rebalnace is currently a recursive process, an error message was printed
for every directory) but didn't fully resolve the root cause for the
failure.

This patch fixes the issue by modifying the code-path which handles the
termination of the rebalance process by issuing a stop command.

fixes: #1627
Change-Id: I604f2b0f8b1ccb1026b8425a14200bbd1dc5bd03
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

