### PR TITLE
Georep:cli response for geo-rep status gives failure even in proper o…

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -4856,7 +4856,14 @@ gf_cli_gsync_status_output(dict_t *dict, gf_boolean_t is_detail)
 
         gf_log("cli", GF_LOG_INFO, "%s", errmsg);
         cli_out("%s", errmsg);
-        ret = -1;
+
+        /*
+         * The status query for geo-rep returns
+         * command failure if the return value isn't 0
+         * even though the status command gives a valid
+         * response stating no active session.
+         */
+        ret = 0;
         goto out;
     }
 


### PR DESCRIPTION
…peration

Issue: When querying for the status of the geo-rep, the response
is the geo-rep sessions details. But when there is no session, the
response received is as follows,

$ No active geo-replication sessions
$ geo-replication command failed

Now, the first message itself is enough for the user to get an
idea that there is no active geo-replication status. Hence, that
itself is a a valid response. Hence the second message which states
that the command has failed might send imply that something wrong
had happened. Also the command didn't fail as such.

Code Changes:
1. changing the value of ret value in function
gf_cli_gsync_status_output to 0 in cli-rpc-ops.c so that
when the value is analysed in cli_cmd_log_rotate_cbk so that
the command failure isn't displayed to the user when
querying.

Reasoning behind the approach:
1. User should get a clear idea of what is happening and
hence the value of ret is changed to 0 so that it would
imply that the command succeeded after giving a proper
reply.

Fixes: #1367
Change-Id: I04058f8db2a275db534be5e79b11b1121689ce55
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

