### PR TITLE
runner: moving to posix_spawnp instead of fork

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -5159,7 +5159,8 @@ gf_fop_int(char *fop)
 }
 
 int
-close_fds_except(int *fdv, size_t count)
+close_fds_except_custom(int *fdv, size_t count, void *prm,
+                        void closer(int fd, void *prm))
 {
     int i = 0;
     size_t j = 0;
@@ -5196,7 +5197,7 @@ close_fds_except(int *fdv, size_t count)
             }
         }
         if (should_close)
-            sys_close(i);
+            closer(i, prm);
     }
     sys_closedir(d);
 #else  /* !GF_LINUX_HOST_OS */
@@ -5216,10 +5217,22 @@ close_fds_except(int *fdv, size_t count)
             }
         }
         if (should_close)
-            sys_close(i);
+            closer(i, prm);
     }
 #endif /* !GF_LINUX_HOST_OS */
     return 0;
+}
+
+void
+closer_close(int fd, void *prm)
+{
+    sys_close(fd);
+}
+
+int
+close_fds_except(int *fdv, size_t count)
+{
+    return close_fds_except_custom(fdv, count, NULL, closer_close);
 }
 
 /**

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -5223,7 +5223,7 @@ close_fds_except_custom(int *fdv, size_t count, void *prm,
     return 0;
 }
 
-void
+static void
 closer_close(int fd, void *prm)
 {
     sys_close(fd);

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1185,9 +1185,6 @@ int
 close_fds_except_custom(int *fdv, size_t count, void *prm,
                         void closer(int fd, void *prm));
 
-void
-closer_close(int fd, void *prm);
-
 int
 close_fds_except(int *fdv, size_t count);
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1182,6 +1182,13 @@ char *
 get_ip_from_addrinfo(struct addrinfo *addr, char **ip);
 
 int
+close_fds_except_custom(int *fdv, size_t count, void *prm,
+                        void closer(int fd, void *prm));
+
+void
+closer_close(int fd, void *prm);
+
+int
 close_fds_except(int *fdv, size_t count);
 
 int

--- a/libglusterfs/src/run.c
+++ b/libglusterfs/src/run.c
@@ -45,7 +45,7 @@ extern char **environ;
  * $ cc -DRUN_DO_DEMO -DRUN_STANDALONE -orun run.c
  */
 #if defined(RUN_STANDALONE) || defined(RUN_DO_DEMO)
-int
+void
 closer_posix_spawnp(int fd, void *prm);
 
 int
@@ -105,12 +105,17 @@ close_fds_except_custom(int *fdv, size_t count, void *prm,
 #endif
 
 #include "glusterfs/run.h"
+/* Using a fake/temporary fd i.e, 0, to safely close the
+   open fds within 3 to MAX_FD by remapping the
+   target fd. Otherwise, it leads to undefined reference
+   in memory while closing them.
+*/
+
 void
 closer_posix_spawnp(int fd, void *prm)
 {
-    int fakeFd = 0;
     posix_spawn_file_actions_t *file_actionsp = prm;
-    posix_spawn_file_actions_adddup2(file_actionsp, fakeFd, fd);
+    posix_spawn_file_actions_adddup2(file_actionsp, 0, fd);
     posix_spawn_file_actions_addclose(file_actionsp, fd);
 }
 void

--- a/libglusterfs/src/run.c
+++ b/libglusterfs/src/run.c
@@ -45,9 +45,6 @@ extern char **environ;
  * $ cc -DRUN_DO_DEMO -DRUN_STANDALONE -orun run.c
  */
 #if defined(RUN_STANDALONE) || defined(RUN_DO_DEMO)
-void
-closer_posix_spawnp(int fd, void *prm);
-
 int
 close_fds_except_custom(int *fdv, size_t count, void *prm,
                         void closer(int fd, void *prm));
@@ -111,7 +108,7 @@ close_fds_except_custom(int *fdv, size_t count, void *prm,
    in memory while closing them.
 */
 
-void
+static void
 closer_posix_spawnp(int fd, void *prm)
 {
     posix_spawn_file_actions_t *file_actionsp = prm;


### PR DESCRIPTION
Removed the fork(), and implemented the
posix_spwanp() acccrodingly, as it provides much better
performance than fork(). More detailed description about
the benefits can be found in the description of the issue
linked below.

Fixes:#810

Signed-off-by: nik-redhat <nladha@redhat.com>