### PR TITLE
nfs: Don't call svc_run() from multiple threads

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -460,6 +460,7 @@ struct rpcsvc_program {
     gf_boolean_t alive;
 
     gf_boolean_t synctask;
+    bool needs_server; /* Used for NFS services when svc_run() is needed. */
     unsigned long request_queue_status[EVENT_MAX_THREADS / __BITS_PER_LONG];
 };
 

--- a/xlators/nfs/server/src/mount3udp_svc.c
+++ b/xlators/nfs/server/src/mount3udp_svc.c
@@ -208,31 +208,25 @@ mountudp_program_3(struct svc_req *rqstp, register SVCXPRT *transp)
     return;
 }
 
-void *
-mount3udp_thread(void *argv)
+int32_t
+mount3udp_register(xlator_t *nfsx)
 {
-    xlator_t *nfsx = argv;
     register SVCXPRT *transp = NULL;
 
     GF_ASSERT(nfsx);
-
-    THIS = nfsx;
 
     transp = svcudp_create(RPC_ANYSOCK);
     if (transp == NULL) {
         gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_SVC_ERROR,
                "svcudp_create error");
-        return NULL;
+        return -1;
     }
     if (!svc_register(transp, MOUNT_PROGRAM, MOUNT_V3, mountudp_program_3,
                       IPPROTO_UDP)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_SVC_ERROR,
                "svc_register error");
-        return NULL;
+        return -1;
     }
 
-    svc_run();
-    gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_SVC_RUN_RETURNED,
-           "svc_run returned");
-    return NULL;
+    return 0;
 }

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -11,6 +11,8 @@
 #ifndef __NFS_H__
 #define __NFS_H__
 
+#include <pthread.h>
+
 #include "rpcsvc.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/xlator.h>
@@ -101,6 +103,11 @@ struct nfs_state {
     char *rpc_statd_pid_file;
     gf_boolean_t rdirplus;
     uint32_t event_threads;
+
+    pthread_mutex_t server_lock;
+    pthread_t server_thread;
+    uint32_t server_count;
+    bool server_running;
 };
 
 struct nfs_inode_ctx {

--- a/xlators/nfs/server/src/nlmcbk_svc.c
+++ b/xlators/nfs/server/src/nlmcbk_svc.c
@@ -81,54 +81,47 @@ nlmcbk_program_0(struct svc_req *rqstp, register SVCXPRT *transp)
     return;
 }
 
-void *
-nsm_thread(void *argv)
+int32_t
+nsm_register(xlator_t *nfsx)
 {
-    xlator_t *nfsx = argv;
     register SVCXPRT *transp;
     int ret = 0;
 
     GF_ASSERT(nfsx);
 
-    THIS = nfsx;
-
     ret = pmap_unset(NLMCBK_PROGRAM, NLMCBK_V1);
     if (ret == 0) {
         gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_PMAP_UNSET_FAIL,
                "pmap_unset failed");
-        return NULL;
+        return -1;
     }
     transp = svcudp_create(RPC_ANYSOCK);
     if (transp == NULL) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_UDP_SERV_FAIL,
                "cannot create udp service.");
-        return NULL;
+        return -1;
     }
     if (!svc_register(transp, NLMCBK_PROGRAM, NLMCBK_V1, nlmcbk_program_0,
                       IPPROTO_UDP)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_REG_NLMCBK_FAIL,
                "unable to register (NLMCBK_PROGRAM, "
                "NLMCBK_V0, udp).");
-        return NULL;
+        return -1;
     }
 
     transp = svctcp_create(RPC_ANYSOCK, 0, 0);
     if (transp == NULL) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_TCP_SERV_FAIL,
                "cannot create tcp service.");
-        return NULL;
+        return -1;
     }
     if (!svc_register(transp, NLMCBK_PROGRAM, NLMCBK_V1, nlmcbk_program_0,
                       IPPROTO_TCP)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_REG_NLMCBK_FAIL,
                "unable to register (NLMCBK_PROGRAM, "
                "NLMCBK_V0, tcp).");
-        return NULL;
+        return -1;
     }
 
-    svc_run();
-    gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_SVC_RUN_RETURNED,
-           "svc_run returned");
-    return NULL;
-    /* NOTREACHED */
+    return 0;
 }


### PR DESCRIPTION
svc_run() starts a polling loop that listens from all registered
connections and handles requests. When this is done from multiple
threads, a race can happen where both threads are trying to process
the same connection simultaneously. This causes memory corruption.

To avoid this problem, the threads for UDP and NLM connections have
been removed and replaced by a unique thread that only runs svc_run()
when needed.

Current termination procedures in gNFS are incomplete and probably
unreliable (glusterd kills the process instead of terminating it
when it needs to reconfigure it). For this reason the controlled
termination of the new thread is not handled in this patch.

Change-Id: I8ca775d5a627a259c1fa653049f8fc69e16799df
Updates: #1009
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

