### PR TITLE
fuse: sanitize FUSE_OP_HIGH

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -40,36 +40,6 @@
 #include <glusterfs/syncop.h>
 #include <glusterfs/gidcache.h>
 
-#if defined(GF_LINUX_HOST_OS) || defined(__FreeBSD__) || defined(__NetBSD__)
-
-/*
- * TODO:
- * So, with the addition of copy_file_range support, it might
- * require a bump up of fuse kernel minor version (like it was
- * done when support for lseek fop was added. But, as of now,
- * the copy_file_range support has just landed in upstream
- * kernel fuse module. So, until, there is a release of that
- * fuse as part of a kernel, the FUSE_KERNEL_MINOR_VERSION
- * from fuse_kernel.h in the contrib might not be changed.
- * If so, then the highest op available should be based on
- * the current minor version (which is 24). So, selectively
- * determine. When, the minor version is changed to 28 in
- * fuse_kernel.h from contrib (because in upstream linux
- * kernel source tree, the kernel minor version which
- * contains support for copy_file_range is 28), then remove
- * the reference to FUSE_LSEEK below and just determine
- * FUSE_OP_HIGH based on copy_file_range.
- */
-#if FUSE_KERNEL_MINOR_VERSION >= 28
-#define FUSE_OP_HIGH (FUSE_COPY_FILE_RANGE + 1)
-#else
-#define FUSE_OP_HIGH (FUSE_LSEEK + 1)
-#endif
-
-#endif
-#ifdef GF_DARWIN_HOST_OS
-#define FUSE_OP_HIGH (FUSE_DESTROY + 1)
-#endif
 #define GLUSTERFS_XATTR_LEN_MAX 65536
 
 #define MAX_FUSE_PROC_DELAY 1


### PR DESCRIPTION
The idea behind FUSE_OP_HIGH was that it should be
the upper limit for the opcodes we can ever get from kernel
(maximum opcode that can occur plus one).

The problem with this idea is that this depends on the FUSE
protocol version; and since the fuse proto header does not export
this value, it has to be retroactively defined considering
the particular opcode values in the protocol header. That is, not
just the value, but the definition itself depends on the FUSE
protocol version. So we ended up maintaining -- or indeed, not
even maintaining, just living with -- a mess of conditional
defines for FUSE_OP_HIGH.

Now we change the meaning of it: FUSE_OP_HIGH will simply be
upper limit of the opcodes for which we define a handler
(the highest such opcode plus one, which is the same as the
size of the fuse optable).

The practical implication of this change is as follows.

Potentially there is a gap between the new and the old value
of FUSE_OP_HIGH: those opcodes which might occur in requests
but are higher than any opcode we handle. With the old definition
of FUSE_OP_HIGH we could statically dispatch these opcodes to
fuse_enosys() (a function that sends a FUSE response with error
ENOSYS).

With the new definition we don't know the upper limit of this gap,
so we need to dispatch the opcodes of the gap to fuse_enosys()
dynamically (perform a runtime check if the opcode is
greater-or-equal than the new FUSE_OP_HIGH, and if yes, then call
fuse_enosys()).

Change-Id: I8cd26ead538de8ce36c91feaf938e4c5dc59c88c
Updates: gluster#1000
Signed-off-by: Csaba Henk <csaba@redhat.com>