### PR TITLE
test: The test case tests/bugs/bug-1064147.t is failing

### DIFF
--- a/tests/bugs/bug-1064147.t
+++ b/tests/bugs/bug-1064147.t
@@ -25,6 +25,9 @@ EXPECT 'Started' volinfo_field $V0 'Status';
 TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 --entry-timeout=0 $M0;
 #------------------------------------------------------------
 
+#Run lookup to create a layout
+TEST ls $M0/
+
 # Test case 1 - Subvolume down + Healing
 #------------------------------------------------------------
 # Kill 2nd brick process


### PR DESCRIPTION
test: The test case tests/bugs/bug-1064147.t is failing

The test case tests/bugs/bug-1064147.t is failing at
the time of comparing root permission with permission changed
while one of the brick was down.The permission was not matching
because layout was not not exist on root at the time of healing
a permission so correct permission was not healed on
newly started brick

Fixes: #1661
Change-Id: If63ea47576dd14f4b91681dd390e2f84f8b6ac18
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

