### PR TITLE
tests: Add ip-hostname entry in /etc/hosts

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -405,7 +405,7 @@ check_host_list(void)
     /* Hostlist is a comma separated list now */
     hostname = strtok(hostlist, ",");
     while (hostname != NULL) {
-        ret = gf_is_local_addr(hostname);
+        ret = glusterd_gf_is_local_addr(hostname);
         if (ret) {
             gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_NFS_GNS_HOST_FOUND,
                    "ganesha host found "

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -1161,7 +1161,7 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
                      "only checking probe address vs. bind address");
         ret = gf_is_same_address(bind_name, hostname);
     } else {
-        ret = gf_is_local_addr(hostname);
+        ret = glusterd_gf_is_local_addr(hostname);
     }
     if (ret) {
         glusterd_xfer_cli_probe_resp(req, 0, GF_PROBE_LOCALHOST, NULL, hostname,
@@ -2189,7 +2189,7 @@ __glusterd_handle_sync_volume(rpcsvc_request_t *req)
            "for volume %s",
            (flags & GF_CLI_SYNC_ALL) ? "all" : volname);
 
-    if (gf_is_local_addr(hostname)) {
+    if (glusterd_gf_is_local_addr(hostname)) {
         ret = -1;
         snprintf(msg, sizeof(msg),
                  "sync from localhost"

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1025,7 +1025,7 @@ __server_getspec(rpcsvc_request_t *req)
      * meant for external users.
      * For unix domain socket, address will be empty.
      */
-    if (strlen(addrstr) == 0 || gf_is_local_addr(addrstr)) {
+    if (strlen(addrstr) == 0 || glusterd_gf_is_local_addr(addrstr)) {
         ret = build_volfile_path(volume, filename, sizeof(filename),
                                  TRUSTED_PREFIX, dict);
     } else {

--- a/xlators/mgmt/glusterd/src/glusterd-mem-types.h
+++ b/xlators/mgmt/glusterd/src/glusterd-mem-types.h
@@ -53,6 +53,7 @@ typedef enum gf_gld_mem_types_ {
     gf_gld_mt_snap_create_args_t,
     gf_gld_mt_glusterd_brick_proc_t,
     gf_gld_mt_glusterd_svc_proc_t,
+    gf_gld_mt_hostname_t,
     gf_gld_mt_end,
 } gf_gld_mem_types_t;
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -1682,7 +1682,7 @@ glusterd_op_stage_sync_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    if (gf_is_local_addr(hostname)) {
+    if (glusterd_gf_is_local_addr(hostname)) {
         // volname is not present in case of sync all
         ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
         if (!ret) {
@@ -3139,7 +3139,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    if (!gf_is_local_addr(hostname)) {
+    if (!glusterd_gf_is_local_addr(hostname)) {
         ret = 0;
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -249,14 +249,14 @@ glusterd_hostname_to_uuid(char *hostname, uuid_t uuid)
     priv = this->private;
     GF_ASSERT(priv);
 
-    peerinfo = glusterd_peerinfo_find_by_hostname(hostname);
-    if (peerinfo) {
+    if (glusterd_gf_is_local_addr(hostname)) {
+        gf_uuid_copy(uuid, MY_UUID);
         ret = 0;
-        gf_uuid_copy(uuid, peerinfo->uuid);
     } else {
-        if (gf_is_local_addr(hostname)) {
-            gf_uuid_copy(uuid, MY_UUID);
+        peerinfo = glusterd_peerinfo_find_by_hostname(hostname);
+        if (peerinfo) {
             ret = 0;
+            gf_uuid_copy(uuid, peerinfo->uuid);
         } else {
             ret = -1;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -272,7 +272,7 @@ glusterd_op_stage_replace_brick(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    if (gf_is_local_addr(host)) {
+    if (glusterd_gf_is_local_addr(host)) {
         ret = glusterd_validate_and_create_brickpath(
             dst_brickinfo, volinfo->volume_id, volinfo->volname, op_errstr,
             is_force, _gf_false);
@@ -280,7 +280,7 @@ glusterd_op_stage_replace_brick(dict_t *dict, char **op_errstr,
             goto out;
     }
 
-    if (!gf_is_local_addr(host)) {
+    if (!glusterd_gf_is_local_addr(host)) {
         RCU_READ_LOCK;
 
         peerinfo = glusterd_peerinfo_find(NULL, host);

--- a/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
@@ -145,7 +145,7 @@ glusterd_reset_brick_prevalidate(dict_t *dict, char **op_errstr,
     ret = dict_get_int32n(dict, "ignore-partition", SLEN("ignore-partition"),
                           &ignore_partition);
     ret = 0;
-    if (gf_is_local_addr(host)) {
+    if (glusterd_gf_is_local_addr(host)) {
         ret = glusterd_validate_and_create_brickpath(
             dst_brickinfo, volinfo->volume_id, volinfo->volname, op_errstr,
             is_force, ignore_partition);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -153,6 +153,82 @@ is_brick_mx_enabled(void)
     return ret ? _gf_false : enabled;
 }
 
+static gf_boolean_t
+gd_has_local_address(glusterd_conf_t *priv, const char *hostname)
+{
+    glusterd_hostname_t *hostname_obj = NULL;
+
+    cds_list_for_each_entry(hostname_obj, &priv->hostnames, hostname_list)
+    {
+        if (strcmp(hostname_obj->hostname, hostname) == 0) {
+            return _gf_true;
+        }
+    }
+
+    return _gf_false;
+}
+
+static int
+glusterd_hostname_new(xlator_t *this, const char *hostname,
+                      glusterd_hostname_t **name)
+{
+    glusterd_hostname_t *hostname_obj = NULL;
+    int32_t ret = -1;
+
+    GF_ASSERT(hostname);
+    GF_ASSERT(name);
+
+    hostname_obj = GF_MALLOC(sizeof(*hostname_obj), gf_gld_mt_hostname_t);
+
+    if (!hostname_obj) {
+        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_NO_MEMORY, NULL);
+        goto out;
+    }
+
+    hostname_obj->hostname = gf_strdup(hostname);
+    CDS_INIT_LIST_HEAD(&hostname_obj->hostname_list);
+
+    *name = hostname_obj;
+    ret = 0;
+
+out:
+    gf_msg_debug("glusterd", 0, "Returning %d", ret);
+    return ret;
+}
+
+gf_boolean_t
+glusterd_gf_is_local_addr(char *hostname)
+{
+    xlator_t *this = NULL;
+    glusterd_conf_t *priv = NULL;
+    glusterd_hostname_t *hostname_obj = NULL;
+    gf_boolean_t found = _gf_false;
+    int ret = 1;
+
+    this = THIS;
+    priv = this->private;
+
+    if (gd_has_local_address(priv, hostname)) {
+        found = _gf_true;
+        goto out;
+    }
+
+    if (gf_is_local_addr(hostname)) {
+        ret = glusterd_hostname_new(this, hostname, &hostname_obj);
+        if (ret) {
+             gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
+                     NULL);
+            goto out;
+        }
+        found = _gf_true;
+        cds_list_add_tail_rcu(&hostname_obj->hostname_list, &priv->hostnames);
+    }
+
+out:
+    return found;
+
+}
+
 int
 get_mux_limit_per_process(int *mux_limit)
 {
@@ -14262,7 +14338,7 @@ rb_update_dstbrick_port(glusterd_brickinfo_t *dst_brickinfo, dict_t *rsp_dict,
     if (!dict_ret)
         dst_brickinfo->port = dst_port;
 
-    if (gf_is_local_addr(dst_brickinfo->hostname)) {
+    if (glusterd_gf_is_local_addr(dst_brickinfo->hostname)) {
         gf_msg("glusterd", GF_LOG_INFO, 0, GD_MSG_BRK_PORT_NO_ADD_INDO,
                "adding dst-brick port no %d", dst_port);
 
@@ -14406,7 +14482,7 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
         goto out;
     }
 
-    if (gf_is_local_addr((*src_brickinfo)->hostname)) {
+    if (glusterd_gf_is_local_addr((*src_brickinfo)->hostname)) {
         gf_msg_debug(this->name, 0, "I AM THE SOURCE HOST");
         if ((*src_brickinfo)->port && rsp_dict) {
             ret = dict_set_int32n(rsp_dict, "src-brick-port",

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -86,6 +86,11 @@ typedef struct glusterd_dict_ctx_ {
     char *prefix;
 } glusterd_dict_ctx_t;
 
+typedef struct glusterd_hostname_ {
+    char *hostname;
+    struct cds_list_head hostname_list;
+} glusterd_hostname_t;
+
 gf_boolean_t
 is_brick_mx_enabled(void);
 
@@ -861,5 +866,6 @@ int32_t
 glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
                            char **volname, char **bricks, int32_t *brick_count,
                            int32_t sub_count);
-
+gf_boolean_t
+glusterd_gf_is_local_addr(char *hostname);
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1388,6 +1388,22 @@ out:
     return ret;
 }
 
+void
+glusterd_destroy_hostname_list(glusterd_conf_t *priv)
+{
+    glusterd_hostname_t *hostname_obj = NULL;
+    glusterd_hostname_t *tmp = NULL;
+
+    cds_list_for_each_entry_safe(hostname_obj, tmp, &priv->hostnames,
+                                 hostname_list)
+    {
+         GF_FREE(hostname_obj->hostname);
+         cds_list_del_init(&hostname_obj->hostname_list);
+         GF_FREE(hostname_obj);
+    }
+}
+
+
 /*
  * init - called during glusterd initialization
  *
@@ -1866,6 +1882,7 @@ init(xlator_t *this)
     CDS_INIT_LIST_HEAD(&conf->missed_snaps_list);
     CDS_INIT_LIST_HEAD(&conf->brick_procs);
     CDS_INIT_LIST_HEAD(&conf->shd_procs);
+    CDS_INIT_LIST_HEAD(&conf->hostnames);
     pthread_mutex_init(&conf->attach_lock, NULL);
     pthread_mutex_init(&conf->volume_lock, NULL);
 
@@ -2115,6 +2132,7 @@ fini(xlator_t *this)
 
     glusterd_stop_uds_listener(this); /*stop unix socket rpc*/
     glusterd_stop_listener(this);     /*stop tcp/ip socket rpc*/
+    glusterd_destroy_hostname_list(this->private); /*Destroy hostname list */
 
 #if 0
        /* Running threads might be using these resourses, we have to cancel/stop

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -236,6 +236,7 @@ typedef struct {
     char workdir[VALID_GLUSTERD_PATHMAX];
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
+    struct cds_list_head hostnames;
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {


### PR DESCRIPTION
The test case ./tests/bugs/core/bug-1650403.t is consuming more than
500s while running a regression job so the regression is failing.
After executed the test case in softserve environment i have found it is getting timed-out
because dns call is consuming time by glusterd while it is trying to disbale/enable shd.

time ./tests/bugs/core/bug-1650403.t
real 20m52.952s
user 0m20.842s
sys 0m9.824s

After add the hostname-ip entry into /etc/hosts the time is significantly reduced
time ./tests/bugs/core/bug-1650403.t
real 1m29.467s
user 0m23.366s
sys 0m10.395s

Fixes: #1663
Change-Id: Iee3462075f84897faa294e48d81af9761929613a
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

