### PR TITLE
glusterd: wrong comparison in glusterd_brick_start() function

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -6717,14 +6717,14 @@ glusterd_brick_start(glusterd_volinfo_t *volinfo,
         goto out;
     }
 
-    if (strncmp(uuid_utoa(volinfo->volume_id), uuid_utoa(volid),
-                GF_UUID_BUF_SIZE)) {
+    if (gf_uuid_compare(volinfo->volume_id, volid)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Mismatching %s extended attribute on brick root (%s),"
                " brick is deemed not to be a part of the volume (%s)",
                GF_XATTR_VOL_ID_KEY, brickinfo->path, volinfo->volname);
         goto out;
     }
+
     is_service_running = gf_is_service_running(pidfile, &pid);
     if (is_service_running) {
         if (is_brick_mx_enabled()) {


### PR DESCRIPTION
Call gf_uuid_compare in glusterd_brick_start to compare two
uuid instead of calling strncmp.

Fixes: #1659
Change-Id: Icd1bdcc1ed4dfab4407fc51ae4ba248989a32f17
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

