### PR TITLE
glusterd: Optmize RCU_READ_(LOCK|UNLOCK) macros

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1483,20 +1483,11 @@ cleanup_and_exit(int signum)
 #endif
 
         trav = NULL;
-
-        /* previously we were releasing the cleanup mutex lock before the
-           process exit. As we are releasing the cleanup mutex lock, before
-           the process can exit some other thread which is blocked on
-           cleanup mutex lock is acquiring the cleanup mutex lock and
-           trying to acquire some resources which are already freed as a
-           part of cleanup. To avoid this, we are exiting the process without
-           releasing the cleanup mutex lock. This will not cause any lock
-           related issues as the process which acquired the lock is going down
-         */
-        /* NOTE: Only the least significant 8 bits i.e (signum & 255)
-           will be available to parent process on calling exit() */
-        exit(abs(signum));
     }
+    pthread_mutex_unlock(&ctx->cleanup_lock);
+    /* NOTE: Only the least significant 8 bits i.e (signum & 255)
+       will be available to parent process on calling exit() */
+    exit(abs(signum));
 }
 
 static void

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1887,7 +1887,7 @@ static rpc_clnt_prog_t gd_clnt_mgmt_hndsk_prog = {
 };
 
 static int
-glusterd_event_connected_inject(glusterd_peerctx_t *peerctx)
+glusterd_event_connected_inject(xlator_t *this, glusterd_peerctx_t *peerctx)
 {
     GF_ASSERT(peerctx);
 
@@ -2084,7 +2084,7 @@ __glusterd_mgmt_hndsk_version_ack_cbk(struct rpc_req *req, struct iovec *iov,
     ret = default_notify(this, GF_EVENT_CHILD_UP, NULL);
 
     if (GD_MODE_ON == peerctx->args.mode) {
-        (void)glusterd_event_connected_inject(peerctx);
+        (void)glusterd_event_connected_inject(this, peerctx);
         peerctx->args.req = NULL;
     } else if (GD_MODE_SWITCH_ON == peerctx->args.mode) {
         peerctx->args.mode = GD_MODE_ON;
@@ -2486,7 +2486,7 @@ __glusterd_peer_dump_version_cbk(struct rpc_req *req, struct iovec *iov,
     ret = default_notify(this, GF_EVENT_CHILD_UP, NULL);
 
     if (GD_MODE_ON == peerctx->args.mode) {
-        (void)glusterd_event_connected_inject(peerctx);
+        (void)glusterd_event_connected_inject(this, peerctx);
         peerctx->args.req = NULL;
     } else if (GD_MODE_SWITCH_ON == peerctx->args.mode) {
         peerctx->args.mode = GD_MODE_ON;

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -422,8 +422,10 @@ glusterd_chk_peers_connected_befriended(uuid_t skip_uuid)
     gf_boolean_t ret = _gf_true;
     glusterd_peerinfo_t *peerinfo = NULL;
     glusterd_conf_t *priv = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
-    priv = THIS->private;
+    priv = this->private;
     GF_ASSERT(priv);
 
     RCU_READ_LOCK;
@@ -454,8 +456,10 @@ glusterd_uuid_to_hostname(uuid_t uuid)
     char *hostname = NULL;
     glusterd_conf_t *priv = NULL;
     glusterd_peerinfo_t *entry = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
-    priv = THIS->private;
+    priv = this->private;
     GF_ASSERT(priv);
 
     if (!gf_uuid_compare(MY_UUID, uuid)) {
@@ -526,6 +530,8 @@ glusterd_are_vol_all_peers_up(glusterd_volinfo_t *volinfo,
     glusterd_peerinfo_t *peerinfo = NULL;
     glusterd_brickinfo_t *brickinfo = NULL;
     gf_boolean_t ret = _gf_false;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     cds_list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
     {

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -449,6 +449,8 @@ __glusterd_friend_add_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int32_t op_errno = EINVAL;
     glusterd_probe_ctx_t *ctx = NULL;
     glusterd_friend_update_ctx_t *ev_ctx = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     if (-1 == req->rpc_status) {
         rsp.op_ret = -1;
@@ -560,8 +562,10 @@ __glusterd_friend_remove_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int32_t op_errno = 0;
     glusterd_probe_ctx_t *ctx = NULL;
     gf_boolean_t move_sm_now = _gf_true;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
-    conf = THIS->private;
+    conf = this->private;
     GF_ASSERT(conf);
 
     ctx = ((call_frame_t *)myframe)->local;

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -235,6 +235,8 @@ glusterd_ac_reverse_probe_begin(glusterd_friend_sm_event_t *event, void *ctx)
     glusterd_peerinfo_t *peerinfo = NULL;
     glusterd_friend_sm_event_t *new_event = NULL;
     glusterd_probe_ctx_t *new_ev_ctx = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     GF_ASSERT(event);
     GF_ASSERT(ctx);
@@ -247,7 +249,7 @@ glusterd_ac_reverse_probe_begin(glusterd_friend_sm_event_t *event, void *ctx)
     if (!peerinfo) {
         RCU_READ_UNLOCK;
         ret = -1;
-        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_PEER_NOT_FOUND,
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PEER_NOT_FOUND,
                "Could not find peer %s(%s)", event->peername,
                uuid_utoa(event->peerid));
         goto out;
@@ -850,11 +852,13 @@ glusterd_ac_handle_friend_remove_req(glusterd_friend_sm_event_t *event,
     glusterd_friend_req_ctx_t *ev_ctx = NULL;
     glusterd_friend_sm_event_t *new_event = NULL;
     glusterd_conf_t *priv = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     GF_ASSERT(ctx);
     ev_ctx = ctx;
 
-    priv = THIS->private;
+    priv = this->private;
     GF_ASSERT(priv);
 
     ret = glusterd_xfer_friend_remove_resp(ev_ctx->req, ev_ctx->hostname,
@@ -898,6 +902,8 @@ glusterd_ac_friend_remove(glusterd_friend_sm_event_t *event, void *ctx)
 {
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     GF_ASSERT(event);
 
@@ -906,7 +912,7 @@ glusterd_ac_friend_remove(glusterd_friend_sm_event_t *event, void *ctx)
     peerinfo = glusterd_peerinfo_find(event->peerid, event->peername);
     if (!peerinfo) {
         RCU_READ_UNLOCK;
-        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_PEER_NOT_FOUND,
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PEER_NOT_FOUND,
                "Could not find peer %s(%s)", event->peername,
                uuid_utoa(event->peerid));
         goto out;
@@ -914,7 +920,7 @@ glusterd_ac_friend_remove(glusterd_friend_sm_event_t *event, void *ctx)
     ret = glusterd_friend_remove_cleanup_vols(peerinfo->uuid);
     RCU_READ_UNLOCK;
     if (ret)
-        gf_msg(THIS->name, GF_LOG_WARNING, 0, GD_MSG_VOL_CLEANUP_FAIL,
+        gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_VOL_CLEANUP_FAIL,
                "Volumes cleanup failed");
 
     /* Exiting read critical section as glusterd_peerinfo_cleanup calls
@@ -923,7 +929,7 @@ glusterd_ac_friend_remove(glusterd_friend_sm_event_t *event, void *ctx)
 
     ret = glusterd_peerinfo_cleanup(peerinfo);
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_PEER_DETACH_CLEANUP_FAIL,
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PEER_DETACH_CLEANUP_FAIL,
                "Cleanup returned: %d", ret);
     }
 out:
@@ -1102,6 +1108,8 @@ glusterd_friend_sm_transition_state(uuid_t peerid, char *peername,
 {
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     GF_ASSERT(state);
     GF_ASSERT(peername);
@@ -1109,7 +1117,7 @@ glusterd_friend_sm_transition_state(uuid_t peerid, char *peername,
     RCU_READ_LOCK;
     peerinfo = glusterd_peerinfo_find(peerid, peername);
     if (!peerinfo) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_PEER_NOT_FOUND, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_PEER_NOT_FOUND, NULL);
         goto out;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -47,6 +47,8 @@ gd_collate_errors(struct syncargs *args, int op_ret, int op_errno,
     int len = -1;
     char *peer_str = NULL;
     glusterd_peerinfo_t *peerinfo = NULL;
+    xlator_t *this = THIS;
+    GF_ASSERT(this);
 
     if (op_ret) {
         args->op_ret = op_ret;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -236,6 +236,7 @@ typedef struct {
     char workdir[VALID_GLUSTERD_PATHMAX];
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
+    gf_boolean_t call_fini; /*Flag is use to sync between fini and actor function */
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {
@@ -764,18 +765,14 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
     } while (0)
 
 #define RCU_READ_LOCK                                                          \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_lock();                                                       \
-    }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    }
 
 #define RCU_READ_UNLOCK                                                        \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_unlock();                                                     \
-    }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    }
 
 #define GLUSTERD_DUMP_PEERS(head, member, xpeers)                              \
     do {                                                                       \
@@ -922,10 +919,6 @@ glusterd_op_commit_send_resp(rpcsvc_request_t *req, int32_t op, int32_t status,
 int
 glusterd_xfer_friend_remove_resp(rpcsvc_request_t *req, char *hostname,
                                  int port);
-
-int
-glusterd_deprobe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
-                       uuid_t uuid, dict_t *dict, int *op_errno);
 
 int
 glusterd_handle_cli_deprobe(rpcsvc_request_t *req);


### PR DESCRIPTION
Change the definition of macros to avoid glusterfs_this_location
call again and again

Fixes: #1619
Change-Id: I4c9d4161d24d60366323ca420aad6a9641057d61
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

