### PR TITLE
dht/rebalance - fixed dhtfcnt_thread wakeup time to be in absolute time

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4020,7 +4020,7 @@ dht_file_counter_thread(void *args)
     dht_build_root_loc(defrag->root_inode, &root_loc);
 
     while (defrag->defrag_status == GF_DEFRAG_STATUS_STARTED) {
-        timespec_now(&time_to_wait);
+        timespec_now_realtime(&time_to_wait);
         time_to_wait.tv_sec += 600;
 
         pthread_mutex_lock(&defrag->fc_mutex);


### PR DESCRIPTION
The dhtfcnt_thread is designed to wakeup each 10min.
Changed the time units passed to pthread_cond_timedwait()
to be in absolute time (epoc time)

fixes: #1507
Change-Id: I1a81ff23ff2c313463add9e0a5fc05c84ac1b4a5
Signed-off-by: Tamar Shacked <tshacked@redhat.com>
