### PR TITLE
rpcsvc/transport: gracefully disconnect when graph is not ready

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -362,11 +362,12 @@ err:
 /* this procedure can only pass 4 arguments to registered notifyfn. To send more
  * arguments call wrapper->notify directly.
  */
-static void
+static int
 rpcsvc_program_notify(rpcsvc_listener_t *listener, rpcsvc_event_t event,
                       void *data)
 {
     rpcsvc_notify_wrapper_t *wrapper = NULL;
+    int ret = 0;
 
     if (!listener) {
         goto out;
@@ -375,12 +376,12 @@ rpcsvc_program_notify(rpcsvc_listener_t *listener, rpcsvc_event_t event,
     list_for_each_entry(wrapper, &listener->svc->notify, list)
     {
         if (wrapper->notify) {
-            wrapper->notify(listener->svc, wrapper->data, event, data);
+            ret = wrapper->notify(listener->svc, wrapper->data, event, data);
         }
     }
 
 out:
-    return;
+    return ret;
 }
 
 static int
@@ -395,8 +396,7 @@ rpcsvc_accept(rpcsvc_t *svc, rpc_transport_t *listen_trans,
         goto out;
     }
 
-    rpcsvc_program_notify(listener, RPCSVC_EVENT_ACCEPT, new_trans);
-    ret = 0;
+    ret = rpcsvc_program_notify(listener, RPCSVC_EVENT_ACCEPT, new_trans);
 out:
     return ret;
 }

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -376,7 +376,10 @@ rpcsvc_program_notify(rpcsvc_listener_t *listener, rpcsvc_event_t event,
     list_for_each_entry(wrapper, &listener->svc->notify, list)
     {
         if (wrapper->notify) {
-            ret = wrapper->notify(listener->svc, wrapper->data, event, data);
+            if (wrapper->notify(listener->svc, wrapper->data, event, data) <
+                    0 &&
+                ret == 0)
+                ret = -1;
         }
     }
 

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -565,9 +565,10 @@ server_rpc_notify(rpcsvc_t *rpc, void *xl, rpcsvc_event_t event, void *data)
         default:
             break;
     }
-
+    ret = 0;
 out:
-    return 0;
+    /* Only case when ret == -1 is the initial validation */
+    return ret;
 }
 
 void *


### PR DESCRIPTION
There was a crash reported when the brick rpc get's an accept
request from a client before the server xlator is fully inited.

The fix https://review.gluster.org/#/c/glusterfs/+/22339/ solves
the crash, but it leaves the connection alive with out adding
the rpc to xprts list of server conf. This will leads to problems
with upcall, dump, and other cleanup codes.

So this patch will make the rpc to fail and disconnect if a
connection attempted before the server is fully inited.

Signed-off-by: Mohammed Rafi KC rafi.kavungal@iternity.com