### PR TITLE
libglusterfs/coverity: pointer to local outside the scope

### DIFF
--- a/libglusterfs/src/glusterfs/store.h
+++ b/libglusterfs/src/glusterfs/store.h
@@ -60,7 +60,8 @@ gf_store_unlink_tmppath(gf_store_handle_t *shandle);
 
 int
 gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
-                           gf_store_op_errno_t *store_errno);
+                           gf_store_op_errno_t *store_errno, char *str,
+                           size_t buf_size);
 
 int32_t
 gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value);

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -184,7 +184,8 @@ out:
 
 int
 gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
-                           gf_store_op_errno_t *store_errno)
+                           gf_store_op_errno_t *store_errno, char *str,
+                           size_t buf_size)
 {
     int32_t ret = -1;
     char *savetok = NULL;
@@ -192,7 +193,6 @@ gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
     char *value = NULL;
     char *temp = NULL;
     size_t str_len = 0;
-    char str[8192];
 
     GF_ASSERT(file);
     GF_ASSERT(iter_key);
@@ -200,7 +200,7 @@ gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
     GF_ASSERT(store_errno);
 
 retry:
-    temp = fgets(str, 8192, file);
+    temp = fgets(str, buf_size, file);
     if (temp == NULL || feof(file)) {
         ret = -1;
         *store_errno = GD_STORE_EOF;
@@ -274,8 +274,9 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
         fseek(handle->read, 0, SEEK_SET);
     }
     do {
+        char buf[8192];
         ret = gf_store_read_and_tokenize(handle->read, &iter_key, &iter_val,
-                                         &store_errno);
+                                         &store_errno, buf, 8192);
         if (ret < 0) {
             gf_msg_trace("", 0,
                          "error while reading key '%s': "
@@ -579,6 +580,8 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     int32_t ret = -1;
     char *iter_key = NULL;
     char *iter_val = NULL;
+    char buf[8192];
+
     gf_store_op_errno_t store_errno = GD_STORE_SUCCESS;
 
     GF_ASSERT(iter);
@@ -586,7 +589,7 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     GF_ASSERT(value);
 
     ret = gf_store_read_and_tokenize(iter->file, &iter_key, &iter_val,
-                                     &store_errno);
+                                     &store_errno, buf, 8192);
     if (ret < 0) {
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4020,8 +4020,9 @@ glusterd_store_retrieve_missed_snaps_list(xlator_t *this)
     }
 
     do {
+        char buf[8192];
         ret = gf_store_read_and_tokenize(fp, &missed_node_info, &value,
-                                         &store_errno);
+                                         &store_errno, buf, 8192);
         if (ret) {
             if (store_errno == GD_STORE_EOF) {
                 gf_msg_debug(this->name, 0, "EOF for missed_snap_list");


### PR DESCRIPTION
issue: gf_store_read_and_tokenize() returns the address
of the locally referred string.

fix: pass the buf to gf_store_read_and_tokenize() and
use it for tokenize.

CID: 1430143

Updates: #1060

Change-Id: Ifc346540c263f58f4014ba2ba8c1d491c20ac609
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

