### PR TITLE
DHT - Implement Global Layout in Rebalance

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -499,6 +499,8 @@ struct gf_defrag_info_ {
     gf_boolean_t stats;
     /* lock migration flag */
     gf_boolean_t lock_migration_enabled;
+
+    dht_layout_t *root_layout;
 };
 
 typedef struct gf_defrag_info_ gf_defrag_info_t;
@@ -818,6 +820,9 @@ xlator_t *
 dht_subvol_get_hashed(xlator_t *this, loc_t *loc);
 xlator_t *
 dht_subvol_get_cached(xlator_t *this, inode_t *inode);
+xlator_t *
+dht_subvol_get_hashed_root_layout(xlator_t *this, loc_t *loc,
+                                  dht_layout_t *root_layout);
 xlator_t *
 dht_subvol_next(xlator_t *this, xlator_t *prev);
 xlator_t *

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -956,6 +956,44 @@ out:
     return subvol;
 }
 
+/* Get the layout of the root dir.
+ * This method does not unref the layout - this needs to be done externally */
+xlator_t *
+dht_subvol_get_hashed_root_layout(xlator_t *this, loc_t *loc,
+                                  dht_layout_t *root_layout)
+{
+    xlator_t *subvol = NULL;
+    dht_conf_t *conf = NULL;
+    dht_methods_t *methods = NULL;
+
+    GF_VALIDATE_OR_GOTO("dht", this, out);
+    GF_VALIDATE_OR_GOTO(this->name, loc, out);
+
+    conf = this->private;
+    GF_VALIDATE_OR_GOTO(this->name, conf, out);
+
+    methods = &(conf->methods);
+
+    if (__is_root_gfid(loc->gfid)) {
+        subvol = dht_first_up_subvol(this);
+        goto out;
+    }
+
+    GF_VALIDATE_OR_GOTO(this->name, loc->parent, out);
+    GF_VALIDATE_OR_GOTO(this->name, loc->name, out);
+
+    subvol = methods->layout_search(this, root_layout, loc->name);
+
+    if (!subvol) {
+        gf_msg_debug(this->name, 0, "No hashed subvolume for path=%s",
+                     loc->path);
+        goto out;
+    }
+
+out:
+    return subvol;
+}
+
 xlator_t *
 dht_subvol_get_cached(xlator_t *this, inode_t *inode)
 {


### PR DESCRIPTION
This patch modifies rebalance to operate in a Global Layout
environemnt.
In the per-dir layout moel, rebalance decides whether or not a
file needs to be migrated based on comparing the file's hashed
subvol (which is obtained using the with the layout of it's
parent dir through the parent's dir indoe) and the cached subvol.
This mechanism will be changed so the hashed subvol will be
obtained through the root-dir's (and the not parent dir's) layout.

In this patch the fix-layout operation is completely removed from
rebalance, apart for the root dir (hence effectively ignoring the
per-directory layout and only caring about root layout).

Notes:
1 - This patch, in combination with other patches that will
follow, will be used to test rebalance in a simulated
Global Layout environment.
2 - This patch will currently *FAIL* CI and cannot be expected
to pass regression. Regression tests (especially DHT and
rebalance rests) expects files to be present in certain locations.
As we simulate a different distribution mechanism, this patch
will fail regression until tests are modified as well.
3 - In order to verify the validity of this work (as current
regression is not relevant until changed), a number of files
were created in the root dir. In addition to these files, a
number of sub-dirs were created and in each of these sub-dirs
files were created with the same amount and names of the files
in the root dir itself. When triggering rebalance, it was
verified that all the files in the sub-dirs migrate in the
exact same manner as the files in the root dir (for the files
in the root dir it does not matter of distribution is per-dir
or Global Layout).

fixes: #1685
Change-Id: Iccd024f461c7fd6b44193bbd0109b6f4f2b9c579
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

