### PR TITLE
enhancement: combine inode unlink with unref and forget

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -405,12 +405,9 @@ glfsflags_from_gfapiflags(struct glfs_stat *stat, int *glvalid)
 int
 glfs_loc_unlink(loc_t *loc)
 {
-    inode_unlink(loc->inode, loc->parent, loc->name);
-
     /* since glfs_h_* objects hold a reference to inode
      * it is safe to keep lookup count to '0' */
-    if (!inode_has_dentry(loc->inode))
-        inode_forget(loc->inode, 0);
+    inode_unlink2(loc->inode, loc->parent, loc->name, false, true, 0, true);
 
     return 0;
 }

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -1530,8 +1530,7 @@ pub_glfs_h_close(struct glfs_object *object)
 {
     /* since glfs_h_* objects hold a reference to inode
      * it is safe to keep lookup count to '0' */
-    inode_forget(object->inode, 0);
-    inode_unref(object->inode);
+    inode_forget_with_unref(object->inode, 0);
     GF_FREE(object);
 
     return 0;

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -409,11 +409,9 @@ glfs_resolve_component(struct glfs *fs, xlator_t *subvol, inode_t *parent,
          * A stale mapping might exist for a dentry/inode that has been
          * removed from another client.
          */
-        if (-ret == ENOENT) {
-            inode_unlink(loc.inode, loc.parent, loc.name);
-            if (!inode_has_dentry(loc.inode))
-                inode_forget(loc.inode, 0);
-        }
+        if (-ret == ENOENT)
+            inode_unlink2(loc.inode, loc.parent, loc.name, false, true, 0,
+                          true);
 
         inode_unref(loc.inode);
         gf_uuid_clear(loc.gfid);

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -147,6 +147,10 @@ inode_link(inode_t *inode, inode_t *parent, const char *name,
 void
 inode_unlink(inode_t *inode, inode_t *parent, const char *name);
 
+void
+inode_unlink2(inode_t *inode, inode_t *parent, const char *name, bool i_unref,
+              bool i_forget, uint64_t nref, bool dlist_check);
+
 inode_t *
 inode_parent(inode_t *inode, uuid_t pargfid, const char *name);
 

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -828,6 +828,7 @@ inode_table_with_invalidator
 __inode_table_set_lru_limit
 inode_table_set_lru_limit
 inode_unlink
+inode_unlink2
 inode_unref
 int_to_data
 iobref_add

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -1475,9 +1475,8 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if ((local->loc2.inode == NULL) ||
                 gf_uuid_compare(stbuf->ia_gfid, local->loc2.inode->gfid)) {
                 if (local->loc2.inode != NULL) {
-                    inode_unlink(local->loc2.inode, local->loc2.parent,
-                                 local->loc2.name);
-                    inode_unref(local->loc2.inode);
+                    inode_unlink2(local->loc2.inode, local->loc2.parent,
+                                  local->loc2.name, true, false, 0, false);
                 }
 
                 local->loc2.inode = inode_link(local->loc2_copy.inode,

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1124,8 +1124,11 @@ fuse_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
          * removed from another client.
          */
         if (op_errno == ENOENT)
-            inode_unlink(state->loc.inode, state->loc.parent, state->loc.name);
-        inode_unref(state->loc.inode);
+            inode_unlink2(state->loc.inode, state->loc.parent, state->loc.name,
+                          true, false, 0, false);
+        else
+            inode_unref(state->loc.inode);
+
         state->loc.inode = inode_new(itable);
         state->is_revalidate = 2;
         if (gf_uuid_is_null(state->gfid))

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -339,8 +339,7 @@ nfs_inode_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_ret == -1)
         goto do_not_unlink;
 
-    inode_unlink(nfl->inode, nfl->parent, nfl->path);
-    inode_forget(nfl->inode, 0);
+    inode_unlink2(nfl->inode, nfl->parent, nfl->path, false, true, 0, false);
 
 do_not_unlink:
     inodes_nfl_to_prog_data(nfl, progcbk, frame);
@@ -385,8 +384,7 @@ nfs_inode_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_ret == -1)
         goto do_not_unlink;
 
-    inode_unlink(nfl->inode, nfl->parent, nfl->path);
-    inode_forget(nfl->inode, 0);
+    inode_unlink2(nfl->inode, nfl->parent, nfl->path, false, true, 0, false);
 
 do_not_unlink:
     inodes_nfl_to_prog_data(nfl, progcbk, frame);

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -74,9 +74,8 @@ void
 server_post_unlink(server_state_t *state, gfs3_unlink_rsp *rsp,
                    struct iatt *preparent, struct iatt *postparent)
 {
-    inode_unlink(state->loc.inode, state->loc.parent, state->loc.name);
-
-    forget_inode_if_no_dentry(state->loc.inode);
+    inode_unlink2(state->loc.inode, state->loc.parent, state->loc.name, false,
+                  true, 0, true);
 
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
@@ -86,12 +85,12 @@ void
 server_post_rmdir(server_state_t *state, gfs3_rmdir_rsp *rsp,
                   struct iatt *preparent, struct iatt *postparent)
 {
-    inode_unlink(state->loc.inode, state->loc.parent, state->loc.name);
     /* parent should not be found for directories after
      * inode_unlink, since directories cannot have
      * hardlinks.
      */
-    forget_inode_if_no_dentry(state->loc.inode);
+    inode_unlink2(state->loc.inode, state->loc.parent, state->loc.name, false,
+                  true, 0, true);
 
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
@@ -312,11 +311,9 @@ server_post_rename(call_frame_t *frame, server_state_t *state,
      */
     tmp_inode = inode_grep(state->loc.inode->table, state->loc2.parent,
                            state->loc2.name);
-    if (tmp_inode) {
-        inode_unlink(tmp_inode, state->loc2.parent, state->loc2.name);
-        forget_inode_if_no_dentry(tmp_inode);
-        inode_unref(tmp_inode);
-    }
+    if (tmp_inode)
+        inode_unlink2(tmp_inode, state->loc2.parent, state->loc2.name, true,
+                      true, 0, true);
 
     inode_rename(state->itable, state->loc.parent, state->loc.name,
                  state->loc2.parent, state->loc2.name, state->loc.inode, stbuf);
@@ -550,12 +547,12 @@ void
 server4_post_entry_remove(server_state_t *state, gfx_common_2iatt_rsp *rsp,
                           struct iatt *prebuf, struct iatt *postbuf)
 {
-    inode_unlink(state->loc.inode, state->loc.parent, state->loc.name);
     /* parent should not be found for directories after
      * inode_unlink, since directories cannot have
      * hardlinks.
      */
-    forget_inode_if_no_dentry(state->loc.inode);
+    inode_unlink2(state->loc.inode, state->loc.parent, state->loc.name, false,
+                  true, 0, true);
 
     gfx_stat_from_iattx(&rsp->prestat, prebuf);
     gfx_stat_from_iattx(&rsp->poststat, postbuf);
@@ -675,11 +672,9 @@ server4_post_rename(call_frame_t *frame, server_state_t *state,
      */
     tmp_inode = inode_grep(state->loc.inode->table, state->loc2.parent,
                            state->loc2.name);
-    if (tmp_inode) {
-        inode_unlink(tmp_inode, state->loc2.parent, state->loc2.name);
-        forget_inode_if_no_dentry(tmp_inode);
-        inode_unref(tmp_inode);
-    }
+    if (tmp_inode)
+        inode_unlink2(tmp_inode, state->loc2.parent, state->loc2.name, true,
+                      true, 0, true);
 
     inode_rename(state->itable, state->loc.parent, state->loc.name,
                  state->loc2.parent, state->loc2.name, state->loc.inode, stbuf);

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -129,8 +129,6 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_ret) {
         if (state->is_revalidate && op_errno == ENOENT) {
             if (!__is_root_gfid(state->resolve.gfid)) {
-                inode_unlink(state->loc.inode, state->loc.parent,
-                             state->loc.name);
                 /**
                  * If the entry is not present, then just
                  * unlinking the associated dentry is not
@@ -147,7 +145,8 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  * lookups will be successful, if the lookup
                  * is a soft lookup)
                  */
-                forget_inode_if_no_dentry(state->loc.inode);
+                inode_unlink2(state->loc.inode, state->loc.parent,
+                              state->loc.name, false, true, 0, true);
             }
         }
         goto out;

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -115,8 +115,6 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_ret) {
         if (state->is_revalidate && op_errno == ENOENT) {
             if (!__is_root_gfid(state->resolve.gfid)) {
-                inode_unlink(state->loc.inode, state->loc.parent,
-                             state->loc.name);
                 /**
                  * If the entry is not present, then just
                  * unlinking the associated dentry is not
@@ -133,7 +131,8 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  * lookups will be successful, if the lookup
                  * is a soft lookup)
                  */
-                forget_inode_if_no_dentry(state->loc.inode);
+                inode_unlink2(state->loc.inode, state->loc.parent,
+                              state->loc.name, false, true, 0, true);
             }
         }
         goto out;


### PR DESCRIPTION
issue:
In most part of the code, inode_unlink() is followed many times
with either or both inode_unref() and inode_forget(). Both
inode_unlink() and inode_unref() take inode->table->lock lock
and do the job but it doesn't make sense to do these actvities
in seperate steps as the same lock is acquired and released in
both functions. Rather we can have a single function which does
both unlink and unref acquiring the lock which reduces the
locking the same lock multiple times.

Also, the above mentioned functions prune the inode table every
time they are called. If we are doing unlink and unref or
unlink and forget or unlink, unref and forget() in seperate
steps then we end up pruning the inode table multiple times.
So multiple calls to inode_table_prune() can be avoided by
combining the above mentioned functions.

This patch provides 3 functions do the required job.
inode_unlink_and_unref()
inode_unlink_and_forget()
inode_unlink_unref_and_forget()

Fixes: #1316

Change-Id: Ia23b04f0f9732c7ec34b80d0d16cce079f2f1e80
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

