### PR TITLE
fuse/liburing: read/write on /dev/fuse using liburing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1451,7 +1451,6 @@ if test -n "$LIBURING"; then
    AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled])
    BUILD_LIBURING=yes
 fi
-
 dnl gnfs section
 BUILD_GNFS="no"
 RPCBIND_SERVICE=""

--- a/configure.ac
+++ b/configure.ac
@@ -1451,6 +1451,7 @@ if test -n "$LIBURING"; then
    AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled])
    BUILD_LIBURING=yes
 fi
+
 dnl gnfs section
 BUILD_GNFS="no"
 RPCBIND_SERVICE=""

--- a/configure.ac
+++ b/configure.ac
@@ -1444,12 +1444,17 @@ if test -n "$LIBAIO"; then
 fi
 
 BUILD_LIBURING=no
-AC_CHECK_HEADERS([liburing.h])
-AC_CHECK_LIB([uring],[io_uring_queue_init],[LIBURING="-luring"])
+AC_ARG_ENABLE([liburing],
+              AC_HELP_STRING([--enable-liburing],
+                             [Enable iouring for system calls]))
+if test "x$enable_liburing" = "xyes"; then
+    AC_CHECK_HEADERS([liburing.h])
+    AC_CHECK_LIB([uring],[io_uring_queue_init],[LIBURING="-luring"])
 
-if test -n "$LIBURING"; then
-   AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled])
-   BUILD_LIBURING=yes
+    if test -n "$LIBURING"; then
+        AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled])
+        BUILD_LIBURING=yes
+    fi
 fi
 dnl gnfs section
 BUILD_GNFS="no"

--- a/xlators/mount/fuse/src/Makefile.am
+++ b/xlators/mount/fuse/src/Makefile.am
@@ -27,7 +27,7 @@ fuse_la_SOURCES = fuse-helpers.c fuse-resolve.c fuse-bridge.c \
 	$(CONTRIBDIR)/fuse-lib/misc.c $(mount_source)
 
 fuse_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
-fuse_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la $(GF_LDADD) @GF_FUSE_LDADD@
+fuse_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la $(GF_LDADD) $(LIBURING) @GF_FUSE_LDADD@
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -25,7 +25,10 @@
 #include <glusterfs/defaults.h>
 #include <glusterfs/common-utils.h>
 #include <glusterfs/statedump.h>
+
+#if HAVE_LIBURING
 #include <liburing.h>
+#endif
 
 #ifdef GF_DARWIN_HOST_OS
 #include "fuse_kernel_macfuse.h"
@@ -182,10 +185,13 @@ struct fuse_private {
     /* counters for fusdev errnos */
     uint8_t fusedev_errno_cnt[FUSEDEV_EMAXPLUS];
     pthread_mutex_t fusedev_errno_cnt_mutex;
+
+#if HAVE_LIBURING
     /* io_uring */
     struct io_uring ring;
     pthread_mutex_t sq_mutex;
     pthread_mutex_t cq_mutex;
+#endif
 };
 typedef struct fuse_private fuse_private_t;
 

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -25,6 +25,7 @@
 #include <glusterfs/defaults.h>
 #include <glusterfs/common-utils.h>
 #include <glusterfs/statedump.h>
+#include <liburing.h>
 
 #ifdef GF_DARWIN_HOST_OS
 #include "fuse_kernel_macfuse.h"
@@ -181,6 +182,10 @@ struct fuse_private {
     /* counters for fusdev errnos */
     uint8_t fusedev_errno_cnt[FUSEDEV_EMAXPLUS];
     pthread_mutex_t fusedev_errno_cnt_mutex;
+    /* io_uring */
+    struct io_uring ring;
+    pthread_mutex_t sq_mutex;
+    pthread_mutex_t cq_mutex;
 };
 typedef struct fuse_private fuse_private_t;
 

--- a/xlators/mount/fuse/src/fuse-mem-types.h
+++ b/xlators/mount/fuse/src/fuse-mem-types.h
@@ -26,6 +26,17 @@ enum gf_fuse_mem_types_ {
     gf_fuse_mt_pthread_t,
     gf_fuse_mt_timed_message_t,
     gf_fuse_mt_interrupt_record_t,
+    gf_fuse_mt_uring_ctx,
+    gf_fuse_mt_out_header_t,
+    gf_fuse_mt_open_out_t,
+    gf_fuse_mt_entry_out_t,
+    gf_fuse_mt_init_out_t,
+    gf_fuse_mt_statfs_out_t,
+    gf_fuse_mt_attr_out_t,
+    gf_fuse_mt_getxattr_out_t,
+    gf_fuse_mt_write_out_t,
+    gf_fuse_mt_lseek_out_t,
+    gf_fuse_mt_lk_out_t,
     gf_fuse_mt_end
 };
 #endif

--- a/xlators/mount/fuse/src/fuse-mem-types.h
+++ b/xlators/mount/fuse/src/fuse-mem-types.h
@@ -26,6 +26,7 @@ enum gf_fuse_mem_types_ {
     gf_fuse_mt_pthread_t,
     gf_fuse_mt_timed_message_t,
     gf_fuse_mt_interrupt_record_t,
+#if HAVE_LIBURING
     gf_fuse_mt_uring_ctx,
     gf_fuse_mt_out_header_t,
     gf_fuse_mt_open_out_t,
@@ -37,6 +38,7 @@ enum gf_fuse_mem_types_ {
     gf_fuse_mt_write_out_t,
     gf_fuse_mt_lseek_out_t,
     gf_fuse_mt_lk_out_t,
+#endif
     gf_fuse_mt_end
 };
 #endif


### PR DESCRIPTION
Initial draft. work in progress. Still in experimental
phase.

Adding iouring support to /dev/fuse communication.

changed funcs:
fuse_thread_proc()
send_fuse_iov()

The performance numbers are pretty much same as that of
vanilla gluster code (without iouring).

Improvement points:
1. The submit queue part requires mutex to be held which
   is causing performance hit.
2. iouring provides way to register fixed buffers and those
   buffers always be mapped to memory by kernel. This needs
   some gluster side memory management.

Fixes: #1479

Change-Id: Ib4c763917e63dfadc8a769451745bf7946bc39ec
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

