### PR TITLE
DHT - Remove redundant lookup operation in Rebalance

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3599,7 +3599,6 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
                 defrag->total_failures++;
             }
             ret = 0;
-            goto out;
         } else {
             gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_DIR_LOOKUP_FAILED,
                    "lookup failed for:%s", loc->path);
@@ -3609,9 +3608,9 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
             if (conf->decommission_in_progress) {
                 defrag->defrag_status = GF_DEFRAG_STATUS_FAILED;
                 ret = -1;
-                goto out;
             }
         }
+        goto out;
     }
 
     fd = fd_create(loc->inode, defrag->pid);


### PR DESCRIPTION
Remove a redundant lookup (and correlated operations)
and slightly changed error handling.

- The lookup which is removed is redundant as a lookup
on the dir specified by "loc" is done at the entry to
the method.
- Error handling was changed a bit to remove special handling
for "root" dir (as it is not necessary).
In addition, error handling was changed so increments of
defrag->total_failures in case of a failure will done inside the
error-checking blocks of the operations inside gf_defrag_fix_layout
instead of in the calling methods.

fixes: #1695
Change-Id: I85c8791988bd314ce706d3627e01e15e4f983329
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

