### PR TITLE
build: /usr/lib/systemd tests for Debian/Ubuntu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,7 +462,7 @@ AC_ARG_WITH(systemddir,
             [systemddir=$withval],
             [systemddir='${prefix}/lib/systemd/system'])
 AC_SUBST(systemddir)
-AM_CONDITIONAL([USE_SYSTEMD], test [ -d '/usr/lib/systemd/system' ])
+AM_CONDITIONAL([USE_SYSTEMD], test [ -d '/usr/lib/systemd/'])
 
 AC_ARG_WITH(initdir,
             [  --with-initdir=DIR init.d scripts in DIR @<:@/etc/init.d@:>@],


### PR DESCRIPTION
The Debian/Ubuntu pbuilder chroot build environments in newer releases
don't populate /usr/lib/systemd, with the result that USE_SYSTEMD isn't
set and several files are omitted from the packages.

Debian 10 (buster) and 11 (sid/bullseye) and Ubuntu 20.04 (focal) and
20.10 (groovy) are the releases that are affected.

Keep the more specific test for /usr/lib/systemd/system, but if that
doesn't exist fall back to testing for /usr/lib/systemd, which these
releases still have.

Change-Id: Ic443512d36a8d616dbc237548ce797168fd9522e
Fixes: #1000
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

