### PR TITLE
nfs: Fix inconsistency between glibc and libtirpc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1173,6 +1173,10 @@ if test "x${with_libtirpc}" = "xyes" || test "x${with_ipv6_default}" = "xyes" ; 
        [with_libtirpc="missing"; with_ipv6_default="no"])
 fi
 
+if test "x${with_libtirpc}" = "xyes" ; then
+    AC_DEFINE(HAVE_LIBTIRPC, 1, [Using libtirpc])
+fi
+
 if test "x${with_libtirpc}" = "xmissing" ; then
     AC_CHECK_HEADERS([rpc/rpc.h],[
         AC_MSG_WARN([

--- a/xlators/nfs/server/src/mount3udp_svc.c
+++ b/xlators/nfs/server/src/mount3udp_svc.c
@@ -231,8 +231,7 @@ mount3udp_thread(void *argv)
         return NULL;
     }
 
-    svc_run();
-    gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_SVC_RUN_RETURNED,
-           "svc_run returned");
+    nfs_start_rpc_poller(nfsx->private);
+
     return NULL;
 }

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -1055,6 +1055,10 @@ nfs_init_state(xlator_t *this)
         }
     }
 
+#ifdef HAVE_LIBTIRPC
+    pthread_mutex_init(&nfs->svc_mutex, NULL);
+#endif
+
     GF_OPTION_INIT("nfs.rdirplus", nfs->rdirplus, bool, free_foppool);
 
     GF_OPTION_INIT(OPT_SERVER_RPC_STATD, nfs->rpc_statd, path, free_foppool);
@@ -1539,6 +1543,11 @@ fini(xlator_t *this)
     nfs = (struct nfs_state *)this->private;
     gf_msg_debug(GF_NFS, 0, "NFS service going down");
     nfs_deinit_versions(&nfs->versions, this);
+
+#ifdef HAVE_LIBTIRPC
+    pthread_mutex_destroy(&nfs->svc_mutex);
+#endif
+
     GF_FREE(this->instance_name);
     return;
 }
@@ -1666,6 +1675,38 @@ nfs_priv(xlator_t *this)
     }
 out:
     return ret;
+}
+
+void
+nfs_start_rpc_poller(struct nfs_state *state)
+{
+/* RPC implementation in glibc uses per-thread global variables, while
+ * libtirpc uses global shared variables. This causes a big difference
+ * in svc_run():
+ *
+ *   - In glibc, svc_run() needs to be called in the same thread that
+ *     registered the service.
+ *
+ *   - In libtirpc, only one thread can call svc_run() and will serve
+ *     all registered services, from any thread.
+ */
+#ifdef HAVE_LIBTIRPC
+    pthread_mutex_lock(&state->svc_mutex);
+
+    if (state->svc_running) {
+        pthread_mutex_unlock(&state->svc_mutex);
+
+        return;
+    }
+
+    state->svc_running = true;
+
+    pthread_mutex_unlock(&state->svc_mutex);
+#endif
+
+    svc_run();
+    gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_SVC_RUN_RETURNED,
+           "svc_run returned");
 }
 
 int32_t

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -60,19 +60,23 @@ struct nfs_initer_list {
 };
 
 struct nfs_state {
-    rpcsvc_t *rpcsvc;
     struct list_head versions;
+    gid_cache_t gid_cache;
+    gf_lock_t svinitlock;
+    rpcsvc_t *rpcsvc;
     struct mount3_state *mstate;
     struct nfs3_state *nfs3state;
     struct nlm4_state *nlm4state;
     struct mem_pool *foppool;
-    unsigned int memfactor;
     xlator_list_t *subvols;
-
-    gf_lock_t svinitlock;
+    xlator_t **initedxl;
+    char *rmtab;
+    struct rpc_clnt *rpc_clnt;
+    char *rpc_statd;
+    char *rpc_statd_pid_file;
+    unsigned int memfactor;
     int allsubvols;
     int upsubvols;
-    xlator_t **initedxl;
     int subvols_started;
     int dynamicvolumes;
     int enable_ino32;
@@ -90,17 +94,13 @@ struct nfs_state {
     unsigned int auth_refresh_time_secs;
     unsigned int auth_cache_ttl_sec;
 
-    char *rmtab;
-    struct rpc_clnt *rpc_clnt;
-    gf_boolean_t server_aux_gids;
     uint32_t server_aux_gids_max_age;
-    gid_cache_t gid_cache;
     uint32_t generation;
-    gf_boolean_t register_portmap;
-    char *rpc_statd;
-    char *rpc_statd_pid_file;
-    gf_boolean_t rdirplus;
     uint32_t event_threads;
+
+    gf_boolean_t server_aux_gids;
+    gf_boolean_t register_portmap;
+    gf_boolean_t rdirplus;
 
 #ifdef HAVE_LIBTIRPC
     bool svc_running;

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -103,7 +103,6 @@ struct nfs_state {
     uint32_t event_threads;
 
 #ifdef HAVE_LIBTIRPC
-    pthread_mutex_t svc_mutex;
     bool svc_running;
 #endif
 };

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -101,6 +101,11 @@ struct nfs_state {
     char *rpc_statd_pid_file;
     gf_boolean_t rdirplus;
     uint32_t event_threads;
+
+#ifdef HAVE_LIBTIRPC
+    pthread_mutex_t svc_mutex;
+    bool svc_running;
+#endif
 };
 
 struct nfs_inode_ctx {
@@ -151,4 +156,8 @@ nfs_subvolume_started(struct nfs_state *nfs, xlator_t *xl);
 
 extern void
 nfs_fix_groups(xlator_t *this, call_stack_t *root);
+
+void
+nfs_start_rpc_poller(struct nfs_state *state);
+
 #endif

--- a/xlators/nfs/server/src/nlmcbk_svc.c
+++ b/xlators/nfs/server/src/nlmcbk_svc.c
@@ -126,9 +126,8 @@ nsm_thread(void *argv)
         return NULL;
     }
 
-    svc_run();
-    gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_SVC_RUN_RETURNED,
-           "svc_run returned");
+    nfs_start_rpc_poller(nfsx->private);
+
     return NULL;
     /* NOTREACHED */
 }


### PR DESCRIPTION
There's a critical difference between RPC implementation in glibc
and libtirpc.

In libtirpc, svc_run() starts a polling loop that listens from all
registered connections and handles requests. When this is done from
multiple threads, a race can happen where both threads are trying
to process the same connection simultaneously. This causes memory
corruption.

However, in glibc, svc_run() only handles the registered connections
on the current thread, so it's necessary to call svc_run() on all
threads that register services.

This patch fixes that problem by calling svc_run() from all threads
only if libtirpc is not used. Otherwise it's called only once.

Change-Id: I97c3c39a9aad90115e7e23c70884a4ee7769a2dd
Updates: #1009
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

