### PR TITLE
features/shard: avoid repeatative calls to gf_uuid_unparse()

### DIFF
--- a/tests/bugs/shard/issue-1425.t
+++ b/tests/bugs/shard/issue-1425.t
@@ -21,7 +21,13 @@ TEST $CLI volume profile $V0 start
 
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
 
+echo `$CLI volume profile $V0 info incremental | grep -w LOOKUP | awk '{print $8}'` > /dev/zero
+
 TEST fallocate -l 20M $M0/foo
+
+# There should be 1+4 shards and we expect 4 lookups less than on the build without this patch
+EXPECT "5" echo `$CLI volume profile $V0 info incremental | grep -w LOOKUP | awk '{print $8}'`
+
 gfid_new=$(get_gfid_string $M0/foo)
 
 # Check for the base shard
@@ -30,9 +36,6 @@ TEST stat $B0/${V0}0/foo
 
 # There should be 4 associated shards
 EXPECT_WITHIN $FILE_COUNT_TIME 4 get_file_count $B0/${V0}0/.shard/$gfid_new
-
-# There should be 1+4 shards and we expect 4 lookups less than on the build without this patch
-EXPECT "21" echo `$CLI volume profile $V0 info incremental | grep -w LOOKUP | awk '{print $8}'`
 
 # Delete the base shard and check shards get cleaned up
 TEST unlink $M0/foo

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -199,6 +199,19 @@ shard_unlock_entrylk(call_frame_t *frame, xlator_t *this);
         }                                                                      \
     } while (0)
 
+#define SHARD_BUILD_BASE_PATH(path, gfid, prefix_len)                          \
+    do {                                                                       \
+        strcpy(path, "/" GF_SHARD_DIR "/");                                    \
+        uuid_utoa_r(gfid, path + sizeof(GF_SHARD_DIR) + 1);                    \
+        prefix_len = sizeof(GF_SHARD_DIR) + GF_UUID_BUF_SIZE;                  \
+    } while (0)
+
+#define SHARD_BUILD_ABS_PATH(path, prefix_len, shard_idx_iter)                 \
+    do {                                                                       \
+        snprintf(path + prefix_len, sizeof(path) - prefix_len, ".%d",          \
+                 shard_idx_iter);                                              \
+    } while (0)
+
 typedef enum {
     SHARD_BG_DELETION_NONE = 0,
     SHARD_BG_DELETION_LAUNCHING,


### PR DESCRIPTION
The issue is shard_make_block_abspath() calls gf_uuid_unparse()
every time while constructing shard path. The gfid can be parsed
and saved once and passed while constructing the path. Thus
we can avoid calling gf_uuid_unparse().

Fixes: #1423

Change-Id: Ia26fbd5f09e812bbad9e5715242f14143c013c9c
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

