### PR TITLE
glusterd: Optmize RCU_READ_(LOCK|UNLOCK) macros

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1483,20 +1483,11 @@ cleanup_and_exit(int signum)
 #endif
 
         trav = NULL;
-
-        /* previously we were releasing the cleanup mutex lock before the
-           process exit. As we are releasing the cleanup mutex lock, before
-           the process can exit some other thread which is blocked on
-           cleanup mutex lock is acquiring the cleanup mutex lock and
-           trying to acquire some resources which are already freed as a
-           part of cleanup. To avoid this, we are exiting the process without
-           releasing the cleanup mutex lock. This will not cause any lock
-           related issues as the process which acquired the lock is going down
-         */
-        /* NOTE: Only the least significant 8 bits i.e (signum & 255)
-           will be available to parent process on calling exit() */
-        exit(abs(signum));
     }
+    pthread_mutex_unlock(&ctx->cleanup_lock);
+    /* NOTE: Only the least significant 8 bits i.e (signum & 255)
+       will be available to parent process on calling exit() */
+    exit(abs(signum));
 }
 
 static void

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -76,7 +76,11 @@ glusterd_big_locked_handler(rpcsvc_request_t *req, rpcsvc_actor actor_fn)
     int ret = -1;
 
     synclock_lock(&priv->big_lock);
+    /* If flag is set it means got terminate signal */
+    if (priv->call_fini)
+        goto out;
     ret = actor_fn(req);
+out:
     synclock_unlock(&priv->big_lock);
 
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -2133,8 +2133,20 @@ out:
 void
 fini(xlator_t *this)
 {
+    glusterd_conf_t *priv = NULL;
+
     if (!this || !this->private)
         goto out;
+
+    priv = this->private;
+    /* Set call_fini flag to true to avoid RPC actor function
+       calling after got a terminate signal
+    */
+    synclock_lock(&priv->big_lock);
+    {
+        priv->call_fini = _gf_true;
+    }
+    synclock_unlock(&priv->big_lock);
 
     glusterd_stop_uds_listener(this);              /*stop unix socket rpc*/
     glusterd_stop_listener(this);                  /*stop tcp/ip socket rpc*/

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -238,6 +238,8 @@ typedef struct {
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
     struct list_head hostnames;
+    gf_boolean_t
+        call_fini; /*Flag is use to sync between fini and actor function */
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {
@@ -769,18 +771,14 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
     } while (0)
 
 #define RCU_READ_LOCK                                                          \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_lock();                                                       \
-    }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    }
 
 #define RCU_READ_UNLOCK                                                        \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_unlock();                                                     \
-    }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    }
 
 #define GLUSTERD_DUMP_PEERS(head, member, xpeers)                              \
     do {                                                                       \


### PR DESCRIPTION
Change the definition of macros to avoid glusterfs_this_location
call again and again

Fixes: #1619
Change-Id: I4c9d4161d24d60366323ca420aad6a9641057d61
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

