### PR TITLE
cluster/afr: Remove redundant afr_fd_ctx_get calls

### DIFF
--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1072,9 +1072,6 @@ afr_blocking_lock(call_frame_t *frame, xlator_t *this);
 int
 afr_internal_lock_finish(call_frame_t *frame, xlator_t *this);
 
-int
-__afr_fd_ctx_set(xlator_t *this, fd_t *fd);
-
 afr_fd_ctx_t *
 afr_fd_ctx_get(fd_t *fd, xlator_t *this);
 


### PR DESCRIPTION
Description:
__afr_fd_ctx_get() is calling __fd_ctx_get().
If that fails, it goes to __afr_fd_ctx_set().
__afr_fd_ctx_set() is now calling __fd_ctx_get() again.
When we get back from __afr_fd_ctx_set(), we are calling
__fd_ctx_get() again.
we could just change __afr_fd_ctx_set() to return ctx as
the return value and NULL in case of failure.

Change-Id: Ifdb9b86984a3438abac52b2b74a8f0e0a4966093
updates: #1251
Signed-off-by: Ashish Pandey <aspandey@redhat.com>

