### PR TITLE
posix: Use MALLOC instead of alloca to allocate memory for xattrs list

### DIFF
--- a/xlators/storage/posix/src/posix-gfid-path.c
+++ b/xlators/storage/posix/src/posix-gfid-path.c
@@ -117,7 +117,8 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
             if (size == 0)
                 goto done;
         }
-        list = alloca(size);
+
+        list = GF_MALLOC(size, gf_posix_mt_char);
         if (!list) {
             *op_errno = errno;
             goto err;
@@ -231,6 +232,7 @@ done:
             GF_FREE(paths[j]);
     }
     ret = 0;
+    GF_FREE(list);
     return ret;
 err:
     if (path)
@@ -239,5 +241,6 @@ err:
         if (paths[j])
             GF_FREE(paths[j]);
     }
+    GF_FREE(list);
     return ret;
 }

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -347,7 +347,7 @@ _posix_get_marker_all_contributions(posix_xattr_filler_t *filler)
         goto out;
     }
 
-    list = alloca(size);
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         goto out;
     }
@@ -376,6 +376,7 @@ _posix_get_marker_all_contributions(posix_xattr_filler_t *filler)
     ret = 0;
 
 out:
+    GF_FREE(list);
     return ret;
 }
 

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -3391,7 +3391,7 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
         goto out;
     }
 
-    list = alloca(size);
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         *op_errno = errno;
         goto out;
@@ -3470,6 +3470,7 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
     op_ret = 0;
 
 out:
+    GF_FREE(list);
     return op_ret;
 }
 
@@ -3899,7 +3900,8 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         if (size == 0)
             goto done;
     }
-    list = alloca(size);
+
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         op_errno = errno;
         goto out;
@@ -4026,6 +4028,7 @@ out:
         dict_unref(dict);
     }
 
+    GF_FREE(list);
     return 0;
 }
 
@@ -4225,7 +4228,8 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         if (size == 0)
             goto done;
     }
-    list = alloca(size + 1);
+
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         op_ret = -1;
         op_errno = ENOMEM;
@@ -4326,6 +4330,8 @@ out:
 
     if (dict)
         dict_unref(dict);
+
+    GF_FREE(list);
 
     return 0;
 }


### PR DESCRIPTION
In case of file is having huge xattrs on backend a brick process is
crashed while alloca(size) limit has been crossed 256k because iot_worker
stack size is 256k.

Use MALLOC to allocate memory if xattr size is greater than 32k
Fixes: #1699
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: I100468234f83329a7d65b43cbe4e10450c1ccecd

