### PR TITLE
xlators: fixes for gcc-10 -Wstringop-overflow and -Wstringop-truncation

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -7504,9 +7504,9 @@ afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
 
     keylen = strlen(local->cont.getxattr.name);
     for (i = 0; i < priv->child_count; i++) {
-        if (!local->replies[i].valid || local->replies[i].op_ret)
+        if (!local->replies[i].valid || local->replies[i].op_ret) {
             data = (char *)default_str;
-        else {
+        } else {
             ret = dict_get_strn(local->replies[i].xattr,
                                 local->cont.getxattr.name, keylen, &data);
             if (ret) {
@@ -7515,17 +7515,15 @@ afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
                 goto out;
             }
         }
-        str_len = strlen(data);
-        if (p + str_len + 2 < buf + bufsize) {
-            /* Have space for string and delimeter. */
-            memcpy(p, data, str_len);
-            p += str_len;
-            *p = delimiter;
-            *++p = '\0';
-        } else {
+
+        p = stpncpy(p, data, (buf + bufsize - 1) - p);
+        if (p >= buf + bufsize - 1) {
+            /* Not enough space for string and delimeter. */
             ret = -1;
             goto out;
         }
+        *p = delimiter;
+        *++p = '\0';
     }
     /* Remove the last delimeter. */
     *--p = '\0';

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -750,7 +750,6 @@ afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
     int ret = 0;
     char *xattr_serz = NULL;
     long cky = 0;
-    int32_t tlen = 0;
 
     local = frame->local;
     priv = this->private;
@@ -806,8 +805,9 @@ unlock:
             goto unwind;
         }
 
-        ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
-                                                  UUID0_STR, &tlen, ' ');
+        ret = afr_serialize_xattrs_with_delimiter(
+            frame, this, xattr_serz, local->cont.getxattr.xattr_len, UUID0_STR,
+            ' ');
         if (ret) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1343,8 +1343,8 @@ afr_is_inode_refresh_reqd(inode_t *inode, xlator_t *this, int event_gen1,
 
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter);
+                                    char *buf, int32_t bufsize,
+                                    const char *default_str, char delimiter);
 gf_boolean_t
 afr_is_symmetric_error(call_frame_t *frame, xlator_t *this);
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3765,10 +3765,10 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("ios-dump-format", dump_format_str, options, str, out);
     ios_set_log_format_code(conf, dump_format_str);
     if (conf->ios_sample_interval) {
-        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
-                         int32, out);
+        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size,
+                         options, int32, out);
     } else {
-        ios_sample_buf_size_configure (this->name, conf);
+        ios_sample_buf_size_configure(this->name, conf);
     }
 
     GF_OPTION_RECONF("sys-log-level", sys_log_str, options, str, out);
@@ -3916,9 +3916,9 @@ init(xlator_t *this)
 
     ret = dict_get_strn(this->options, "volume-id", SLEN("volume-id"),
                         &volume_id);
-    if (!ret) {
-        strncpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
-    }
+    if (!ret)
+        snprintf(this->graph->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
+
     /*
      * Init it just after calloc, so that we are sure the lock is inited
      * in case of error paths.
@@ -3951,7 +3951,7 @@ init(xlator_t *this)
         GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
                        out);
     } else {
-        ios_sample_buf_size_configure (this->name, conf);
+        ios_sample_buf_size_configure(this->name, conf);
     }
 
     ret = ios_init_sample_buf(conf);

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1970,7 +1970,7 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
     if (bname) {
         len = gf_asprintf(path, "%s%s", result, bname);
         if ((len < 0) || (len >= PATH_MAX)) {
-            free(*path);
+            GF_FREE(*path);
             ret = -1;
             goto out;
         }

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1967,11 +1967,15 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
         gf_uuid_copy(pargfid, tmp_gfid);
     }
 
-    if (bname)
-        strncat(result, bname, strlen(bname) + 1);
-
-    *path = gf_strdup(result);
-
+    if (bname) {
+        len = gf_asprintf(path, "%s%s", result, bname);
+        if ((len < 0) || (len >= PATH_MAX)) {
+            free(*path);
+            ret = -1;
+            goto out;
+        }
+    } else
+        *path = gf_strdup(result);
 out:
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15061,8 +15061,7 @@ glusterd_add_peers_to_auth_list(char *volname)
     len += strlen(auth_allow_list) + 1;
 
     new_auth_allow_list = GF_CALLOC(1, len, gf_common_mt_char);
-    strcpy(new_auth_allow_list, auth_allow_list);
-    p = new_auth_allow_list + strlen(auth_allow_list);
+    p = stpcpy(new_auth_allow_list, auth_allow_list);
 
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14915,7 +14915,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
         if (tmpptr == NULL)
             goto check_failed;
         addrlen = strlen(brick) - strlen(tmpptr);
-        strncpy(brick_addr, brick, addrlen);
+        strncpy(brick_addr, brick, sizeof(brick_addr));
         brick_addr[addrlen] = '\0';
         ret = getaddrinfo(brick_addr, NULL, NULL, &ai_info);
         if (ret != 0) {
@@ -15030,6 +15030,7 @@ glusterd_add_peers_to_auth_list(char *volname)
     xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     int32_t len = 0;
+    char *p;
     char *auth_allow_list = NULL;
     char *new_auth_allow_list = NULL;
 
@@ -15055,24 +15056,22 @@ glusterd_add_peers_to_auth_list(char *volname)
     }
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {
-        len += strlen(peerinfo->hostname);
+        len += strlen(peerinfo->hostname) + 1;
     }
     len += strlen(auth_allow_list) + 1;
 
     new_auth_allow_list = GF_CALLOC(1, len, gf_common_mt_char);
+    strcpy(new_auth_allow_list, auth_allow_list);
+    p = new_auth_allow_list + strlen(auth_allow_list);
 
-    new_auth_allow_list = strncat(new_auth_allow_list, auth_allow_list,
-                                  strlen(auth_allow_list));
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {
         ret = search_peer_in_auth_list(peerinfo->hostname, new_auth_allow_list);
         if (!ret) {
             gf_log(this->name, GF_LOG_DEBUG,
                    "peer %s not found in auth.allow list", peerinfo->hostname);
-            new_auth_allow_list = strcat(new_auth_allow_list, ",");
-            new_auth_allow_list = strncat(new_auth_allow_list,
-                                          peerinfo->hostname,
-                                          strlen(peerinfo->hostname));
+            p += snprintf(p, len - (p - new_auth_allow_list), ",%s",
+                          peerinfo->hostname);
         }
     }
     if (strcmp(new_auth_allow_list, auth_allow_list) != 0) {

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -1101,8 +1101,7 @@ __mnt3_fresh_lookup(mnt3_resolve_t *mres)
 {
     inode_unlink(mres->resolveloc.inode, mres->resolveloc.parent,
                  mres->resolveloc.name);
-    strncpy(mres->remainingdir, mres->resolveloc.path,
-            strlen(mres->resolveloc.path));
+    snprintf(mres->remainingdir, MNTPATHLEN, "%s", mres->resolveloc.path);
     nfs_loc_wipe(&mres->resolveloc);
     return __mnt3_resolve_subdir(mres);
 }

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -808,9 +808,8 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 op_ret = -1;
                 goto out;
             }
-        } else {
-            strncpy(ctx->volume_id, volume_id, GF_UUID_BUF_SIZE);
-        }
+        } else
+            snprintf(ctx->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
     }
 
     uint32_t child_up_int;

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -380,7 +380,7 @@ posix_handle_pump(xlator_t *this, char *buf, int len, int maxlen,
     memmove(buf + base_len + blen, buf + base_len,
             (strlen(buf) - base_len) + 1);
 
-    strncpy(base_str + pfx_len, linkname + 6, 42);
+    strncpy(base_str + pfx_len, linkname + 6, base_len - pfx_len);
 
     strncpy(buf + pfx_len, linkname + 6, link_len - 6);
 out:


### PR DESCRIPTION
Fix warnings issued by gcc-10 -Wstringop-overflow and -Wstringop-truncation.
Adjust xlators/debug/io-stats/src/io-stats.c as noticed by clang-format as well.

Change-Id: I8ed1739735953bae9062560625fcf63599dd9ae5
Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Updates: #1681

