### PR TITLE
core: rcu lock called only in child function

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -795,9 +795,7 @@ __glusterd_handle_cluster_lock(rpcsvc_request_t *req)
     gf_msg_debug(this->name, 0, "Received LOCK from uuid: %s",
                  uuid_utoa(lock_req.uuid));
 
-    RCU_READ_LOCK;
     ret = (glusterd_peerinfo_find_by_uuid(lock_req.uuid) == NULL);
-    RCU_READ_UNLOCK;
     if (ret) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_PEER_NOT_FOUND,
                "%s doesn't "
@@ -961,9 +959,7 @@ __glusterd_handle_stage_op(rpcsvc_request_t *req)
     ret = dict_get_bin(req_ctx->dict, "transaction_id", (void **)&txn_id);
     gf_msg_debug(this->name, 0, "transaction ID = %s", uuid_utoa(*txn_id));
 
-    RCU_READ_LOCK;
     ret = (glusterd_peerinfo_find_by_uuid(op_req.uuid) == NULL);
-    RCU_READ_UNLOCK;
     if (ret) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_PEER_NOT_FOUND,
                "%s doesn't "
@@ -1047,9 +1043,7 @@ __glusterd_handle_commit_op(rpcsvc_request_t *req)
         goto out;
     }
 
-    RCU_READ_LOCK;
     ret = (glusterd_peerinfo_find_by_uuid(op_req.uuid) == NULL);
-    RCU_READ_UNLOCK;
     if (ret) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_PEER_NOT_FOUND,
                "%s doesn't "
@@ -2448,9 +2442,7 @@ __glusterd_handle_cluster_unlock(rpcsvc_request_t *req)
     gf_msg_debug(this->name, 0, "Received UNLOCK from uuid: %s",
                  uuid_utoa(unlock_req.uuid));
 
-    RCU_READ_LOCK;
     ret = (glusterd_peerinfo_find_by_uuid(unlock_req.uuid) == NULL);
-    RCU_READ_LOCK;
     if (ret) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_PEER_NOT_FOUND,
                "%s doesn't "

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -8197,8 +8197,10 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
         }
 
     } else {
+        RCU_READ_LOCK;
         peerinfo = glusterd_peerinfo_find_by_uuid(newbrickinfo->uuid);
         if (peerinfo == NULL) {
+            RCU_READ_UNLOCK;
             ret = -1;
             snprintf(op_errstr, len, "Failed to find host %s",
                      newbrickinfo->hostname);
@@ -8206,6 +8208,7 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
         }
 
         if ((!peerinfo->connected)) {
+            RCU_READ_UNLOCK;
             snprintf(op_errstr, len, "Host %s not connected",
                      newbrickinfo->hostname);
             ret = -1;
@@ -8213,6 +8216,7 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
         }
 
         if (peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) {
+            RCU_READ_UNLOCK;
             snprintf(op_errstr, len,
                      "Host %s is not in \'Peer "
                      "in Cluster\' state",
@@ -8220,6 +8224,7 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
             ret = -1;
             goto out;
         }
+        RCU_READ_UNLOCK;
     }
 
     ret = 0;


### PR DESCRIPTION
RCU_READ_LOCK was called twice when calling
glusterd_peerinfo_find_by_uuid. This patch fixes it by
calling it only in the child function

fixes: #1524

Change-Id: Ie4f1e0d7065f57155d06d0d358f6f90a11209cd2
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

