### PR TITLE
xlators: fixes for gcc-10 -Wstringop-overflow and -Wstringop-truncation

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -7490,17 +7490,13 @@ afr_fav_child_reset_sink_xattrs(void *opaque)
  */
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter)
+                                    char *buf, int32_t bufsize,
+                                    const char *default_str, char delimiter)
 {
     afr_private_t *priv = NULL;
     afr_local_t *local = NULL;
-    char *xattr = NULL;
-    int i = 0;
-    int len = 0;
-    int keylen = 0;
-    size_t str_len = 0;
-    int ret = -1;
+    char *p = buf, *data = NULL;
+    int i = 0, keylen = 0, ret = -1;
 
     priv = this->private;
     local = frame->local;
@@ -7508,31 +7504,28 @@ afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
     keylen = strlen(local->cont.getxattr.name);
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid || local->replies[i].op_ret) {
-            str_len = strlen(default_str);
-            buf = strncat(buf, default_str, str_len);
-            len += str_len;
-            buf[len++] = delimiter;
-            buf[len] = '\0';
+            data = (char *)default_str;
         } else {
             ret = dict_get_strn(local->replies[i].xattr,
-                                local->cont.getxattr.name, keylen, &xattr);
+                                local->cont.getxattr.name, keylen, &data);
             if (ret) {
                 gf_msg("TEST", GF_LOG_ERROR, -ret, AFR_MSG_DICT_GET_FAILED,
-                       "Failed to get the node_uuid of brick "
-                       "%d",
-                       i);
+                       "Failed to get the node_uuid of brick %d", i);
                 goto out;
             }
-            str_len = strlen(xattr);
-            buf = strncat(buf, xattr, str_len);
-            len += str_len;
-            buf[len++] = delimiter;
-            buf[len] = '\0';
         }
+
+        p = stpncpy(p, data, (buf + bufsize - 1) - p);
+        if (p >= buf + bufsize - 1) {
+            /* Not enough space for string and delimeter. */
+            ret = -1;
+            goto out;
+        }
+        *p = delimiter;
+        *++p = '\0';
     }
-    buf[--len] = '\0'; /*remove the last delimiter*/
-    if (serz_len)
-        *serz_len = ++len;
+    /* Remove the last delimeter. */
+    *--p = '\0';
     ret = 0;
 
 out:

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -750,7 +750,6 @@ afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
     int ret = 0;
     char *xattr_serz = NULL;
     long cky = 0;
-    int32_t tlen = 0;
 
     local = frame->local;
     priv = this->private;
@@ -806,8 +805,9 @@ unlock:
             goto unwind;
         }
 
-        ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
-                                                  UUID0_STR, &tlen, ' ');
+        ret = afr_serialize_xattrs_with_delimiter(
+            frame, this, xattr_serz, local->cont.getxattr.xattr_len, UUID0_STR,
+            ' ');
         if (ret) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1343,8 +1343,8 @@ afr_is_inode_refresh_reqd(inode_t *inode, xlator_t *this, int event_gen1,
 
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter);
+                                    char *buf, int32_t bufsize,
+                                    const char *default_str, char delimiter);
 gf_boolean_t
 afr_is_symmetric_error(call_frame_t *frame, xlator_t *this);
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3765,10 +3765,10 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("ios-dump-format", dump_format_str, options, str, out);
     ios_set_log_format_code(conf, dump_format_str);
     if (conf->ios_sample_interval) {
-        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size, options,
-                         int32, out);
+        GF_OPTION_RECONF("ios-sample-buf-size", conf->ios_sample_buf_size,
+                         options, int32, out);
     } else {
-        ios_sample_buf_size_configure (this->name, conf);
+        ios_sample_buf_size_configure(this->name, conf);
     }
 
     GF_OPTION_RECONF("sys-log-level", sys_log_str, options, str, out);
@@ -3917,8 +3917,9 @@ init(xlator_t *this)
     ret = dict_get_strn(this->options, "volume-id", SLEN("volume-id"),
                         &volume_id);
     if (!ret) {
-        strncpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
+        snprintf(this->graph->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
     }
+
     /*
      * Init it just after calloc, so that we are sure the lock is inited
      * in case of error paths.
@@ -3951,7 +3952,7 @@ init(xlator_t *this)
         GF_OPTION_INIT("ios-sample-buf-size", conf->ios_sample_buf_size, int32,
                        out);
     } else {
-        ios_sample_buf_size_configure (this->name, conf);
+        ios_sample_buf_size_configure(this->name, conf);
     }
 
     ret = ios_init_sample_buf(conf);

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1967,11 +1967,15 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
         gf_uuid_copy(pargfid, tmp_gfid);
     }
 
-    if (bname)
-        strncat(result, bname, strlen(bname) + 1);
-
-    *path = gf_strdup(result);
-
+    if (bname) {
+        len = gf_asprintf(path, "%s%s", result, bname);
+        if ((len < 0) || (len >= PATH_MAX)) {
+            GF_FREE(*path);
+            ret = -1;
+            goto out;
+        }
+    } else
+        *path = gf_strdup(result);
 out:
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -3712,7 +3712,7 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
     glusterd_conf_t *conf = NULL;
     glusterd_brickinfo_t *brick = NULL;
     glusterd_brickinfo_t *ta_brick = NULL;
-    char *ptr = NULL;
+    char *ptr = NULL, *curr = NULL;
     int i = 0;
     int index = -1;
     int ret = 0;
@@ -3751,12 +3751,13 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
 
     i = 1;
     index = 0;
+    curr = ptr;
 
     cds_list_for_each_entry(brick, &volinfo->bricks, brick_list)
     {
         if (index == clusters)
             break;
-        strncat(ptr, brick->brick_id, strlen(brick->brick_id));
+        curr = stpncpy(curr, brick->brick_id, (ptr + list_size) - curr);
         if (i == volinfo->replica_count) {
             /* add ta client xlator in afr-pending-xattrs before making entries
              * for client xlators in volfile.
@@ -3767,7 +3768,11 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
              */
             ta_brick_index = 0;
             if (volinfo->thin_arbiter_count == 1) {
-                ptr[strlen(brick->brick_id)] = ',';
+                if (curr >= ptr + list_size - 1) {
+                    ret = -1;
+                    goto out;
+                }
+                *curr++ = ',';
                 cds_list_for_each_entry(ta_brick, &volinfo->ta_bricks,
                                         brick_list)
                 {
@@ -3777,14 +3782,10 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
                     ta_brick_index++;
                 }
                 if (conf->op_version < GD_OP_VERSION_7_3) {
-                    strncat(ptr, ta_brick->brick_id,
-                            strlen(ta_brick->brick_id));
+                    curr = stpncpy(curr, ta_brick->brick_id, (ptr + list_size) - curr);
                 } else {
-                    char ta_volname[PATH_MAX] = "";
-                    int len = snprintf(ta_volname, PATH_MAX, "%s.%s",
-                                       ta_brick->brick_id,
-                                       uuid_utoa(volinfo->volume_id));
-                    strncat(ptr, ta_volname, len);
+                    curr += snprintf(curr, (ptr + list_size) - curr, "%s.%s",
+                                     ta_brick->brick_id, uuid_utoa(volinfo->volume_id));
                 }
             }
 
@@ -3794,12 +3795,16 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
                 goto out;
             memset(afr_xattrs_list, 0, list_size);
             ptr = afr_xattrs_list;
+            curr = ptr;
             i = 1;
             subvol_index++;
             continue;
         }
-        ptr[strlen(brick->brick_id)] = ',';
-        ptr += strlen(brick->brick_id) + 1;
+        if (curr >= ptr + list_size - 1) {
+            ret = -1;
+            goto out;
+        }
+        *curr++ = ',';
         i++;
     }
 

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -1101,8 +1101,7 @@ __mnt3_fresh_lookup(mnt3_resolve_t *mres)
 {
     inode_unlink(mres->resolveloc.inode, mres->resolveloc.parent,
                  mres->resolveloc.name);
-    strncpy(mres->remainingdir, mres->resolveloc.path,
-            strlen(mres->resolveloc.path));
+    snprintf(mres->remainingdir, MNTPATHLEN, "%s", mres->resolveloc.path);
     nfs_loc_wipe(&mres->resolveloc);
     return __mnt3_resolve_subdir(mres);
 }

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -809,7 +809,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 goto out;
             }
         } else {
-            strncpy(ctx->volume_id, volume_id, GF_UUID_BUF_SIZE);
+            snprintf(ctx->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
         }
     }
 
@@ -998,8 +998,8 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
         /* If any value is set, the first element will be non-0.
            It would be '0', but not '\0' :-) */
         if (!this->ctx->volume_id[0]) {
-            strncpy(this->ctx->volume_id, this->graph->volume_id,
-                    GF_UUID_BUF_SIZE);
+            snprintf(this->ctx->volume_id, GF_UUID_BUF_SIZE,
+                     "%s", this->graph->volume_id);
         }
         if (this->ctx->volume_id[0]) {
             ret = dict_set_str(options, "volume-id", this->ctx->volume_id);

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -380,7 +380,7 @@ posix_handle_pump(xlator_t *this, char *buf, int len, int maxlen,
     memmove(buf + base_len + blen, buf + base_len,
             (strlen(buf) - base_len) + 1);
 
-    strncpy(base_str + pfx_len, linkname + 6, 42);
+    strncpy(base_str + pfx_len, linkname + 6, base_len - pfx_len);
 
     strncpy(buf + pfx_len, linkname + 6, link_len - 6);
 out:


### PR DESCRIPTION
Fix warnings issued by gcc-10 -Wstringop-overflow and -Wstringop-truncation.
Adjust xlators/debug/io-stats/src/io-stats.c as noticed by clang-format as well.

Change-Id: I8ed1739735953bae9062560625fcf63599dd9ae5
Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Updates: #1681

