### PR TITLE
glusterd: resource leaks

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1755,7 +1755,7 @@ out:
         if (!rpcreq) {
             memset(&rpcreq_static, 0,
                    sizeof(rpcreq_static)); /* To handle frame destroy in case
-                                              any of the above is not defined */
+                                              rpcreq was not defined */
             rpcreq = &rpcreq_static;
         }
         rpcreq->rpc_status = -1;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1611,10 +1611,9 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
         0,
     };
     struct rpc_req *rpcreq = NULL;
+    struct rpc_req rpcreq_static;
     rpc_transport_req_t req;
-    int ret = -2; /* ret = -2 is done here so as to destroy the frame in the
-                   __glusterd_send_svc_configure_req() in case of memory alloc
-                   failure */
+    int ret = -1;
     int proglen = 0;
     char new_iobref = 0;
     uint64_t callid = 0;
@@ -1629,6 +1628,8 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
 
     rpcreq = mem_get(rpc->reqpool);
     if (rpcreq == NULL) {
+        memset(&rpcreq_static, 0, sizeof(rpcreq_static));
+        rpcreq = &rpcreq_static;
         goto out;
     }
 
@@ -1756,7 +1757,9 @@ out:
         if (rpcreq) {
             rpcreq->rpc_status = -1;
             cbkfn(rpcreq, NULL, 0, frame);
-            mem_put(rpcreq);
+            if (rpcreq != &rpcreq_static) {
+                mem_put(rpcreq);
+            }
         }
     }
     return ret;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1621,10 +1621,6 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     call_frame_t *cframe = frame;
 
     if (!rpc || !prog || !frame) {
-        memset(&rpcreq_static, 0,
-               sizeof(rpcreq_static)); /* To handle frame destroy in case any of
-                                          the above is not defined */
-        rpcreq = &rpcreq_static;
         goto out;
     }
 
@@ -1632,10 +1628,6 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
 
     rpcreq = mem_get(rpc->reqpool);
     if (rpcreq == NULL) {
-        memset(&rpcreq_static, 0,
-               sizeof(rpcreq_static)); /* To handle frame destroy in mem_get
-                                          failure */
-        rpcreq = &rpcreq_static;
         goto out;
     }
 
@@ -1760,6 +1752,12 @@ out:
     }
 
     if (frame && (ret == -1)) {
+        if (!rpcreq) {
+            memset(&rpcreq_static, 0,
+                   sizeof(rpcreq_static)); /* To handle frame destroy in case
+                                              any of the above is not defined */
+            rpcreq = &rpcreq_static;
+        }
         rpcreq->rpc_status = -1;
         cbkfn(rpcreq, NULL, 0, frame);
         if (rpcreq != &rpcreq_static) {

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1628,7 +1628,9 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
 
     rpcreq = mem_get(rpc->reqpool);
     if (rpcreq == NULL) {
-        memset(&rpcreq_static, 0, sizeof(rpcreq_static));
+        memset(&rpcreq_static, 0,
+               sizeof(rpcreq_static)); /* To handle frame destroy in mem_get
+                                          failure */
         rpcreq = &rpcreq_static;
         goto out;
     }

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1621,6 +1621,10 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     call_frame_t *cframe = frame;
 
     if (!rpc || !prog || !frame) {
+        memset(&rpcreq_static, 0,
+               sizeof(rpcreq_static)); /* To handle frame destroy in case any of
+                                          the above is not defined */
+        rpcreq = &rpcreq_static;
         goto out;
     }
 

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1612,7 +1612,9 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     };
     struct rpc_req *rpcreq = NULL;
     rpc_transport_req_t req;
-    int ret = -2;
+    int ret = -2; /* ret = -2 is done here so as to destroy the frame in the
+                   __glusterd_send_svc_configure_req() in case of memory alloc
+                   failure */
     int proglen = 0;
     char new_iobref = 0;
     uint64_t callid = 0;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1756,12 +1756,10 @@ out:
     }
 
     if (frame && (ret == -1)) {
-        if (rpcreq) {
-            rpcreq->rpc_status = -1;
-            cbkfn(rpcreq, NULL, 0, frame);
-            if (rpcreq != &rpcreq_static) {
-                mem_put(rpcreq);
-            }
+        rpcreq->rpc_status = -1;
+        cbkfn(rpcreq, NULL, 0, frame);
+        if (rpcreq != &rpcreq_static) {
+            mem_put(rpcreq);
         }
     }
     return ret;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1612,7 +1612,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     };
     struct rpc_req *rpcreq = NULL;
     rpc_transport_req_t req;
-    int ret = -1;
+    int ret = -2;
     int proglen = 0;
     char new_iobref = 0;
     uint64_t callid = 0;
@@ -1636,6 +1636,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     if (!iobref) {
         iobref = iobref_new();
         if (!iobref) {
+            ret = -1;
             goto out;
         }
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -886,8 +886,16 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     ret = rpc_clnt_submit(rpc, &gd_brick_prog, op, cbkfn, &iov, 1, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
 
+    /* Checking if the rpc_clnt_submit() failed beacuse of memory allocation,
+     * which implies the frame is not destroyed there. So, it needs to be
+     * destroyed here */
     if (ret != -2)
         frame = NULL;
+
+    /* Changing ret back to -1 so as to avoid -2 being passed to caller,
+     * considering that its not the usual error number used in the code */
+    if (ret == -2)
+        ret = -1;
 err:
     if (iobuf) {
         iobuf_unref(iobuf);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -886,16 +886,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     ret = rpc_clnt_submit(rpc, &gd_brick_prog, op, cbkfn, &iov, 1, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
 
-    /* Checking if the rpc_clnt_submit() failed beacuse of memory allocation,
-     * which implies the frame is not destroyed there. So, it needs to be
-     * destroyed here */
-    if (ret != -2)
-        frame = NULL;
-
-    /* Changing ret back to -1 so as to avoid -2 being passed to caller,
-     * considering that its not the usual error number used in the code */
-    if (ret == -2)
-        ret = -1;
+    frame = NULL;
 err:
     if (iobuf) {
         iobuf_unref(iobuf);
@@ -911,7 +902,7 @@ err:
     GF_FREE(volfile_content);
     if (spec_fd >= 0)
         sys_close(spec_fd);
-    if (ret && frame)
+    if (frame && ret)
         STACK_DESTROY(frame->root);
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -886,7 +886,8 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     ret = rpc_clnt_submit(rpc, &gd_brick_prog, op, cbkfn, &iov, 1, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
 
-    frame = NULL;
+    if (ret != -2)
+        frame = NULL;
 err:
     if (iobuf) {
         iobuf_unref(iobuf);


### PR DESCRIPTION
Issue:
iobref was not freed before exiting the function
if all the checks were OK, which caused the resource
leak.

Fix:
Modified the code a bit to avoid use of an extra reference
to the label, and to free the iobref and iobuf if not NULL,
and then exit the function.

CID: 1430118

Updates: #1060