### PR TITLE
glusterd: fix bug in enabling granular-entry-heal

### DIFF
--- a/tests/basic/afr/granular-esh/cli.t
+++ b/tests/basic/afr/granular-esh/cli.t
@@ -11,23 +11,38 @@ TESTS_EXPECTED_IN_LOOP=4
 TEST glusterd
 TEST pidof glusterd
 
-TEST   $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
-# Test that enabling the option should work on a newly created volume
-TEST   $CLI volume set $V0 cluster.granular-entry-heal on
-TEST   $CLI volume set $V0 cluster.granular-entry-heal off
-
 #########################
 ##### DISPERSE TEST #####
 #########################
 # Execute the same command on a disperse volume and make sure it fails.
 TEST $CLI volume create $V1 disperse 3 redundancy 1 $H0:$B0/${V1}{0,1,2}
+EXPECT "no" volume_get_field $V1 cluster.granular-entry-heal
 TEST $CLI volume start $V1
 TEST ! $CLI volume heal $V1 granular-entry-heal enable
 TEST ! $CLI volume heal $V1 granular-entry-heal disable
+TEST $CLI volume stop $V1
+TEST $CLI volume delete $V1
+
+#########################
+##### PLAIN DISTRIBUTE TEST #####
+#########################
+# Execute the same command on a distribute volume and make sure it fails.
+TEST $CLI volume create $V1 $H0:$B0/${V1}{0,1,2}
+EXPECT "no" volume_get_field $V1 cluster.granular-entry-heal
+TEST $CLI volume start $V1
+TEST ! $CLI volume heal $V1 granular-entry-heal enable
+TEST ! $CLI volume heal $V1 granular-entry-heal disable
+TEST $CLI volume stop $V1
+TEST $CLI volume delete $V1
 
 ######################
 ### REPLICATE TEST ###
 ######################
+TEST   $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
+EXPECT "on" volume_get_field $V0 cluster.granular-entry-heal
+# Test that enabling the option should work on a newly created volume
+TEST   $CLI volume set $V0 cluster.granular-entry-heal on
+TEST   $CLI volume set $V0 cluster.granular-entry-heal off
 TEST   $CLI volume start $V0
 TEST   $CLI volume set $V0 cluster.data-self-heal off
 TEST   $CLI volume set $V0 cluster.metadata-self-heal off

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -13217,7 +13217,8 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
     }
 
     if ((conf->op_version >= GD_OP_VERSION_9_0) &&
-        (volinfo->status == GLUSTERD_STATUS_NONE)) {
+        (volinfo->status == GLUSTERD_STATUS_NONE) &&
+        (volinfo->type == GF_CLUSTER_TYPE_REPLICATE)) {
         ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                          "cluster.granular-entry-heal", "on");
         if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -597,7 +597,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
 
     if (((heal_op == GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE) ||
          (heal_op == GF_SHD_OP_GRANULAR_ENTRY_HEAL_DISABLE)) &&
-        (volinfo->type == GF_CLUSTER_TYPE_DISPERSE)) {
+        (volinfo->type != GF_CLUSTER_TYPE_REPLICATE)) {
         ret = -1;
         goto out;
     }


### PR DESCRIPTION
commit f5e1eb87d4af44be3b317b7f99ab88f89c2f0b1a meant to enable  the
volume option only for replica volumes but inadvertently enabled
it for all volume types. Fixing it now.

Fixes: #1483
Change-Id: Icb6c169a8eec44cc4fb4dd636405d3b3485e91b4
Reported-by: Sheetal Pamecha <spamecha@redhat.com>
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

