### PR TITLE
tests: Fix issues in CentOS 8

### DIFF
--- a/tests/bugs/nfs/bug-1053579.t
+++ b/tests/bugs/nfs/bug-1053579.t
@@ -39,6 +39,10 @@ do
 done
 TEST useradd -o -M -u ${NEW_UID} -g ${NEW_GID} -G ${NEW_USER}-${NEW_GIDS} ${NEW_USER}
 
+# It's not guaranteed that the latest added group will be returned as the last
+# group for the user. To be sure, we take the latest group returned by 'id'
+LAST_GID="$(id -G ${NEW_USER} | tr ' ' '\n' | tail -1)"
+
 # preparation done, start the tests
 
 TEST glusterd


### PR DESCRIPTION
Due to some configuration changes in CentOS 8/RHEL 8, ssl-ciphers.t
and bug-1053579.t were failing.

The first one was failing because TLS v1.0 is disabled by default. The
test hash been updated to check that at least one of TLS v1.0, v1.1 or
v1.2 succeeds.

For the second case, the issue is that the test assumed that the
latest added group to a user should always be listed the last, but
this is not always true because nsswitch.conf now uses 'sss' before
'files', which means that data comes from a db that could not be
sorted.

Updates: #1009
Change-Id: I4ca01a099854ec25926c3d76b3a98072175bab06
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

