### PR TITLE
inode: implement namespace at inode level

### DIFF
--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -439,7 +439,7 @@ glfs_resolve_component(struct glfs *fs, xlator_t *subvol, inode_t *parent,
             goto out;
         }
 
-        ret = dict_set_int32(xattr_req, GF_NAMESPACE_KEY, 1);
+        ret = dict_set_int32_sizen(xattr_req, GF_NAMESPACE_KEY, 1);
         ret = syncop_lookup(subvol, &loc, &ciatt, NULL, xattr_req, &xattr_rsp);
     }
     DECODE_SYNCOP_ERR(ret);

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -396,7 +396,7 @@ glfs_resolve_component(struct glfs *fs, xlator_t *subvol, inode_t *parent,
             errno = ENOMEM;
             goto out;
         }
-        ret = dict_set_int32(xattr_req, GF_NAMESPACE_KEY, 1);
+        ret = dict_set_int32_sizen(xattr_req, GF_NAMESPACE_KEY, 1);
     }
 
     glret = priv_glfs_loc_touchup(&loc);

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -129,6 +129,9 @@
 
 #define XATTR_IS_BD(x) (strncmp(x, BD_XATTR_KEY, SLEN(BD_XATTR_KEY)) == 0)
 
+/* required for namespace */
+#define GF_NAMESPACE_KEY "trusted.glusterfs.namespace"
+
 #define GF_XATTR_LINKINFO_KEY "trusted.distribute.linkinfo"
 #define GFID_XATTR_KEY "trusted.gfid"
 #define PGFID_XATTR_KEY_PREFIX "trusted.pgfid."

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -102,6 +102,7 @@ struct _inode {
     uuid_t gfid;
     gf_lock_t lock;
     gf_atomic_t nlookup;
+    gf_atomic_t kids;
     uint32_t fd_count;            /* Open fd count */
     uint32_t active_fd_count;     /* Active open fd count */
     uint32_t ref;                 /* reference count on this inode */
@@ -111,6 +112,7 @@ struct _inode {
     struct list_head hash;        /* hash table pointers */
     struct list_head list;        /* active/lru/purge */
 
+    struct _inode *ns_inode; /* This inode would point to namespace inode */
     struct _inode_ctx *_ctx; /* replacement for dict_t *(inode->ctx) */
     bool in_invalidate_list; /* Set if inode is in table invalidate list */
     bool invalidate_sent;    /* Set it if invalidator_fn is called for inode */
@@ -307,4 +309,8 @@ inode_ctx_size(inode_t *inode);
 
 void
 inode_find_directory_name(inode_t *inode, const char **name);
+
+void
+inode_set_namespace_inode(inode_t *inode, inode_t *ns_inode);
+
 #endif /* _INODE_H */

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -985,14 +985,6 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
             GF_ASSERT(!"link attempted b/w inodes of diff table");
         }
 
-        /* similarly, we should not link between an inode with different
-         * namespace to another */
-        if (inode->ns_inode && (inode->ns_inode != parent->ns_inode)) {
-            errno = EINVAL;
-            GF_ASSERT(!"link attempted b/w inodes of different namespaces");
-            return NULL;
-        }
-
         if (parent->ia_type != IA_IFDIR) {
             errno = EINVAL;
             GF_ASSERT(!"link attempted on non-directory parent");

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -818,6 +818,7 @@ inode_ref
 inode_ref_reduce_by_n
 inode_rename
 inode_resolve
+inode_set_namespace_inode
 inode_set_need_lookup
 inode_table_ctx_free
 inode_table_destroy

--- a/tests/basic/inode-namespace.t
+++ b/tests/basic/inode-namespace.t
@@ -64,4 +64,7 @@ echo "$(grep 'cross-device' $(glusterfsd --print-logdir)/bricks/* | grep server_
 
 TEST mv $M1/test2/file12 $M1/test2/file10 ;
 
+
+TEST ! setfattr -x trusted.glusterfs.namespace -v true $M2/test1;
+
 cleanup;

--- a/tests/basic/inode-namespace.t
+++ b/tests/basic/inode-namespace.t
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+. $(dirname $0)/../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume info;
+
+TEST $CLI volume create $V0 $H0:$B0/${V0}
+TEST $CLI volume start $V0;
+
+## Mount FUSE
+TEST $GFS -s $H0 --volfile-id $V0 $M1;
+
+TEST mkdir $M1/test1;
+TEST mkdir $M1/test2;
+
+# User from regular mount can't set namespace, but only the special pid (ie, <0)
+TEST ! setfattr -n trusted.glusterfs.namespace -v true $M1/test2;
+
+## Mount FUSE
+TEST $GFS -s $H0 --volfile-id $V0 --client-pid=-10 --process-name=namespace-test $M2;
+#TEST $GFS -s $H0 --volfile-id $V0 --process-name=namespace-test $M2;
+
+TEST df -h $M1
+
+sleep 1;
+
+TEST setfattr -n trusted.glusterfs.namespace -v true $M2/test1;
+TEST setfattr -n trusted.glusterfs.namespace -v true $M2/test2;
+
+
+TEST touch $M1/test2/file{1,2,11,12};
+TEST touch $M1/test1/file{1,2,11,12};
+
+# This technically fails if we can only check rename(2).
+mv $M1/test1/file1 $M1/test2/file3 ;
+TEST grep 'cross-device' $(glusterfsd --print-logdir)/bricks/*
+
+TEST mv $M1/test2/file2 $M1/test2/file4 ;
+
+
+TEST ! ln $M1/test1/file11 $M1/test2/file5 ;
+TEST ln $M1/test1/file2 $M1/test1/file6 ;
+
+TEST kill_brick $V0 $H0 $B0/${V0};
+
+TEST $CLI volume start $V0 force;
+
+sleep 3;
+
+TEST ! ln $M2/test1/file12 $M2/test2/file7 ;
+TEST ln $M2/test1/file2 $M2/test1/file8  ;
+
+TEST $CLI volume stop $V0;
+TEST $CLI volume start $V0;
+
+sleep 3;
+mv $M1/test2/file11 $M1/test1/file9 ;
+echo "$(grep 'cross-device' $(glusterfsd --print-logdir)/bricks/* | grep server_rename_resume)"
+
+TEST mv $M1/test2/file12 $M1/test2/file10 ;
+
+cleanup;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1191,7 +1191,7 @@ fuse_lookup_resume(fuse_state_t *state)
                state->finh->unique, state->loc.path);
         state->loc.inode = inode_new(state->loc.parent->table);
         if (gf_uuid_is_null(state->gfid)) {
-            /* this is when its all completely new lookup, send namespace key
+            /* this is when it's all completely new lookup, send namespace key
              * here */
             if (state->xdata) {
                 int ret = dict_set_int32(state->xdata, GF_NAMESPACE_KEY, 1);

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1194,7 +1194,8 @@ fuse_lookup_resume(fuse_state_t *state)
             /* this is when it's all completely new lookup, send namespace key
              * here */
             if (state->xdata) {
-                int ret = dict_set_int32_sizen(state->xdata, GF_NAMESPACE_KEY, 1);
+                int ret = dict_set_int32_sizen(state->xdata, GF_NAMESPACE_KEY,
+                                               1);
                 if (ret) {
                     gf_log(THIS->name, GF_LOG_DEBUG,
                            "BUG: dict set failed (path: %s), still continuing",

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1194,7 +1194,7 @@ fuse_lookup_resume(fuse_state_t *state)
             /* this is when it's all completely new lookup, send namespace key
              * here */
             if (state->xdata) {
-                int ret = dict_set_int32(state->xdata, GF_NAMESPACE_KEY, 1);
+                int ret = dict_set_int32_sizen(state->xdata, GF_NAMESPACE_KEY, 1);
                 if (ret) {
                     gf_log(THIS->name, GF_LOG_DEBUG,
                            "BUG: dict set failed (path: %s), still continuing",

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -783,7 +783,8 @@ out:
 /*TODO: Handle revalidate path */
 void
 server4_post_lookup(gfx_common_2iatt_rsp *rsp, call_frame_t *frame,
-                    server_state_t *state, inode_t *inode, struct iatt *stbuf)
+                    server_state_t *state, inode_t *inode, struct iatt *stbuf,
+                    dict_t *xdata)
 {
     inode_t *root_inode = NULL;
     inode_t *link_inode = NULL;
@@ -795,6 +796,10 @@ server4_post_lookup(gfx_common_2iatt_rsp *rsp, call_frame_t *frame,
         link_inode = inode_link(inode, state->loc.parent, state->loc.name,
                                 stbuf);
         if (link_inode) {
+            if (dict_get_sizen(xdata, GF_NAMESPACE_KEY)) {
+                inode_set_namespace_inode(link_inode, link_inode);
+            }
+
             inode_lookup(link_inode);
             inode_unref(link_inode);
         }

--- a/xlators/protocol/server/src/server-common.h
+++ b/xlators/protocol/server/src/server-common.h
@@ -187,7 +187,8 @@ void
 server4_post_lease(gfx_lease_rsp *rsp, struct gf_lease *lease);
 void
 server4_post_lookup(gfx_common_2iatt_rsp *rsp, call_frame_t *frame,
-                    server_state_t *state, inode_t *inode, struct iatt *stbuf);
+                    server_state_t *state, inode_t *inode, struct iatt *stbuf,
+                    dict_t *xdata);
 void
 server4_post_link(server_state_t *state, gfx_common_3iatt_rsp *rsp,
                   inode_t *inode, struct iatt *stbuf, struct iatt *pre,

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -871,8 +871,8 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
         /* This inode onwards we will set namespace */
         gf_msg(THIS->name, GF_LOG_INFO, 0, PS_MSG_SETXATTR_INFO,
-	       "client=%s, path=%s", STACK_CLIENT_NAME(frame->root),
-	       state->loc.path);
+               "client=%s, path=%s", STACK_CLIENT_NAME(frame->root),
+               state->loc.path);
         inode_set_namespace_inode(state->loc.inode, state->loc.inode);
     }
 

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -3264,6 +3264,8 @@ err:
     server4_lookup_cbk(frame, NULL, frame->this, state->resolve.op_ret,
                        state->resolve.op_errno, NULL, NULL, NULL, NULL);
 
+    if (xdata)
+        dict_unref(xdata);
     return 0;
 }
 
@@ -4425,7 +4427,6 @@ server4_0_setxattr(rpcsvc_request_t *req)
         dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
         gf_smsg("server", GF_LOG_ERROR, 0, PS_MSG_SETXATTR_INFO, "path=%s",
                 state->loc.path, "key=%s", GF_NAMESPACE_KEY, NULL);
-        ret = -1;
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;
     }

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -2769,6 +2769,15 @@ server4_removexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
     if (state->resolve.op_ret != 0)
         goto err;
 
+    if (dict_get_sizen(state->xdata, GF_NAMESPACE_KEY) ||
+        !strncmp(GF_NAMESPACE_KEY, state->name, sizeof(GF_NAMESPACE_KEY))) {
+        gf_msg(bound_xl->name, GF_LOG_ERROR, ENOTSUP, 0,
+               "%s: removal of namespace is not allowed", state->loc.path);
+        state->resolve.op_errno = ENOTSUP;
+        state->resolve.op_ret = -1;
+        goto err;
+    }
+
     STACK_WIND(frame, server4_removexattr_cbk, bound_xl,
                bound_xl->fops->removexattr, &state->loc, state->name,
                state->xdata);
@@ -2789,6 +2798,15 @@ server4_fremovexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
     if (state->resolve.op_ret != 0)
         goto err;
 
+    if (dict_get_sizen(state->xdata, GF_NAMESPACE_KEY) ||
+        !strncmp(GF_NAMESPACE_KEY, state->name, sizeof(GF_NAMESPACE_KEY))) {
+        gf_msg(bound_xl->name, GF_LOG_ERROR, ENOTSUP, 0,
+               "%s: removal of namespace is not allowed",
+               uuid_utoa(state->fd->inode->gfid));
+        state->resolve.op_errno = ENOTSUP;
+        state->resolve.op_ret = -1;
+        goto err;
+    }
     STACK_WIND(frame, server4_fremovexattr_cbk, bound_xl,
                bound_xl->fops->fremovexattr, state->fd, state->name,
                state->xdata);

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -139,7 +139,7 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    server4_post_lookup(&rsp, frame, state, inode, stbuf);
+    server4_post_lookup(&rsp, frame, state, inode, stbuf, xdata);
 out:
     rsp.op_ret = op_ret;
     rsp.op_errno = gf_errno_to_error(op_errno);
@@ -852,8 +852,9 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
+    state = CALL_STATE(frame);
+
     if (op_ret == -1) {
-        state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
 
@@ -865,6 +866,11 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     "error-xlator=%s", STACK_ERR_XL_NAME(frame->root), NULL);
         }
         goto out;
+    }
+
+    if (dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
+        /* This inode onwards we will set namespace */
+        inode_set_namespace_inode(state->loc.inode, state->loc.inode);
     }
 
 out:
@@ -2914,6 +2920,17 @@ server4_setxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
     if (state->resolve.op_ret != 0)
         goto err;
 
+    /* Let the namespace setting can happen only from special mounts, this
+       should prevent all mounts creating fake namespace. */
+    if ((frame->root->pid >= 0) &&
+        dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
+        gf_smsg("server", GF_LOG_ERROR, 0, PS_MSG_SETXATTR_INFO, "path=%s",
+                state->loc.path, "key=%s", GF_NAMESPACE_KEY, NULL);
+        state->resolve.op_ret = -1;
+        state->resolve.op_errno = EPERM;
+        goto err;
+    }
+
     STACK_WIND(frame, server4_setxattr_cbk, bound_xl, bound_xl->fops->setxattr,
                &state->loc, state->dict, state->flags, state->xdata);
     return 0;
@@ -3186,19 +3203,42 @@ int
 server4_lookup_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
+    dict_t *xdata = NULL;
 
     state = CALL_STATE(frame);
 
     if (state->resolve.op_ret != 0)
         goto err;
 
-    if (!state->loc.inode)
+    xdata = state->xdata ? dict_ref(state->xdata) : dict_new();
+    if (!state->loc.inode) {
         state->loc.inode = server_inode_new(state->itable, state->loc.gfid);
-    else
+        if (xdata) {
+            int ret = dict_set_int32(xdata, GF_NAMESPACE_KEY, 1);
+            if (ret) {
+                gf_log(THIS->name, GF_LOG_DEBUG,
+                       "dict set (namespace) failed (path: %s), continuing",
+                       state->loc.path);
+            }
+            if (state->loc.path && (state->loc.path[0] == '<')) {
+                /* This is a lookup on gfid : get full-path */
+                ret = dict_set_int32(xdata, "get-full-path", 1);
+                if (ret) {
+                    gf_log(THIS->name, GF_LOG_DEBUG,
+                           "dict set (full-path) failed (path: %s), continuing",
+                           state->loc.path);
+                }
+            }
+        }
+    } else {
         state->is_revalidate = 1;
+    }
 
     STACK_WIND(frame, server4_lookup_cbk, bound_xl, bound_xl->fops->lookup,
-               &state->loc, state->xdata);
+               &state->loc, xdata);
+
+    if (xdata)
+        dict_unref(xdata);
 
     return 0;
 err:

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -870,6 +870,9 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
         /* This inode onwards we will set namespace */
+        gf_msg(THIS->name, GF_LOG_INFO, 0, PS_MSG_SETXATTR_INFO,
+	       "client=%s, path=%s", STACK_CLIENT_NAME(frame->root),
+	       state->loc.path);
         inode_set_namespace_inode(state->loc.inode, state->loc.inode);
     }
 
@@ -2362,7 +2365,7 @@ server4_rename_resume(call_frame_t *frame, xlator_t *bound_xl)
         goto err;
     }
 
-    if (state->loc.inode->ns_inode != state->loc2.parent->ns_inode) {
+    if (state->loc.parent->ns_inode != state->loc2.parent->ns_inode) {
         /* lets not allow rename across namespaces */
         op_ret = -1;
         op_errno = EXDEV;
@@ -4417,8 +4420,8 @@ server4_0_setxattr(rpcsvc_request_t *req)
         dict_get_sizen(state->dict, GF_NAMESPACE_KEY)) {
         gf_smsg("server", GF_LOG_ERROR, 0, PS_MSG_SETXATTR_INFO, "path=%s",
                 state->loc.path, "key=%s", GF_NAMESPACE_KEY, NULL);
-        state->resolve.op_ret = -1;
-        state->resolve.op_errno = EPERM;
+        ret = -1;
+        SERVER_REQ_SET_ERROR(req, ret);
         goto out;
     }
 

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -363,11 +363,22 @@ parent:
 out:
     if (!op_ret && !gfidless && gf_uuid_is_null(buf.ia_gfid)) {
         gf_msg(this->name, GF_LOG_ERROR, ENODATA, P_MSG_NULL_GFID,
-               "buf->ia_gfid is null for "
-               "%s",
-               (real_path) ? real_path : "");
+               "buf->ia_gfid is null for %s",
+               (real_path) ? real_path : "(null)");
         op_ret = -1;
         op_errno = ENODATA;
+    }
+
+    /* TODO: get the path */
+    /* In the full run of regression, I was not able to hit this case, hence
+       leaving it as TODO. Good to have logic of resolving GFID only access
+       to a path for many other features too. But initial version can just
+       be knowning that we are hitting the scenario in certain usecases */
+    if ((op_ret == 0) && (dict_get_sizen(xdata, "get-full-path"))) {
+        /* Get the path */
+        gf_log(this->name, GF_LOG_INFO,
+               "%s: inode path not completely resolved. Asking for full path",
+               loc->path);
     }
 
     if (op_ret == 0)


### PR DESCRIPTION
With this PR, specially on the brick side graph, inode table would be
properly set with 'namespace' inode reference. It is not guaranteed
with fuse/client side graph due to subdir mount.
    
To get 'namespace' for a corresponding inode, all one needs to do is,
check `ns_inode` pointer in inode structure.
    
Currently only special mounts with `PID < 0` can set the namespace
attribute, and in lookup, if namespace attribute is present, we set
the variable in inode.
    
By default, the ns_inode is set to 'root' inode when inode gets created.
    
Fixes: #1757
Change-Id: I69157e388538ea5d4b4e45d543575a04ee9ef221
Signed-off-by: Amar Tumballi <amar@kadalu.io>