### PR TITLE
core: tcmu-runner process continuous growing logs lru_size showing -1

### DIFF
--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -114,6 +114,7 @@ struct _inode {
     struct _inode_ctx *_ctx; /* replacement for dict_t *(inode->ctx) */
     bool in_invalidate_list; /* Set if inode is in table invalidate list */
     bool invalidate_sent;    /* Set it if invalidator_fn is called for inode */
+    bool in_lru_list;        /* Set if inode is in table lru list */
 };
 
 #define UUID0_STR "00000000-0000-0000-0000-000000000000"

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -573,7 +573,6 @@ __inode_ref(inode_t *inode, bool is_invalidate)
             inode->in_invalidate_list = true;
             inode->table->invalidate_size++;
             list_move_tail(&inode->list, &inode->table->invalidate);
-            inode->in_lru_list = _gf_false;
         } else {
             __inode_activate(inode);
         }


### PR DESCRIPTION
At the time of calling inode_table_prune it checks if current lru_size
is greater than lru_limit but lru_list is empty it throws a log message
"Empty inode lru list found but with (%d) lru_size".As per code reading
it seems lru_size is out of sync with the actual number of inodes in
lru_list. Due to throwing continuous error messages entire disk is
getting full and the user has to restart the tcmu-runner process to use
the volumes.The log message was introduce by a patch
https://review.gluster.org/#/c/glusterfs/+/15087/.

Solution: Introduce a flag in_lru_list to take decision about inode is
          being part of lru_list or not.
Fixes: #1775
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: I4b836bebf4b5db65fbf88ff41c6c88f4a7ac55c1

