### PR TITLE
geo-rep: Nonroot session goes to faulty with rsnapshot case

### DIFF
--- a/tests/00-geo-rep/00-georep-verify-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-setup.t
@@ -64,7 +64,6 @@ TEST $GEOREP_CLI $master $slave config gluster-command-dir ${GLUSTER_CMD_DIR}
 
 #Config gluster-command-dir
 TEST $GEOREP_CLI $master $slave config slave-gluster-command-dir ${GLUSTER_CMD_DIR}
-
 #Enable_metavolume
 TEST $GEOREP_CLI $master $slave config use_meta_volume true
 


### PR DESCRIPTION
/proc/sys/fs/protected_hardlinks (since Linux 3.6)
When  the  value in this file is 0, no restrictions are placed on the creation of
hard links (i.e., this is the historical behavior before Linux 3.6).  When the value
in this file is 1, a hard link can be created to a target file only if one of the
following conditions is true:

*  The calling process has the CAP_FOWNER capability in its user namespace and the
   file UID has a mapping in the namespace.

*  The filesystem UID of the process creating the link matches the owner (UID) of
   the target file (as described in credentials(7), a process's filesystem UID is
   normally the same as its effective UID).

*  All of the following conditions are true:

   ·  the target is a regular file;

   ·  the target file does not have its set-user-ID mode bit enabled;

   ·  the target file does not have both its set-group-ID and group-executable mode
      bits enabled; and

   ·  the caller has permission to read and write the target file (either via the
      file's permissions mask or because it has suitable capabilities).

As the /proc/sys/fs/protected_hardlinks is set 1 by default,
setting CAP_FOWNER in INHERITABLE mode before exec of glusterfs from mountbroker.

PRE-REQUISITES for the patch:
   . libcap-devel should be installed
   . compilation should include -lcap
     i.e, make CFLAGS="-Wall -DDEBUG -lcap -g3 -O0" install 1>/dev/null

Fixes: #1727
Change-Id: Id29b9f433d82226beaf3ae1cc3c64b19f8935cc7
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

