### PR TITLE
geo-rep: Nonroot session goes to faulty with rsnapshot case

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -22,6 +22,7 @@
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/run.h>
+#include <sys/capability.h>
 #include "glusterd-mem-types.h"
 #include "glusterd.h"
 #include "glusterd-utils.h"
@@ -519,6 +520,8 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     xlator_t *this = THIS;
     mode_t orig_umask = 0;
     gf_boolean_t found_label = _gf_false;
+    pid_t pid;
+    cap_t cap;
 
     priv = this->private;
     GF_ASSERT(priv);
@@ -681,6 +684,23 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
 
     runinit(&runner);
     runner_add_arg(&runner, SBIN_DIR "/glusterfs");
+
+    pid = getpid();
+    cap = cap_get_pid(pid);
+    if (cap == NULL) {
+        perror("cap_get_pid");
+        exit(-1);
+    }
+
+    /* inheritable cap_ */
+    cap_value_t cap_list[1];
+    cap_list[0] = CAP_FOWNER;
+    if (cap_set_flag(cap, CAP_INHERITABLE, 1, cap_list, CAP_SET) == -1) {
+        perror("cap_set_flag failed for CAP_DAC_OVERRIDE");
+        cap_free(cap);
+        exit(-1);
+    }
+
     seq_dict_foreach(argdict, _runner_add, &runner);
     runner_add_arg(&runner, mtptemp);
     ret = runner_run_reuse(&runner);


### PR DESCRIPTION
/proc/sys/fs/protected_hardlinks (since Linux 3.6)
When  the  value in this file is 0, no restrictions are placed on the creation of
hard links (i.e., this is the historical behavior before Linux 3.6).  When the value
in this file is 1, a hard link can be created to a target file only if one of the
following conditions is true:

*  The calling process has the CAP_FOWNER capability in its user namespace and the
   file UID has a mapping in the namespace.

*  The filesystem UID of the process creating the link matches the owner (UID) of
   the target file (as described in credentials(7), a process's filesystem UID is
   normally the same as its effective UID).

*  All of the following conditions are true:

   ·  the target is a regular file;

   ·  the target file does not have its set-user-ID mode bit enabled;

   ·  the target file does not have both its set-group-ID and group-executable mode
      bits enabled; and

   ·  the caller has permission to read and write the target file (either via the
      file's permissions mask or because it has suitable capabilities).

As the /proc/sys/fs/protected_hardlinks is set 1 by default,
setting CAP_FOWNER in INHERITABLE mode before exec of glusterfs from mountbroker.

PRE-REQUISITES for the patch:
   . libcap-devel should be installed
   . compilation should include -lcap
     i.e, make CFLAGS="-Wall -DDEBUG -lcap -g3 -O0" install 1>/dev/null

Fixes: #1727
Change-Id: Id29b9f433d82226beaf3ae1cc3c64b19f8935cc7
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

