### PR TITLE
glusterd: modify logic for checking hostname in add-brick

### DIFF
--- a/tests/bugs/glusterd/brick-order-check-add-brick.t
+++ b/tests/bugs/glusterd/brick-order-check-add-brick.t
@@ -47,15 +47,22 @@ EXPECT 'Created' volinfo_field $V0 'Status'
 TEST $CLI_1 volume start $V0
 EXPECT 'Started' volinfo_field $V0 'Status'
 
-#Add-brick with Increasing replica count
+#Add-brick with Increasing replica count from different host should success
 TEST $CLI_1 volume add-brick $V0 replica 3 $H3:$L3/${V0}1
 EXPECT '1 x 3 = 3' volinfo_field $V0 'Number of Bricks'
 
 #Add-brick with Increasing replica count from same host should fail
+TEST ! $CLI_1 volume add-brick $V0 replica 4 $H1:$L1/${V0}2
+
+#Add-brick with Increasing replica count from same host should pass with force
+TEST $CLI_1 volume add-brick $V0 replica 4 $H1:$L1/${V0}2 force
+EXPECT '1 x 4 = 4' volinfo_field $V0 'Number of Bricks'
+
+#Add-brick with Increasing replica count multiple bricks from same host should fail
 TEST ! $CLI_1 volume add-brick $V0 replica 5 $H1:$L1/${V0}2 $H1:$L1/${V0}3
 
-#adding multiple bricks from same host should fail the brick order check
-TEST ! $CLI_1 volume add-brick $V0 replica 3 $H1:$L1/${V0}{4..6} $H2:$L2/${V0}{7..9}
-EXPECT '1 x 3 = 3' volinfo_field $V0 'Number of Bricks'
+#adding multiple bricks without increasing replica count from same host should fail
+TEST ! $CLI_1 volume add-brick $V0 replica 4 $H1:$L1/${V0}{4..7} $H2:$L2/${V0}{8..11}
+EXPECT '1 x 4 = 4' volinfo_field $V0 'Number of Bricks'
 
 cleanup

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1457,21 +1457,21 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
             gf_msg_debug(this->name, 0,
                          "Replicate cluster type "
                          "found. Checking brick order.");
-            if (replica_count)
+            if (replica_count && (replica_count != volinfo->replica_count))
                 ret = glusterd_check_brick_order(dict, msg, volinfo->type,
                                                  &volname, &bricks, &count,
-                                                 replica_count);
+                                                 replica_count, 1);
             else
                 ret = glusterd_check_brick_order(dict, msg, volinfo->type,
                                                  &volname, &bricks, &count,
-                                                 volinfo->replica_count);
+                                                 volinfo->replica_count, 0);
         } else if (volinfo->type == GF_CLUSTER_TYPE_DISPERSE) {
             gf_msg_debug(this->name, 0,
                          "Disperse cluster type"
                          " found. Checking brick order.");
             ret = glusterd_check_brick_order(dict, msg, volinfo->type, &volname,
                                              &bricks, &count,
-                                             volinfo->disperse_count);
+                                             volinfo->disperse_count, 0);
         }
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BAD_BRKORDER,

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15031,7 +15031,6 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     ai_list_tmp2 = NULL;
     if (flag) {
         i = 0;
-        j = 0;
         ai_list_tmp2 = cds_list_first_entry(ai_list->list.next, addrinfo_list_t,
                                             list);
         while (i < count) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14888,11 +14888,6 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     }
     pre_list->info = NULL;
     CDS_INIT_LIST_HEAD(&pre_list->list);
-    if (pre_list == NULL) {
-        gf_msg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
-               "failed to allocate memory");
-	goto out;
-    }
 
     if (!(*volname)) {
         ret = dict_get_strn(dict, "volname", SLEN("volname"), &(*volname));

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14881,6 +14881,11 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     CDS_INIT_LIST_HEAD(&ai_list->list);
 
     pre_list = MALLOC(sizeof(addrinfo_list_t));
+    if (pre_list == NULL) {
+        gf_msg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
+               "failed to allocate memory");
+	goto out;
+    }
     pre_list->info = NULL;
     CDS_INIT_LIST_HEAD(&pre_list->list);
     if (pre_list == NULL) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -865,7 +865,7 @@ glusterd_add_shd_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
 int32_t
 glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
                            char **volname, char **bricks, int32_t *brick_count,
-                           int32_t sub_count);
+                           int32_t sub_count, int flag);
 gf_boolean_t
 glusterd_gf_is_local_addr(char *hostname);
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -1004,7 +1004,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
                              "found. Checking brick order.");
                 ret = glusterd_check_brick_order(dict, msg, type, &volname,
                                                  &bricks, &brick_count,
-                                                 replica_count);
+                                                 replica_count, 0);
             } else if (type == GF_CLUSTER_TYPE_DISPERSE) {
                 ret = dict_get_int32n(dict, "disperse-count",
                                       SLEN("disperse-count"), &disperse_count);
@@ -1019,7 +1019,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
                              " found. Checking brick order.");
                 ret = glusterd_check_brick_order(dict, msg, type, &volname,
                                                  &bricks, &brick_count,
-                                                 disperse_count);
+                                                 disperse_count, 0);
             }
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BAD_BRKORDER,


### PR DESCRIPTION
Problem: add-brick command parses only the bricks provided
in cli for a subvolume. If in same subvolume bricks are
increased, these are not checked with present volume bricks.

Fixes: #1779
Change-Id: I768bcf7359a008f2d6baccef50e582536473a9dc
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>

