### PR TITLE
DHT/Rebalance - Ensure Rebalance reports status only once upon stopping

### DIFF
--- a/tests/bugs/distribute/bug-1286171.t
+++ b/tests/bugs/distribute/bug-1286171.t
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+
+# Initialize
+#------------------------------------------------------------
+cleanup;
+
+volname=bug-1286171
+
+# Start glusterd
+TEST glusterd;
+TEST pidof glusterd;
+TEST $CLI volume info;
+
+# Create a volume
+TEST $CLI volume create $volname $H0:$B0/${volname}{1,2}
+
+# Verify volume creation
+EXPECT "$volname" volinfo_field $volname 'Volume Name';
+EXPECT 'Created' volinfo_field $volname 'Status';
+
+# Start volume and verify successful start
+TEST $CLI volume start $volname;
+EXPECT 'Started' volinfo_field $volname 'Status';
+TEST glusterfs --volfile-id=$volname --volfile-server=$H0 --entry-timeout=0 $M0;
+#------------------------------------------------------------
+
+# Create a nested dir structure and some file under MP
+cd $M0;
+for i in {1..5}
+do
+	mkdir dir$i
+	cd dir$i
+	for j in {1..5}
+	do
+		mkdir dir$i$j
+		cd dir$i$j
+		for k in {1..5}
+		do
+			mkdir dir$i$j$k
+			cd dir$i$j$k
+			touch {1..300}
+			cd ..
+		done
+		touch {1..300}
+		cd ..
+	done
+	touch {1..300}
+	cd ..
+done
+touch {1..300}
+
+# Add-brick and start rebalance
+TEST $CLI volume add-brick $volname $H0:$B0/${volname}4;
+TEST $CLI volume rebalance $volname start;
+
+# Let rebalance run for a while
+sleep 5
+
+# Stop rebalance
+TEST $CLI volume rebalance $volname stop;
+
+# Allow rebalance to stop
+sleep 5
+
+# Examine the logfile for errors
+cd /var/log/glusterfs;
+failures=`grep "failures:" ${volname}-rebalance.log | tail -1 | awk '{ print $25 }' | tr -d ,`;
+
+TEST [ $failures == 0 ];
+
+cleanup;

--- a/tests/bugs/distribute/bug-1286171.t
+++ b/tests/bugs/distribute/bug-1286171.t
@@ -68,7 +68,7 @@ sleep 5
 
 # Examine the logfile for errors
 cd /var/log/glusterfs;
-failures=`grep "failures:" ${volname}-rebalance.log | tail -1 | awk '{ print $25 }' | tr -d ,`;
+failures=`grep "failures:" ${volname}-rebalance.log | tail -1 | sed 's/.*failures: //; s/,.*//'`;
 
 TEST [ $failures == 0 ];
 

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -10884,7 +10884,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_CHILD_DOWN,
                        "Received CHILD_DOWN. Exiting");
                 if (conf->defrag) {
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL, true);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL, _gf_true);
                 } else {
                     kill(getpid(), SIGTERM);
                 }
@@ -10964,12 +10964,12 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                     goto unlock;
                 if ((cmd == GF_DEFRAG_CMD_STATUS) ||
                     (cmd == GF_DEFRAG_CMD_DETACH_STATUS))
-                    gf_defrag_status_get(conf, output, false);
+                    gf_defrag_status_get(conf, output, _gf_false);
                 else if (cmd == GF_DEFRAG_CMD_DETACH_START)
                     defrag->cmd = GF_DEFRAG_CMD_DETACH_START;
                 else if (cmd == GF_DEFRAG_CMD_STOP ||
                          cmd == GF_DEFRAG_CMD_DETACH_STOP)
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output, false);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output, _gf_false);
             }
         unlock:
             UNLOCK(&defrag->lock);

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -10884,7 +10884,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_CHILD_DOWN,
                        "Received CHILD_DOWN. Exiting");
                 if (conf->defrag) {
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL, _gf_true);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL);
                 } else {
                     kill(getpid(), SIGTERM);
                 }
@@ -10969,7 +10969,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                     defrag->cmd = GF_DEFRAG_CMD_DETACH_START;
                 else if (cmd == GF_DEFRAG_CMD_STOP ||
                          cmd == GF_DEFRAG_CMD_DETACH_STOP)
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output, _gf_false);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output);
             }
         unlock:
             UNLOCK(&defrag->lock);

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -10884,7 +10884,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_CHILD_DOWN,
                        "Received CHILD_DOWN. Exiting");
                 if (conf->defrag) {
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_FAILED, NULL, true);
                 } else {
                     kill(getpid(), SIGTERM);
                 }
@@ -10964,12 +10964,12 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                     goto unlock;
                 if ((cmd == GF_DEFRAG_CMD_STATUS) ||
                     (cmd == GF_DEFRAG_CMD_DETACH_STATUS))
-                    gf_defrag_status_get(conf, output);
+                    gf_defrag_status_get(conf, output, false);
                 else if (cmd == GF_DEFRAG_CMD_DETACH_START)
                     defrag->cmd = GF_DEFRAG_CMD_DETACH_START;
                 else if (cmd == GF_DEFRAG_CMD_STOP ||
                          cmd == GF_DEFRAG_CMD_DETACH_STOP)
-                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output);
+                    gf_defrag_stop(conf, GF_DEFRAG_STATUS_STOPPED, output, false);
             }
         unlock:
             UNLOCK(&defrag->lock);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -1134,10 +1134,10 @@ dht_common_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata);
 int
-gf_defrag_status_get(dht_conf_t *conf, dict_t *dict);
+gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status);
 
 int
-gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output);
+gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output, gf_boolean_t log_status);
 
 void *
 gf_defrag_start(void *this);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -1137,7 +1137,7 @@ int
 gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status);
 
 int
-gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output, gf_boolean_t log_status);
+gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output);
 
 void *
 gf_defrag_start(void *this);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4697,8 +4697,7 @@ out:
 }
 
 int
-gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output,
-               gf_boolean_t log_status)
+gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output)
 {
     /* TODO: set a variable 'stop_defrag' here, it should be checked
        in defrag loop */
@@ -4716,7 +4715,7 @@ gf_defrag_stop(dht_conf_t *conf, gf_defrag_status_t status, dict_t *output,
     defrag->defrag_status = status;
 
     if (output)
-        gf_defrag_status_get(conf, output, log_status);
+        gf_defrag_status_get(conf, output, _gf_false);
     ret = 0;
 out:
     gf_msg_debug("", 0, "Returning %d", ret);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4451,7 +4451,7 @@ out:
     status = dict_new();
     LOCK(&defrag->lock);
     {
-        gf_defrag_status_get(conf, status, true);
+        gf_defrag_status_get(conf, status, _gf_true);
         if (ctx && ctx->notify)
             ctx->notify(GF_EN_DEFRAG_STATUS, status);
         if (status)


### PR DESCRIPTION
Upon issuing rebalance stop command, the status of rebalance is being
logged twice to the log file, which can sometime result in an
inconsistent reports (one report states status stopped, while the other
may report something else).

This fix ensures rebalance reports it's status only once and that the
correct status is being reported.

fixes: #1782
Change-Id: Id3206edfad33b3db60e9df8e95a519928dc7cb37
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>