### PR TITLE
posix: avoiding redundant access of dictionary

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -619,11 +619,12 @@ dict_del(dict_t *this, char *key)
     return dict_deln(this, key, strlen(key));
 }
 
-void
+gf_boolean_t
 dict_deln(dict_t *this, char *key, const int keylen)
 {
     int hashval = 0;
     uint32_t hash;
+    gf_boolean_t rc = _gf_false;
 
     if (!this || !key) {
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
@@ -670,6 +671,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
                 mem_put(pair);
             }
             this->count--;
+            rc = _gf_true;
             break;
         }
 
@@ -679,7 +681,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
 
     UNLOCK(&this->lock);
 
-    return;
+    return rc;
 }
 
 void

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -607,13 +607,13 @@ dict_key_count(dict_t *this)
     return ret;
 }
 
-void
+gf_boolean_t
 dict_del(dict_t *this, char *key)
 {
     if (!this || !key) {
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
                          "!this || key=%s", key);
-        return;
+        return _gf_false;
     }
 
     return dict_deln(this, key, strlen(key));
@@ -629,7 +629,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
     if (!this || !key) {
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
                          "!this || key=%s", key);
-        return;
+        return rc;
     }
 
     hash = (uint32_t)XXH64(key, keylen, 0);

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -149,7 +149,7 @@ data_t *
 dict_getn(dict_t *this, char *key, const int keylen);
 void
 dict_del(dict_t *this, char *key);
-void
+gf_boolean_t
 dict_deln(dict_t *this, char *key, const int keylen);
 int
 dict_reset(dict_t *dict);

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -147,7 +147,7 @@ data_t *
 dict_get(dict_t *this, char *key);
 data_t *
 dict_getn(dict_t *this, char *key, const int keylen);
-void
+gf_boolean_t
 dict_del(dict_t *this, char *key);
 gf_boolean_t
 dict_deln(dict_t *this, char *key, const int keylen);

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -213,6 +213,13 @@ enum gf_internal_fop_indicator {
 #define GF_XATTR_XTIME_PATTERN "trusted.glusterfs.*.xtime"
 #define GF_XATTR_TRIGGER_SYNC "glusterfs.geo-rep.trigger-sync"
 
+#define GLUSTERFS_ENTRYLK_COUNT_BIT 0
+#define GLUSTERFS_INODELK_COUNT_BIT 1
+#define GLUSTERFS_INODELK_DOM_COUNT_BIT 2
+#define GLUSTERFS_POSIXLK_COUNT_BIT 3
+#define GLUSTERFS_PARENT_ENTRYLK_BIT 4
+#define GLUSTERFS_MULTIPLE_DOM_LK_CNT_REQUESTS_BIT 5
+
 /* quota xattrs */
 #define QUOTA_SIZE_KEY "trusted.glusterfs.quota.size"
 #define QUOTA_LIMIT_KEY "trusted.glusterfs.quota.limit-set"

--- a/xlators/features/locks/src/locks.h
+++ b/xlators/features/locks/src/locks.h
@@ -245,11 +245,7 @@ typedef struct {
     inode_t *inode;
     off_t offset;
     glusterfs_fop_t op;
-    gf_boolean_t entrylk_count_req;
-    gf_boolean_t inodelk_count_req;
-    gf_boolean_t posixlk_count_req;
-    gf_boolean_t parent_entrylk_req;
-    gf_boolean_t multiple_dom_lk_requests;
+    uint32_t bitfield;
     int update_mlock_enforced_flag;
 } pl_local_t;
 

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -239,6 +239,7 @@ pl_get_xdata_requests(pl_local_t *local, dict_t *xdata)
                                                   GLUSTERFS_INODELK_DOM_COUNT);
     if (local->inodelk_dom_count_req) {
         data_ref(local->inodelk_dom_count_req);
+        dict_del_sizen(xdata, GLUSTERFS_INODELK_DOM_COUNT);
     }
 }
 


### PR DESCRIPTION
This patch fixes the redundant access of dictionary
for the same information by the macro PL_LOCAL_GET_REQUESTS

fixes: #1707

Change-Id: I48047537436ce920e74bc11cecd9773d7fe4457c
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

