### PR TITLE
features/index: Optimize link-count fetching code path

### DIFF
--- a/tests/afr.rc
+++ b/tests/afr.rc
@@ -7,11 +7,27 @@ function create_brick_xattrop_entry {
         local params=`echo "$@" | cut -d' ' -f2-`
         echo $params
 
+        exit_val=0
         for file in $params
         do
                 gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $1/$file))
-                ln $xattrop_dir/$base_entry $xattrop_dir/$gfid_str
+                if [ -z "$base_entry"];
+                then
+                        touch $xattrop_dir/$gfid_str
+                else
+                        ln $xattrop_dir/$base_entry $xattrop_dir/$gfid_str
+                fi
+
+                if [ $? -ne 0 ];
+                then
+                        exit_val=1
+                fi
         done
+
+        if [ $exit_val -eq 1 ];
+        then
+                false
+        fi
 }
 
 function diff_dirs {

--- a/tests/basic/afr/bug-1493415-gfid-heal-non-granular.t
+++ b/tests/basic/afr/bug-1493415-gfid-heal-non-granular.t
@@ -56,7 +56,7 @@ TEST rm $B0/${V0}1/.glusterfs/${gfid_str_f2:0:2}/${gfid_str_f2:2:2}/$gfid_str_f2
 
 #Now simulate setting of pending entry xattr on parent dir of 1st brick.
 TEST setfattr -n trusted.afr.$V0-client-1 -v 0x000000000000000000000001 $B0/${V0}0/dir
-create_brick_xattrop_entry $B0/${V0}0 dir
+TEST create_brick_xattrop_entry $B0/${V0}0 dir
 
 # storage/posix considers that a file without gfid changed less than a second
 # before doesn't exist, so we need to wait for a second to force posix to

--- a/tests/basic/afr/bug-1722507-type-mismatch-error-handling-non-granular.t
+++ b/tests/basic/afr/bug-1722507-type-mismatch-error-handling-non-granular.t
@@ -33,10 +33,7 @@ setfattr -n trusted.afr.$V0-client-1 -v 0x000000000000000000000001 $B0/$V0"0"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir to trigger index heal.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/${V0}0 dir
 EXPECT "^1$" get_pending_heal_count $V0
 
 # Remove the gfid xattr and the link file on one brick.
@@ -79,10 +76,7 @@ setfattr -n trusted.afr.$V0-client-1 -v 0x000000000000000000000001 $B0/$V0"0"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir to trigger index heal.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/${V0}0 dir
 EXPECT "^1$" get_pending_heal_count $V0
 
 # Remove the gfid xattr and the link file on two bricks.

--- a/tests/basic/afr/bug-1749322-entry-heal-not-happening-non-granular.t
+++ b/tests/basic/afr/bug-1749322-entry-heal-not-happening-non-granular.t
@@ -64,10 +64,7 @@ setfattr -n trusted.afr.$V0-client-0 -v 0x000000000000000000000001 $B0/$V0"2"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir on first brick.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-TEST ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/$V0"0" dir
 
 EXPECT "^1$" get_pending_heal_count $V0
 

--- a/tests/basic/afr/entry-self-heal-anon-dir-off.t
+++ b/tests/basic/afr/entry-self-heal-anon-dir-off.t
@@ -316,16 +316,10 @@ $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 
-#Create base entry in indices/xattrop
-echo "Data" > $M0/FILE
-rm -f $M0/FILE
-EXPECT "1" count_index_entries $B0/${V0}0
-EXPECT "1" count_index_entries $B0/${V0}1
-
 TEST $CLI volume stop $V0;
 
 #Create entries for fool_heal and fool_me to ensure they are fully healed and dirty xattrs erased, before triggering index heal
-create_brick_xattrop_entry $B0/${V0}0 fool_heal fool_me source_creations_heal/dir1
+TEST create_brick_xattrop_entry $B0/${V0}0 fool_heal fool_me source_creations_heal/dir1
 
 $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1

--- a/tests/basic/afr/entry-self-heal.t
+++ b/tests/basic/afr/entry-self-heal.t
@@ -316,16 +316,10 @@ $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 
-#Create base entry in indices/xattrop
-echo "Data" > $M0/FILE
-rm -f $M0/FILE
-EXPECT "1" count_index_entries $B0/${V0}0
-EXPECT "1" count_index_entries $B0/${V0}1
-
 TEST $CLI volume stop $V0;
 
 #Create entries for fool_heal and fool_me to ensure they are fully healed and dirty xattrs erased, before triggering index heal
-create_brick_xattrop_entry $B0/${V0}0 fool_heal fool_me source_creations_heal/dir1
+TEST create_brick_xattrop_entry $B0/${V0}0 fool_heal fool_me source_creations_heal/dir1
 
 $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1

--- a/tests/bugs/replicate/bug-1101647.t
+++ b/tests/bugs/replicate/bug-1101647.t
@@ -11,17 +11,20 @@ TEST pidof glusterd
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{1,2};
 TEST $CLI volume start $V0;
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0
+TEST kill_brick $V0 $H0 $B0/${V0}2
+#Create base entry in indices/xattrop
+echo "Data">$M0/file
+EXPECT 3 count_index_entries  $B0/$V0"1"
+TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
-
-#Create base entry in indices/xattrop
-echo "Data">$M0/file
-
 TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+
+
 #Entries from indices/xattrop should not be cleared after a heal.
 EXPECT 1 count_index_entries  $B0/$V0"1"
-EXPECT 1 count_index_entries  $B0/$V0"2"
 
 TEST kill_brick $V0 $H0 $B0/${V0}2
 echo "More data">>$M0/file

--- a/tests/bugs/replicate/bug-1493415-gfid-heal.t
+++ b/tests/bugs/replicate/bug-1493415-gfid-heal.t
@@ -14,9 +14,6 @@ EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 0
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST $CLI volume set $V0 self-heal-daemon off
 
-# Create base entry in indices/xattrop
-echo "Data" > $M0/FILE
-
 #------------------------------------------------------------------------------#
 TEST touch $M0/f1
 gfid_f1=$(gf_get_gfid_xattr $B0/${V0}0/f1)
@@ -55,7 +52,7 @@ TEST rm $B0/${V0}1/.glusterfs/${gfid_str_f2:0:2}/${gfid_str_f2:2:2}/$gfid_str_f2
 
 #Now simulate setting of pending entry xattr on parent dir of 1st brick.
 TEST setfattr -n trusted.afr.$V0-client-1 -v 0x000000010000000000000001 $B0/${V0}0/dir
-create_brick_xattrop_entry $B0/${V0}0 dir
+TEST create_brick_xattrop_entry $B0/${V0}0 dir
 
 # storage/posix considers that a file without gfid changed less than a second
 # before doesn't exist, so we need to wait for a second to force posix to

--- a/tests/bugs/replicate/bug-1626994-info-split-brain.t
+++ b/tests/bugs/replicate/bug-1626994-info-split-brain.t
@@ -22,13 +22,6 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2
 
-# Create base entry in indices/xattrop
-echo "Data" > $M0/FILE
-rm -f $M0/FILE
-EXPECT "1" count_index_entries $B0/${V0}0
-EXPECT "1" count_index_entries $B0/${V0}1
-EXPECT "1" count_index_entries $B0/${V0}2
-
 TEST mkdir $M0/dirty_dir
 TEST mkdir $M0/pending_dir
 
@@ -37,7 +30,7 @@ TEST mkdir $M0/pending_dir
 TEST setfattr -n trusted.afr.dirty -v 0x000000000000000000000001 $B0/${V0}0/dirty_dir
 TEST setfattr -n trusted.afr.dirty -v 0x000000000000000000000001 $B0/${V0}1/dirty_dir
 TEST setfattr -n trusted.afr.dirty -v 0x000000000000000000000001 $B0/${V0}2/dirty_dir
-create_brick_xattrop_entry $B0/${V0}0  dirty_dir
+TEST create_brick_xattrop_entry $B0/${V0}0  dirty_dir
 # Should not show up as split-brain.
 EXPECT "0" afr_get_split_brain_count $V0
 
@@ -46,7 +39,7 @@ EXPECT "0" afr_get_split_brain_count $V0
 TEST setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/${V0}0
 TEST setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/${V0}1
 TEST setfattr -n trusted.afr.dirty -v 0x000000000000000000000001 $B0/${V0}2
-create_brick_xattrop_entry $B0/${V0}0 "/"
+TEST create_brick_xattrop_entry $B0/${V0}0 "/"
 # Should not show up as split-brain.
 EXPECT "0" afr_get_split_brain_count $V0
 
@@ -55,7 +48,7 @@ EXPECT "0" afr_get_split_brain_count $V0
 TEST setfattr -n trusted.afr.$V0-client-1 -v 0x000000000000000000000001 $B0/${V0}0/pending_dir
 TEST setfattr -n trusted.afr.$V0-client-2 -v 0x000000000000000000000001 $B0/${V0}1/pending_dir
 TEST setfattr -n trusted.afr.$V0-client-0 -v 0x000000000000000000000001 $B0/${V0}2/pending_dir
-create_brick_xattrop_entry $B0/${V0}0 pending_dir
+TEST create_brick_xattrop_entry $B0/${V0}0 pending_dir
 # Should show up as split-brain.
 EXPECT "1" afr_get_split_brain_count $V0
 

--- a/tests/bugs/replicate/bug-1722507-type-mismatch-error-handling.t
+++ b/tests/bugs/replicate/bug-1722507-type-mismatch-error-handling.t
@@ -34,10 +34,7 @@ setfattr -n trusted.afr.$V0-client-1 -v 0x000000010000000000000001 $B0/$V0"0"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000010000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir to trigger index heal.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/$V0"0" dir
 EXPECT "^1$" get_pending_heal_count $V0
 
 # Remove the gfid xattr and the link file on one brick.
@@ -82,10 +79,7 @@ setfattr -n trusted.afr.$V0-client-1 -v 0x000000010000000000000001 $B0/$V0"0"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000010000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir to trigger index heal.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/$V0"0" dir
 EXPECT "^1$" get_pending_heal_count $V0
 
 # Remove the gfid xattr and the link file on two bricks.

--- a/tests/bugs/replicate/bug-1749322-entry-heal-not-happening.t
+++ b/tests/bugs/replicate/bug-1749322-entry-heal-not-happening.t
@@ -66,10 +66,7 @@ setfattr -n trusted.afr.$V0-client-0 -v 0x000000010000000000000001 $B0/$V0"2"/di
 setfattr -n trusted.afr.$V0-client-2 -v 0x000000010000000000000001 $B0/$V0"0"/dir
 
 # Add entry to xattrop dir on first brick.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/dir/))
-TEST ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_str
+TEST create_brick_xattrop_entry $B0/$V0"0" dir
 
 EXPECT "^1$" get_pending_heal_count $V0
 

--- a/tests/bugs/replicate/bug-1756938-replica-3-sbrain-cli.t
+++ b/tests/bugs/replicate/bug-1756938-replica-3-sbrain-cli.t
@@ -79,21 +79,11 @@ TEST setfattr -n trusted.afr.$V0-client-1 -v 0x000000010000000100000000 $B0/${V0
 
 #-------------------------------------------------------------------------------
 #Add entry to xattrop dir on first brick and check for split-brain.
-xattrop_dir0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_dir0`
-
-gfid_f1=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/file1))
-TEST ln  $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_f1
 
 gfid_f2_shard1=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/.shard/$gfid_f2.1))
-TEST ln  $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_f2_shard1
 
 gfid_f3=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/${V0}0/file3))
-gfid_f3_shard1=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/.shard/$gfid_f3.1))
-TEST ln $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_f3_shard1
-
-gfid_f4_shard1=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/.shard/$gfid_f4.1))
-TEST ln  $xattrop_dir0/$base_entry_b0 $xattrop_dir0/$gfid_f4_shard1
+TEST create_brick_xattrop_entry $B0/$V0"0" file1 .shard/$gfid_f2.1 .shard/$gfid_f3.1 .shard/$gfid_f4.1
 
 #-------------------------------------------------------------------------------
 #gfid split-brain won't show up in split-brain count.

--- a/tests/bugs/replicate/mdata-heal-no-xattrs.t
+++ b/tests/bugs/replicate/mdata-heal-no-xattrs.t
@@ -2,6 +2,7 @@
 
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../afr.rc
 cleanup;
 
 TEST glusterd
@@ -23,10 +24,7 @@ TEST [ $ret -eq 0 ]
 TEST chmod +x $B0/$V0"0"/FILE
 
 # Add gfid to xattrop
-xattrop_b0=$(afr_get_index_path $B0/$V0"0")
-base_entry_b0=`ls $xattrop_b0`
-gfid_str_FILE=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $B0/$V0"0"/FILE))
-TEST ln $xattrop_b0/$base_entry_b0 $xattrop_b0/$gfid_str_FILE
+TEST create_brick_xattrop_entry $B0/$V0"0" FILE
 EXPECT_WITHIN $HEAL_TIMEOUT "^1$" get_pending_heal_count $V0
 
 TEST $CLI volume set $V0 cluster.self-heal-daemon on

--- a/tests/features/index/index-link-count-lifecycle.t
+++ b/tests/features/index/index-link-count-lifecycle.t
@@ -69,9 +69,9 @@ EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count_shd $V0 0
 TEST $CLI volume heal $V0
 EXPECT_WITHIN $HEAL_TIMEOUT "0" get_pending_heal_count $V0
 EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
-#Two heals would have completed making the count further -ve to -3
-EXPECT "^-3$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
-EXPECT "^-3$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+#pending-count is never requested on disperse so it will be stuck at -1(i.e. cache is invalidated) after heal completes
+EXPECT "^-1$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^-1$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
 cleanup;
 
 #Same tests for distribute volume

--- a/tests/features/index/index-link-count-lifecycle.t
+++ b/tests/features/index/index-link-count-lifecycle.t
@@ -1,0 +1,88 @@
+#!/bin/bash
+#Index link-count lifecycle tests
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/brick{0,1,2}
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume start $V0
+TEST $CLI volume heal $V0 disable
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#When the bricks are started link-count should be zero if no heals are needed
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+
+#When heal is needed xattrop-pending-count should reflect number of files to be healed
+TEST kill_brick $V0 $H0 $B0/brick0
+echo abc > $M0/a
+TEST ls $M0 #Perform a lookup to make sure the values are updated
+EXPECT "^2$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^2$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+
+#Once heals are completed pending count should be back to zero
+TEST $CLI volume heal $V0 enable
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "0" get_pending_heal_count $V0
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+
+cleanup;
+
+#Same tests for EC volume, EC doesn't fetch link-count, so it is not refreshed
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 disperse 3 $H0:$B0/brick{0,1,2}
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume start $V0
+TEST $CLI volume heal $V0 disable
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#When the bricks are started link-count should be zero if no heals are needed
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+
+#When heal is needed xattrop-pending-count should reflect number of files to be healed
+TEST kill_brick $V0 $H0 $B0/brick0
+echo abc > $M0/a
+TEST ls $M0 #EC doesn't request link-count, so the values will stay '-1'
+EXPECT "^-1$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^-1$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+
+#Once heals are completed pending count should be back to zero
+TEST $CLI volume heal $V0 enable
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count_shd $V0 0
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "0" get_pending_heal_count $V0
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
+#Two heals would have completed making the count further -ve to -3
+EXPECT "^-3$" get_value_from_brick_statedump $V0 $H0 $B0/brick1 "xattrop-pending-count"
+EXPECT "^-3$" get_value_from_brick_statedump $V0 $H0 $B0/brick2 "xattrop-pending-count"
+cleanup;
+
+#Same tests for distribute volume
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/brick0
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#When the brick is started link-count should be zero
+EXPECT "^0$" get_value_from_brick_statedump $V0 $H0 $B0/brick0 "xattrop-pending-count"
+
+cleanup;

--- a/tests/volume.rc
+++ b/tests/volume.rc
@@ -838,6 +838,19 @@ function check_brick_multiplex() {
         fi
 }
 
+function get_value_from_brick_statedump {
+    local vol="$1"
+    local host="$2"
+    local brick="$3"
+    local key="$4"
+
+    local statedump="$(generate_brick_statedump $vol $host $brick)"
+    value="$(grep "$key" $statedump | cut -f2 -d'=' | tail -1)"
+
+    rm -f "$statedump"
+    echo "$value"
+}
+
 function get_fd_count {
         local vol=$1
         local host=$2

--- a/xlators/features/index/src/index.h
+++ b/xlators/features/index/src/index.h
@@ -55,7 +55,7 @@ typedef struct index_priv {
     dict_t *dirty_watchlist;
     dict_t *pending_watchlist;
     dict_t *complete_watchlist;
-    int32_t pending_count;
+    int64_t pending_count;
     pthread_t thread;
     gf_boolean_t down;
     gf_atomic_t stub_cnt;

--- a/xlators/features/index/src/index.h
+++ b/xlators/features/index/src/index.h
@@ -55,7 +55,7 @@ typedef struct index_priv {
     dict_t *dirty_watchlist;
     dict_t *pending_watchlist;
     dict_t *complete_watchlist;
-    int64_t pending_count;
+    int32_t pending_count;
     pthread_t thread;
     gf_boolean_t down;
     gf_atomic_t stub_cnt;


### PR DESCRIPTION
Problem:
AFR requests 'link-count' in lookup to check if there are any pending
heals. Based on this information, afr will set dirent->inode to NULL in
readdirp when heals are ongoing to prevent serving bad data. When heals
are completed, link-count xattr is leading to doing an opendir of
xattrop directory and then reading the contents to figure out that there
is no healing needed for every lookup. This was not detected until this
github issue because ZFS in some cases can lead to very slow readdir()
calls. Since Glusterfs does lot of lookups, this was slowing down
all operations increasing load on the system.

Code problem:
index xlator on any xattrop operation adds index to the relevant dirs
and after the xattrop operation is done, will delete/keep the index in
that directory based on the value fetched in xattrop from posix. AFR
sends all-zero xattrop for changelog xattrs. This is leading to
priv->pending_count manipulation which sets the count back to -1. Next
Lookup operation triggers opendir/readdir to find the actual link-count in
lookup because in memory priv->pending_count is -ve.

Fix:
1) Don't add to index on all-zero xattrop for a key.
2) Set pending-count to -1 when the first gfid is added into xattrop
   directory, so that the next lookup can compute the link-count.

fixes: #1764
Change-Id: I8a02c7e811a72c46d78ddb2d9d4fdc2222a444e9
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

