### PR TITLE
posix: fix io_uring crash in reconfigure

### DIFF
--- a/tests/bugs/posix/posix-reconfigure-uring-crash.t
+++ b/tests/bugs/posix/posix-reconfigure-uring-crash.t
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0..2};
+TEST $CLI volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status';
+TEST $CLI volume add-brick $V0 replica 3 $H0:$B0/${V0}{3..5}
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}2
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}3
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}4
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}5
+cleanup;

--- a/xlators/storage/posix/src/posix-io-uring.c
+++ b/xlators/storage/posix/src/posix-io-uring.c
@@ -606,10 +606,13 @@ posix_io_uring_on(xlator_t *this)
 int
 posix_io_uring_off(xlator_t *this)
 {
+    struct posix_private *priv = this->private;
+
     this->fops->readv = posix_readv;
     this->fops->writev = posix_writev;
     this->fops->fsync = posix_fsync;
-    posix_io_uring_fini(this);
+    if (priv->io_uring_capable)
+        posix_io_uring_fini(this);
 
     return 0;
 }


### PR DESCRIPTION
Call posix_io_uring_fini only if it was inited to begin with.

Fixes: #1794
Reported-by: Mohit Agrawal <moagrawa@redhat.com>
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

Change-Id: I0e840b6b1d1f26b104b30c8c4b88c14ce4aaac0d

