### PR TITLE
ganesha-ha: revised regex exprs for --status

### DIFF
--- a/extras/ganesha/scripts/ganesha-ha.sh
+++ b/extras/ganesha/scripts/ganesha-ha.sh
@@ -947,18 +947,18 @@ status()
     # check if the VIP and port block/unblock RAs are on the expected nodes
     for n in ${nodes[*]}; do
 
-        grep -E -x "${n}-nfs_block \(ocf::heartbeat:portblock\): Started ${n}" > /dev/null 2>&1 ${scratch}
+        grep -E -x "${n}-nfs_block +\(ocf::heartbeat:portblock\): +Started ${n}" > /dev/null 2>&1 ${scratch}
         result=$?
         ((healthy+=${result}))
-        grep -E -x "${n}-cluster_ip-1 \(ocf::heartbeat:IPaddr\): Started ${n}" > /dev/null 2>&1 ${scratch}
+        grep -E -x "${n}-cluster_ip-1 +\(ocf::heartbeat:IPaddr\): +Started ${n}" > /dev/null 2>&1 ${scratch}
         result=$?
         ((healthy+=${result}))
-        grep -E -x "${n}-nfs_unblock \(ocf::heartbeat:portblock\): Started ${n}" > /dev/null 2>&1 ${scratch}
+        grep -E -x "${n}-nfs_unblock +\(ocf::heartbeat:portblock\): +Started ${n}" > /dev/null 2>&1 ${scratch}
         result=$?
         ((healthy+=${result}))
     done
 
-    grep -E "\):\ Stopped|FAILED" > /dev/null 2>&1 ${scratch}
+    grep -E "\): +Stopped|FAILED" > /dev/null 2>&1 ${scratch}
     result=$?
 
     if [ ${result} -eq 0 ]; then


### PR DESCRIPTION
better whitespace in regex

This has worked for years, but somehow no longer works on rhel8

Updates: #1000
Change-Id: I2c1a3537573d125608334772ba1a263c55407dd4
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

