### PR TITLE
glusterd: fix a bug in enabling nfs ganesha

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -1177,7 +1177,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
             }
         } else if (len_strcmp(key, keylen, "ganesha.enable")) {
             key_matched = _gf_true;
-            if (!strcmp(value, "off") == 0) {
+            if (strcmp(value, "off") == 0) {
                 ret = ganesha_manage_export(dict, "off", _gf_true, op_errstr);
                 if (ret)
                     goto out;


### PR DESCRIPTION
As detailed in the github issue,`gluster volume set Svolname ganesha.enable on`
is currently broken due to a minor typo in the commit e081ac683b6a5bda548913,

Fixing it now.

Updates:1778
Change-Id: I99276fedc43f40e8a439e545bd2b8d1698aa03ee
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

