### PR TITLE
afr: return -EIO for gfid split-brains.

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -245,7 +245,8 @@ int
 afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
                             inode_t *inode, uuid_t pargfid, const char *bname,
                             int src_idx, int child_idx,
-                            unsigned char *locked_on, int *src, dict_t *xdata)
+                            unsigned char *locked_on, int *src, dict_t *req,
+                            dict_t *rsp)
 {
     afr_private_t *priv = NULL;
     char g1[64] = {
@@ -266,8 +267,8 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                "All the bricks should be up to resolve the gfid split "
                "barin");
-        if (xdata) {
-            ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
+        if (rsp) {
+            ret = dict_set_sizen_str_sizen(rsp, "gfid-heal-msg",
                                            SALL_BRICKS_UP_TO_RESOLVE);
             if (ret)
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_DICT_SET_FAILED,
@@ -277,8 +278,8 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
         goto out;
     }
 
-    if (xdata) {
-        ret = dict_get_int32_sizen(xdata, "heal-op", &heal_op);
+    if (req) {
+        ret = dict_get_int32_sizen(req, "heal-op", &heal_op);
         if (ret)
             goto fav_child;
     } else {
@@ -292,8 +293,8 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
             if (*src == -1) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SNO_BIGGER_FILE);
-                if (xdata) {
-                    ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
+                if (rsp) {
+                    ret = dict_set_sizen_str_sizen(rsp, "gfid-heal-msg",
                                                    SNO_BIGGER_FILE);
                     if (ret)
                         gf_msg(this->name, GF_LOG_ERROR, 0,
@@ -310,8 +311,8 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
             if (*src == -1) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SNO_DIFF_IN_MTIME);
-                if (xdata) {
-                    ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
+                if (rsp) {
+                    ret = dict_set_sizen_str_sizen(rsp, "gfid-heal-msg",
                                                    SNO_DIFF_IN_MTIME);
                     if (ret)
                         gf_msg(this->name, GF_LOG_ERROR, 0,
@@ -323,7 +324,7 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
             break;
 
         case GF_SHD_OP_SBRAIN_HEAL_FROM_BRICK:
-            ret = dict_get_str_sizen(xdata, "child-name", &src_brick);
+            ret = dict_get_str_sizen(req, "child-name", &src_brick);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        "Error getting the source "
@@ -335,8 +336,8 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
             if (*src == -1) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SERROR_GETTING_SRC_BRICK);
-                if (xdata) {
-                    ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
+                if (rsp) {
+                    ret = dict_set_sizen_str_sizen(rsp, "gfid-heal-msg",
                                                    SERROR_GETTING_SRC_BRICK);
                     if (ret)
                         gf_msg(this->name, GF_LOG_ERROR, 0,
@@ -400,7 +401,7 @@ out:
                  uuid_utoa_r(replies[child_idx].poststat.ia_gfid, g1), src_idx,
                  priv->children[src_idx]->name, src_idx,
                  uuid_utoa_r(replies[src_idx].poststat.ia_gfid, g2));
-        return -1;
+        return -EIO;
     }
     return 0;
 }

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -399,7 +399,7 @@ afr_selfheal_detect_gfid_and_type_mismatch(xlator_t *this,
             (ia_type == replies[i].poststat.ia_type)) {
             ret = afr_gfid_split_brain_source(this, replies, inode, pargfid,
                                               bname, src_idx, i, locked_on, src,
-                                              NULL);
+                                              NULL, NULL);
             if (ret)
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        "Skipping conservative merge on the "
@@ -474,7 +474,7 @@ __afr_selfheal_merge_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
         return ret;
 
     /* In case of type mismatch / unable to resolve gfid mismatch on the
-     * entry, return -1.*/
+     * entry, return -EIO.*/
     ret = afr_selfheal_detect_gfid_and_type_mismatch(
         this, replies, inode, fd->inode->gfid, name, source, locked_on, &src);
 
@@ -905,7 +905,7 @@ afr_selfheal_entry_do_subvol(call_frame_t *frame, xlator_t *this, fd_t *fd,
                 break;
             }
 
-            if (ret == -1) {
+            if (ret == -EIO) {
                 /* gfid or type mismatch. */
                 mismatch = _gf_true;
                 ret = 0;
@@ -1072,7 +1072,7 @@ afr_selfheal_entry_do(call_frame_t *frame, xlator_t *this, fd_t *fd, int source,
         else
             ret = afr_selfheal_entry_do_subvol(frame, this, fd, i);
 
-        if (ret == -1) {
+        if (ret == -EIO) {
             /* gfid or type mismatch. */
             mismatch = _gf_true;
             ret = 0;

--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -126,7 +126,7 @@ afr_throttled_selfheal(call_frame_t *frame, xlator_t *this);
 
 int
 afr_selfheal_name(xlator_t *this, uuid_t gfid, const char *name, void *gfid_req,
-                  dict_t *xdata);
+                  dict_t *req, dict_t *rsp);
 
 int
 afr_selfheal_data(call_frame_t *frame, xlator_t *this, fd_t *fd);
@@ -356,7 +356,8 @@ int
 afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
                             inode_t *inode, uuid_t pargfid, const char *bname,
                             int src_idx, int child_idx,
-                            unsigned char *locked_on, int *src, dict_t *xdata);
+                            unsigned char *locked_on, int *src, dict_t *req,
+                            dict_t *rsp);
 int
 afr_mark_source_sinks_if_file_empty(xlator_t *this, unsigned char *sources,
                                     unsigned char *sinks,

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -295,7 +295,7 @@ afr_shd_selfheal_name(struct subvol_healer *healer, int child, uuid_t parent,
 {
     int ret = -1;
 
-    ret = afr_selfheal_name(THIS, parent, bname, NULL, NULL);
+    ret = afr_selfheal_name(THIS, parent, bname, NULL, NULL, NULL);
 
     return ret;
 }


### PR DESCRIPTION
Problem:
entry-self-heal-anon-dir-off.t was failing occasionally because
afr_gfid_split_brain_source() returned -1 instead of -EIO for
split-brains, causing the code to proceed to afr_lookup_done(), which
in turn succeeded the lookup if there was a parallel client side heal
going on.

Fix:
Return -EIO instead of -1

Fixes: #1739
Credits Pranith Karampuri <pranith.karampuri@phonepe.com>
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

Change-Id: I5cb4c547fb25e6bfc8bec1740f7eb64e1a5ad443

