### PR TITLE
posix: Use MALLOC instead of alloca to allocate memory for xattrs lis…

### DIFF
--- a/xlators/storage/posix/src/posix-gfid-path.c
+++ b/xlators/storage/posix/src/posix-gfid-path.c
@@ -196,7 +196,8 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
             if (size == 0)
                 goto done;
         }
-        list = alloca(size);
+
+        list = GF_MALLOC(size, gf_posix_mt_char);
         if (!list) {
             *op_errno = errno;
             goto err;
@@ -310,6 +311,7 @@ done:
             GF_FREE(paths[j]);
     }
     ret = 0;
+    GF_FREE(list);
     return ret;
 err:
     if (path)
@@ -318,5 +320,6 @@ err:
         if (paths[j])
             GF_FREE(paths[j]);
     }
+    GF_FREE(list);
     return ret;
 }

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -341,7 +341,7 @@ _posix_get_marker_all_contributions(posix_xattr_filler_t *filler)
         goto out;
     }
 
-    list = alloca(size);
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         goto out;
     }
@@ -371,6 +371,7 @@ _posix_get_marker_all_contributions(posix_xattr_filler_t *filler)
     ret = 0;
 
 out:
+    GF_FREE(list);
     return ret;
 }
 

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -3215,7 +3215,7 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
         goto out;
     }
 
-    list = alloca(size);
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         *op_errno = errno;
         goto out;
@@ -3295,6 +3295,7 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
     op_ret = 0;
 
 out:
+    GF_FREE(list);
     return op_ret;
 }
 
@@ -3724,7 +3725,8 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         if (size == 0)
             goto done;
     }
-    list = alloca(size);
+
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         op_errno = errno;
         goto out;
@@ -3851,6 +3853,7 @@ out:
         dict_unref(dict);
     }
 
+    GF_FREE(list);
     return 0;
 }
 
@@ -4050,7 +4053,8 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         if (size == 0)
             goto done;
     }
-    list = alloca(size + 1);
+
+    list = GF_MALLOC(size, gf_posix_mt_char);
     if (!list) {
         op_ret = -1;
         op_errno = ENOMEM;
@@ -4153,6 +4157,8 @@ out:
 
     if (dict)
         dict_unref(dict);
+
+    GF_FREE(list);
 
     return 0;
 }


### PR DESCRIPTION
…t (#1730)

In case of file is having huge xattrs on backend a brick process is
crashed while alloca(size) limit has been crossed 256k because iot_worker
stack size is 256k.

Fixes: #1699
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: I100468234f83329a7d65b43cbe4e10450c1ccecd

