### PR TITLE
afr: call afr_is_lock_mode_mandatory only while xdata is valid (#1797)

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -5279,17 +5279,17 @@ afr_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     local->cont.lk.cmd = cmd;
     local->cont.lk.user_flock = *flock;
     local->cont.lk.ret_flock = *flock;
-    if (xdata)
+    if (xdata) {
         local->xdata_req = dict_ref(xdata);
-
-    if (afr_is_lock_mode_mandatory(xdata)) {
-        ret = synctask_new(this->ctx->env, afr_lk_transaction,
-                           afr_lk_transaction_cbk, frame, frame);
-        if (ret) {
-            op_errno = ENOMEM;
-            goto out;
+        if (afr_is_lock_mode_mandatory(xdata)) {
+            ret = synctask_new(this->ctx->env, afr_lk_transaction,
+                               afr_lk_transaction_cbk, frame, frame);
+            if (ret) {
+                op_errno = ENOMEM;
+                goto out;
+            }
+            return 0;
         }
-        return 0;
     }
 
     STACK_WIND_COOKIE(frame, afr_lk_cbk, (void *)(long)0, priv->children[i],


### PR DESCRIPTION
afr_is_lock_mode_mandatory throws a warning message while xdata
is not valid, to avoid a message call a function only while xdata
is valid.

Fixes: #1796
Change-Id: I32d37960ea4e936ba87e65811c1792a2f1158c0d
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

