### PR TITLE
io-stats: Change latency to nanoseconds from microseconds

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -444,7 +444,8 @@ BIT_VALUE(unsigned char *array, unsigned int index)
         }                                                                      \
     } while (0)
 
-void gf_assert(void);
+void
+gf_assert(void);
 
 #ifdef DEBUG
 #define GF_ASSERT(x) assert(x);
@@ -1245,18 +1246,11 @@ gf_tvdiff(struct timeval *start, struct timeval *end)
 
 /* Return delta value in nanoseconds. */
 
-static inline double
+static inline int64_t
 gf_tsdiff(struct timespec *start, struct timespec *end)
 {
-    struct timespec t;
-
-    if (start->tv_nsec > end->tv_nsec)
-        t.tv_sec = end->tv_sec - 1, t.tv_nsec = end->tv_nsec + 1000000000;
-    else
-        t.tv_sec = end->tv_sec, t.tv_nsec = end->tv_nsec;
-
-    return (double)(t.tv_sec - start->tv_sec) * 1e9 +
-           (double)(t.tv_nsec - start->tv_nsec);
+    return (int64_t)(end->tv_sec - start->tv_sec) * GF_SEC_IN_NS +
+           (int64_t)(end->tv_nsec - start->tv_nsec);
 }
 
 #endif /* _COMMON_UTILS_H */

--- a/libglusterfs/src/latency.c
+++ b/libglusterfs/src/latency.c
@@ -41,7 +41,7 @@ gf_latency_update(gf_latency_t *lat, struct timespec *begin,
         return;
     }
 
-    double elapsed = gf_tsdiff(begin, end);
+    int64_t elapsed = gf_tsdiff(begin, end);
 
     if (lat->max < elapsed)
         lat->max = elapsed;

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1693,7 +1693,7 @@ is_fresh_file(struct timespec *ts)
     int64_t elapsed;
 
     timespec_now_realtime(&now);
-    elapsed = (int64_t)gf_tsdiff(ts, &now);
+    elapsed = gf_tsdiff(ts, &now);
 
     if (elapsed < 0) {
         /* The file has been modified in the future !!!
@@ -1703,7 +1703,7 @@ is_fresh_file(struct timespec *ts)
     }
 
     /* If the file is newer than a second, we consider it fresh. */
-    return elapsed < 1000000;
+    return elapsed < 1000000000;
 }
 
 int


### PR DESCRIPTION
Changes:

- In 'BUMP_THROUGHPUT' macro changed 'elapsed' from microseconds to nanoseconds.
- In 'update_ios_latency' function 'elapsed' is now in nanoseconds.
- In 'collect_ios_latency_sample' function removed conversion from nano to micro,
  instead directly assigned as 'nano' to 'tv_nsec' of 'timespec' macro
- in 'ios_sample_t' macro changed 'timeval' to 'timespec' to support above change.
- In '_io_stats_write_latency_sample' function changed formula to from 1e+6 to 1e+9
  since 'ios_sample_t' macro now has 'timespec'
- In 'BUMP_THROUGHPUT','_ios_sample_t','collect_ios_latency_sample' & update_ios_latency'
  changed 'elapsed' datatype from 'double' to 'int64_t'
- In glusterfs/libglusterfs/src/glusterfs/common-utils.h changed return type of
  'gf_tsdiff' function from 'double' to 'int64_t' since it can return negative values.
- In glusterfs/libglusterfs/src/latency.c, libglusterfs/src/glusterfs/common-utils.h,
  xlators/debug/io-stats/src/io-stats.c & xlators/storage/posix/src/posix-helpers.c
  'elapsed' is now of type 'int64_t'

Fixes: #1825 