### PR TITLE
glusterd: resource leaks

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1615,6 +1615,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
         0,
     };
     struct rpc_req *rpcreq = NULL;
+    struct rpc_req rpcreq_static;
     rpc_transport_req_t req;
     int ret = -1;
     int proglen = 0;
@@ -1754,9 +1755,15 @@ out:
     }
 
     if (frame && (ret == -1)) {
-        if (rpcreq) {
-            rpcreq->rpc_status = -1;
-            cbkfn(rpcreq, NULL, 0, frame);
+        if (!rpcreq) {
+            memset(&rpcreq_static, 0,
+                   sizeof(rpcreq_static)); /* To handle frame destroy in case
+                                              rpcreq was not defined */
+            rpcreq = &rpcreq_static;
+        }
+        rpcreq->rpc_status = -1;
+        cbkfn(rpcreq, NULL, 0, frame);
+        if (rpcreq != &rpcreq_static) {
             mem_put(rpcreq);
         }
     }

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1641,6 +1641,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     if (!iobref) {
         iobref = iobref_new();
         if (!iobref) {
+            ret = -1;
             goto out;
         }
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -728,7 +728,6 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     gd1_mgmt_brick_op_req brick_req;
     dict_t *dict = NULL;
     void *req = &brick_req;
-    void *errlbl = &&err;
     struct rpc_clnt_connection *conn;
     xlator_t *this = THIS;
     glusterd_conf_t *conf = THIS->private;
@@ -757,14 +756,14 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
 
     frame = create_frame(this, this->ctx->pool);
     if (!frame) {
-        goto *errlbl;
+        goto err;
     }
 
     if (op == GLUSTERD_SVC_ATTACH) {
         dict = dict_new();
         if (!dict) {
             ret = -ENOMEM;
-            goto *errlbl;
+            goto err;
         }
 
         (void)build_volfile_path(volfile_id, path, sizeof(path), NULL, dict);
@@ -774,21 +773,21 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SVC_ATTACH_FAIL,
                    "Unable to stat %s (%s)", path, strerror(errno));
             ret = -EINVAL;
-            goto *errlbl;
+            goto err;
         }
 
         file_len = stbuf.st_size;
         volfile_content = GF_MALLOC(file_len + 1, gf_common_mt_char);
         if (!volfile_content) {
             ret = -ENOMEM;
-            goto *errlbl;
+            goto err;
         }
         spec_fd = open(path, O_RDONLY);
         if (spec_fd < 0) {
             gf_msg(THIS->name, GF_LOG_WARNING, 0, GD_MSG_SVC_ATTACH_FAIL,
                    "failed to read volfile %s", path);
             ret = -EIO;
-            goto *errlbl;
+            goto err;
         }
         ret = sys_read(spec_fd, volfile_content, file_len);
         if (ret == file_len) {
@@ -800,7 +799,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
                    "read size=%d",
                    path, file_len, ret);
             ret = -EIO;
-            goto *errlbl;
+            goto err;
         }
         if (dict->count > 0) {
             ret = dict_allocate_and_serialize(dict, &brick_req.dict.dict_val,
@@ -810,7 +809,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
                        GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                        "Failed to serialize dict "
                        "to request buffer");
-                goto *errlbl;
+                goto err;
             }
             dict->extra_free = brick_req.dict.dict_val;
         }
@@ -824,33 +823,23 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     req_size = xdr_sizeof((xdrproc_t)xdr_gd1_mgmt_brick_op_req, req);
     iobuf = iobuf_get2(rpc->ctx->iobuf_pool, req_size);
     if (!iobuf) {
-        goto *errlbl;
+        goto err;
     }
-    errlbl = &&maybe_free_iobuf;
 
     iov.iov_base = iobuf->ptr;
     iov.iov_len = iobuf_pagesize(iobuf);
 
     iobref = iobref_new();
     if (!iobref) {
-        goto *errlbl;
+        goto err;
     }
-    errlbl = &&free_iobref;
 
     iobref_add(iobref, iobuf);
-    /*
-     * Drop our reference to the iobuf.  The iobref should already have
-     * one after iobref_add, so when we unref that we'll free the iobuf as
-     * well.  This allows us to pass just the iobref as frame->local.
-     */
-    iobuf_unref(iobuf);
-    /* Set the pointer to null so we don't free it on a later error. */
-    iobuf = NULL;
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, req, (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
     if (ret == -1) {
-        goto *errlbl;
+        goto err;
     }
     iov.iov_len = ret;
 
@@ -858,29 +847,26 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     GF_ATOMIC_INC(conf->blockers);
     ret = rpc_clnt_submit(rpc, &gd_brick_prog, op, cbkfn, &iov, 1, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
-    if (dict)
-        dict_unref(dict);
-    GF_FREE(volfile_content);
-    if (spec_fd >= 0)
-        sys_close(spec_fd);
-    return ret;
-
-free_iobref:
-    iobref_unref(iobref);
-maybe_free_iobuf:
+    frame = NULL;
+err:
     if (iobuf) {
         iobuf_unref(iobuf);
     }
-err:
+    if (iobref) {
+        iobref_unref(iobref);
+    }
     if (dict)
         dict_unref(dict);
+
+    if (ret && brick_req.dict.dict_val)
+        GF_FREE(brick_req.dict.dict_val);
 
     GF_FREE(volfile_content);
     if (spec_fd >= 0)
         sys_close(spec_fd);
-    if (frame)
+    if (frame && ret)
         STACK_DESTROY(frame->root);
-    return -1;
+    return ret;
 }
 
 int


### PR DESCRIPTION
Issue:
iobref was not freed before exiting the function
if all the checks were OK, which caused the resource
leak.

Fix:
Modified the code a bit to avoid use of an extra reference
to the label, and to free the iobref and iobuf if not NULL,
and then exit the function.

CID: 1430118

Updates: #1060
This PR is the backport for PR #1748 in the devel branch.

Signed-off-by: nik-redhat <nladha@redhat.com>

