### PR TITLE
glusterd: resource leaks

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1645,6 +1645,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     if (!iobref) {
         iobref = iobref_new();
         if (!iobref) {
+            ret = -1;
             goto out;
         }
 

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1619,6 +1619,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
         0,
     };
     struct rpc_req *rpcreq = NULL;
+    struct rpc_req rpcreq_static;
     rpc_transport_req_t req;
     int ret = -1;
     int proglen = 0;
@@ -1758,9 +1759,15 @@ out:
     }
 
     if (frame && (ret == -1)) {
-        if (rpcreq) {
-            rpcreq->rpc_status = -1;
-            cbkfn(rpcreq, NULL, 0, frame);
+        if (!rpcreq) {
+            memset(&rpcreq_static, 0,
+                   sizeof(rpcreq_static)); /* To handle frame destroy in case
+                                              rpcreq was not defined */
+            rpcreq = &rpcreq_static;
+        }
+        rpcreq->rpc_status = -1;
+        cbkfn(rpcreq, NULL, 0, frame);
+        if (rpcreq != &rpcreq_static) {
             mem_put(rpcreq);
         }
     }


### PR DESCRIPTION
Issue:
iobref was not freed before exiting the function
if all the checks were OK, which caused the resource
leak.

Fix:
Modified the code a bit to avoid use of an extra reference
to the label, and to free the iobref and iobuf if not NULL,
and then exit the function.

CID: 1430118

Updates: #1060
This PR is the backport for PR #1748 in the devel branch.

Signed-off-by: nik-redhat <nladha@redhat.com>

