### PR TITLE
CLI: Added an error message in case of timeout

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -3867,7 +3867,10 @@ gf_cli_get_next_volume(call_frame_t *frame, xlator_t *this, void *data)
         if ((global_state->mode & GLUSTER_MODE_XML))
             goto end_xml;
 
-        cli_err("No volumes present");
+        if (ret)
+            cli_err("Failed to get volume info");
+        else
+            cli_err("No volumes present");
         goto out;
     }
 


### PR DESCRIPTION
Added an error message in CLI when there are volumes present in the cluster
but timeout happens while fetching them.

This PR fixes #1738
Backport of #1738

This PR is the backport for PR #1744 in the devel branch.

Signed-off-by: nik-redhat <nladha@redhat.com>

