### PR TITLE
change 'master' xlator to 'primary' xlator

### DIFF
--- a/doc/developer-guide/brickmux-thread-reduction.md
+++ b/doc/developer-guide/brickmux-thread-reduction.md
@@ -31,7 +31,7 @@ each brick does not make sense. But io-thread translator is loaded in
 the graph, and the position of io-thread translator decides from when
 the fops will be parallelised across threads. We cannot entirely move
 the io-threads to libglusterfs and say the multiplexing happens from
-the master translator or so. Hence, the io-thread orchestrator code
+the primary translator or so. Hence, the io-thread orchestrator code
 is moved to libglusterfs, which ensures there is only one set of
 io-threads that is shared among the io-threads translator in each brick.
 This poses performance issues due to lock-contention in the io-threds

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -550,7 +550,7 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
-    xlator_t *master = NULL;
+    xlator_t *primary = NULL;
 
     cmd_args = &ctx->cmd_args;
     if (!cmd_args->mount_point) {
@@ -564,31 +564,31 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
         return -1;
     }
 
-    master = GF_CALLOC(1, sizeof(*master), gfd_mt_xlator_t);
-    if (!master)
+    primary = GF_CALLOC(1, sizeof(*primary), gfd_mt_xlator_t);
+    if (!primary)
         goto err;
 
-    master->name = gf_strdup("fuse");
-    if (!master->name)
+    primary->name = gf_strdup("fuse");
+    if (!primary->name)
         goto err;
 
-    if (xlator_set_type(master, "mount/fuse") == -1) {
+    if (xlator_set_type(primary, "mount/fuse") == -1) {
         gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_8,
                 "MOUNT-POINT=%s", cmd_args->mount_point, NULL);
         goto err;
     }
 
-    master->ctx = ctx;
-    master->options = dict_new();
-    if (!master->options)
+    primary->ctx = ctx;
+    primary->options = dict_new();
+    if (!primary->options)
         goto err;
 
-    ret = set_fuse_mount_options(ctx, master->options);
+    ret = set_fuse_mount_options(ctx, primary->options);
     if (ret)
         goto err;
 
     if (cmd_args->fuse_mountopts) {
-        ret = dict_set_static_ptr(master->options, ZR_FUSE_MOUNTOPTS,
+        ret = dict_set_static_ptr(primary->options, ZR_FUSE_MOUNTOPTS,
                                   cmd_args->fuse_mountopts);
         if (ret < 0) {
             gf_smsg("glusterfsd", GF_LOG_ERROR, 0, glusterfsd_msg_3,
@@ -597,19 +597,19 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
         }
     }
 
-    ret = xlator_init(master);
+    ret = xlator_init(primary);
     if (ret) {
         gf_msg_debug("glusterfsd", 0, "failed to initialize fuse translator");
         goto err;
     }
 
-    ctx->primary = master;
+    ctx->primary = primary;
 
     return 0;
 
 err:
-    if (master) {
-        xlator_destroy(master);
+    if (primary) {
+        xlator_destroy(primary);
     }
 
     return 1;

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -791,7 +791,7 @@ glusterfs_graph_activate(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
     list_add(&graph->list, &ctx->graphs);
     ctx->active = graph;
 
-    /* XXX: attach to master and set active pointer */
+    /* XXX: attach to primary and set active pointer */
     if (ctx->primary) {
         ret = xlator_notify(ctx->primary, GF_EVENT_GRAPH_NEW, graph);
         if (ret) {
@@ -1154,11 +1154,11 @@ glusterfs_graph_destroy_residual(glusterfs_graph_t *graph)
 /* This function destroys all the xlator members except for the
  * xlator strcuture and its mem accounting field.
  *
- * If otherwise, it would destroy the master xlator object as well
+ * If otherwise, it would destroy the primary xlator object as well
  * its mem accounting, which would mean after calling glusterfs_graph_destroy()
- * there cannot be any reference to GF_FREE() from the master xlator, this is
+ * there cannot be any reference to GF_FREE() from the primary xlator, this is
  * not possible because of the following dependencies:
- * - glusterfs_ctx_t will have mem pools allocated by the master xlators
+ * - glusterfs_ctx_t will have mem pools allocated by the primary xlators
  * - xlator objects will have references to those mem pools(g: dict)
  *
  * Ordering the freeing in any of the order will also not solve the dependency:

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1197,7 +1197,7 @@ inode_invalidate(inode_t *inode)
     }
 
     /*
-     * The master xlator is not in the graph but it can define an invalidate
+     * The primary xlator is not in the graph but it can define an invalidate
      * handler.
      */
     xl = inode->table->xl->ctx->primary;

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -847,11 +847,11 @@ xlator_members_free(xlator_t *xl)
 /* This function destroys all the xlator members except for the
  * xlator strcuture and its mem accounting field.
  *
- * If otherwise, it would destroy the master xlator object as well
+ * If otherwise, it would destroy the primary xlator object as well
  * its mem accounting, which would mean after calling glusterfs_graph_destroy()
- * there cannot be any reference to GF_FREE() from the master xlator, this is
+ * there cannot be any reference to GF_FREE() from the primary xlator, this is
  * not possible because of the following dependencies:
- * - glusterfs_ctx_t will have mem pools allocated by the master xlators
+ * - glusterfs_ctx_t will have mem pools allocated by the primary xlators
  * - xlator objects will have references to those mem pools(g: dict)
  *
  * Ordering the freeing in any of the order will also not solve the dependency:


### PR DESCRIPTION
These were the only offensive language occurences in the code (.c) after
making the changes for geo-rep (whichis tracked in issue 1415).

Change-Id: I21cd558fdcf8098e988617991bd3673ef86e120d
Updates: #1000
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

