### PR TITLE
glusterd: Can't run rebalance due to long unix socket

### DIFF
--- a/tests/bugs/glusterd/bug-1720556.t
+++ b/tests/bugs/glusterd/bug-1720556.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+
+
+cleanup;
+V0="TestLongVolnamec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9abcd"
+V1="TestLongVolname3102bd28a16c49440bd5210e4ec4d5d93102bd28a16c49440bd5210e4ec4d5d933102bd28a16c49440bd5210e4ebbcd"
+TEST launch_cluster 2;
+TEST $CLI_1 peer probe $H2;
+
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+$CLI_1 volume create $V0 $H1:$B1/$V0  $H2:$B2/$V0
+EXPECT 'Created' cluster_volinfo_field 1 $V0 'Status';
+$CLI_1 volume create $V1 $H1:$B1/$V1  $H2:$B2/$V1
+EXPECT 'Created' cluster_volinfo_field 1 $V1 'Status';
+
+$CLI_1 volume start $V0
+EXPECT 'Started' cluster_volinfo_field 1 $V0 'Status';
+
+$CLI_1 volume start $V1
+EXPECT 'Started' cluster_volinfo_field 1 $V1 'Status';
+
+#Mount FUSE
+TEST glusterfs -s $H1 --volfile-id=$V0 $M0;
+
+
+#Mount FUSE
+TEST glusterfs -s $H1 --volfile-id=$V1 $M1;
+
+TEST mkdir $M0/dir{1..4};
+TEST touch $M0/dir{1..4}/files{1..4};
+
+TEST mkdir $M1/dir{1..4};
+TEST touch $M1/dir{1..4}/files{1..4};
+
+TEST $CLI_1 volume add-brick $V0 $H1:$B1/${V0}_1 $H2:$B2/${V0}_1
+TEST $CLI_1 volume add-brick $V1 $H1:$B1/${V1}_1 $H2:$B2/${V1}_1
+
+
+TEST $CLI_1 volume rebalance $V0 start
+TEST $CLI_1 volume rebalance $V1  start
+
+EXPECT_WITHIN $REBALANCE_TIMEOUT "completed" cluster_rebalance_status_field 1 $V0
+EXPECT_WITHIN $REBALANCE_TIMEOUT "completed" cluster_rebalance_status_field 1  $V1
+
+cleanup;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -861,30 +861,21 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         }                                                                      \
     } while (0)
 
-#define GLUSTERD_GET_DEFRAG_SOCK_FILE_OLD(path, volinfo, priv)                 \
-    do {                                                                       \
-        char defrag_path[PATH_MAX];                                            \
-        int32_t _sockfile_old_len;                                             \
-        GLUSTERD_GET_DEFRAG_DIR(defrag_path, volinfo, priv);                   \
-        _sockfile_old_len = snprintf(path, PATH_MAX, "%s/%s.sock",             \
-                                     defrag_path, uuid_utoa(MY_UUID));         \
-        if ((_sockfile_old_len < 0) || (_sockfile_old_len >= PATH_MAX)) {      \
-            path[0] = 0;                                                       \
-        }                                                                      \
-    } while (0)
-
 #define GLUSTERD_GET_DEFRAG_SOCK_FILE(path, volinfo)                           \
     do {                                                                       \
-        char operation[NAME_MAX];                                              \
         int32_t _defrag_sockfile_len;                                          \
-        GLUSTERD_GET_DEFRAG_PROCESS(operation, volinfo);                       \
+        char tmppath[PATH_MAX] = {                                             \
+            0,                                                                 \
+        };                                                                     \
         _defrag_sockfile_len = snprintf(                                       \
-            path, UNIX_PATH_MAX,                                               \
-            DEFAULT_VAR_RUN_DIRECTORY "/gluster-%s-%s.sock", operation,        \
-            uuid_utoa(volinfo->volume_id));                                    \
+            tmppath, PATH_MAX,                                                 \
+            DEFAULT_VAR_RUN_DIRECTORY "/gluster-%s-%s-%s.sock", "rebalance",   \
+            volinfo->volname, uuid_utoa(MY_UUID));                             \
         if ((_defrag_sockfile_len < 0) ||                                      \
             (_defrag_sockfile_len >= PATH_MAX)) {                              \
             path[0] = 0;                                                       \
+        } else {                                                               \
+            glusterd_set_socket_filepath(tmppath, path, sizeof(path));         \
         }                                                                      \
     } while (0)
 


### PR DESCRIPTION
Problem: glusterd populate unix socket file name based
         on volname and if volname is lengthy socket
         system call's are failed due to breach maximum length
         is defined in the kernel.

Solution:Convert unix socket name to hash to resolve the issue

> Change-Id: I5072e8184013095587537dbfa4767286307fff65
> fixes: bz#1720566
> Signed-off-by: Mohit Agrawal <moagrawal@redhat.com>
> (Cherry pick from commit 2d7b77eb971700c1073db2b74f5877c1ae8293fc)
> (Reviewed on upstream link https://review.gluster.org/#/c/glusterfs/+/22869/)

Fixes: #1852
Change-Id: I4c3b22344ecfcd1fc9e8292cdc8a11f895d9f78c
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

