### PR TITLE
build: introduce a check before use git

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,9 @@ clang-check:
 	@$(top_srcdir)/extras/clang-checker.sh
 
 gen-ChangeLog:
-	(cd $(srcdir) && git diff && echo ===== git log ==== && git log) > $(distdir)/ChangeLog
+	if test -d $(srcdir)/.git; then            	\
+	  (cd $(srcdir) && git diff && echo ===== git log ==== && git log) > $(distdir)/ChangeLog; \
+	fi
 
 .PHONY : gen-VERSION
 gen-VERSION:


### PR DESCRIPTION
When compile GlusterFS without git repository, a git error will fail the make.
Avoid to execute git commands when there is no git repository.

Fixes: #1855
Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>

