### PR TITLE
posix: In the commit 2f044c4587c6db3cb82b6128f056ec2ea2bc1b98 the ret

### DIFF
--- a/xlators/storage/posix/src/posix-gfid-path.c
+++ b/xlators/storage/posix/src/posix-gfid-path.c
@@ -120,6 +120,7 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
 
         list = GF_MALLOC(size, gf_posix_mt_char);
         if (!list) {
+            ret = -1;
             *op_errno = errno;
             goto err;
         }


### PR DESCRIPTION
       update was missed in the function posix_get_gfid2path if
       GF_MALLOC is failed.

Solution: Update the ret value to -1 if GF_MALLOC is failed

Fixes: #1836
Change-Id: I510ebf0605ee49b84ff3570948771319f283b10e
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

