### PR TITLE
core: Optimize _xlator->stats structure to make memory access friendly

### DIFF
--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -289,10 +289,8 @@ get_the_pt_fop(void *base_fop, int fop_idx)
                      frame->root, old_THIS->name, THIS->name);                 \
         /* Need to capture counts at leaf node */                              \
         if (!next_xl->pass_through && !next_xl->children) {                    \
-            GF_ATOMIC_INC(next_xl->stats.total.metrics[opn].fop);              \
-            GF_ATOMIC_INC(next_xl->stats.interval.metrics[opn].fop);           \
-            GF_ATOMIC_INC(next_xl->stats.total.count);                         \
-            GF_ATOMIC_INC(next_xl->stats.interval.count);                      \
+            GF_ATOMIC_INC(next_xl->stats[opn].total_fop);                      \
+            GF_ATOMIC_INC(next_xl->stats[opn].interval_fop);                   \
         }                                                                      \
                                                                                \
         if (next_xl->pass_through) {                                           \
@@ -354,10 +352,8 @@ get_the_pt_fop(void *base_fop, int fop_idx)
             timespec_now(&_new->begin);                                        \
         _new->op = get_fop_index_from_fn((_new->this), (fn));                  \
         if (!obj->pass_through) {                                              \
-            GF_ATOMIC_INC(obj->stats.total.metrics[_new->op].fop);             \
-            GF_ATOMIC_INC(obj->stats.interval.metrics[_new->op].fop);          \
-            GF_ATOMIC_INC(obj->stats.total.count);                             \
-            GF_ATOMIC_INC(obj->stats.interval.count);                          \
+            GF_ATOMIC_INC(obj->stats[_new->op].total_fop);                     \
+            GF_ATOMIC_INC(obj->stats[_new->op].interval_fop);                  \
         } else {                                                               \
             /* we want to get to the actual fop to call */                     \
             next_xl_fn = get_the_pt_fop(&obj->pass_through_fops->stat,         \
@@ -417,8 +413,8 @@ get_the_pt_fop(void *base_fop, int fop_idx)
                 timespec_now(&_parent->end);                                   \
         }                                                                      \
         if (op_ret < 0) {                                                      \
-            GF_ATOMIC_INC(THIS->stats.total.metrics[frame->op].cbk);           \
-            GF_ATOMIC_INC(THIS->stats.interval.metrics[frame->op].cbk);        \
+            GF_ATOMIC_INC(THIS->stats[frame->op].total_fop_cbk);               \
+            GF_ATOMIC_INC(THIS->stats[frame->op].interval_fop_cbk);            \
         }                                                                      \
         fn(_parent, frame->cookie, _parent->this, op_ret, op_errno, params);   \
         THIS = old_THIS;                                                       \

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -796,22 +796,12 @@ struct _xlator {
     gf_loglevel_t loglevel; /* Log level for translator */
 
     struct {
-        struct {
-            /* for latency measurement */
-            fop_metrics_t metrics[GF_FOP_MAXVALUE];
-
-            gf_atomic_t count;
-        } total;
-
-        struct {
-            /* for latency measurement */
-            gf_latency_t latencies[GF_FOP_MAXVALUE];
-            /* for latency measurement */
-            fop_metrics_t metrics[GF_FOP_MAXVALUE];
-
-            gf_atomic_t count;
-        } interval;
-    } stats;
+        gf_atomic_t total_fop;
+        gf_atomic_t interval_fop;
+        gf_atomic_t total_fop_cbk;
+        gf_atomic_t interval_fop_cbk;
+        gf_latency_t latencies;
+    } stats[GF_FOP_MAXVALUE];
 
     /* Misc */
     eh_t *history; /* event history context */

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -42,6 +42,10 @@
 #define gf_attr_atime_set(mode) ((mode)&GF_SET_ATTR_ATIME)
 #define gf_attr_mtime_set(mode) ((mode)&GF_SET_ATTR_MTIME)
 
+#ifndef CAA_CACHE_LINE_SIZE
+#define CAA_CACHE_LINE_SIZE 128
+#endif
+
 struct _xlator;
 typedef struct _xlator xlator_t;
 struct _dir_entry;
@@ -801,7 +805,7 @@ struct _xlator {
         gf_atomic_t total_fop_cbk;
         gf_atomic_t interval_fop_cbk;
         gf_latency_t latencies;
-    } stats[GF_FOP_MAXVALUE];
+    } stats[GF_FOP_MAXVALUE] __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
 
     /* Misc */
     eh_t *history; /* event history context */

--- a/libglusterfs/src/latency.c
+++ b/libglusterfs/src/latency.c
@@ -79,6 +79,6 @@ gf_frame_latency_update(call_frame_t *frame)
         return;
     }
 
-    lat = &frame->this->stats.interval.latencies[frame->op];
+    lat = &frame->this->stats[frame->op].latencies;
     gf_latency_update(lat, &frame->begin, &frame->end);
 }

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -80,7 +80,6 @@ dump_latency_and_count(xlator_t *xl, int fd)
     uint64_t fop = 0;
     uint64_t cbk = 0;
     uint64_t total_fop_count = 0;
-    uint64_t total_fop_cbk = 0;
     uint64_t interval_fop_count = 0;
 
     if (xl->winds) {
@@ -99,19 +98,16 @@ dump_latency_and_count(xlator_t *xl, int fd)
                     gf_fop_list[index], fop);
             total_fop_count += fop;
         }
-        GF_ATOMIC_SWAP(xl->stats[index].interval_fop, fop);
+        fop = GF_ATOMIC_SWAP(xl->stats[index].interval_fop, 0);
         if (fop) {
             dprintf(fd, "%s.interval.%s.count %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], fop);
             interval_fop_count += fop;
-            fop = 0;
         }
-        GF_ATOMIC_SWAP(xl->stats[index].interval_fop_cbk, cbk);
+        cbk = GF_ATOMIC_SWAP(xl->stats[index].interval_fop_cbk, 0);
         if (cbk) {
             dprintf(fd, "%s.interval.%s.fail_count %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], cbk);
-            total_fop_cbk += cbk;
-            cbk = 0;
         }
         if (xl->stats[index].latencies.count != 0) {
             dprintf(fd, "%s.interval.%s.latency %lf\n", xl->name,
@@ -123,8 +119,6 @@ dump_latency_and_count(xlator_t *xl, int fd)
             dprintf(fd, "%s.interval.%s.min %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], xl->stats[index].latencies.min);
         }
-        GF_ATOMIC_INIT(xl->stats[index].interval_fop_cbk, 0);
-        GF_ATOMIC_INIT(xl->stats[index].interval_fop, 0);
         memset(&xl->stats[index].latencies, 0,
                sizeof(xl->stats[index].latencies));
     }

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -79,7 +79,8 @@ dump_latency_and_count(xlator_t *xl, int fd)
     int32_t index = 0;
     uint64_t fop;
     uint64_t cbk;
-    uint64_t count;
+    uint64_t total_fop_count;
+    uint64_t interval_fop_count;
 
     if (xl->winds) {
         dprintf(fd, "%s.total.pending-winds.count %" PRIu64 "\n", xl->name,
@@ -90,46 +91,44 @@ dump_latency_and_count(xlator_t *xl, int fd)
     if ((xl != xl->ctx->root) && (xl->ctx->active != xl->graph))
         return;
 
-    count = GF_ATOMIC_GET(xl->stats.total.count);
-    dprintf(fd, "%s.total.fop-count %" PRIu64 "\n", xl->name, count);
-
-    count = GF_ATOMIC_GET(xl->stats.interval.count);
-    dprintf(fd, "%s.interval.fop-count %" PRIu64 "\n", xl->name, count);
-    GF_ATOMIC_INIT(xl->stats.interval.count, 0);
-
     for (index = 0; index < GF_FOP_MAXVALUE; index++) {
-        fop = GF_ATOMIC_GET(xl->stats.total.metrics[index].fop);
+        fop = GF_ATOMIC_GET(xl->stats[index].total_fop);
         if (fop) {
             dprintf(fd, "%s.total.%s.count %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], fop);
+            total_fop_count += fop;
         }
-        fop = GF_ATOMIC_GET(xl->stats.interval.metrics[index].fop);
+        fop = GF_ATOMIC_GET(xl->stats[index].interval_fop);
         if (fop) {
             dprintf(fd, "%s.interval.%s.count %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], fop);
+            interval_fop_count += fop;
         }
-        cbk = GF_ATOMIC_GET(xl->stats.interval.metrics[index].cbk);
+        cbk = GF_ATOMIC_GET(xl->stats[index].interval_fop_cbk);
         if (cbk) {
             dprintf(fd, "%s.interval.%s.fail_count %" PRIu64 "\n", xl->name,
                     gf_fop_list[index], cbk);
         }
-        if (xl->stats.interval.latencies[index].count != 0) {
+        if (xl->stats[index].latencies.count != 0) {
             dprintf(fd, "%s.interval.%s.latency %lf\n", xl->name,
                     gf_fop_list[index],
-                    (((double)xl->stats.interval.latencies[index].total) /
-                     xl->stats.interval.latencies[index].count));
+                    (((double)xl->stats[index].latencies.total) /
+                     xl->stats[index].latencies.count));
             dprintf(fd, "%s.interval.%s.max %" PRIu64 "\n", xl->name,
                     gf_fop_list[index],
-                    xl->stats.interval.latencies[index].max);
+                    xl->stats[index].latencies.max);
             dprintf(fd, "%s.interval.%s.min %" PRIu64 "\n", xl->name,
                     gf_fop_list[index],
-                    xl->stats.interval.latencies[index].min);
+                    xl->stats[index].latencies.min);
         }
-        GF_ATOMIC_INIT(xl->stats.interval.metrics[index].cbk, 0);
-        GF_ATOMIC_INIT(xl->stats.interval.metrics[index].fop, 0);
+        GF_ATOMIC_INIT(xl->stats[index].interval_fop_cbk, 0);
+        GF_ATOMIC_INIT(xl->stats[index].interval_fop, 0);
+        memset(&xl->stats[index].latencies, 0,
+           sizeof(xl->stats[index].latencies));
     }
-    memset(xl->stats.interval.latencies, 0,
-           sizeof(xl->stats.interval.latencies));
+
+    dprintf(fd, "%s.total.fop-count %" PRIu64 "\n", xl->name, total_fop_count);
+    dprintf(fd, "%s.interval.fop-count %" PRIu64 "\n", xl->name, interval_fop_count);
 }
 
 static inline void

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -227,7 +227,7 @@ gf_proc_dump_xl_latency_info(xlator_t *xl)
     for (i = 0; i < GF_FOP_MAXVALUE; i++) {
         gf_proc_dump_build_key(key, key_prefix, "%s", (char *)gf_fop_list[i]);
 
-        gf_latency_t *lat = &xl->stats.interval.latencies[i];
+        gf_latency_t *lat = &xl->stats[i].latencies;
 
         gf_latency_statedump_and_reset(key, lat);
     }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -359,7 +359,7 @@ xlator_dynload_apis(xlator_t *xl)
            sizeof(uint32_t) * GF_MAX_RELEASES);
 
     for (i = 0; i < GF_FOP_MAXVALUE; i++) {
-        gf_latency_reset(&xl->stats.interval.latencies[i]);
+        gf_latency_reset(&xl->stats[i].latencies);
     }
 
     ret = 0;
@@ -600,14 +600,12 @@ __xlator_init(xlator_t *xl)
 
     /* initialize the metrics related locks */
     for (fop_idx = 0; fop_idx < GF_FOP_MAXVALUE; fop_idx++) {
-        GF_ATOMIC_INIT(xl->stats.total.metrics[fop_idx].fop, 0);
-        GF_ATOMIC_INIT(xl->stats.total.metrics[fop_idx].cbk, 0);
+        GF_ATOMIC_INIT(xl->stats[fop_idx].total_fop, 0);
+        GF_ATOMIC_INIT(xl->stats[fop_idx].total_fop_cbk, 0);
 
-        GF_ATOMIC_INIT(xl->stats.interval.metrics[fop_idx].fop, 0);
-        GF_ATOMIC_INIT(xl->stats.interval.metrics[fop_idx].cbk, 0);
+        GF_ATOMIC_INIT(xl->stats[fop_idx].interval_fop, 0);
+        GF_ATOMIC_INIT(xl->stats[fop_idx].interval_fop_cbk, 0);
     }
-    GF_ATOMIC_INIT(xl->stats.total.count, 0);
-    GF_ATOMIC_INIT(xl->stats.interval.count, 0);
 
     xlator_init_lock();
     handle_default_options(xl, xl->options);


### PR DESCRIPTION
Current xlator->stats is not efficient for frequently access memroy
variables, to make it friendly optimize stats structure.

Fixes: #1583
Change-Id: I5c9d263b11d9bbf0bf5501e461bdd3cce03591f9
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

