### PR TITLE
all: change 'primary' to 'root' where it makes sense

### DIFF
--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -440,7 +440,7 @@ glfs_process_upcall_event(struct glfs *fs, void *data)
             goto label;                                                        \
         }                                                                      \
         old_THIS = THIS;                                                       \
-        THIS = fs->ctx->primary;                                               \
+        THIS = fs->ctx->root;                                                  \
     } while (0)
 
 #define __GLFS_EXIT_FS                                                         \
@@ -456,7 +456,7 @@ glfs_process_upcall_event(struct glfs *fs, void *data)
             goto label;                                                        \
         }                                                                      \
         old_THIS = THIS;                                                       \
-        THIS = glfd->fd->inode->table->xl->ctx->primary;                       \
+        THIS = glfd->fd->inode->table->xl->ctx->root;                          \
     } while (0)
 
 #define __GLFS_LOCK_WAIT(fs)                                                   \

--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -275,7 +275,7 @@ mgmt_get_volinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    fs = ((xlator_t *)ctx->primary)->private;
+    fs = ((xlator_t *)ctx->root)->private;
 
     if (-1 == req->rpc_status) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
@@ -566,7 +566,7 @@ glfs_mgmt_getspec_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    fs = ((xlator_t *)ctx->primary)->private;
+    fs = ((xlator_t *)ctx->root)->private;
 
     if (-1 == req->rpc_status) {
         ret = -1;
@@ -828,7 +828,7 @@ mgmt_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
     if (!ctx)
         goto out;
 
-    fs = ((xlator_t *)ctx->primary)->private;
+    fs = ((xlator_t *)ctx->root)->private;
 
     switch (event) {
         case RPC_CLNT_DISCONNECT:

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -207,7 +207,7 @@ create_primary(struct glfs *fs)
         goto err;
     }
 
-    fs->ctx->primary = primary;
+    fs->ctx->root = primary;
     THIS = primary;
 
     return 0;
@@ -1252,7 +1252,7 @@ pub_glfs_fini(struct glfs *fs)
         goto free_fs;
     }
 
-    THIS = fs->ctx->primary;
+    THIS = fs->ctx->root;
 
     if (ctx->mgmt) {
         rpc_clnt_disable(ctx->mgmt);

--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -221,7 +221,7 @@ done_parsing:
         return EXIT_FAILURE;
     }
 
-    rpc = rpc_clnt_new(options, fs->ctx->primary, "gf-attach-rpc", 0);
+    rpc = rpc_clnt_new(options, fs->ctx->root, "gf-attach-rpc", 0);
     if (!rpc) {
         fprintf(stderr, "rpc_clnt_new failed\n");
         return EXIT_FAILURE;
@@ -237,5 +237,5 @@ done_parsing:
         return EXIT_FAILURE;
     }
 
-    return send_brick_req(fs->ctx->primary, rpc, argv[optind + 1], op);
+    return send_brick_req(fs->ctx->root, rpc, argv[optind + 1], op);
 }

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -550,7 +550,7 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
-    xlator_t *primary = NULL;
+    xlator_t *root = NULL;
 
     cmd_args = &ctx->cmd_args;
     if (!cmd_args->mount_point) {
@@ -564,31 +564,31 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
         return -1;
     }
 
-    primary = GF_CALLOC(1, sizeof(*primary), gfd_mt_xlator_t);
-    if (!primary)
+    root = GF_CALLOC(1, sizeof(*root), gfd_mt_xlator_t);
+    if (!root)
         goto err;
 
-    primary->name = gf_strdup("fuse");
-    if (!primary->name)
+    root->name = gf_strdup("fuse");
+    if (!root->name)
         goto err;
 
-    if (xlator_set_type(primary, "mount/fuse") == -1) {
+    if (xlator_set_type(root, "mount/fuse") == -1) {
         gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_8,
                 "MOUNT-POINT=%s", cmd_args->mount_point, NULL);
         goto err;
     }
 
-    primary->ctx = ctx;
-    primary->options = dict_new();
-    if (!primary->options)
+    root->ctx = ctx;
+    root->options = dict_new();
+    if (!root->options)
         goto err;
 
-    ret = set_fuse_mount_options(ctx, primary->options);
+    ret = set_fuse_mount_options(ctx, root->options);
     if (ret)
         goto err;
 
     if (cmd_args->fuse_mountopts) {
-        ret = dict_set_static_ptr(primary->options, ZR_FUSE_MOUNTOPTS,
+        ret = dict_set_static_ptr(root->options, ZR_FUSE_MOUNTOPTS,
                                   cmd_args->fuse_mountopts);
         if (ret < 0) {
             gf_smsg("glusterfsd", GF_LOG_ERROR, 0, glusterfsd_msg_3,
@@ -597,19 +597,19 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
         }
     }
 
-    ret = xlator_init(primary);
+    ret = xlator_init(root);
     if (ret) {
         gf_msg_debug("glusterfsd", 0, "failed to initialize fuse translator");
         goto err;
     }
 
-    ctx->primary = primary;
+    ctx->root = root;
 
     return 0;
 
 err:
-    if (primary) {
-        xlator_destroy(primary);
+    if (root) {
+        xlator_destroy(root);
     }
 
     return 1;
@@ -1465,7 +1465,7 @@ cleanup_and_exit(int signum)
         /* Call fini() of FUSE xlator first:
          * so there are no more requests coming and
          * 'umount' of mount point is done properly */
-        trav = ctx->primary;
+        trav = ctx->root;
         if (trav && trav->fini) {
             THIS = trav;
             trav->fini(trav);

--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -156,8 +156,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
              * Handle case of CHILD_* & AUTH_FAILED event specially, send
              * it to fuse.
              */
-            if (!parent && this->ctx && this->ctx->primary) {
-                xlator_notify(this->ctx->primary, event, this->graph, NULL);
+            if (!parent && this->ctx && this->ctx->root) {
+                xlator_notify(this->ctx->root, event, this->graph, NULL);
             }
 
             while (parent) {
@@ -167,8 +167,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
             }
 
             if (event == GF_EVENT_CHILD_DOWN &&
-                !(this->ctx && this->ctx->primary) && (graph->top == this)) {
-                /* Make sure this is not a daemon with primary xlator */
+                !(this->ctx && this->ctx->root) && (graph->top == this)) {
+                /* Make sure this is not a daemon with root xlator */
                 pthread_mutex_lock(&graph->mutex);
                 {
                     if (graph->parent_down ==
@@ -183,8 +183,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
         case GF_EVENT_UPCALL: {
             xlator_list_t *parent = this->parents;
 
-            if (!parent && this->ctx && this->ctx->primary)
-                xlator_notify(this->ctx->primary, event, data, NULL);
+            if (!parent && this->ctx && this->ctx->root)
+                xlator_notify(this->ctx->root, event, data, NULL);
 
             while (parent) {
                 if (parent->xlator->init_succeeded)

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -645,7 +645,7 @@ struct _glusterfs_ctx {
     glusterfs_graph_t *active;
 
     /* fuse or nfs (but not protocol/server) */
-    void *primary;
+    void *root;
 
     /* xlator implementing MOPs for centralized logging, volfile server */
     void *mgmt;

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -229,7 +229,7 @@ glusterfs_graph_insert(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
 {
     xlator_t *ixl = NULL;
 
-    if (!ctx->primary) {
+    if (!ctx->root) {
         gf_msg("glusterfs", GF_LOG_ERROR, 0, LG_MSG_VOLUME_ERROR,
                "volume \"%s\" can be added from command line only "
                "on client side",
@@ -308,7 +308,7 @@ glusterfs_graph_meta(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
 {
     int ret = 0;
 
-    if (!ctx->primary)
+    if (!ctx->root)
         return 0;
 
     ret = glusterfs_graph_insert(graph, ctx, "meta", "meta-autoload", 1);
@@ -791,15 +791,15 @@ glusterfs_graph_activate(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
     list_add(&graph->list, &ctx->graphs);
     ctx->active = graph;
 
-    /* XXX: attach to primary and set active pointer */
-    if (ctx->primary) {
-        ret = xlator_notify(ctx->primary, GF_EVENT_GRAPH_NEW, graph);
+    /* XXX: attach to root and set active pointer */
+    if (ctx->root) {
+        ret = xlator_notify(ctx->root, GF_EVENT_GRAPH_NEW, graph);
         if (ret) {
             gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_EVENT_NOTIFY_FAILED,
                    "graph new notification failed");
             return ret;
         }
-        ((xlator_t *)ctx->primary)->next = graph->top;
+        ((xlator_t *)ctx->root)->next = graph->top;
     }
 
     /* XXX: perform parent up */
@@ -1154,11 +1154,11 @@ glusterfs_graph_destroy_residual(glusterfs_graph_t *graph)
 /* This function destroys all the xlator members except for the
  * xlator strcuture and its mem accounting field.
  *
- * If otherwise, it would destroy the primary xlator object as well
+ * If otherwise, it would destroy the root xlator object as well
  * its mem accounting, which would mean after calling glusterfs_graph_destroy()
- * there cannot be any reference to GF_FREE() from the primary xlator, this is
+ * there cannot be any reference to GF_FREE() from the root xlator, this is
  * not possible because of the following dependencies:
- * - glusterfs_ctx_t will have mem pools allocated by the primary xlators
+ * - glusterfs_ctx_t will have mem pools allocated by the root xlators
  * - xlator objects will have references to those mem pools(g: dict)
  *
  * Ordering the freeing in any of the order will also not solve the dependency:

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1204,10 +1204,10 @@ inode_invalidate(inode_t *inode)
     }
 
     /*
-     * The primary xlator is not in the graph but it can define an invalidate
+     * The root xlator is not in the graph but it can define an invalidate
      * handler.
      */
-    xl = inode->table->xl->ctx->primary;
+    xl = inode->table->xl->ctx->root;
     if (xl && xl->cbks->invalidate) {
         old_THIS = THIS;
         THIS = xl;

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -87,7 +87,7 @@ dump_latency_and_count(xlator_t *xl, int fd)
     }
 
     /* Need 'fuse' data, and don't need all the old graph info */
-    if ((xl != xl->ctx->primary) && (xl->ctx->active != xl->graph))
+    if ((xl != xl->ctx->root) && (xl->ctx->active != xl->graph))
         return;
 
     count = GF_ATOMIC_GET(xl->stats.total.count);
@@ -211,8 +211,8 @@ dump_xl_metrics(glusterfs_ctx_t *ctx, int fd)
         xl = xl->next;
     }
 
-    if (ctx->primary) {
-        xl = ctx->primary;
+    if (ctx->root) {
+        xl = ctx->root;
 
         dump_latency_and_count(xl, fd);
         dump_mem_acct_details(xl, fd);

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -902,9 +902,9 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
     gf_proc_dump_add_section("dict");
     gf_proc_dump_dict_info(ctx);
 
-    if (ctx->primary) {
+    if (ctx->root) {
         gf_proc_dump_add_section("fuse");
-        gf_proc_dump_single_xlator_info(ctx->primary);
+        gf_proc_dump_single_xlator_info(ctx->root);
     }
 
     if (ctx->active) {

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -847,11 +847,11 @@ xlator_members_free(xlator_t *xl)
 /* This function destroys all the xlator members except for the
  * xlator strcuture and its mem accounting field.
  *
- * If otherwise, it would destroy the primary xlator object as well
+ * If otherwise, it would destroy the root xlator object as well
  * its mem accounting, which would mean after calling glusterfs_graph_destroy()
- * there cannot be any reference to GF_FREE() from the primary xlator, this is
+ * there cannot be any reference to GF_FREE() from the root xlator, this is
  * not possible because of the following dependencies:
- * - glusterfs_ctx_t will have mem pools allocated by the primary xlators
+ * - glusterfs_ctx_t will have mem pools allocated by the root xlators
  * - xlator objects will have references to those mem pools(g: dict)
  *
  * Ordering the freeing in any of the order will also not solve the dependency:

--- a/tests/basic/meta.t
+++ b/tests/basic/meta.t
@@ -31,10 +31,10 @@ TEST json_verify < $M0/.meta/version;
 TEST grep -q 7 $M0/.meta/logging/loglevel;
 
 # check for attribute_timeout exposed through state dump
-TEST grep -q attribute_timeout $M0/.meta/primary/private;
+TEST grep -q attribute_timeout $M0/.meta/root/private;
 
 # check for mount point specified as an option
-TEST grep -q $M0 $M0/.meta/primary/options/mountpoint;
+TEST grep -q $M0 $M0/.meta/root/options/mountpoint;
 
 TEST $CLI volume stop $V0;
 EXPECT 'Stopped' volinfo_field $V0 'Status';

--- a/xlators/meta/src/meta-hooks.h
+++ b/xlators/meta/src/meta-hooks.h
@@ -40,7 +40,7 @@ DECLARE_HOOK(name_file);
 DECLARE_HOOK(private_file);
 DECLARE_HOOK(mallinfo_file);
 DECLARE_HOOK(history_file);
-DECLARE_HOOK(primary_dir);
+DECLARE_HOOK(root);
 DECLARE_HOOK(meminfo_file);
 DECLARE_HOOK(measure_file);
 DECLARE_HOOK(profile_file);

--- a/xlators/meta/src/root-dir.c
+++ b/xlators/meta/src/root-dir.c
@@ -54,9 +54,9 @@ static struct meta_dirent root_dir_dirents[] = {
         .hook = meta_mallinfo_file_hook,
     },
     {
-        .name = "primary",
+        .name = "root",
         .type = IA_IFDIR,
-        .hook = meta_primary_dir_hook,
+        .hook = meta_root_hook,
     },
     {
         .name = "measure_latency",

--- a/xlators/meta/src/xlator-dir.c
+++ b/xlators/meta/src/xlator-dir.c
@@ -86,10 +86,9 @@ meta_xlator_dir_hook(call_frame_t *frame, xlator_t *this, loc_t *loc,
 }
 
 int
-meta_primary_dir_hook(call_frame_t *frame, xlator_t *this, loc_t *loc,
-                      dict_t *xdata)
+meta_root_hook(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
-    meta_ctx_set(loc->inode, this, this->ctx->primary);
+    meta_ctx_set(loc->inode, this, this->ctx->root);
 
     meta_ops_set(loc->inode, this, &xlator_dir_ops);
 

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -793,7 +793,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
            just debug message */
         gf_msg_debug(this->name, EINVAL,
                      "failed to get 'volume-id' from reply dict");
-    } else if (ctx->primary && strncmp("snapd", remote_subvol, 5)) {
+    } else if (ctx->root && strncmp("snapd", remote_subvol, 5)) {
         /* TODO: if it is a fuse mount or a snapshot enabled client, don't
            bother */
         /* If any value is set, the first element will be non-0.


### PR DESCRIPTION
As a part of offensive language removal, we changed 'master' to 'primary' in
some parts of the code that are *not* related to geo-replication via
commits e4c9a14429c51d8d059287c2a2c7a76a5116a362 and
0fd92465333be674485b984e54b08df3e431bb0d.

But it is better to use 'root' in some places to distinguish it from the
geo-rep changes which use 'primary/secondary' instead of 'master/slave'.

This patch mainly changes glusterfs_ctx_t->primary to
glusterfs_ctx_t->root. Other places like meta xlator is also changed.
gf-changelog.c is not changed since it is related to geo-rep.

Updates: #1000
Change-Id: I3cd610f7bea06c7a28ae2c0104f34291023d1daf
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

