### PR TITLE
AFR - Fixing Coverity issue (Illegal memory access)

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4152,8 +4152,10 @@ __afr_fd_ctx_set(xlator_t *this, fd_t *fd)
     if (ret)
         gf_msg_debug(this->name, 0, "failed to set fd ctx (%p)", fd);
 out:
-    if (ret && fd_ctx)
+    if (ret && fd_ctx) {
         _afr_cleanup_fd_ctx(this, fd_ctx);
+        fd_ctx = NULL;
+    }
     return fd_ctx;
 }
 


### PR DESCRIPTION
CID 1437682
Fixing use-after-free bug by setting the released pointer to NULL

Change-Id: I15b4ec01ab04f212d6fd30bdc274b0d9e30973c2
updates: #1060
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

