### PR TITLE
NFS - Fixing Coverity issue (Dereference null return value)

### DIFF
--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -1424,8 +1424,10 @@ err:
         ncf = nlm4_notify_init(cs);
         if (ncf) {
             ncf->frame = copy_frame(frame);
-            ncf->frame->local = ncf;
-            nlm4svc_send_granted(ncf);
+            if(ncf->frame){
+            	ncf->frame->local = ncf;
+            	nlm4svc_send_granted(ncf);
+            }
         }
     } else {
         nlm4_generic_reply(cs->req, cs->args.nlm4_lockargs.cookie, stat);


### PR DESCRIPTION
CID 1430123
Fixing dereference null return value by checking the value returned by
an allocating method

Change-Id: I3fc18208fd4cec2db4b2b5d1f47ef7d7f1c9a4b3
updates: #1060
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

