### PR TITLE
geo-rep : Change in attribute for getting function name in py 3

### DIFF
--- a/extras/geo-rep/schedule_georep.py.in
+++ b/extras/geo-rep/schedule_georep.py.in
@@ -102,7 +102,7 @@ def cache_output_with_args(func):
     """
     def wrapper(*args, **kwargs):
         global cache_data
-        key = "_".join([func.func_name] + list(args))
+        key = "_".join([func.__name__] + list(args))
         if cache_data.get(key, None) is None:
             cache_data[key] = func(*args, **kwargs)
 


### PR DESCRIPTION
Issue: The schedule_geo-rep script uses `func_name` to obtain
the name of the function being referred to but from python3
onwards, the attribute has been changed to `__name__`.

Code Change:
 Changing `func_name` to `__name__`.

Fixes: #1898
Change-Id: I4ed69a06cffed9db17c8f8949b8000c74be1d717
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

