### PR TITLE
locks: taking and releasing locks more efficiently

### DIFF
--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -192,8 +192,8 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
             __destroy_lock(plock);
         }
     }
-    pthread_mutex_unlock(&pl_inode->mutex);
     grant_blocked_locks(this, pl_inode);
+    pthread_mutex_unlock(&pl_inode->mutex);
     ret = 0;
 out:
     *blkd = bcount;

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -968,11 +968,7 @@ grant_blocked_locks(xlator_t *this, pl_inode_t *pl_inode)
     pl_local_t *local = NULL;
     INIT_LIST_HEAD(&granted_list);
 
-    pthread_mutex_lock(&pl_inode->mutex);
-    {
-        __grant_blocked_locks(this, pl_inode, &granted_list);
-    }
-    pthread_mutex_unlock(&pl_inode->mutex);
+    __grant_blocked_locks(this, pl_inode, &granted_list);
 
     list_for_each_entry_safe(lock, tmp, &granted_list, list)
     {
@@ -1108,11 +1104,11 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
             ret = -1;
         }
     }
-    pthread_mutex_unlock(&pl_inode->mutex);
 
     grant_blocked_locks(this, pl_inode);
-
     do_blocked_rw(pl_inode);
+
+    pthread_mutex_unlock(&pl_inode->mutex);
 
 out:
     return ret;


### PR DESCRIPTION
grant_blocked_locks is taking lock which is just
released before the call. So we deffer the release
of this lock after calling grant_blocked_locks.

Fixes: #1333

Change-Id: I3f994375a835afda09ab02d970b59aa71c743cca
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

