### PR TITLE
runner: fix for coverity issues in runner_start()

### DIFF
--- a/libglusterfs/src/run.c
+++ b/libglusterfs/src/run.c
@@ -311,6 +311,9 @@ runner_start(runner_t *runner)
         }
     }
 
+    if (ret == -1)
+        return -1;
+
     ret = posix_spawn_file_actions_init(&file_actions);
     if (ret != 0)
         return -1;
@@ -322,7 +325,7 @@ runner_start(runner_t *runner)
     ret = 0;
     for (i = 0; i < 3; i++) {
         if (ret == -1)
-            break;
+            return -1;
         switch (runner->chfd[i]) {
             case -1:
                 // no redir
@@ -331,15 +334,11 @@ runner_start(runner_t *runner)
                 // redir to pipe
                 ret = posix_spawn_file_actions_adddup2(&file_actions,
                                                        pi[i][i ? 1 : 0], i);
-                if (ret)
-                    return -1;
                 break;
             default:
                 // redir to file
                 ret = posix_spawn_file_actions_adddup2(&file_actions,
                                                        runner->chfd[i], i);
-                if (ret)
-                    return -1;
         }
     }
 
@@ -349,6 +348,9 @@ runner_start(runner_t *runner)
         ret = close_fds_except_custom(fdv, sizeof(fdv) / sizeof(*fdv),
                                       &file_actions, closer_posix_spawnp);
     }
+
+    if (ret == -1)
+        return -1;
 
     file_actionsp = &file_actions;
 


### PR DESCRIPTION
Fixed dead code and few unused assignments in the runner_start()
in run.c file.

CID:1437641
CID:1437644
CID:1437646

Updates: #1060

Change-Id: I30ac234e9ff1f768b0e33a81eb3ffbf0de576784
Signed-off-by: nik-redhat <nladha@redhat.com>

