### PR TITLE
core: combined inode_link and inode_lookup

### DIFF
--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -145,6 +145,10 @@ inode_link(inode_t *inode, inode_t *parent, const char *name,
            struct iatt *stbuf);
 
 void
+inode_link_lookup(inode_t *inode, inode_t *parent, const char *name,
+                  struct iatt *stbuf);
+
+void
 inode_unlink(inode_t *inode, inode_t *parent, const char *name);
 
 inode_t *

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -144,7 +144,7 @@ inode_t *
 inode_link(inode_t *inode, inode_t *parent, const char *name,
            struct iatt *stbuf);
 
-void
+inode_t *
 inode_link_lookup(inode_t *inode, inode_t *parent, const char *name,
                   struct iatt *stbuf);
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1105,7 +1105,7 @@ inode_link(inode_t *inode, inode_t *parent, const char *name, struct iatt *iatt)
     return linked_inode;
 }
 
-void
+inode_t *
 inode_link_lookup(inode_t *inode, inode_t *parent, const char *name,
                   struct iatt *iatt)
 {
@@ -1116,7 +1116,12 @@ inode_link_lookup(inode_t *inode, inode_t *parent, const char *name,
     if (!inode) {
         gf_msg_callingfn(THIS->name, GF_LOG_WARNING, 0, LG_MSG_INODE_NOT_FOUND,
                          "inode not found");
-        return;
+        return NULL;
+    }
+
+    if (name && strchr(name, '/')) {
+        GF_ASSERT(!"inode link attempted with '/' in name");
+        return NULL;
     }
 
     table = inode->table;
@@ -1125,21 +1130,16 @@ inode_link_lookup(inode_t *inode, inode_t *parent, const char *name,
         hash = hash_dentry(parent, name, table->dentry_hashsize);
     }
 
-    if (name && strchr(name, '/')) {
-        GF_ASSERT(!"inode link attempted with '/' in name");
-        return;
-    }
-
     pthread_mutex_lock(&table->lock);
     linked_inode = __inode_link(inode, parent, name, iatt, hash);
-    pthread_mutex_unlock(&table->lock);
-
     if (linked_inode)
-        GF_ATOMIC_INC(linked_inode->nlookup);
+        __inode_ref(linked_inode, false);
+    GF_ATOMIC_INC(linked_inode->nlookup);
+    pthread_mutex_unlock(&table->lock);
 
     inode_table_prune(table);
 
-    return;
+    return linked_inode;
 }
 
 int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -807,6 +807,7 @@ inode_has_dentry
 inode_invalidate
 inode_is_linked
 inode_link
+inode_link_lookup
 inode_lookup
 inode_needs_lookup
 inode_new

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -43,15 +43,11 @@ server_post_mknod(server_state_t *state, gfs3_mknod_rsp *rsp,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, inode_t *inode)
 {
-    inode_t *link_inode = NULL;
-
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
 }
 
 void
@@ -59,15 +55,11 @@ server_post_mkdir(server_state_t *state, gfs3_mkdir_rsp *rsp, inode_t *inode,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
-    inode_t *link_inode = NULL;
-
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
 }
 
 void
@@ -102,15 +94,11 @@ server_post_symlink(server_state_t *state, gfs3_symlink_rsp *rsp,
                     inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
-    inode_t *link_inode = NULL;
-
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
 }
 
 void
@@ -118,15 +106,11 @@ server_post_link(server_state_t *state, gfs3_link_rsp *rsp, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
-    inode_t *link_inode = NULL;
-
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc2.parent, state->loc2.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc2.parent, state->loc2.name, stbuf);
 }
 
 void
@@ -447,18 +431,12 @@ server_post_lookup(gfs3_lookup_rsp *rsp, call_frame_t *frame,
                    struct iatt *postparent)
 {
     inode_t *root_inode = NULL;
-    inode_t *link_inode = NULL;
     static uuid_t rootgfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
     root_inode = frame->root->client->bound_xl->itable->root;
 
     if (!__is_root_gfid(inode->gfid)) {
-        link_inode = inode_link(inode, state->loc.parent, state->loc.name,
-                                stbuf);
-        if (link_inode) {
-            inode_lookup(link_inode);
-            inode_unref(link_inode);
-        }
+        inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
     }
 
     if ((inode == root_inode) || (state->client->subdir_mount &&
@@ -501,8 +479,6 @@ server4_post_common_3iatt(server_state_t *state, gfx_common_3iatt_rsp *rsp,
                           inode_t *inode, struct iatt *stbuf,
                           struct iatt *preparent, struct iatt *postparent)
 {
-    inode_t *link_inode = NULL;
-
     gfx_stat_from_iattx(&rsp->stat, stbuf);
     if (state->client->subdir_mount &&
         !gf_uuid_compare(preparent->ia_gfid, state->client->subdir_gfid)) {
@@ -523,9 +499,7 @@ server4_post_common_3iatt(server_state_t *state, gfx_common_3iatt_rsp *rsp,
     gfx_stat_from_iattx(&rsp->preparent, preparent);
     gfx_stat_from_iattx(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
 }
 
 void
@@ -786,18 +760,12 @@ server4_post_lookup(gfx_common_2iatt_rsp *rsp, call_frame_t *frame,
                     server_state_t *state, inode_t *inode, struct iatt *stbuf)
 {
     inode_t *root_inode = NULL;
-    inode_t *link_inode = NULL;
     static uuid_t rootgfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
     root_inode = frame->root->client->bound_xl->itable->root;
 
     if (!__is_root_gfid(inode->gfid)) {
-        link_inode = inode_link(inode, state->loc.parent, state->loc.name,
-                                stbuf);
-        if (link_inode) {
-            inode_lookup(link_inode);
-            inode_unref(link_inode);
-        }
+        inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
     }
 
     if ((inode == root_inode) || (state->client->subdir_mount &&
@@ -830,13 +798,9 @@ server4_post_link(server_state_t *state, gfx_common_3iatt_rsp *rsp,
                   inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent)
 {
-    inode_t *link_inode = NULL;
-
     gfx_stat_from_iattx(&rsp->stat, stbuf);
     gfx_stat_from_iattx(&rsp->preparent, preparent);
     gfx_stat_from_iattx(&rsp->postparent, postparent);
 
-    link_inode = inode_link(inode, state->loc2.parent, state->loc2.name, stbuf);
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc2.parent, state->loc2.name, stbuf);
 }

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -43,11 +43,15 @@ server_post_mknod(server_state_t *state, gfs3_mknod_rsp *rsp,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, inode_t *inode)
 {
+    inode_t *link_inode = NULL;
+
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc.parent, state->loc.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }
 
 void
@@ -55,11 +59,15 @@ server_post_mkdir(server_state_t *state, gfs3_mkdir_rsp *rsp, inode_t *inode,
                   struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
+    inode_t *link_inode = NULL;
+
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc.parent, state->loc.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }
 
 void
@@ -94,11 +102,15 @@ server_post_symlink(server_state_t *state, gfs3_symlink_rsp *rsp,
                     inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
+    inode_t *link_inode = NULL;
+
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc.parent, state->loc.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }
 
 void
@@ -106,11 +118,15 @@ server_post_link(server_state_t *state, gfs3_link_rsp *rsp, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
+    inode_t *link_inode = NULL;
+
     gf_stat_from_iatt(&rsp->stat, stbuf);
     gf_stat_from_iatt(&rsp->preparent, preparent);
     gf_stat_from_iatt(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc2.parent, state->loc2.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc2.parent, state->loc2.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }
 
 void
@@ -431,12 +447,17 @@ server_post_lookup(gfs3_lookup_rsp *rsp, call_frame_t *frame,
                    struct iatt *postparent)
 {
     inode_t *root_inode = NULL;
+    inode_t *link_inode = NULL;
     static uuid_t rootgfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
     root_inode = frame->root->client->bound_xl->itable->root;
 
     if (!__is_root_gfid(inode->gfid)) {
-        inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+        link_inode = inode_link_lookup(inode, state->loc.parent,
+                                       state->loc.name, stbuf);
+        if (link_inode) {
+            inode_unref(link_inode);
+        }
     }
 
     if ((inode == root_inode) || (state->client->subdir_mount &&
@@ -479,6 +500,8 @@ server4_post_common_3iatt(server_state_t *state, gfx_common_3iatt_rsp *rsp,
                           inode_t *inode, struct iatt *stbuf,
                           struct iatt *preparent, struct iatt *postparent)
 {
+    inode_t *link_inode = NULL;
+
     gfx_stat_from_iattx(&rsp->stat, stbuf);
     if (state->client->subdir_mount &&
         !gf_uuid_compare(preparent->ia_gfid, state->client->subdir_gfid)) {
@@ -499,7 +522,9 @@ server4_post_common_3iatt(server_state_t *state, gfx_common_3iatt_rsp *rsp,
     gfx_stat_from_iattx(&rsp->preparent, preparent);
     gfx_stat_from_iattx(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc.parent, state->loc.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }
 
 void
@@ -760,12 +785,17 @@ server4_post_lookup(gfx_common_2iatt_rsp *rsp, call_frame_t *frame,
                     server_state_t *state, inode_t *inode, struct iatt *stbuf)
 {
     inode_t *root_inode = NULL;
+    inode_t *link_inode = NULL;
     static uuid_t rootgfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
     root_inode = frame->root->client->bound_xl->itable->root;
 
     if (!__is_root_gfid(inode->gfid)) {
-        inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+        link_inode = inode_link_lookup(inode, state->loc.parent,
+                                       state->loc.name, stbuf);
+        if (link_inode) {
+            inode_unref(link_inode);
+        }
     }
 
     if ((inode == root_inode) || (state->client->subdir_mount &&
@@ -798,9 +828,13 @@ server4_post_link(server_state_t *state, gfx_common_3iatt_rsp *rsp,
                   inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent)
 {
+    inode_t *link_inode = NULL;
+
     gfx_stat_from_iattx(&rsp->stat, stbuf);
     gfx_stat_from_iattx(&rsp->preparent, preparent);
     gfx_stat_from_iattx(&rsp->postparent, postparent);
 
-    inode_link_lookup(inode, state->loc2.parent, state->loc2.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc2.parent, state->loc2.name,
+                                   stbuf);
+    inode_unref(link_inode);
 }

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -46,7 +46,6 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     server_state_t *state = NULL;
     server_resolve_t *resolve = NULL;
-    inode_t *link_inode = NULL;
     loc_t *resolve_loc = NULL;
 
     state = CALL_STATE(frame);
@@ -85,14 +84,7 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    link_inode = inode_link(inode, resolve_loc->parent, resolve_loc->name, buf);
-
-    if (!link_inode)
-        goto out;
-
-    inode_lookup(link_inode);
-
-    inode_unref(link_inode);
+    inode_link_lookup(inode, resolve_loc->parent, resolve_loc->name, buf);
 
 out:
     loc_wipe(resolve_loc);

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -46,6 +46,7 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     server_state_t *state = NULL;
     server_resolve_t *resolve = NULL;
+    inode_t *link_inode = NULL;
     loc_t *resolve_loc = NULL;
 
     state = CALL_STATE(frame);
@@ -84,7 +85,13 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    inode_link_lookup(inode, resolve_loc->parent, resolve_loc->name, buf);
+    link_inode = inode_link_lookup(inode, resolve_loc->parent,
+                                   resolve_loc->name, buf);
+
+    if (!link_inode)
+        goto out;
+
+    inode_unref(link_inode);
 
 out:
     loc_wipe(resolve_loc);

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -2086,7 +2086,6 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     struct iatt *stbuf, dict_t *xdata)
 {
     server_state_t *state = NULL;
-    inode_t *link_inode = NULL;
     rpcsvc_request_t *req = NULL;
     gfx_common_iatt_rsp rsp = {
         0,
@@ -2109,16 +2108,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "ICREATE [%s]",
                  frame->root->unique, uuid_utoa(stbuf->ia_gfid));
 
-    link_inode = inode_link(inode, state->loc.parent, state->loc.name, stbuf);
-
-    if (!link_inode) {
-        op_ret = -1;
-        op_errno = ENOENT;
-        goto out;
-    }
-
-    inode_lookup(link_inode);
-    inode_unref(link_inode);
+    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
 
     gfx_stat_from_iattx(&rsp.stat, stbuf);
 

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -2086,6 +2086,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     struct iatt *stbuf, dict_t *xdata)
 {
     server_state_t *state = NULL;
+    inode_t *link_inode = NULL;
     rpcsvc_request_t *req = NULL;
     gfx_common_iatt_rsp rsp = {
         0,
@@ -2108,7 +2109,16 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "ICREATE [%s]",
                  frame->root->unique, uuid_utoa(stbuf->ia_gfid));
 
-    inode_link_lookup(inode, state->loc.parent, state->loc.name, stbuf);
+    link_inode = inode_link_lookup(inode, state->loc.parent, state->loc.name,
+                                   stbuf);
+
+    if (!link_inode) {
+        op_ret = -1;
+        op_errno = ENOENT;
+        goto out;
+    }
+
+    inode_unref(link_inode);
 
     gfx_stat_from_iattx(&rsp.stat, stbuf);
 


### PR DESCRIPTION
combined inode_link and inode_lookup into more efficient function
inode_link_lookup where we can avoid reference and unreference of
the linked_inode.

Fixes: #1341

Change-Id: Ic878b2c028a422a359aa45d7dd0824faa0e35c05
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

