### PR TITLE
glusterd: Enable GLUSTER_BRICK_GRACEFUL_CLEANUP option

### DIFF
--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -161,8 +161,14 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
             }
 
             while (parent) {
-                if (parent->xlator->init_succeeded)
-                    xlator_notify(parent->xlator, event, this, NULL);
+                if (parent->xlator->init_succeeded) {
+                    if ((this->ctx->process_mode == GF_SERVER_PROCESS) &&
+                        (event == GF_EVENT_CHILD_DOWN)) {
+                        xlator_notify(parent->xlator, event, victim, NULL);
+                    } else {
+                        xlator_notify(parent->xlator, event, this, NULL);
+                    }
+                }
                 parent = parent->next;
             }
 

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -2148,6 +2148,7 @@ _gf_log_eh(const char *function, const char *fmt, ...)
         goto out;
     }
 
+    /*logline is freed by cb_buffer_destroy */
     ret = gf_asprintf(&logline, "[%d] %s: %s",
                       ((this->graph) ? this->graph->id : 0), function, msg);
     if (-1 == ret) {
@@ -2157,7 +2158,6 @@ _gf_log_eh(const char *function, const char *fmt, ...)
     ret = eh_save_history(this->history, logline);
 
 out:
-    GF_FREE(logline);
 
     FREE(msg);
 

--- a/tests/bugs/bug-1371806_1.t
+++ b/tests/bugs/bug-1371806_1.t
@@ -23,6 +23,7 @@ TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 $H0:$B0/${V0}{0,1,2,3}
 TEST $CLI volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 4 online_brick_count
 
 TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 $M0;
 

--- a/tests/bugs/glusterd/daemon-log-level-option.t
+++ b/tests/bugs/glusterd/daemon-log-level-option.t
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 . $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
 
 function Info_messages_count() {
         local shd_log=$1
@@ -60,6 +61,7 @@ rm -f /var/log/glusterfs/glustershd.log
 # set cluster.daemon-log-level option to WARNING and start the volume
 TEST $CLI volume set all cluster.daemon-log-level WARNING
 TEST $CLI volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 6 online_brick_count
 
 # log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
 EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
@@ -72,11 +74,13 @@ EXPECT 0 Trace_messages_count "/var/log/glusterfs/glustershd.log"
 
 # stop the volume and remove glustershd log
 TEST $CLI volume stop $V0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 0 online_brick_count
 rm -f /var/log/glusterfs/glustershd.log
 
 # set cluster.daemon-log-level option to ERROR and start the volume
 TEST $CLI volume set all cluster.daemon-log-level ERROR
 TEST $CLI volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 6 online_brick_count
 
 # log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
 EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"

--- a/tests/bugs/glusterd/replace-brick-operations.t
+++ b/tests/bugs/glusterd/replace-brick-operations.t
@@ -28,6 +28,7 @@ TEST ! $CLI volume replace-brick $V0 $H0:$B0/${V0}2 $H0:$B0/${V0}3 abort
 
 ## replace-brick commit force command should success
 TEST $CLI volume replace-brick $V0 $H0:$B0/${V0}2 $H0:$B0/${V0}3 commit force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 2 online_brick_count
 
 #bug-1242543-replace-brick validation
 
@@ -39,6 +40,7 @@ TEST $CLI volume replace-brick $V0 $H0:$B0/${V0}1 $H0:$B0/${V0}1_new commit forc
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 
 TEST kill_brick $V0 $H0 $B0/${V0}1_new
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 1 online_brick_count
 
 # Replace brick1 after killing the brick
 TEST $CLI volume replace-brick $V0 $H0:$B0/${V0}1_new $H0:$B0/${V0}1_newer commit force

--- a/tests/bugs/glusterfs/bug-902610.t
+++ b/tests/bugs/glusterfs/bug-902610.t
@@ -56,7 +56,9 @@ TEST ls -l $M0
 
 ## kill 2 bricks to bring down available subvol < spread count
 kill_brick $V0 $H0 $B0/${V0}2
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 3 online_brick_count
 kill_brick $V0 $H0 $B0/${V0}3
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 2 online_brick_count
 
 mkdir $M0/dir1 2>/dev/null
 

--- a/tests/bugs/replicate/bug-1297695.t
+++ b/tests/bugs/replicate/bug-1297695.t
@@ -28,6 +28,7 @@ TEST mkdir $M0/dir
 TEST touch $M0/dir/file
 
 TEST kill_brick $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 1 online_brick_count
 TEST `echo 'abc' > $M0/dir/file`
 
 TEST $CLI volume start $V0 force

--- a/tests/bugs/replicate/bug-921231.t
+++ b/tests/bugs/replicate/bug-921231.t
@@ -25,7 +25,7 @@ write_to_file &
 write_to_file &
 wait
 #Test if the MAX [F]INODELK fop latency is of the order of seconds.
-inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{9,}")
 TEST [ -z $inodelk_max_latency ]
 
 cleanup;

--- a/tests/glusterfind/glusterfind-basic.t
+++ b/tests/glusterfind/glusterfind-basic.t
@@ -17,6 +17,7 @@ mkdir -p /var/lib/glusterd/glusterfind/.keys
 #create_and_start test_volume
 TEST $CLI volume create test-vol $H0:$B0/b1 $H0:$B0/b2 $H0:$B0/b3
 TEST gluster volume start test-vol
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 3 online_brick_count
 
 ##Mount test-vol
 TEST glusterfs -s $H0 --volfile-id test-vol $M0

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -625,9 +625,15 @@ function cleanup()
         # till the stale mount in /tmp is found.
         umount $flag /tmp/mnt* 2>/dev/null
 
-
-        # Send SIGTERM to all gluster processes and rpc.statd that are still running
-        terminate_pids $(process_pids glusterfs glusterfsd glusterd rpc.statd)
+        pid=`pgrep glusterd`
+        if [ ! -z "$pid" ];
+        then 
+            for vol in `gluster v list`; do gluster v stop $vol --mode=script; done
+            sleep 2
+            for vol in `gluster v list`; do gluster v status $vol --mode=script; done
+        fi 
+        # Send SIGTERM to all brick processes and rpc.statd that are still running
+        terminate_pids $(process_pids glusterfs glusterd rpc.statd)
 
         test x"$OSTYPE" = x"NetBSD" && pkill -9 perfused || true
 

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -83,7 +83,7 @@ const glusterd_all_vol_opts valid_all_vol_opts[] = {
     {GLUSTERD_VOL_CNT_PER_THRD, GLUSTERD_VOL_CNT_PER_THRD_DEFAULT_VALUE},
     {GLUSTERD_LOCALTIME_LOGGING_KEY, "disable"},
     {GLUSTERD_DAEMON_LOG_LEVEL_KEY, "INFO"},
-    {GLUSTER_BRICK_GRACEFUL_CLEANUP, "disable"},
+    {GLUSTER_BRICK_GRACEFUL_CLEANUP, "enable"},
     {NULL},
 };
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -158,7 +158,7 @@ is_brick_graceful_cleanup_enabled(dict_t *opts)
 {
     char *value = NULL;
     int ret = 0;
-    gf_boolean_t enabled = _gf_false;
+    gf_boolean_t enabled = _gf_true;
 
     ret = dict_get_strn(opts, GLUSTER_BRICK_GRACEFUL_CLEANUP,
                         SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), &value);
@@ -166,7 +166,7 @@ is_brick_graceful_cleanup_enabled(dict_t *opts)
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
-    return ret ? _gf_false : enabled;
+    return enabled;
 }
 
 static gf_boolean_t

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -2932,10 +2932,10 @@ struct volopt_map_entry glusterd_volopt_map[] = {
                     "brick process."},
     {.key = GLUSTER_BRICK_GRACEFUL_CLEANUP,
      .voltype = "mgmt/glusterd",
-     .value = "disable",
+     .value = "enable",
      .op_version = GD_OP_VERSION_9_0,
      .validate_fn = validate_boolean,
-     .type = GLOBAL_NO_DOC,
+     .type = GLOBAL_DOC,
      .description = "This global option can be used to enable/disable "
                     "graceful cleanup, after enable graceful cleanup "
                     "glusterd always sends a detach rpc request to stop a "

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1711,6 +1711,7 @@ server_notify(xlator_t *this, int32_t event, void *data, ...)
              * still traversing, which will cause us to crash unless we use
              * list_for_each_entry_safe.
              */
+            victim_name = gf_strdup(victim->name);
             list_for_each_entry_safe(xprt, xp_next, &conf->xprt_list, list)
             {
                 if (!xprt->xl_private) {


### PR DESCRIPTION
There was a new option (GLUSTER_BRICK_GRACEFUL_CLEANUP) introduced from the
bug #1751 to stop a brick process gracefully but the option was disabled.

Solution: Now enable the option as a default after finished the testing.

Note: To validate the option followed below testing
1) Create 100 2x3 volumes
2) Mount first 33 volumes on node 1 , next 33 volumes on node 2
   and last 34 volumes on node 3
3) Untar kernel.tar file on all the volumes in while[1] loop by a
   script in background so that all tar should be running always
4) Run a script on server node to start/stop all the volumes
5) No brick process should be crash

Fixes: #1931
Change-Id: Iecb565a44224e85a8696ca26c469c7a2b9090bc9
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

