### PR TITLE
glusterd: start brick process with proper logger option

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2267,6 +2267,10 @@ retry:
         }
     }
 
+    if (this->ctx->cmd_args.logger == gf_logger_syslog) {
+        runner_argprintf(&runner, "--logger=syslog");
+    }
+
     runner_add_arg(&runner, "--xlator-option");
     runner_argprintf(&runner, "%s-server.listen-port=%d", volinfo->volname,
                      port);
@@ -14895,7 +14899,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     if (pre_list == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
                "failed to allocate memory");
-	goto out;
+        goto out;
     }
     pre_list->info = NULL;
     CDS_INIT_LIST_HEAD(&pre_list->list);


### PR DESCRIPTION
Check if 'glusterd' is started with `--logger` option as syslog, and
use the same option to brick processes.

Updates: #1935
Change-Id: Ib0ea76322d48cccf6db30097bffe01903125650e
Signed-off-by: Amar Tumballi <amar@kadalu.io>

