### PR TITLE
NFS - Fixing a clang issue

### DIFF
--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -1424,9 +1424,9 @@ err:
         ncf = nlm4_notify_init(cs);
         if (ncf) {
             ncf->frame = copy_frame(frame);
-            if(ncf->frame){
-            	ncf->frame->local = ncf;
-            	nlm4svc_send_granted(ncf);
+            if (ncf->frame) {
+                ncf->frame->local = ncf;
+                nlm4svc_send_granted(ncf);
             }
         }
     } else {


### PR DESCRIPTION
Smoke tests verified PR https://github.com/gluster/glusterfs/pull/1894,
even though there was a clang issue present, and the PR was merged.
Smoke tests have been fixed so sending this PR to rectify the clang
issue.

Change-Id: I3df5d2c77d9f3dd1872f2f28824565d5f24d82ec
updates: #1060
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

