### PR TITLE
configure: enabling LTO with gcc 10 or above (#1791)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1351,6 +1351,24 @@ case $host_os in
         ;;
 esac
 
+# LTO section
+AC_ARG_ENABLE([lto],
+              AC_HELP_STRING([--disable-lto],
+                             [Disable buidling with LTO]))
+
+LTO_BUILD=no
+AS_IF([ test "x$enable_lto" != "xno" ], [
+    CC_VER=`"$CC" -dumpversion 2>/dev/null`
+    AS_IF([ test ! -z "$CC_VER" && test "$CC_VER" -ge "10" ], [
+        GF_CFLAGS="${GF_CFLAGS} -flto"
+        GF_LDFLAGS="${GF_LDFLAGS} -flto"
+        LTO_BUILD=yes
+        AC_MSG_NOTICE([building with LTO])],
+        [AC_MSG_NOTICE([not using LTO for gcc_ver=$CC_VER]) ]) 
+    ], [
+    AC_MSG_NOTICE([LTO is disabled])
+])
+
 # Default value for sbindir
 prefix_temp=$prefix
 exec_prefix_temp=$exec_prefix
@@ -1728,6 +1746,7 @@ echo "Cloudsync            : $BUILD_CLOUDSYNC"
 echo "Metadata dispersal   : $BUILD_METADISP"
 echo "Link with TCMALLOC   : $BUILD_TCMALLOC"
 echo "Enable Brick Mux     : $USE_BRICKMUX"
+echo "Building with LTO    : $LTO_BUILD"
 echo
 
 # dnl Note: ${X^^} capitalization assumes bash >= 4.x


### PR DESCRIPTION
Adding LTO to the build when gcc_version >= 10
Applicable for source and RPMs build

To disable: ./configure  --disable-lto

Fixes: #1772
Change-Id: Ia50210af2e88a5cc188c47b4e61a66397e179257
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

