### PR TITLE
DHT: fix coverity issue of argument cannot be negative

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -11337,7 +11337,7 @@ int
 dht_pt_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                 const char *key, dict_t *xdata)
 {
-    int op_errno = -1;
+    int op_errno = EINVAL;
     dht_local_t *local = NULL;
 
     VALIDATE_OR_GOTO(frame, err);


### PR DESCRIPTION
CID 1438086:
Initialize op_errno to a positive error, because it
might be passed to a parameter that cannot be negative.

updates: #1060
Change-Id: I1b5fda4dbbd5b1a50ea1c293af3b265d385d891c
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

