### PR TITLE
glusterd - fixing coverity issues

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15143,19 +15143,15 @@ found_bad_brick_order:
 
     ret = -1;
 out:
-    ai_list_tmp2 = NULL;
     GF_FREE(brick_list_ptr);
     if (pre_list != NULL) {
         cds_list_for_each_entry(pre_list_tmp1, &pre_list->list, list)
         {
             if (pre_list_tmp1->info)
                 freeaddrinfo(pre_list_tmp1->info);
-            free(ai_list_tmp2);
-            ai_list_tmp2 = pre_list_tmp1;
+            free(pre_list_tmp1);
         }
         free(pre_list);
-        free(ai_list_tmp2);
-        ai_list_tmp2 = NULL;
     }
 
     if (ai_list != NULL) {
@@ -15163,11 +15159,9 @@ out:
         {
             if (ai_list_tmp1->info)
                 freeaddrinfo(ai_list_tmp1->info);
-            free(ai_list_tmp2);
-            ai_list_tmp2 = ai_list_tmp1;
+            free(ai_list_tmp1);
         }
         free(ai_list);
-        free(ai_list_tmp2);
     }
 
     gf_msg_debug("glusterd", 0, "Returning %d", ret);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14921,6 +14921,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     glusterd_brickinfo_t *brickinfo = NULL;
     addrinfo_list_t *pre_list = NULL;
     addrinfo_list_t *pre_list_tmp1 = NULL;
+    addrinfo_list_t *pre_list_tmp2 = NULL;
     int count = 0;
 
     const char failed_string[2048] =
@@ -15145,23 +15146,25 @@ found_bad_brick_order:
 out:
     GF_FREE(brick_list_ptr);
     if (pre_list != NULL) {
-        cds_list_for_each_entry(pre_list_tmp1, &pre_list->list, list)
+        cds_list_for_each_entry_safe(pre_list_tmp1, pre_list_tmp2,
+                                     &pre_list->list, list)
         {
             if (pre_list_tmp1->info)
                 freeaddrinfo(pre_list_tmp1->info);
-            free(pre_list_tmp1);
+            FREE(pre_list_tmp1);
         }
-        free(pre_list);
+        FREE(pre_list);
     }
 
     if (ai_list != NULL) {
-        cds_list_for_each_entry(ai_list_tmp1, &ai_list->list, list)
+        cds_list_for_each_entry_safe(ai_list_tmp1, ai_list_tmp2, &ai_list->list,
+                                     list)
         {
             if (ai_list_tmp1->info)
                 freeaddrinfo(ai_list_tmp1->info);
-            free(ai_list_tmp1);
+            FREE(ai_list_tmp1);
         }
-        free(ai_list);
+        FREE(ai_list);
     }
 
     gf_msg_debug("glusterd", 0, "Returning %d", ret);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15155,6 +15155,7 @@ out:
         }
         free(pre_list);
         free(ai_list_tmp2);
+        ai_list_tmp2 = NULL;
     }
 
     if (ai_list != NULL) {


### PR DESCRIPTION
- Dereference after null check (CID 1437686)
- Dereference null return value (CID 1437687)

- A check for the return value of a memory allocation was missing, added
it.
- A value of a pointer was being dereferenced after a NULL-pointer check.
With this change the pointer is no longer dereferenced.

Change-Id: I10bf8a2cb08612981dbb788315dad7dbb4efe2cb
updates: #1060
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>