### PR TITLE
xlators, libglusterfs: fixes for gcc-10 string overflow warnings

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -488,6 +488,12 @@ gf_assert(void);
          ? 0                                                                   \
          : 1)
 
+#define gf_snprintf(dest, size, fmt, ...)                                      \
+    do {                                                                       \
+        if (snprintf(dest, size, fmt, __VA_ARGS__) >= size)                    \
+            GF_ABORT();                                                        \
+    } while (0)
+
 union gf_sock_union {
     struct sockaddr_storage storage;
     struct sockaddr_in6 sin6;

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -491,9 +491,7 @@ fill_uuid(char *uuid, int size, struct timeval tv)
     }
 
     gf_time_fmt_tv(now_str, sizeof now_str, &tv, gf_timefmt_dirent);
-    snprintf(uuid, size, "%s-%d-%s", hostname, getpid(), now_str);
-
-    return;
+    gf_snprintf(uuid, size, "%s-%d-%s", hostname, getpid(), now_str);
 }
 
 static int

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -750,7 +750,6 @@ afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
     int ret = 0;
     char *xattr_serz = NULL;
     long cky = 0;
-    int32_t tlen = 0;
 
     local = frame->local;
     priv = this->private;
@@ -806,8 +805,9 @@ unlock:
             goto unwind;
         }
 
-        ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
-                                                  UUID0_STR, &tlen, ' ');
+        ret = afr_serialize_xattrs_with_delimiter(
+            frame, this, xattr_serz, local->cont.getxattr.xattr_len, UUID0_STR,
+            ' ');
         if (ret) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -147,8 +147,8 @@ afr_handle_anon_inode_options(afr_private_t *priv, dict_t *options)
     GF_ASSERT(strlen(AFR_ANON_DIR_PREFIX) + strlen(volfile_id_str) <= NAME_MAX);
     /*anon_inode_name is not supposed to change once assigned*/
     if (!priv->anon_inode_name[0]) {
-        snprintf(priv->anon_inode_name, sizeof(priv->anon_inode_name), "%s-%s",
-                 AFR_ANON_DIR_PREFIX, volfile_id_str);
+        gf_snprintf(priv->anon_inode_name, sizeof(priv->anon_inode_name),
+                    "%s-%s", AFR_ANON_DIR_PREFIX, volfile_id_str);
         gf_uuid_parse(volfile_id_str, anon_inode_gfid);
         /*Flip a bit to make sure volfile-id and anon-gfid are not same*/
         anon_inode_gfid[0] ^= 1;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1340,8 +1340,8 @@ afr_is_inode_refresh_reqd(inode_t *inode, xlator_t *this, int event_gen1,
 
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter);
+                                    char *buf, int32_t bufsize,
+                                    const char *default_str, char delimiter);
 gf_boolean_t
 afr_is_symmetric_error(call_frame_t *frame, xlator_t *this);
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3916,7 +3916,7 @@ init(xlator_t *this)
     ret = dict_get_strn(this->options, "volume-id", SLEN("volume-id"),
                         &volume_id);
     if (!ret) {
-        strncpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
+        gf_snprintf(this->graph->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
     }
     /*
      * Init it just after calloc, so that we are sure the lock is inited

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1967,11 +1967,15 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
         gf_uuid_copy(pargfid, tmp_gfid);
     }
 
-    if (bname)
-        strncat(result, bname, strlen(bname) + 1);
-
-    *path = gf_strdup(result);
-
+    if (bname) {
+        len = gf_asprintf(path, "%s%s", result, bname);
+        if ((len < 0) || (len >= PATH_MAX)) {
+            GF_FREE(*path);
+            ret = -1;
+            goto out;
+        }
+    } else
+        *path = gf_strdup(result);
 out:
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4359,7 +4359,7 @@ glusterd_store_uuid_peerpath_set(glusterd_peerinfo_t *peerinfo, char *peerfpath,
 
     glusterd_store_peerinfo_dirpath_set(peerdir, sizeof(peerdir));
     gf_uuid_unparse(peerinfo->uuid, str);
-    snprintf(peerfpath, len, "%s/%s", peerdir, str);
+    gf_snprintf(peerfpath, len, "%s/%s", peerdir, str);
 }
 
 static void
@@ -4373,7 +4373,7 @@ glusterd_store_hostname_peerpath_set(glusterd_peerinfo_t *peerinfo,
     GF_ASSERT(len >= PATH_MAX);
 
     glusterd_store_peerinfo_dirpath_set(peerdir, sizeof(peerdir));
-    snprintf(peerfpath, len, "%s/%s", peerdir, peerinfo->hostname);
+    gf_snprintf(peerfpath, len, "%s/%s", peerdir, peerinfo->hostname);
 }
 
 int32_t

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15030,7 +15030,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
         if (tmpptr == NULL)
             goto check_failed;
         addrlen = strlen(brick) - strlen(tmpptr);
-        strncpy(brick_addr, brick, addrlen);
+        strncpy(brick_addr, brick, sizeof(brick_addr));
         brick_addr[addrlen] = '\0';
         ret = getaddrinfo(brick_addr, NULL, NULL, &ai_info);
         if (ret != 0) {
@@ -15185,6 +15185,7 @@ glusterd_add_peers_to_auth_list(char *volname)
     xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     int32_t len = 0;
+    char *p;
     char *auth_allow_list = NULL;
     char *new_auth_allow_list = NULL;
 
@@ -15210,24 +15211,21 @@ glusterd_add_peers_to_auth_list(char *volname)
     }
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {
-        len += strlen(peerinfo->hostname);
+        len += strlen(peerinfo->hostname) + 1;
     }
     len += strlen(auth_allow_list) + 1;
 
     new_auth_allow_list = GF_CALLOC(1, len, gf_common_mt_char);
+    p = stpcpy(new_auth_allow_list, auth_allow_list);
 
-    new_auth_allow_list = strncat(new_auth_allow_list, auth_allow_list,
-                                  strlen(auth_allow_list));
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {
         ret = search_peer_in_auth_list(peerinfo->hostname, new_auth_allow_list);
         if (!ret) {
             gf_log(this->name, GF_LOG_DEBUG,
                    "peer %s not found in auth.allow list", peerinfo->hostname);
-            new_auth_allow_list = strcat(new_auth_allow_list, ",");
-            new_auth_allow_list = strncat(new_auth_allow_list,
-                                          peerinfo->hostname,
-                                          strlen(peerinfo->hostname));
+            p += snprintf(p, len - (p - new_auth_allow_list), ",%s",
+                          peerinfo->hostname);
         }
     }
     if (strcmp(new_auth_allow_list, auth_allow_list) != 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -3712,7 +3712,7 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
     glusterd_conf_t *conf = NULL;
     glusterd_brickinfo_t *brick = NULL;
     glusterd_brickinfo_t *ta_brick = NULL;
-    char *ptr = NULL;
+    char *ptr = NULL, *curr = NULL;
     int i = 0;
     int index = -1;
     int ret = 0;
@@ -3751,12 +3751,13 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
 
     i = 1;
     index = 0;
+    curr = ptr;
 
     cds_list_for_each_entry(brick, &volinfo->bricks, brick_list)
     {
         if (index == clusters)
             break;
-        strncat(ptr, brick->brick_id, strlen(brick->brick_id));
+        curr = stpncpy(curr, brick->brick_id, (ptr + list_size) - curr);
         if (i == volinfo->replica_count) {
             /* add ta client xlator in afr-pending-xattrs before making entries
              * for client xlators in volfile.
@@ -3767,7 +3768,11 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
              */
             ta_brick_index = 0;
             if (volinfo->thin_arbiter_count == 1) {
-                ptr[strlen(brick->brick_id)] = ',';
+                if (curr >= ptr + list_size - 1) {
+                    ret = -1;
+                    goto out;
+                }
+                *curr++ = ',';
                 cds_list_for_each_entry(ta_brick, &volinfo->ta_bricks,
                                         brick_list)
                 {
@@ -3777,14 +3782,12 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
                     ta_brick_index++;
                 }
                 if (conf->op_version < GD_OP_VERSION_7_3) {
-                    strncat(ptr, ta_brick->brick_id,
-                            strlen(ta_brick->brick_id));
+                    curr = stpncpy(curr, ta_brick->brick_id,
+                                   (ptr + list_size) - curr);
                 } else {
-                    char ta_volname[PATH_MAX] = "";
-                    int len = snprintf(ta_volname, PATH_MAX, "%s.%s",
-                                       ta_brick->brick_id,
-                                       uuid_utoa(volinfo->volume_id));
-                    strncat(ptr, ta_volname, len);
+                    curr += snprintf(curr, (ptr + list_size) - curr, "%s.%s",
+                                     ta_brick->brick_id,
+                                     uuid_utoa(volinfo->volume_id));
                 }
             }
 
@@ -3794,12 +3797,16 @@ set_afr_pending_xattrs_option(volgen_graph_t *graph,
                 goto out;
             memset(afr_xattrs_list, 0, list_size);
             ptr = afr_xattrs_list;
+            curr = ptr;
             i = 1;
             subvol_index++;
             continue;
         }
-        ptr[strlen(brick->brick_id)] = ',';
-        ptr += strlen(brick->brick_id) + 1;
+        if (curr >= ptr + list_size - 1) {
+            ret = -1;
+            goto out;
+        }
+        *curr++ = ',';
         i++;
     }
 

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -1101,8 +1101,7 @@ __mnt3_fresh_lookup(mnt3_resolve_t *mres)
 {
     inode_unlink(mres->resolveloc.inode, mres->resolveloc.parent,
                  mres->resolveloc.name);
-    strncpy(mres->remainingdir, mres->resolveloc.path,
-            strlen(mres->resolveloc.path));
+    snprintf(mres->remainingdir, MNTPATHLEN, "%s", mres->resolveloc.path);
     nfs_loc_wipe(&mres->resolveloc);
     return __mnt3_resolve_subdir(mres);
 }

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -809,7 +809,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 goto out;
             }
         } else {
-            strncpy(ctx->volume_id, volume_id, GF_UUID_BUF_SIZE);
+            snprintf(ctx->volume_id, GF_UUID_BUF_SIZE, "%s", volume_id);
         }
     }
 
@@ -998,8 +998,8 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
         /* If any value is set, the first element will be non-0.
            It would be '0', but not '\0' :-) */
         if (!this->ctx->volume_id[0]) {
-            strncpy(this->ctx->volume_id, this->graph->volume_id,
-                    GF_UUID_BUF_SIZE);
+            snprintf(this->ctx->volume_id, GF_UUID_BUF_SIZE, "%s",
+                     this->graph->volume_id);
         }
         if (this->ctx->volume_id[0]) {
             ret = dict_set_str(options, "volume-id", this->ctx->volume_id);

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -380,7 +380,7 @@ posix_handle_pump(xlator_t *this, char *buf, int len, int maxlen,
     memmove(buf + base_len + blen, buf + base_len,
             (strlen(buf) - base_len) + 1);
 
-    strncpy(base_str + pfx_len, linkname + 6, 42);
+    strncpy(base_str + pfx_len, linkname + 6, base_len - pfx_len);
 
     strncpy(buf + pfx_len, linkname + 6, link_len - 6);
 out:

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1089,7 +1089,7 @@ posix_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 #ifndef FALLOC_FL_KEEP_SIZE
     ret = EOPNOTSUPP;
 
-#else  /* FALLOC_FL_KEEP_SIZE */
+#else /* FALLOC_FL_KEEP_SIZE */
     int32_t flags = FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
     struct iatt statpre = {
         0,
@@ -3435,8 +3435,8 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
 
         nlink_samepgfid = ntoh32(nlink_samepgfid);
 
-        snprintf(pgfidstr, sizeof(pgfidstr), "%s",
-                 key + SLEN(PGFID_XATTR_KEY_PREFIX));
+        gf_snprintf(pgfidstr, sizeof(pgfidstr), "%s",
+                    key + SLEN(PGFID_XATTR_KEY_PREFIX));
         gf_uuid_parse(pgfidstr, pgfid);
 
         handle_size = POSIX_GFID_HANDLE_SIZE(priv->base_path_length);


### PR DESCRIPTION
Fix warnings issued by gcc-10 -Wstringop-overflow,
-Wstringop-truncation, and -Wformat-truncation.

Change-Id: I8ed1739735953bae9062560625fcf63599dd9ae5
Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Updates: #1681

