### PR TITLE
Fixing the split-brain link where going for a 2 replicated volume.

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -708,9 +708,8 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
                         " to split-brain. Use "
                         "Arbiter or Replica 3 to "
                         "avoid this. See: "
-                        "http://docs.gluster.org/en/latest/"
-                        "Administrator%20Guide/"
-                        "Split%20brain%20and%20ways%20to%20deal%20with%20it/."
+                        "http://docs.gluster.org/en/latest/Administrator-Guide/"
+                        "Split-brain-and-ways-to-deal-with-it/."
                         "\nDo you still want to "
                         "continue?\n";
                     answer = cli_cmd_get_confirmation(state, question);
@@ -1934,8 +1933,8 @@ cli_cmd_volume_add_brick_parse(struct cli_state *state, const char **words,
                     "Replica 2 volumes are prone to "
                     "split-brain. Use Arbiter or "
                     "Replica 3 to avoid this. See: "
-                    "http://docs.gluster.org/en/latest/Administrator%20Guide/"
-                    "Split%20brain%20and%20ways%20to%20deal%20with%20it/."
+                    "http://docs.gluster.org/en/latest/Administrator-Guide/"
+                    "Split-brain-and-ways-to-deal-with-it/."
                     "\nDo you still want to continue?\n";
                 answer = cli_cmd_get_confirmation(state, question);
                 if (GF_ANSWER_NO == answer) {
@@ -2062,8 +2061,8 @@ cli_cmd_volume_remove_brick_parse(struct cli_state *state, const char **words,
                     "Replica 2 volumes are prone to "
                     "split-brain. Use Arbiter or Replica 3 "
                     "to avoid this. See: "
-                    "http://docs.gluster.org/en/latest/Administrator%20Guide/"
-                    "Split%20brain%20and%20ways%20to%20deal%20with%20it/."
+                    "http://docs.gluster.org/en/latest/Administrator-Guide/"
+                    "Split-brain-and-ways-to-deal-with-it/."
                     "\nDo you still want to continue?\n";
                 answer = cli_cmd_get_confirmation(state, ques);
                 if (GF_ANSWER_NO == answer) {


### PR DESCRIPTION
Fixes in functions:
	- cli_cmd_volume_create_parse()
	- cli_cmd_volume_add_brick_parse()
	- cli_cmd_volume_remove_brick_parse()

Fixes: #1959

