### PR TITLE
glusterd: Fix for shared storage in ipv6 env

### DIFF
--- a/extras/hook-scripts/set/post/S32gluster_enable_shared_storage.sh
+++ b/extras/hook-scripts/set/post/S32gluster_enable_shared_storage.sh
@@ -46,7 +46,7 @@ do
 
     key=`echo $line | cut -d ':' -f 1`
     if [ "$key" == "Hostname" ]; then
-        hostname=`echo $line | cut -d ':' -f 2 | xargs`
+        hostname=`echo $line | cut -d ' ' -f 2 | xargs`
     fi
 
     if [ "$key" == "State" ]; then


### PR DESCRIPTION
Issue:
Mounting shared storage volume was failing in ipv6 env if the hostnames were FQDNs.
The brickname for the volume was being cut off, as a result, volume creation was failing.

Change-Id: Ib38993724c709b35b603f9ac666630c50c932c3e
Fixes: #1406
Signed-off-by: nik-redhat <nladha@redhat.com>

