### PR TITLE
afr: don't reopen fds on which POSIX locks are held

### DIFF
--- a/rpc/rpc-lib/src/protocol-common.h
+++ b/rpc/rpc-lib/src/protocol-common.h
@@ -315,6 +315,12 @@ enum glusterd_mgmt_v3_procnum {
     GLUSTERD_MGMT_V3_MAXVALUE,
 };
 
+enum gf_fd_reopen_status {
+    FD_REOPEN_ALLOWED = 0,
+    FD_REOPEN_NOT_ALLOWED,
+    FD_BAD,
+};
+
 typedef struct gf_gsync_detailed_status_ gf_gsync_status_t;
 
 enum gf_get_volume_info_type {

--- a/tests/bugs/replicate/do-not-reopen-fd.t
+++ b/tests/bugs/replicate/do-not-reopen-fd.t
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../fileio.rc
+
+cleanup;
+
+TEST glusterd;
+TEST pidof glusterd
+
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.open-behind off
+TEST $CLI volume set $V0 client.strict-locks on
+TEST $CLI volume heal $V0 disable
+TEST $CLI volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status';
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M1
+
+TEST touch $M0/a
+
+# Kill one brick and take lock on the fd and do a write.
+TEST kill_brick $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" afr_child_up_status_meta $M0 $V0-replicate-0 0
+TEST fd1=`fd_available`
+TEST fd_open $fd1 'rw' $M0/a
+
+TEST flock -x $fd1
+TEST fd_write $fd1 "data-1"
+
+# Restart the brick and then write. Now fd should not get re-opened but write
+# should still succeed as there were no quorum disconnects.
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 0
+TEST fd_write $fd1 "data-2"
+EXPECT "" cat $B0/${V0}0/a
+EXPECT "data-2" cat $B0/${V0}1/a
+EXPECT "data-2" cat $B0/${V0}2/a
+
+# Check there is no fd opened on the 1st brick by checking for the gfid inside
+# /proc/pid-of-brick/fd/ directory
+gfid_a=$(gf_get_gfid_xattr $B0/${V0}0/a)
+gfid_str_a=$(gf_gfid_xattr_to_str $gfid_a)
+
+EXPECT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+TEST fd2=`fd_available`
+TEST fd_open $fd2 'rw' $M1/a
+
+# Kill 2nd brick and try writing to the file. The write should fail due to
+# quorum failure.
+TEST kill_brick $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" afr_child_up_status_meta $M0 $V0-replicate-0 1
+TEST ! fd_write $fd1 "data-3"
+TEST ! fd_cat $fd1
+
+# Restart the bricks and try writing to the file. This should fail as two bricks
+# which were down previously, will return EBADFD now.
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 1
+TEST ! fd_write $fd1 "data-4"
+TEST ! fd_cat $fd1
+
+# Enable heal and check the files will have same content on all the bricks after
+# the heal is completed.
+EXPECT_WITHIN $HEAL_TIMEOUT "^2$" get_pending_heal_count $V0
+TEST $CLI volume heal $V0 enable
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+EXPECT "data-4" cat $B0/${V0}0/a
+EXPECT "data-4" cat $B0/${V0}1/a
+EXPECT "data-4" cat $B0/${V0}2/a
+TEST $CLI volume heal $V0 disable
+
+# Try writing to the file again on the same fd, which should fail again, since
+# it is not yet re-opened.
+TEST ! fd_write $fd1 "data-5"
+
+# At this point only one brick will have the lock. Try taking the lock again on
+# the bad fd, which should also fail with EBADFD.
+TEST ! flock -x $fd1
+
+# Kill the only brick that is having lock and try taking lock on another client
+# which should succeed.
+TEST kill_brick $V0 $H0 $B0/${V0}2
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" afr_child_up_status_meta $M0 $V0-replicate-0 2
+TEST flock -x $fd2
+TEST fd_write $fd2 "data-6"
+
+# Bring the brick up and try writing & reading on the old fd, which should still
+# fail and operations on the 2nd fd should succeed.
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}2
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 2
+TEST ! fd_write $fd1 "data-7"
+
+TEST ! fd_cat $fd1
+TEST fd_cat $fd2
+
+# Close both the fds which will release the locks and then re-open and take lock
+# on the old fd. Operations on that fd should succeed afterwards.
+TEST fd_close $fd1
+TEST fd_close $fd2
+
+TEST ! ls /proc/$$/fd/$fd1
+TEST ! ls /proc/$$/fd/$fd2
+EXPECT_WITHIN $REOPEN_TIMEOUT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT_WITHIN $REOPEN_TIMEOUT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT_WITHIN $REOPEN_TIMEOUT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+TEST fd1=`fd_available`
+TEST fd_open $fd1 'rw' $M0/a
+EXPECT_WITHIN $REOPEN_TIMEOUT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT_WITHIN $REOPEN_TIMEOUT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT_WITHIN $REOPEN_TIMEOUT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+TEST flock -x $fd1
+TEST fd_write $fd1 "data-8"
+TEST fd_cat $fd1
+
+EXPECT "data-8" head -n 1 $B0/${V0}0/a
+EXPECT "data-8" head -n 1 $B0/${V0}1/a
+EXPECT "data-8" head -n 1 $B0/${V0}2/a
+
+TEST fd_close $fd1
+
+# Heal the volume
+TEST $CLI volume heal $V0 enable
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+TEST $CLI volume heal $V0 disable
+
+# Kill one brick and open a fd.
+TEST kill_brick $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" afr_child_up_status_meta $M0 $V0-replicate-0 0
+TEST fd1=`fd_available`
+TEST fd_open $fd1 'rw' $M0/a
+
+EXPECT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+# Restart the brick and then write. Now fd should get re-opened and write should
+# succeed on the previously down brick as well since there are no locks held on
+# any of the bricks.
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 0
+TEST fd_write $fd1 "data-10"
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+
+EXPECT "data-10" head -n 1 $B0/${V0}0/a
+EXPECT "data-10" head -n 1 $B0/${V0}1/a
+EXPECT "data-10" head -n 1 $B0/${V0}2/a
+TEST fd_close $fd1
+
+# Kill one brick, open and take lock on a fd.
+TEST kill_brick $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" afr_child_up_status_meta $M0 $V0-replicate-0 0
+TEST fd1=`fd_available`
+TEST fd_open $fd1 'rw' $M0/a
+TEST flock -x $fd1
+
+EXPECT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+# Kill & restart another brick so that it will return EBADFD
+TEST kill_brick $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT "0" brick_up_status $V0 $H0 $B0/${V0}1
+
+# Restart the bricks and then write. Now fd should not get re-opened since lock
+# is still held on one brick and write should also fail as there is no quorum.
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^1$" brick_up_status $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_meta $M0 $V0-replicate-0 1
+TEST ! fd_write $fd1 "data-11"
+EXPECT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}0 $gfid_str_a
+EXPECT "N" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}1 $gfid_str_a
+EXPECT "Y" gf_check_file_opened_in_brick $V0 $H0 $B0/${V0}2 $gfid_str_a
+
+EXPECT "data-10" head -n 1 $B0/${V0}0/a
+EXPECT "data-10" head -n 1 $B0/${V0}1/a
+EXPECT "data-11" head -n 1 $B0/${V0}2/a
+
+TEST fd_close $fd1
+cleanup

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -2738,6 +2738,8 @@ afr_local_cleanup(afr_local_t *local, xlator_t *this)
             dict_unref(local->cont.entrylk.xdata);
     }
 
+    GF_FREE(local->need_open);
+
     if (local->xdata_req)
         dict_unref(local->xdata_req);
 
@@ -6526,6 +6528,14 @@ afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno)
         local->fop_state = TA_SUCCESS;
     }
     local->is_new_entry = _gf_false;
+
+    local->need_open = GF_CALLOC(priv->child_count, sizeof(*local->need_open),
+                                 gf_afr_mt_char);
+    if (!local->need_open) {
+        if (op_errno)
+            *op_errno = ENOMEM;
+        goto out;
+    }
 
     INIT_LIST_HEAD(&local->healer);
     return 0;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -941,6 +941,9 @@ typedef struct _afr_local {
     gf_boolean_t need_full_crawl;
     gf_boolean_t is_read_txn;
     gf_boolean_t is_new_entry;
+
+    /* For fix_open */
+    unsigned char *need_open;
 } afr_local_t;
 
 typedef struct afr_spbc_timeout {

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -343,7 +343,7 @@ client_pre_readv(xlator_t *this, gfs3_read_req *req, fd_t *fd, size_t size,
     int op_errno = ESTALE;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_READ, out);
 
     req->size = size;
     req->offset = offset;
@@ -368,7 +368,7 @@ client_pre_writev(xlator_t *this, gfs3_write_req *req, fd_t *fd, size_t size,
     int op_errno = ESTALE;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_WRITE, out);
 
     req->size = size;
     req->offset = offset;
@@ -429,7 +429,8 @@ client_pre_flush(xlator_t *this, gfs3_flush_req *req, fd_t *fd, dict_t *xdata)
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FLUSH, out);
 
     req->fd = remote_fd;
     memcpy(req->gfid, fd->inode->gfid, 16);
@@ -450,7 +451,7 @@ client_pre_fsync(xlator_t *this, gfs3_fsync_req *req, fd_t *fd, int32_t flags,
     int op_errno = 0;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FSYNC, out);
 
     req->fd = remote_fd;
     req->data = flags;
@@ -591,7 +592,8 @@ client_pre_fsyncdir(xlator_t *this, gfs3_fsyncdir_req *req, fd_t *fd,
     int32_t op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSYNCDIR, out);
 
     req->fd = remote_fd;
     req->data = flags;
@@ -668,7 +670,8 @@ client_pre_ftruncate(xlator_t *this, gfs3_ftruncate_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = EINVAL;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FTRUNCATE, out);
 
     req->offset = offset;
     req->fd = remote_fd;
@@ -687,7 +690,8 @@ client_pre_fstat(xlator_t *this, gfs3_fstat_req *req, fd_t *fd, dict_t *xdata)
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSTAT, out);
 
     req->fd = remote_fd;
     memcpy(req->gfid, fd->inode->gfid, 16);
@@ -710,7 +714,8 @@ client_pre_lk(xlator_t *this, gfs3_lk_req *req, int32_t cmd,
     int32_t gf_type = 0;
     int ret = 0;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_LK, out);
 
     ret = client_cmd_to_gf_cmd(cmd, &gf_cmd);
     if (ret) {
@@ -787,7 +792,8 @@ client_pre_readdir(xlator_t *this, gfs3_readdir_req *req, fd_t *fd, size_t size,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_READDIR, out);
 
     req->size = size;
     req->offset = offset;
@@ -869,7 +875,7 @@ client_pre_finodelk(xlator_t *this, gfs3_finodelk_req *req, fd_t *fd, int cmd,
     int32_t gf_cmd = 0;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FINODELK, out);
 
     if (cmd == F_GETLK || cmd == F_GETLK64)
         gf_cmd = GF_LK_GETLK;
@@ -952,7 +958,8 @@ client_pre_fentrylk(xlator_t *this, gfs3_fentrylk_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FENTRYLK, out);
 
     req->fd = remote_fd;
     req->cmd = cmd_entrylk;
@@ -1013,7 +1020,7 @@ client_pre_fxattrop(xlator_t *this, gfs3_fxattrop_req *req, fd_t *fd,
     int64_t remote_fd = -1;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FXATTROP, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -1039,7 +1046,8 @@ client_pre_fgetxattr(xlator_t *this, gfs3_fgetxattr_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FGETXATTR, out);
 
     req->namelen = 1; /* Use it as a flag */
     req->fd = remote_fd;
@@ -1065,7 +1073,8 @@ client_pre_fsetxattr(xlator_t *this, gfs3_fsetxattr_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSETXATTR, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -1091,7 +1100,8 @@ client_pre_rchecksum(xlator_t *this, gfs3_rchecksum_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_RCHECKSUM, out);
 
     req->len = len;
     req->offset = offset;
@@ -1141,7 +1151,8 @@ client_pre_fsetattr(xlator_t *this, gfs3_fsetattr_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSETATTR, out);
 
     req->fd = remote_fd;
     req->valid = valid;
@@ -1161,7 +1172,8 @@ client_pre_readdirp(xlator_t *this, gfs3_readdirp_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_READDIRP, out);
 
     req->size = size;
     req->offset = offset;
@@ -1187,7 +1199,8 @@ client_pre_fremovexattr(xlator_t *this, gfs3_fremovexattr_req *req, fd_t *fd,
     if (!(fd && fd->inode))
         goto out;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FREMOVEXATTR, out);
 
     memcpy(req->gfid, fd->inode->gfid, 16);
     req->name = (char *)name;
@@ -1208,7 +1221,8 @@ client_pre_fallocate(xlator_t *this, gfs3_fallocate_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FALLOCATE, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -1230,7 +1244,8 @@ client_pre_discard(xlator_t *this, gfs3_discard_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_DISCARD, out);
 
     req->fd = remote_fd;
     req->offset = offset;
@@ -1251,7 +1266,8 @@ client_pre_zerofill(xlator_t *this, gfs3_zerofill_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_ZEROFILL, out);
 
     req->fd = remote_fd;
     req->offset = offset;
@@ -1286,7 +1302,8 @@ client_pre_seek(xlator_t *this, gfs3_seek_req *req, fd_t *fd, off_t offset,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_SEEK, out);
 
     memcpy(req->gfid, fd->inode->gfid, 16);
     req->fd = remote_fd;
@@ -2508,7 +2525,7 @@ client_pre_readv_v2(xlator_t *this, gfx_read_req *req, fd_t *fd, size_t size,
     int op_errno = ESTALE;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_READ, out);
 
     req->size = size;
     req->offset = offset;
@@ -2532,7 +2549,7 @@ client_pre_writev_v2(xlator_t *this, gfx_write_req *req, fd_t *fd, size_t size,
     int op_errno = ESTALE;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_WRITE, out);
 
     req->size = size;
     req->offset = offset;
@@ -2567,10 +2584,10 @@ client_pre_copy_file_range_v2(xlator_t *this, gfx_copy_file_range_req *req,
     int op_errno = ESTALE;
 
     CLIENT_GET_REMOTE_FD(this, fd_in, FALLBACK_TO_ANON_FD, remote_fd_in,
-                         op_errno, out);
+                         op_errno, GFS3_OP_COPY_FILE_RANGE, out);
 
     CLIENT_GET_REMOTE_FD(this, fd_out, FALLBACK_TO_ANON_FD, remote_fd_out,
-                         op_errno, out);
+                         op_errno, GFS3_OP_COPY_FILE_RANGE, out);
     req->size = size;
     req->off_in = off_in;
     req->off_out = off_out;
@@ -2623,7 +2640,8 @@ client_pre_flush_v2(xlator_t *this, gfx_flush_req *req, fd_t *fd, dict_t *xdata)
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FLUSH, out);
 
     req->fd = remote_fd;
     memcpy(req->gfid, fd->inode->gfid, 16);
@@ -2643,7 +2661,7 @@ client_pre_fsync_v2(xlator_t *this, gfx_fsync_req *req, fd_t *fd, int32_t flags,
     int op_errno = 0;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FSYNC, out);
 
     req->fd = remote_fd;
     req->data = flags;
@@ -2778,7 +2796,8 @@ client_pre_fsyncdir_v2(xlator_t *this, gfx_fsyncdir_req *req, fd_t *fd,
     int32_t op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSYNCDIR, out);
 
     req->fd = remote_fd;
     req->data = flags;
@@ -2852,7 +2871,8 @@ client_pre_ftruncate_v2(xlator_t *this, gfx_ftruncate_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = EINVAL;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FTRUNCATE, out);
 
     req->offset = offset;
     req->fd = remote_fd;
@@ -2870,7 +2890,8 @@ client_pre_fstat_v2(xlator_t *this, gfx_fstat_req *req, fd_t *fd, dict_t *xdata)
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSTAT, out);
 
     req->fd = remote_fd;
     memcpy(req->gfid, fd->inode->gfid, 16);
@@ -2892,7 +2913,8 @@ client_pre_lk_v2(xlator_t *this, gfx_lk_req *req, int32_t cmd,
     int32_t gf_type = 0;
     int ret = 0;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_LK, out);
 
     ret = client_cmd_to_gf_cmd(cmd, &gf_cmd);
     if (ret) {
@@ -2967,7 +2989,8 @@ client_pre_readdir_v2(xlator_t *this, gfx_readdir_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_READDIR, out);
 
     req->size = size;
     req->offset = offset;
@@ -3048,7 +3071,7 @@ client_pre_finodelk_v2(xlator_t *this, gfx_finodelk_req *req, fd_t *fd, int cmd,
     int32_t gf_cmd = 0;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FINODELK, out);
 
     if (cmd == F_GETLK || cmd == F_GETLK64)
         gf_cmd = GF_LK_GETLK;
@@ -3129,7 +3152,8 @@ client_pre_fentrylk_v2(xlator_t *this, gfx_fentrylk_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FENTRYLK, out);
 
     req->fd = remote_fd;
     req->cmd = cmd_entrylk;
@@ -3185,7 +3209,7 @@ client_pre_fxattrop_v2(xlator_t *this, gfx_fxattrop_req *req, fd_t *fd,
     int64_t remote_fd = -1;
 
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
-                         out);
+                         GFS3_OP_FXATTROP, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -3207,7 +3231,8 @@ client_pre_fgetxattr_v2(xlator_t *this, gfx_fgetxattr_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FGETXATTR, out);
 
     req->namelen = 1; /* Use it as a flag */
     req->fd = remote_fd;
@@ -3232,7 +3257,8 @@ client_pre_fsetxattr_v2(xlator_t *this, gfx_fsetxattr_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSETXATTR, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -3256,7 +3282,8 @@ client_pre_rchecksum_v2(xlator_t *this, gfx_rchecksum_req *req, fd_t *fd,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_RCHECKSUM, out);
 
     req->len = len;
     req->offset = offset;
@@ -3304,7 +3331,8 @@ client_pre_fsetattr_v2(xlator_t *this, gfx_fsetattr_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FSETATTR, out);
 
     memcpy(req->gfid, fd->inode->gfid, 16);
     req->fd = remote_fd;
@@ -3324,7 +3352,8 @@ client_pre_readdirp_v2(xlator_t *this, gfx_readdirp_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_READDIRP, out);
 
     req->size = size;
     req->offset = offset;
@@ -3349,7 +3378,8 @@ client_pre_fremovexattr_v2(xlator_t *this, gfx_fremovexattr_req *req, fd_t *fd,
     if (!(fd && fd->inode))
         goto out;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FREMOVEXATTR, out);
 
     memcpy(req->gfid, fd->inode->gfid, 16);
     req->name = (char *)name;
@@ -3369,7 +3399,8 @@ client_pre_fallocate_v2(xlator_t *this, gfx_fallocate_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_FALLOCATE, out);
 
     req->fd = remote_fd;
     req->flags = flags;
@@ -3390,7 +3421,8 @@ client_pre_discard_v2(xlator_t *this, gfx_discard_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_DISCARD, out);
 
     req->fd = remote_fd;
     req->offset = offset;
@@ -3410,7 +3442,8 @@ client_pre_zerofill_v2(xlator_t *this, gfx_zerofill_req *req, fd_t *fd,
     int op_errno = ESTALE;
     int64_t remote_fd = -1;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_ZEROFILL, out);
 
     req->fd = remote_fd;
     req->offset = offset;
@@ -3439,7 +3472,8 @@ client_pre_seek_v2(xlator_t *this, gfx_seek_req *req, fd_t *fd, off_t offset,
     int64_t remote_fd = -1;
     int op_errno = ESTALE;
 
-    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno, out);
+    CLIENT_GET_REMOTE_FD(this, fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
+                         GFS3_OP_SEEK, out);
 
     memcpy(req->gfid, fd->inode->gfid, 16);
     req->fd = remote_fd;
@@ -3586,4 +3620,25 @@ client_post_rename_v2(xlator_t *this, gfx_rename_rsp *rsp, struct iatt *stbuf,
     }
 
     return xdr_to_dict(&rsp->xdata, xdata);
+}
+
+void
+set_fd_reopen_status(xlator_t *this, dict_t *xdata,
+                     enum gf_fd_reopen_status fd_reopen_status)
+{
+    clnt_conf_t *conf = NULL;
+
+    conf = this->private;
+    if (!conf) {
+        gf_msg_debug(this->name, ENOMEM, "Failed to get client conf");
+        return;
+    }
+
+    if (!conf->strict_locks)
+        fd_reopen_status = FD_REOPEN_ALLOWED;
+
+    if (dict_set_int32(xdata, "fd-reopen-status", fd_reopen_status))
+        gf_smsg(this->name, GF_LOG_WARNING, ENOMEM, PC_MSG_NO_MEM, NULL);
+
+    return;
 }

--- a/xlators/protocol/client/src/client-common.h
+++ b/xlators/protocol/client/src/client-common.h
@@ -627,4 +627,8 @@ client_pre_copy_file_range_v2(xlator_t *this, gfx_copy_file_range_req *req,
                               off64_t off_out, size_t size, int32_t flags,
                               dict_t **xdata);
 
+void
+set_fd_reopen_status(xlator_t *this, dict_t *xdata,
+                     enum gf_fd_reopen_status fd_reopen_allowed);
+
 #endif /* __CLIENT_COMMON_H__ */

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -2214,6 +2214,13 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
 
+    if (local->check_reopen) {
+        if (lock.l_type == F_WRLCK)
+            set_fd_reopen_status(this, xdata, FD_REOPEN_NOT_ALLOWED);
+        else
+            set_fd_reopen_status(this, xdata, FD_REOPEN_ALLOWED);
+    }
+
 out:
     if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
@@ -4703,6 +4710,7 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
             0,
         },
     };
+    dict_t *xdata = NULL;
     int32_t gf_cmd = 0;
     clnt_local_t *local = NULL;
     clnt_conf_t *conf = NULL;
@@ -4729,6 +4737,10 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
         goto unwind;
     }
 
+    ret = dict_get_int32(args->xdata, "fd-reopen-status", &local->check_reopen);
+    if (ret)
+        local->check_reopen = 0;
+
     local->owner = frame->root->lk_owner;
     local->cmd = args->cmd;
     local->fd = fd_ref(args->fd);
@@ -4742,6 +4754,13 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
             client_is_setlk(local->cmd)) {
             client_add_lock_for_recovery(local->fd, args->flock, &local->owner,
                                          local->cmd);
+        } else if (local->check_reopen) {
+            xdata = dict_new();
+            if (xdata == NULL) {
+                op_errno = ENOMEM;
+                goto unwind;
+            }
+            set_fd_reopen_status(this, xdata, FD_BAD);
         }
 
         goto unwind;
@@ -4758,8 +4777,10 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, xdata);
     GF_FREE(req.xdata.pairs.pairs_val);
+    if (xdata)
+        dict_unref(xdata);
 
     return 0;
 }
@@ -6022,7 +6043,7 @@ client4_0_rchecksum(call_frame_t *frame, xlator_t *this, void *data)
     conf = this->private;
 
     CLIENT_GET_REMOTE_FD(this, args->fd, DEFAULT_REMOTE_FD, remote_fd, op_errno,
-                         unwind);
+                         GFS3_OP_RCHECKSUM, unwind);
 
     req.len = args->len;
     req.offset = args->offset;

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -54,10 +54,10 @@ typedef enum {
         args_##fop##_cbk_store(this_args_cbk, _op_ret, _op_errno, params);     \
     } while (0)
 
-#define CLIENT_GET_REMOTE_FD(xl, fd, flags, remote_fd, op_errno, label)        \
+#define CLIENT_GET_REMOTE_FD(xl, fd, flags, remote_fd, op_errno, fop, label)   \
     do {                                                                       \
         int _ret = 0;                                                          \
-        _ret = client_get_remote_fd(xl, fd, flags, &remote_fd);                \
+        _ret = client_get_remote_fd(xl, fd, flags, &remote_fd, fop);           \
         if (_ret < 0) {                                                        \
             op_errno = errno;                                                  \
             goto label;                                                        \
@@ -201,6 +201,7 @@ typedef struct client_local {
     client_posix_lock_t *client_lock;
     gf_lkowner_t owner;
     int32_t cmd;
+    int32_t check_reopen;
     struct list_head lock_list;
     pthread_mutex_t mutex;
     char *name;
@@ -328,7 +329,8 @@ client_default_reopen_done(clnt_fd_ctx_t *fdctx, int64_t rfd, xlator_t *this);
 void
 client_attempt_reopen(fd_t *fd, xlator_t *this);
 int
-client_get_remote_fd(xlator_t *this, fd_t *fd, int flags, int64_t *remote_fd);
+client_get_remote_fd(xlator_t *this, fd_t *fd, int flags, int64_t *remote_fd,
+                     enum gf_fop_procnum fop);
 int
 client_fd_fop_prepare_local(call_frame_t *frame, fd_t *fd, int64_t remote_fd);
 gf_boolean_t


### PR DESCRIPTION
When client.strict-locks is enabled on a volume and there are POSIX
locks held on the files, after disconnect and reconnection of the
clients do not re-open such fds which might lead to multiple clients
acquiring the locks and cause data corruption.

Change-Id: I8777ffbc2cc8d15ab57b58b72b56eb67521787c5
Fixes: #1977
Signed-off-by: karthik-us <ksubrahm@redhat.com>

