### PR TITLE
avoiding memory allocation while printing trace

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -90,12 +90,12 @@ char *xattrs_to_heal[] = {"user.",
                           GF_XATTR_MDATA_KEY,
                           NULL};
 
-void gf_assert(void)
+void
+gf_assert(void)
 {
     if (gf_signal_on_assert) {
         raise(SIGCONT);
     }
-
 }
 
 void
@@ -897,16 +897,7 @@ gf_dump_config_flags()
 
 /* Define to the full name and version of this package. */
 #ifdef PACKAGE_STRING
-    {
-        char *msg = NULL;
-        int ret = -1;
-
-        ret = gf_asprintf(&msg, "package-string: %s", PACKAGE_STRING);
-        if (ret >= 0) {
-            gf_msg_plain_nomem(GF_LOG_ALERT, msg);
-            GF_FREE(msg);
-        }
-    }
+    gf_msg_plain_nomem(GF_LOG_ALERT, "package-string: " PACKAGE_STRING);
 #endif
 
     return;


### PR DESCRIPTION
Printing trace can fail due to memory allocation issues
this patch avoids that.

Fixes: #1966

Change-Id: I14157303a2ff5d19de0e4ece0a460ff0cbd58c26
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

