### PR TITLE
glusterd: handle logger option in all cases

### DIFF
--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -651,6 +651,10 @@ gf_log_init(void *data, const char *file, const char *ident)
         ctx->log.gf_log_logfile = NULL;
     }
 
+    if ((ctx->log.logger == gf_logger_syslog) &&
+        ctx->log.log_control_file_found && ctx->log.gf_log_syslog) {
+        return 0;
+    }
     if (strcmp(file, "-") == 0) {
         int dupfd = -1;
 

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -327,6 +327,10 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
         if (strcmp(localtime_logging, "enable") == 0)
             runner_add_arg(&runner, "--localtime-logging");
     }
+    if (this->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    }
 
     gfproxyd_port = pmap_assign_port(this, volinfo->gfproxyd.port, gfproxyd_id);
     volinfo->gfproxyd.port = gfproxyd_port;

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -327,7 +327,7 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
         if (strcmp(localtime_logging, "enable") == 0)
             runner_add_arg(&runner, "--localtime-logging");
     }
-    if (this->ctx->log.logger == gf_logger_syslog) {
+    if (global_ctx->log.logger == gf_logger_syslog) {
         runner_add_arg(&runner, "--logger");
         runner_argprintf(&runner, "syslog");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -682,7 +682,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     runinit(&runner);
     runner_add_arg(&runner, SBIN_DIR "/glusterfs");
 
-    if (this->ctx->log.logger == gf_logger_syslog) {
+    if (global_ctx->log.logger == gf_logger_syslog) {
         runner_add_arg(&runner, "--logger");
         runner_argprintf(&runner, "syslog");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -681,6 +681,12 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
 
     runinit(&runner);
     runner_add_arg(&runner, SBIN_DIR "/glusterfs");
+
+    if (this->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    }
+
     seq_dict_foreach(argdict, _runner_add, &runner);
     runner_add_arg(&runner, mtptemp);
     ret = runner_run_reuse(&runner);

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -356,6 +356,11 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
                         "--client-pid", QUOTA_CRAWL_PID, "-l", logfile,
                         mountdir, NULL);
 
+    if (THIS->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    }
+
     synclock_unlock(&priv->big_lock);
     ret = runner_run_reuse(&runner);
     synclock_lock(&priv->big_lock);

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -294,6 +294,11 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
         "*dht.assert-no-child-down=yes", "--xlator-option",
         "*dht.readdir-optimize=on", "--process-name", "rebalance", NULL);
 
+    if (this->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    }
+
     runner_add_arg(&runner, "--xlator-option");
     runner_argprintf(&runner, "*dht.rebalance-cmd=%d", cmd);
     runner_add_arg(&runner, "--xlator-option");

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -294,7 +294,7 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
         "*dht.assert-no-child-down=yes", "--xlator-option",
         "*dht.readdir-optimize=on", "--process-name", "rebalance", NULL);
 
-    if (this->ctx->log.logger == gf_logger_syslog) {
+    if (global_ctx->log.logger == gf_logger_syslog) {
         runner_add_arg(&runner, "--logger");
         runner_argprintf(&runner, "syslog");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -329,6 +329,11 @@ glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags)
             runner_add_arg(&runner, "--localtime-logging");
     }
 
+    if (this->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    }
+
     snapd_port = pmap_assign_port(THIS, volinfo->snapd.port, snapd_id);
     if (!snapd_port) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PORTS_EXHAUSTED,

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -329,7 +329,7 @@ glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags)
             runner_add_arg(&runner, "--localtime-logging");
     }
 
-    if (this->ctx->log.logger == gf_logger_syslog) {
+    if (global_ctx->log.logger == gf_logger_syslog) {
         runner_add_arg(&runner, "--logger");
         runner_argprintf(&runner, "syslog");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -218,6 +218,10 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
         if (this->ctx->cmd_args.global_threading) {
             runner_add_arg(&runner, "--global-threading");
         }
+        if (this->ctx->log.logger == gf_logger_syslog) {
+            runner_add_arg(&runner, "--logger");
+            runner_argprintf(&runner, "syslog");
+        }
 
         if (cmdline)
             dict_foreach(cmdline, svc_add_args, (void *)&runner);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -215,10 +215,10 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
             runner_add_arg(&runner, daemon_log_level);
         }
 
-        if (this->ctx->cmd_args.global_threading) {
+        if (global_ctx->cmd_args.global_threading) {
             runner_add_arg(&runner, "--global-threading");
         }
-        if (this->ctx->log.logger == gf_logger_syslog) {
+        if (global_ctx->log.logger == gf_logger_syslog) {
             runner_add_arg(&runner, "--logger");
             runner_argprintf(&runner, "syslog");
         }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2264,8 +2264,9 @@ retry:
         }
     }
 
-    if (this->ctx->cmd_args.logger == gf_logger_syslog) {
-        runner_argprintf(&runner, "--logger=syslog");
+    if (this->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
     }
 
     runner_add_arg(&runner, "--xlator-option");
@@ -14062,6 +14063,11 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
                               &volfileserver) != 0)
                 volfileserver = "localhost";
 
+            if (this->ctx->log.logger == gf_logger_syslog) {
+                runner_add_arg(&runner, "--logger");
+                runner_argprintf(&runner, "syslog");
+            }
+
             snprintf(logfile, sizeof(logfile), "%s/%s-replace-brick-mount.log",
                      priv->logdir, volinfo->volname);
             if (!*logfile) {
@@ -14075,6 +14081,11 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
             break;
 
         case GD_OP_ADD_BRICK:
+            if (this->ctx->log.logger == gf_logger_syslog) {
+                runner_add_arg(&runner, "--logger");
+                runner_argprintf(&runner, "syslog");
+            }
+
             snprintf(logfile, sizeof(logfile), "%s/%s-add-brick-mount.log",
                      priv->logdir, volinfo->volname);
             if (!*logfile) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2264,7 +2264,7 @@ retry:
         }
     }
 
-    if (this->ctx->log.logger == gf_logger_syslog) {
+    if (global_ctx->log.logger == gf_logger_syslog) {
         runner_add_arg(&runner, "--logger");
         runner_argprintf(&runner, "syslog");
     }
@@ -14063,7 +14063,7 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
                               &volfileserver) != 0)
                 volfileserver = "localhost";
 
-            if (this->ctx->log.logger == gf_logger_syslog) {
+            if (global_ctx->log.logger == gf_logger_syslog) {
                 runner_add_arg(&runner, "--logger");
                 runner_argprintf(&runner, "syslog");
             }
@@ -14081,7 +14081,7 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
             break;
 
         case GD_OP_ADD_BRICK:
-            if (this->ctx->log.logger == gf_logger_syslog) {
+            if (global_ctx->log.logger == gf_logger_syslog) {
                 runner_add_arg(&runner, "--logger");
                 runner_argprintf(&runner, "syslog");
             }

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -2727,9 +2727,16 @@ glusterd_clearlocks_mount(glusterd_volinfo_t *volinfo, char **xl_opts,
                                          volinfo->transport_type);
     runner_add_args(&runner, SBIN_DIR "/glusterfs", "-f", NULL);
     runner_argprintf(&runner, "%s", client_volfpath);
-    runner_add_arg(&runner, "-l");
-    runner_argprintf(&runner, "%s/%s-clearlocks-mnt.log", priv->logdir,
-                     volinfo->volname);
+
+    if (THIS->ctx->log.logger == gf_logger_syslog) {
+        runner_add_arg(&runner, "--logger");
+        runner_argprintf(&runner, "syslog");
+    } else {
+        runner_add_arg(&runner, "-l");
+        runner_argprintf(&runner, "%s/%s-clearlocks-mnt.log", priv->logdir,
+                         volinfo->volname);
+    }
+
     if (volinfo->memory_accounting)
         runner_add_arg(&runner, "--mem-accounting");
 

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1627,27 +1627,26 @@ init(xlator_t *this)
     if (!cmd_history_file) {
         snprintf(cmd_log_filename, PATH_MAX, "%s/cmd_history.log", logdir);
     } else {
-        if (cmd_history_file[0] != '/') {
-            gf_msg(
-                this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                "Expects an absolute file for 'command-history-file', got %s",
-                cmd_history_file);
+        if ((cmd_history_file[0] == '/') || (strstr(cmd_history_file, "../"))) {
+            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
+                   "Expects a relative path for 'command-history-file', got %s",
+                   cmd_history_file);
             exit(1);
         }
-        ret = sys_stat(cmd_history_file, &buf);
+        snprintf(cmd_log_filename, PATH_MAX, "%s/%s", logdir, cmd_history_file);
+        ret = sys_stat(cmd_log_filename, &buf);
         if ((ret == -1) && (errno != ENOENT)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "'command-history-file'(%s): failed for perform stat() %s",
-                   cmd_history_file, strerror(errno));
+                   cmd_log_filename, strerror(errno));
             exit(1);
         }
         if (!ret && !S_ISREG(buf.st_mode)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "'command-history-file'(%s): not a regular file",
-                   cmd_history_file);
+                   cmd_log_filename);
             exit(1);
         }
-        snprintf(cmd_log_filename, PATH_MAX, "%s", cmd_history_file);
     }
 
     ret = gf_cmd_log_init(cmd_log_filename);

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1621,33 +1621,7 @@ init(xlator_t *this)
         exit(1);
     }
 
-    char *cmd_history_file = NULL;
-    ret = dict_get_str_sizen(this->options, "command-history-file",
-                             &cmd_history_file);
-    if (!cmd_history_file) {
-        snprintf(cmd_log_filename, PATH_MAX, "%s/cmd_history.log", logdir);
-    } else {
-        if ((cmd_history_file[0] == '/') || (strstr(cmd_history_file, "../"))) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                   "Expects a relative path for 'command-history-file', got %s",
-                   cmd_history_file);
-            exit(1);
-        }
-        snprintf(cmd_log_filename, PATH_MAX, "%s/%s", logdir, cmd_history_file);
-        ret = sys_stat(cmd_log_filename, &buf);
-        if ((ret == -1) && (errno != ENOENT)) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                   "'command-history-file'(%s): failed for perform stat() %s",
-                   cmd_log_filename, strerror(errno));
-            exit(1);
-        }
-        if (!ret && !S_ISREG(buf.st_mode)) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                   "'command-history-file'(%s): not a regular file",
-                   cmd_log_filename);
-            exit(1);
-        }
-    }
+    snprintf(cmd_log_filename, PATH_MAX, "%s/cmd_history.log", logdir);
 
     ret = gf_cmd_log_init(cmd_log_filename);
 


### PR DESCRIPTION
When 'glusterd' process gets started, if users wants to provide syslog as logger option, there is no need to write logs to a separate glusterfs specific log file, otherwise it would become a duplicate task.

Also provide an option to override cmd_history.log with 'command-history-file' option in glusterd.vol

Updates: #1935
Change-Id: I1b3d6de97cb672131b2b12b112f78f3542170919
Signed-off-by: Amar Tumballi <amar@kadalu.io>

