### PR TITLE
fuse: add an option to specify the mount display name

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -276,8 +276,10 @@ static struct argp_option gf_options[] = {
     {"fuse-dev-eperm-ratelimit-ns", ARGP_FUSE_DEV_EPERM_RATELIMIT_NS_KEY,
      "OPTIONS", OPTION_HIDDEN,
      "rate limit reading from fuse device upon EPERM failure"},
-    {"filesystem-name", ARGP_FUSE_FSNAME_KEY, "OPTIONS", OPTION_HIDDEN,
-     "Filesystem name, displayed with mount point (as source)."},
+    {"fs-display-name", ARGP_FUSE_DISPLAY_NAME_KEY, "DISPLAY-NAME",
+     OPTION_HIDDEN,
+     "Filesystem display name, shown with mount point (as source). Used with "
+     "commands like 'mount', 'df', etc."},
     {"brick-mux", ARGP_BRICK_MUX_KEY, 0, 0, "Enable brick mux. "},
     {0, 0, 0, 0, "Miscellaneous Options:"},
     {
@@ -540,6 +542,11 @@ set_fuse_mount_options(glusterfs_ctx_t *ctx, dict_t *options)
     if (cmd_args->fuse_dev_eperm_ratelimit_ns) {
         DICT_SET_VAL(dict_set_uint32, options, "fuse-dev-eperm-ratelimit-ns",
                      cmd_args->fuse_dev_eperm_ratelimit_ns, glusterfsd_msg_3);
+    }
+
+    if (cmd_args->fs_display_name) {
+        DICT_SET_VAL(dict_set_dynstr, options, "fs-display-name",
+                     cmd_args->fs_display_name, glusterfsd_msg_3);
     }
 
     ret = 0;
@@ -1380,7 +1387,7 @@ parse_opts(int key, char *arg, struct argp_state *state)
             }
 
             break;
-        case ARGP_FUSE_FSNAME_KEY:
+        case ARGP_FUSE_DISPLAY_NAME_KEY:
             cmd_args->fs_display_name = gf_strdup(arg);
             break;
     }

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -276,6 +276,8 @@ static struct argp_option gf_options[] = {
     {"fuse-dev-eperm-ratelimit-ns", ARGP_FUSE_DEV_EPERM_RATELIMIT_NS_KEY,
      "OPTIONS", OPTION_HIDDEN,
      "rate limit reading from fuse device upon EPERM failure"},
+    {"filesystem-name", ARGP_FUSE_FSNAME_KEY, "OPTIONS", OPTION_HIDDEN,
+     "Filesystem name, displayed with mount point (as source)."},
     {"brick-mux", ARGP_BRICK_MUX_KEY, 0, 0, "Enable brick mux. "},
     {0, 0, 0, 0, "Miscellaneous Options:"},
     {
@@ -1377,6 +1379,9 @@ parse_opts(int key, char *arg, struct argp_state *state)
                              arg);
             }
 
+            break;
+        case ARGP_FUSE_FSNAME_KEY:
+            cmd_args->fs_display_name = gf_strdup(arg);
             break;
     }
     return 0;

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -116,6 +116,7 @@ enum argp_option_keys {
     ARGP_BRICK_MUX_KEY = 193,
     ARGP_FUSE_DEV_EPERM_RATELIMIT_NS_KEY = 194,
     ARGP_FUSE_INVALIDATE_LIMIT_KEY = 195,
+    ARGP_FUSE_FSNAME_KEY = 196,
 };
 
 struct _gfd_vol_top_priv {

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -116,7 +116,7 @@ enum argp_option_keys {
     ARGP_BRICK_MUX_KEY = 193,
     ARGP_FUSE_DEV_EPERM_RATELIMIT_NS_KEY = 194,
     ARGP_FUSE_INVALIDATE_LIMIT_KEY = 195,
-    ARGP_FUSE_FSNAME_KEY = 196,
+    ARGP_FUSE_DISPLAY_NAME_KEY = 196,
 };
 
 struct _gfd_vol_top_priv {

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -575,6 +575,7 @@ struct _cmd_args {
     char *subdir_mount;
 
     char *process_name;
+    char *fs_display_name;
     char *event_history;
     int thin_client;
     uint32_t reader_thread_count;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6909,23 +6909,21 @@ init(xlator_t *this_xl)
 
     /* What you need to find with we do 'df -h' */
     cmd_args = &this_xl->ctx->cmd_args;
+    char *subdir = cmd_args->subdir_mount ? cmd_args->subdir_mount : "";
     if (cmd_args->fs_display_name) {
-        strncpy(fsname, cmd_args->fs_display_name, PATH_MAX);
+        snprintf(fsname, PATH_MAX, "%s%s", cmd_args->fs_display_name, subdir);
     } else {
         if (cmd_args->volfile_server) {
-            strncpy(fsname, cmd_args->volfile_server, PATH_MAX);
-            strncat(fsname, ":", PATH_MAX - 1);
-            strncat(fsname, cmd_args->volfile_id, PATH_MAX - 1);
+            snprintf(fsname, PATH_MAX, "%s:%s%s", cmd_args->volfile_server,
+                     cmd_args->volfile_id, subdir);
         } else {
             /* Do we need file path ? */
-            strncpy(fsname, "glusterfs:", PATH_MAX);
             /* volfile-id is mandatory anyways, else we can also write file path
              */
-            strncat(fsname, cmd_args->volfile_id, PATH_MAX - 1);
+            snprintf(fsname, PATH_MAX, "glusterfs:%s%s", cmd_args->volfile_id,
+                     subdir);
         }
     }
-    if (cmd_args->subdir_mount)
-        strncat(fsname, cmd_args->subdir_mount, PATH_MAX - 1);
 
     priv->fdtable = gf_fd_fdtable_alloc();
     if (priv->fdtable == NULL) {

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6910,22 +6910,22 @@ init(xlator_t *this_xl)
     /* What you need to find with we do 'df -h' */
     cmd_args = &this_xl->ctx->cmd_args;
     if (cmd_args->fs_display_name) {
-        strcpy(fsname, cmd_args->fs_display_name);
+        strncpy(fsname, cmd_args->fs_display_name, PATH_MAX);
     } else {
         if (cmd_args->volfile_server) {
-            strcpy(fsname, cmd_args->volfile_server);
-            strcat(fsname, ":");
-            strcat(fsname, cmd_args->volfile_id);
+            strncpy(fsname, cmd_args->volfile_server, PATH_MAX);
+            strncat(fsname, ":", PATH_MAX - 1);
+            strncat(fsname, cmd_args->volfile_id, PATH_MAX - 1);
         } else {
             /* Do we need file path ? */
-            strcpy(fsname, "glusterfs:");
+            strncpy(fsname, "glusterfs:", PATH_MAX);
             /* volfile-id is mandatory anyways, else we can also write file path
              */
-            strcat(fsname, cmd_args->volfile_id);
+            strncat(fsname, cmd_args->volfile_id, PATH_MAX - 1);
         }
     }
     if (cmd_args->subdir_mount)
-        strcat(fsname, cmd_args->subdir_mount);
+        strncat(fsname, cmd_args->subdir_mount, PATH_MAX - 1);
 
     priv->fdtable = gf_fd_fdtable_alloc();
     if (priv->fdtable == NULL) {


### PR DESCRIPTION
There are two things this PR is fixing.
1. When a mount is specified with volfile (-f) option, today, you can't make it out its from glusterfs as only volfile is added as 'fsname', so we add it as 'glusterfs:/<volname>'.
2. Provide an options for admins who wants to show the source of mount other than default (useful when one is not providing 'mount.glusterfs', but using their own scripts.

Updates: #1000
Change-Id: I19e78f309a33807dc5f1d1608a300d93c9996a2f
Signed-off-by: Amar Tumballi <amar@kadalu.io>

