### PR TITLE
posix: Reduce posix_fdstat() calls in IO paths

### DIFF
--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1239,7 +1239,8 @@ posix_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         goto out;
     }
 
-    if (xdata) {
+    if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
+                  dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
         ret = posix_fdstat(this, fd->inode, pfd->fd, &preop);
         if (ret == -1) {
             ret = -errno;
@@ -1613,7 +1614,8 @@ posix_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     pfd->flags = flags;
     pfd->fd = _fd;
 
-    if (xdata) {
+    if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
+                  dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
         op_ret = posix_fdstat(this, fd->inode, pfd->fd, &preop);
         if (op_ret == -1) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1710,7 +1712,8 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     _fd = pfd->fd;
 
-    if (xdata) {
+    if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
+                  dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
         op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
         if (op_ret == -1) {
             op_errno = errno;
@@ -1726,9 +1729,9 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
             op_errno = EIO;
             goto out;
         }
+        posix_update_iatt_buf(&preop, _fd, NULL, xdata);
     }
 
-    posix_update_iatt_buf(&preop, _fd, NULL, xdata);
     op_ret = sys_pread(_fd, iobuf->ptr, size, offset);
     if (op_ret == -1) {
         op_errno = errno;
@@ -5881,7 +5884,8 @@ posix_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     _fd = pfd->fd;
 
-    if (xdata) {
+    if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
+                  dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
         op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
         if (op_ret == -1) {
             op_errno = errno;


### PR DESCRIPTION
The fops(posix_seek, posix_open, posix_readv) are calling
posix_fdstat even cloud sync is not enabled, for these specific
fops prestat is use by only cloud specific function(posix_cs_maintenance)

Fixes: #1981
Change-Id: I4d3b6c41e88925456d2f957aba6b1d2441904f73
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

