### PR TITLE
core: Replace THIS->ctx with global_ctx

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1556,7 +1556,7 @@ glfs_pwritev_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
         goto out;
     }
 
-    ret = iobuf_copy(subvol->ctx->iobuf_pool, iovec, iovcnt, &iobref, &iobuf,
+    ret = iobuf_copy(global_ctx->iobuf_pool, iovec, iovcnt, &iobref, &iobuf,
                      &iov);
     if (ret)
         goto out;
@@ -1906,7 +1906,7 @@ glfs_pwritev_async_common(struct glfs_fd *glfd, const struct iovec *iovec,
         goto out;
     }
 
-    ret = iobuf_copy(subvol->ctx->iobuf_pool, iovec, count, &iobref, &iobuf,
+    ret = iobuf_copy(global_ctx->iobuf_pool, iovec, count, &iobref, &iobuf,
                      gio->iov);
     if (ret)
         goto out;
@@ -5923,7 +5923,7 @@ glfs_cbk_upcall_data(struct glfs *fs, struct gf_upcall *upcall_data)
     if (!args)
         goto out;
 
-    ret = synctask_new(THIS->ctx->env, glfs_cbk_upcall_syncop,
+    ret = synctask_new(global_ctx->env, glfs_cbk_upcall_syncop,
                        glfs_upcall_syncop_cbk, NULL, args);
     /* should we retry incase of failure? */
     if (ret) {
@@ -5955,7 +5955,6 @@ GFAPI_SYMVER_PRIVATE_DEFAULT(glfs_process_upcall_event, 3.7.0)
 void
 priv_glfs_process_upcall_event(struct glfs *fs, void *data)
 {
-    glusterfs_ctx_t *ctx = NULL;
     struct gf_upcall *upcall_data = NULL;
 
     DECLARE_OLD_THIS;
@@ -5973,10 +5972,8 @@ priv_glfs_process_upcall_event(struct glfs *fs, void *data)
      */
     pthread_mutex_lock(&fs->mutex);
     {
-        ctx = fs->ctx;
-
         /* if we're not interested in upcalls (anymore), skip them */
-        if (ctx->cleanup_started || !fs->cache_upcalls) {
+        if (global_ctx->cleanup_started || !fs->cache_upcalls) {
             pthread_mutex_unlock(&fs->mutex);
             goto out;
         }
@@ -6064,7 +6061,7 @@ glfs_anonymous_pwritev(struct glfs *fs, struct glfs_object *object,
 
     size = iov_length(iovec, iovcnt);
 
-    iobuf = iobuf_get2(subvol->ctx->iobuf_pool, size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, size);
     if (!iobuf) {
         ret = -1;
         errno = ENOMEM;

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -2182,7 +2182,6 @@ pub_glfs_h_poll_upcall(struct glfs *fs, struct glfs_upcall **up_arg)
     upcall_entry *u_list = NULL;
     upcall_entry *tmp = NULL;
     xlator_t *subvol = NULL;
-    glusterfs_ctx_t *ctx = NULL;
     int ret = -1;
     struct gf_upcall *upcall_data = NULL;
 
@@ -2206,9 +2205,7 @@ pub_glfs_h_poll_upcall(struct glfs *fs, struct glfs_upcall **up_arg)
      * 'glfs_fini'. Yet cross check if cleanup has started. */
     pthread_mutex_lock(&fs->mutex);
     {
-        ctx = fs->ctx;
-
-        if (ctx->cleanup_started) {
+        if (global_ctx->cleanup_started) {
             pthread_mutex_unlock(&fs->mutex);
             goto out;
         }

--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -175,8 +175,6 @@ struct glfs {
     char *volname;
     uuid_t vol_uuid;
 
-    glusterfs_ctx_t *ctx;
-
     pthread_t poller;
 
     glfs_init_cbk init_cbk;
@@ -440,7 +438,7 @@ glfs_process_upcall_event(struct glfs *fs, void *data)
             goto label;                                                        \
         }                                                                      \
         old_THIS = THIS;                                                       \
-        THIS = fs->ctx->root;                                                  \
+        THIS = global_ctx->root;                                               \
     } while (0)
 
 #define __GLFS_EXIT_FS                                                         \
@@ -456,7 +454,7 @@ glfs_process_upcall_event(struct glfs *fs, void *data)
             goto label;                                                        \
         }                                                                      \
         old_THIS = THIS;                                                       \
-        THIS = glfd->fd->inode->table->xl->ctx->root;                          \
+        THIS = global_ctx->root;                                               \
     } while (0)
 
 #define __GLFS_LOCK_WAIT(fs)                                                   \

--- a/cli/src/cli-cmd-global.c
+++ b/cli/src/cli-cmd-global.c
@@ -111,7 +111,7 @@ cli_cmd_ganesha_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_GANESHA];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -171,7 +171,7 @@ cli_cmd_get_state_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;

--- a/cli/src/cli-cmd-peer.c
+++ b/cli/src/cli-cmd-peer.c
@@ -69,7 +69,7 @@ cli_cmd_peer_probe_cbk(struct cli_state *state, struct cli_cmd_word *word,
             }
     */
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -156,7 +156,7 @@ cli_cmd_peer_deprobe_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -202,7 +202,7 @@ cli_cmd_peer_status_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_LIST_FRIENDS];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -240,7 +240,7 @@ cli_cmd_pool_list_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_LIST_FRIENDS];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame)
         goto out;
 

--- a/cli/src/cli-cmd-snapshot.c
+++ b/cli/src/cli-cmd-snapshot.c
@@ -47,7 +47,7 @@ cli_cmd_snapshot_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (frame == NULL) {
         ret = -1;
         goto out;

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -54,7 +54,7 @@ cli_cmd_getspec_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_GETSPEC];
     if (proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             ret = -1;
             goto out;
@@ -99,7 +99,7 @@ cli_cmd_pmap_b2p_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_PMAP_PORTBYBRICK];
     if (proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             ret = -1;
             goto out;
@@ -138,7 +138,7 @@ cli_cmd_fsm_log_cbk(struct cli_state *state, struct cli_cmd_word *word,
         name = (char *)words[3];
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_FSM_LOG];
     if (proc && proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame)
             goto out;
         ret = proc->fn(frame, THIS, (void *)name);
@@ -162,7 +162,7 @@ cli_cmd_getwd_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_GETWD];
     if (proc && proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame)
             goto out;
         ret = proc->fn(frame, THIS, NULL);
@@ -222,7 +222,7 @@ cli_cmd_mount_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_MOUNT];
     if (proc && proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame)
             goto out;
         ret = proc->fn(frame, THIS, dataa);
@@ -266,7 +266,7 @@ cli_cmd_umount_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_UMOUNT];
     if (proc && proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
             ret = -1;
@@ -306,7 +306,7 @@ cli_cmd_uuid_get_cbk(struct cli_state *state, struct cli_cmd_word *word,
     }
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_UUID_GET];
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -360,7 +360,7 @@ cli_cmd_uuid_reset_cbk(struct cli_state *state, struct cli_cmd_word *word,
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_UUID_RESET];
 
     this = THIS;
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -514,7 +514,7 @@ cli_cmd_sys_exec_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_SYS_EXEC];
     if (proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
             ret = -1;
@@ -575,7 +575,7 @@ cli_cmd_copy_file_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_COPY_FILE];
     if (proc && proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
             ret = -1;

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -83,7 +83,7 @@ cli_cmd_volume_info_cbk(struct cli_state *state, struct cli_cmd_word *word,
     if (!local)
         goto out;
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -171,7 +171,7 @@ cli_cmd_sync_volume_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_SYNC_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
         ret = -1;
@@ -237,7 +237,7 @@ cli_cmd_volume_create_cbk(struct cli_state *state, struct cli_cmd_word *word,
         }
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -318,7 +318,7 @@ cli_cmd_volume_delete_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -398,7 +398,7 @@ cli_cmd_volume_start_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_START_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -540,7 +540,7 @@ cli_cmd_volume_stop_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_STOP_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -605,7 +605,7 @@ cli_cmd_volume_rename_cbk(struct cli_state *state, struct cli_cmd_word *word,
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_RENAME_VOLUME];
 
     if (proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame) {
             ret = -1;
             goto out;
@@ -657,7 +657,7 @@ cli_cmd_volume_defrag_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_DEFRAG_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -718,7 +718,7 @@ cli_cmd_volume_reset_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -776,7 +776,7 @@ cli_cmd_volume_profile_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_PROFILE_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
         ret = -1;
@@ -841,7 +841,7 @@ cli_cmd_volume_set_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1079,7 +1079,7 @@ cli_cmd_volume_add_brick_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_ADD_BRICK];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1119,7 +1119,7 @@ cli_get_soft_limit(dict_t *options, const char **words, dict_t *xdata)
     char *default_sl_dup = NULL;
     int ret = -1;
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1317,7 +1317,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
     if (ret)
         goto out;
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1474,7 +1474,7 @@ cli_cmd_bitrot_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out2;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1626,7 +1626,7 @@ cli_cmd_quota_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1800,7 +1800,7 @@ cli_cmd_volume_remove_brick_cbk(struct cli_state *state,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_REMOVE_BRICK];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1870,7 +1870,7 @@ cli_cmd_volume_reset_brick_cbk(struct cli_state *state,
         }
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1930,7 +1930,7 @@ cli_cmd_volume_replace_brick_cbk(struct cli_state *state,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -1988,7 +1988,7 @@ cli_cmd_volume_top_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_TOP_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
         ret = -1;
@@ -2043,7 +2043,7 @@ cli_cmd_log_rotate_cbk(struct cli_state *state, struct cli_cmd_word *word,
     if (ret)
         goto out;
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
         ret = -1;
@@ -2163,7 +2163,7 @@ cli_cmd_volume_gsync_set_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (frame == NULL) {
         ret = -1;
         goto out;
@@ -2334,7 +2334,7 @@ cli_cmd_volume_status_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         gf_log(THIS->name, GF_LOG_ERROR, "failed to create frame");
         ret = -1;
@@ -2641,7 +2641,7 @@ cli_cmd_volume_heal_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_HEAL_VOLUME];
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -2706,7 +2706,7 @@ cli_cmd_volume_statedump_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_STATEDUMP_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -2741,7 +2741,7 @@ cli_cmd_volume_list_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_LIST_VOLUME];
     if (proc->fn) {
-        frame = create_frame(THIS, THIS->ctx->pool);
+        frame = create_frame(THIS, global_ctx->pool);
         if (!frame)
             goto out;
         ret = proc->fn(frame, THIS, NULL);
@@ -2798,7 +2798,7 @@ cli_cmd_volume_clearlocks_cbk(struct cli_state *state,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_CLRLOCKS_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -2855,7 +2855,7 @@ cli_cmd_volume_barrier_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_BARRIER_VOLUME];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -2909,7 +2909,7 @@ cli_cmd_volume_getopt_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_GET_VOL_OPT];
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;

--- a/cli/src/cli-quotad-client.c
+++ b/cli/src/cli-quotad-client.c
@@ -28,7 +28,7 @@ cli_quotad_submit_request(void *req, call_frame_t *frame, rpc_clnt_prog_t *prog,
 
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, xdr_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iobuf) {
             goto out;
         };

--- a/cli/src/cli-rl.c
+++ b/cli/src/cli-rl.c
@@ -106,13 +106,8 @@ void
 cli_rl_stdin(int fd, int idx, int gen, void *data, int poll_out, int poll_in,
              int poll_err, char event_thread_died)
 {
-    struct cli_state *state = NULL;
-
-    state = data;
-
     rl_callback_read_char();
-
-    gf_event_handled(state->ctx->event_pool, fd, idx, gen);
+    gf_event_handled(global_ctx->event_pool, fd, idx, gen);
 
     return;
 }
@@ -379,7 +374,7 @@ cli_rl_enable(struct cli_state *state)
         goto out;
     }
 
-    ret = gf_event_register(state->ctx->event_pool, 0, cli_rl_stdin, state, 1,
+    ret = gf_event_register(global_ctx->event_pool, 0, cli_rl_stdin, state, 1,
                             0, 0);
     if (ret == -1)
         goto out;

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -249,7 +249,7 @@ cli_submit_request(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, xdr_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iobuf) {
             goto out;
         };
@@ -811,8 +811,6 @@ main(int argc, char *argv[])
     ret = glusterfs_globals_init(ctx);
     if (ret)
         return ret;
-
-    THIS->ctx = ctx;
 
     ret = glusterfs_ctx_defaults_init(ctx);
     if (ret)

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -111,9 +111,6 @@ struct cli_state {
 
     char debug;
 
-    /* for events dispatching */
-    glusterfs_ctx_t *ctx;
-
     /* registry of known commands */
     struct cli_cmd_tree tree;
 

--- a/contrib/umountd/umountd.c
+++ b/contrib/umountd/umountd.c
@@ -104,29 +104,26 @@ log_rotate (int signum)
 static int
 logging_init (void)
 {
-        glusterfs_ctx_t *ctx;
         char log_file[PATH_MAX];
         int ret = -1;
 
-        ctx = glusterfs_ctx_new ();
-        if (!ctx) {
+        if (!glusterfs_ctx_new()) {
                 fprintf (stderr, "glusterfs_ctx_new failed\n");
                 goto out;
         }
 
-        ret = glusterfs_globals_init (ctx);
+        ret = glusterfs_globals_init ();
         if (ret) {
                 fprintf (stderr, "glusterfs_globals_init failed\n");
                 goto out;
         }
 
-        THIS->ctx = ctx;
         xlator_mem_acct_init (THIS, gf_common_mt_end);
 
         snprintf (log_file, PATH_MAX,
                   "%s/umountd.log", DEFAULT_LOG_FILE_DIRECTORY);
 
-        ret = gf_log_init (ctx, log_file, "umountd");
+        ret = gf_log_init (log_file, "umountd");
         if (ret) {
                 fprintf (stderr, "gf_log_init failed\n");
                 goto out;

--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -10,11 +10,11 @@
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/param.h> /* for PATH_MAX */
+#include <unistd.h>
 
 /* NOTE (USE_LIBGLUSTERFS):
  * ------------------------
@@ -24,14 +24,14 @@
  * We unconditionally pass then while building gsyncd binary.
  */
 #ifdef USE_LIBGLUSTERFS
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/globals.h>
 #include <glusterfs/defaults.h>
+#include <glusterfs/globals.h>
+#include <glusterfs/glusterfs.h>
 #endif
 
+#include "procdiggy.h"
 #include <glusterfs/common-utils.h>
 #include <glusterfs/run.h>
-#include "procdiggy.h"
 
 #define _GLUSTERD_CALLED_ "_GLUSTERD_CALLED_"
 #define _GSYNCD_DISPATCHED_ "_GSYNCD_DISPATCHED_"
@@ -327,13 +327,10 @@ main(int argc, char **argv)
     int j = 0;
 
 #ifdef USE_LIBGLUSTERFS
-    glusterfs_ctx_t *ctx = NULL;
-
-    ctx = glusterfs_ctx_new();
-    if (!ctx)
+    if (!glusterfs_ctx_new())
         return ENOMEM;
 
-    if (glusterfs_globals_init(ctx))
+    if (glusterfs_globals_init())
         return 1;
 
     ret = default_mem_acct_init(THIS);

--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -336,7 +336,6 @@ main(int argc, char **argv)
     if (glusterfs_globals_init(ctx))
         return 1;
 
-    THIS->ctx = ctx;
     ret = default_mem_acct_init(THIS);
     if (ret) {
         fprintf(stderr, "internal error: mem accounting failed\n");

--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -78,7 +78,7 @@ send_brick_req(xlator_t *this, struct rpc_clnt *rpc, char *path, int op)
     brick_req.dict.dict_len = 0;
 
     req_size = xdr_sizeof((xdrproc_t)xdr_gd1_mgmt_brick_op_req, req);
-    iobuf = iobuf_get2(rpc->ctx->iobuf_pool, req_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, req_size);
     if (!iobuf)
         goto out;
 
@@ -113,7 +113,7 @@ send_brick_req(xlator_t *this, struct rpc_clnt *rpc, char *path, int op)
     }
     pthread_mutex_unlock(&rpc->conn.lock);
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -221,7 +221,7 @@ done_parsing:
         return EXIT_FAILURE;
     }
 
-    rpc = rpc_clnt_new(options, fs->ctx->root, "gf-attach-rpc", 0);
+    rpc = rpc_clnt_new(options, global_ctx->root, "gf-attach-rpc", 0);
     if (!rpc) {
         fprintf(stderr, "rpc_clnt_new failed\n");
         return EXIT_FAILURE;
@@ -237,5 +237,5 @@ done_parsing:
         return EXIT_FAILURE;
     }
 
-    return send_brick_req(fs->ctx->root, rpc, argv[optind + 1], op);
+    return send_brick_req(global_ctx->root, rpc, argv[optind + 1], op);
 }

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -130,9 +130,9 @@ struct _gfd_vol_top_priv {
 typedef struct _gfd_vol_top_priv gfd_vol_top_priv_t;
 
 int
-glusterfs_mgmt_pmap_signin(glusterfs_ctx_t *ctx);
+glusterfs_mgmt_pmap_signin(void);
 int
-glusterfs_volfile_fetch(glusterfs_ctx_t *ctx);
+glusterfs_volfile_fetch(void);
 void
 cleanup_and_exit(int signum);
 

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -1664,8 +1664,8 @@ main(int argc, char **argv)
 
     if (!volfile_path) {
         if (sys_access(SECURE_ACCESS_FILE, F_OK) == 0) {
-            fs->ctx->secure_mgmt = 1;
-            fs->ctx->ssl_cert_depth = glusterfs_read_secure_access_file();
+            global_ctx->secure_mgmt = 1;
+            global_ctx->ssl_cert_depth = glusterfs_read_secure_access_file();
         }
         if (socket_filepath != NULL) {
             ret = glfs_set_volfile_server(fs, "unix", socket_filepath, 0);

--- a/libglusterfs/src/async.c
+++ b/libglusterfs/src/async.c
@@ -621,7 +621,7 @@ gf_async_adjust_threads(int32_t threads)
 }
 
 int32_t
-gf_async_init(glusterfs_ctx_t *ctx)
+gf_async_init()
 {
     sigset_t set;
     gf_async_worker_t *worker;
@@ -631,8 +631,8 @@ gf_async_init(glusterfs_ctx_t *ctx)
 
     gf_async_cleanup();
 
-    if (!ctx->cmd_args.global_threading ||
-        (ctx->process_mode == GF_GLUSTERD_PROCESS)) {
+    if (!global_ctx->cmd_args.global_threading ||
+        (global_ctx->process_mode == GF_GLUSTERD_PROCESS)) {
         return 0;
     }
 

--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -22,13 +22,13 @@ stub_new(call_frame_t *frame, const char wind, const glusterfs_fop_t fop)
 
     GF_VALIDATE_OR_GOTO("call-stub", frame, out);
 
-    new = mem_get0(frame->this->ctx->stub_mem_pool);
+    new = mem_get0(global_ctx->stub_mem_pool);
     GF_VALIDATE_OR_GOTO("call-stub", new, out);
 
     new->frame = frame;
     new->wind = wind;
     new->fop = fop;
-    new->stub_mem_pool = frame->this->ctx->stub_mem_pool;
+    new->stub_mem_pool = global_ctx->stub_mem_pool;
     INIT_LIST_HEAD(&new->list);
 
     INIT_LIST_HEAD(&new->args_cbk.entries);

--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -130,7 +130,7 @@ gf_client_get(xlator_t *this, client_auth_data_t *cred, char *client_uid,
         return NULL;
     }
 
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     LOCK(&clienttable->lock);
     {
@@ -312,7 +312,7 @@ client_destroy(client_t *client)
         goto out;
     }
 
-    clienttable = client->this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     LOCK(&clienttable->lock);
     {
@@ -323,7 +323,7 @@ client_destroy(client_t *client)
     }
     UNLOCK(&clienttable->lock);
 
-    list_for_each_entry(gtrav, &client->this->ctx->graphs, list)
+    list_for_each_entry(gtrav, &global_ctx->graphs, list)
     {
         gf_client_destroy_recursive(gtrav->top, client);
     }
@@ -368,7 +368,7 @@ gf_client_disconnect(client_t *client)
     int ret = 0;
     glusterfs_graph_t *gtrav = NULL;
 
-    list_for_each_entry(gtrav, &client->this->ctx->graphs, list)
+    list_for_each_entry(gtrav, &global_ctx->graphs, list)
     {
         ret |= gf_client_disconnect_recursive(gtrav->top, client);
     }
@@ -606,7 +606,7 @@ gf_client_dump_fdtables_to_dict(xlator_t *this, dict_t *dict)
     GF_VALIDATE_OR_GOTO(THIS->name, this, out);
     GF_VALIDATE_OR_GOTO(this->name, dict, out);
 
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     if (!clienttable)
         return -1;
@@ -652,7 +652,7 @@ gf_client_dump_fdtables(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO(THIS->name, this, out);
 
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     if (!clienttable)
         return -1;
@@ -716,7 +716,7 @@ gf_client_dump_inodes_to_dict(xlator_t *this, dict_t *dict)
     GF_VALIDATE_OR_GOTO(THIS->name, this, out);
     GF_VALIDATE_OR_GOTO(this->name, dict, out);
 
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     if (!clienttable)
         return -1;
@@ -779,7 +779,7 @@ gf_client_dump_inodes(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO(THIS->name, this, out);
 
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     if (!clienttable)
         goto out;

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4504,7 +4504,7 @@ gf_backtrace_save(char *buf)
     char *bt = NULL;
 
     if (!buf) {
-        bt = THIS->ctx->btbuf;
+        bt = global_ctx->btbuf;
         GF_ASSERT(bt);
 
     } else {

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -900,7 +900,7 @@ gf_dump_config_flags()
 
 /* Obtain a backtrace and print it to the log */
 void
-gf_print_trace(int32_t signum, glusterfs_ctx_t *ctx)
+gf_print_trace(int32_t signum)
 {
     char msg[1024] = {
         0,
@@ -919,13 +919,13 @@ gf_print_trace(int32_t signum, glusterfs_ctx_t *ctx)
      */
     gf_log_flush();
 
-    gf_log_disable_suppression_before_exit(ctx);
+    gf_log_disable_suppression_before_exit(global_ctx);
 
     /* Pending frames, (if any), list them in order */
     gf_msg_plain_nomem(GF_LOG_ALERT, "pending frames:");
     {
         /* FIXME: traversing stacks outside pool->lock */
-        list_for_each_entry(stack, &ctx->pool->all_frames, all_frames)
+        list_for_each_entry(stack, &global_ctx->pool->all_frames, all_frames)
         {
             if (stack->type == GF_OP_TYPE_FOP)
                 sprintf(msg, "frame : type(%d) op(%s)", stack->type,
@@ -3858,7 +3858,7 @@ out:
 
 /* Sets log file path from user provided arguments */
 int
-gf_set_log_file_path(cmd_args_t *cmd_args, glusterfs_ctx_t *ctx)
+gf_set_log_file_path(cmd_args_t *cmd_args)
 {
     int i = 0;
     int j = 0;
@@ -3889,7 +3889,7 @@ gf_set_log_file_path(cmd_args_t *cmd_args, glusterfs_ctx_t *ctx)
         goto done;
     }
 
-    if (ctx && GF_GLUSTERD_PROCESS == ctx->process_mode) {
+    if (GF_GLUSTERD_PROCESS == global_ctx->process_mode) {
         ret = gf_asprintf(&cmd_args->log_file,
                           DEFAULT_LOG_FILE_DIRECTORY "/%s.log", GLUSTERD_NAME);
         if (ret > 0)

--- a/libglusterfs/src/ctx.c
+++ b/libglusterfs/src/ctx.c
@@ -73,29 +73,29 @@ glusterfs_ctx_tw_destroy(struct gf_ctx_tw *ctx_tw)
 }
 
 struct tvec_base *
-glusterfs_ctx_tw_get(glusterfs_ctx_t *ctx)
+glusterfs_ctx_tw_get()
 {
     struct gf_ctx_tw *ctx_tw = NULL;
 
-    LOCK(&ctx->lock);
+    LOCK(&global_ctx->lock);
     {
-        if (ctx->tw) {
-            ctx_tw = GF_REF_GET(ctx->tw);
+        if (global_ctx->tw) {
+            ctx_tw = GF_REF_GET(global_ctx->tw);
         } else {
             ctx_tw = GF_CALLOC(1, sizeof(struct gf_ctx_tw),
                                gf_common_mt_tw_ctx);
             ctx_tw->timer_wheel = gf_tw_init_timers();
             GF_REF_INIT(ctx_tw, glusterfs_ctx_tw_destroy);
-            ctx->tw = ctx_tw;
+            global_ctx->tw = ctx_tw;
         }
     }
-    UNLOCK(&ctx->lock);
+    UNLOCK(&global_ctx->lock);
 
     return ctx_tw->timer_wheel;
 }
 
 void
-glusterfs_ctx_tw_put(glusterfs_ctx_t *ctx)
+glusterfs_ctx_tw_put()
 {
-    GF_REF_PUT(ctx->tw);
+    GF_REF_PUT(global_ctx->tw);
 }

--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -156,7 +156,7 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
              * Handle case of CHILD_* & AUTH_FAILED event specially, send
              * it to fuse.
              */
-            if (!parent && global_ctx && global_ctx->root) {
+            if (!parent && global_ctx->root) {
                 xlator_notify(global_ctx->root, event, this->graph, NULL);
             }
 
@@ -166,8 +166,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
                 parent = parent->next;
             }
 
-            if (event == GF_EVENT_CHILD_DOWN &&
-                !(global_ctx && global_ctx->root) && (graph->top == this)) {
+            if (event == GF_EVENT_CHILD_DOWN && !(global_ctx->root) &&
+                (graph->top == this)) {
                 /* Make sure this is not a daemon with root xlator */
                 pthread_mutex_lock(&graph->mutex);
                 {
@@ -183,7 +183,7 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
         case GF_EVENT_UPCALL: {
             xlator_list_t *parent = this->parents;
 
-            if (!parent && global_ctx && global_ctx->root)
+            if (!parent && global_ctx->root)
                 xlator_notify(global_ctx->root, event, data, NULL);
 
             while (parent) {

--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -156,8 +156,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
              * Handle case of CHILD_* & AUTH_FAILED event specially, send
              * it to fuse.
              */
-            if (!parent && this->ctx && this->ctx->root) {
-                xlator_notify(this->ctx->root, event, this->graph, NULL);
+            if (!parent && global_ctx && global_ctx->root) {
+                xlator_notify(global_ctx->root, event, this->graph, NULL);
             }
 
             while (parent) {
@@ -167,7 +167,7 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
             }
 
             if (event == GF_EVENT_CHILD_DOWN &&
-                !(this->ctx && this->ctx->root) && (graph->top == this)) {
+                !(global_ctx && global_ctx->root) && (graph->top == this)) {
                 /* Make sure this is not a daemon with root xlator */
                 pthread_mutex_lock(&graph->mutex);
                 {
@@ -183,8 +183,8 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
         case GF_EVENT_UPCALL: {
             xlator_list_t *parent = this->parents;
 
-            if (!parent && this->ctx && this->ctx->root)
-                xlator_notify(this->ctx->root, event, data, NULL);
+            if (!parent && global_ctx && global_ctx->root)
+                xlator_notify(global_ctx->root, event, data, NULL);
 
             while (parent) {
                 if (parent->xlator->init_succeeded)

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -36,7 +36,6 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     char *eventstr = NULL;
     va_list arguments;
     char *msg = NULL;
-    glusterfs_ctx_t *ctx = NULL;
     char *host = NULL;
     struct addrinfo hints;
     struct addrinfo *result = NULL;
@@ -44,27 +43,24 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     xlator_t *this = THIS;
     char *volfile_server_transport = NULL;
 
-    /* Global context */
-    ctx = this->ctx;
-
     if (event < 0 || event >= EVENT_LAST) {
         ret = EVENT_ERROR_INVALID_INPUTS;
         goto out;
     }
 
-    if (ctx) {
-        volfile_server_transport = ctx->cmd_args.volfile_server_transport;
+    if (global_ctx) {
+        volfile_server_transport = global_ctx->cmd_args.volfile_server_transport;
     }
     if (!volfile_server_transport) {
         volfile_server_transport = "tcp";
     }
 
     /* host = NULL returns localhost */
-    if (ctx && ctx->cmd_args.volfile_server &&
+    if (global_ctx && global_ctx->cmd_args.volfile_server &&
         (strcmp(volfile_server_transport, "unix"))) {
         /* If it is client code then volfile_server is set
            use that information to push the events. */
-        host = ctx->cmd_args.volfile_server;
+        host = global_ctx->cmd_args.volfile_server;
     }
 
     memset(&hints, 0, sizeof(hints));

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -40,7 +40,6 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     struct addrinfo hints;
     struct addrinfo *result = NULL;
     struct addrinfo *iter_result_ptr = NULL;
-    xlator_t *this = THIS;
     char *volfile_server_transport = NULL;
 
     if (event < 0 || event >= EVENT_LAST) {
@@ -48,15 +47,13 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
         goto out;
     }
 
-    if (global_ctx) {
-        volfile_server_transport = global_ctx->cmd_args.volfile_server_transport;
-    }
+    volfile_server_transport = global_ctx->cmd_args.volfile_server_transport;
     if (!volfile_server_transport) {
         volfile_server_transport = "tcp";
     }
 
     /* host = NULL returns localhost */
-    if (global_ctx && global_ctx->cmd_args.volfile_server &&
+    if (global_ctx->cmd_args.volfile_server &&
         (strcmp(volfile_server_transport, "unix"))) {
         /* If it is client code then volfile_server is set
            use that information to push the events. */

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -145,9 +145,9 @@ global_xl_reconfigure(xlator_t *this, dict_t *options)
     dict_dump_to_log(options);
 
     GF_OPTION_RECONF("measure-latency", bool_opt, options, bool, out);
-    this->ctx->measure_latency = bool_opt;
+    global_ctx->measure_latency = bool_opt;
 
-    GF_OPTION_RECONF("metrics-dump-path", this->ctx->config.metrics_dumppath,
+    GF_OPTION_RECONF("metrics-dump-path", global_ctx->config.metrics_dumppath,
                      options, str, out);
 
     /* TODO: add more things here */
@@ -163,9 +163,9 @@ global_xl_init(xlator_t *this)
     gf_boolean_t bool_opt = false;
 
     GF_OPTION_INIT("measure-latency", bool_opt, bool, out);
-    this->ctx->measure_latency = bool_opt;
+    global_ctx->measure_latency = bool_opt;
 
-    GF_OPTION_INIT("metrics-dump-path", this->ctx->config.metrics_dumppath, str,
+    GF_OPTION_INIT("metrics-dump-path", global_ctx->config.metrics_dumppath, str,
                    out);
 
     ret = 0;

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -165,8 +165,8 @@ global_xl_init(xlator_t *this)
     GF_OPTION_INIT("measure-latency", bool_opt, bool, out);
     global_ctx->measure_latency = bool_opt;
 
-    GF_OPTION_INIT("metrics-dump-path", global_ctx->config.metrics_dumppath, str,
-                   out);
+    GF_OPTION_INIT("metrics-dump-path", global_ctx->config.metrics_dumppath,
+                   str, out);
 
     ret = 0;
 
@@ -348,11 +348,11 @@ gf_globals_init_once()
 }
 
 int
-glusterfs_globals_init(glusterfs_ctx_t *ctx)
+glusterfs_globals_init()
 {
     int ret = 0;
 
-    gf_log_globals_init(ctx, GF_LOG_INFO);
+    gf_log_globals_init(GF_LOG_INFO);
 
     ret = pthread_once(&globals_inited, gf_globals_init_once);
 

--- a/libglusterfs/src/glusterfs/async.h
+++ b/libglusterfs/src/glusterfs/async.h
@@ -174,7 +174,7 @@ struct _gf_async_control {
 extern gf_async_control_t gf_async_ctrl;
 
 int32_t
-gf_async_init(glusterfs_ctx_t *ctx);
+gf_async_init();
 
 void
 gf_async_fini(void);

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -278,9 +278,9 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
 void
 gf_log_dump_graph(FILE *specfp, glusterfs_graph_t *graph);
 void
-gf_print_trace(int32_t signal, glusterfs_ctx_t *ctx);
+gf_print_trace(int32_t signal);
 int
-gf_set_log_file_path(cmd_args_t *cmd_args, glusterfs_ctx_t *ctx);
+gf_set_log_file_path(cmd_args_t *cmd_args);
 int
 gf_set_log_ident(cmd_args_t *cmd_args);
 

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -169,15 +169,15 @@ glusterfs_leaseid_exist(void);
 
 /* init */
 int
-glusterfs_globals_init(glusterfs_ctx_t *ctx);
+glusterfs_globals_init();
 
 void
 gf_thread_needs_cleanup(void);
 
 struct tvec_base *
-glusterfs_ctx_tw_get(glusterfs_ctx_t *ctx);
+glusterfs_ctx_tw_get();
 void
-glusterfs_ctx_tw_put(glusterfs_ctx_t *ctx);
+glusterfs_ctx_tw_put();
 
 extern const char *gf_fop_list[];
 extern const char *gf_upcall_list[];

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -818,8 +818,7 @@ typedef struct lock_migration_info {
 #define SECURE_ACCESS_FILE GLUSTERD_DEFAULT_WORKDIR "/secure-access"
 
 int
-glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
-                        char *volume_name);
+glusterfs_graph_prepare(glusterfs_graph_t *graph, char *volume_name);
 int
 glusterfs_graph_destroy_residual(glusterfs_graph_t *graph);
 int
@@ -829,7 +828,7 @@ glusterfs_graph_destroy(glusterfs_graph_t *graph);
 int
 glusterfs_get_leaf_count(glusterfs_graph_t *graph);
 int
-glusterfs_graph_activate(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx);
+glusterfs_graph_activate(glusterfs_graph_t *graph);
 glusterfs_graph_t *
 glusterfs_graph_construct(FILE *fp);
 int

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -132,7 +132,7 @@ inode_table_with_invalidator(uint32_t lru_limit, xlator_t *xl,
                              uint32_t inode_hashsize);
 
 void
-inode_table_destroy_all(glusterfs_ctx_t *ctx);
+inode_table_destroy_all();
 
 void
 inode_table_destroy(inode_table_t *inode_table);

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -138,9 +138,9 @@ typedef struct log_buf_ {
 } log_buf_t;
 
 void
-gf_log_globals_init(void *ctx, gf_loglevel_t level);
+gf_log_globals_init(gf_loglevel_t level);
 int
-gf_log_init(void *data, const char *filename, const char *ident);
+gf_log_init(const char *filename, const char *ident);
 
 void
 gf_log_logrotate(int signum);
@@ -313,7 +313,7 @@ gf_log_enable_syslog(void);
 gf_loglevel_t
 gf_log_get_loglevel(void);
 void
-gf_log_set_loglevel(struct _glusterfs_ctx *ctx, gf_loglevel_t level);
+gf_log_set_loglevel(gf_loglevel_t level);
 int
 gf_log_get_localtime(void);
 void
@@ -351,13 +351,13 @@ void
 gf_log_set_log_flush_timeout(uint32_t timeout);
 
 void
-gf_log_flush_msgs(struct _glusterfs_ctx *ctx);
+gf_log_flush_msgs();
 
 int
-gf_log_inject_timer_event(struct _glusterfs_ctx *ctx);
+gf_log_inject_timer_event();
 
 void
-gf_log_disable_suppression_before_exit(struct _glusterfs_ctx *ctx);
+gf_log_disable_suppression_before_exit();
 
 #define GF_DEBUG(xl, format, args...)                                          \
     gf_log((xl)->name, GF_LOG_DEBUG, format, ##args)

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -327,14 +327,12 @@ mem_pool_thread_destructor(per_thread_pool_list_t *pool_list);
 #endif /* GF_DISABLE_MEMPOOL */
 
 struct mem_pool *
-mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
-                unsigned long count, char *name);
+mem_pool_new_fn(unsigned long sizeof_type, unsigned long count, char *name);
 
-#define mem_pool_new(type, count)                                              \
-    mem_pool_new_fn(global_ctx, sizeof(type), count, #type)
+#define mem_pool_new(type, count) mem_pool_new_fn(sizeof(type), count, #type)
 
-#define mem_pool_new_ctx(ctx, type, count)                                     \
-    mem_pool_new_fn(ctx, sizeof(type), count, #type)
+#define mem_pool_new_ctx(type, count)                                          \
+    mem_pool_new_fn(sizeof(type), count, #type)
 
 void
 mem_put_pool(void *ptr);
@@ -347,6 +345,6 @@ void
 mem_pool_destroy(struct mem_pool *pool);
 
 void
-gf_mem_acct_enable_set(void *ctx);
+gf_mem_acct_enable_set(void);
 
 #endif /* _MEM_POOL_H */

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -251,7 +251,6 @@ struct mem_pool {
     gf_atomic_t miss;       /* number of std allocs due to miss */
 #endif
     struct list_head owner; /* glusterfs_ctx_t->mempool_list */
-    glusterfs_ctx_t *ctx;   /* take ctx->lock when updating owner */
 
     struct mem_pool_shared *pool; /* the initial pool that was returned */
 };
@@ -332,7 +331,7 @@ mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
                 unsigned long count, char *name);
 
 #define mem_pool_new(type, count)                                              \
-    mem_pool_new_fn(THIS->ctx, sizeof(type), count, #type)
+    mem_pool_new_fn(global_ctx, sizeof(type), count, #type)
 
 #define mem_pool_new_ctx(ctx, type, count)                                     \
     mem_pool_new_fn(ctx, sizeof(type), count, #type)

--- a/libglusterfs/src/glusterfs/monitoring.h
+++ b/libglusterfs/src/glusterfs/monitoring.h
@@ -16,6 +16,6 @@
 #define GLUSTER_METRICS_DIR "/var/run/gluster/metrics"
 
 char *
-gf_monitor_metrics(glusterfs_ctx_t *ctx);
+gf_monitor_metrics();
 
 #endif /* __MONITORING_H__ */

--- a/libglusterfs/src/glusterfs/rbthash.h
+++ b/libglusterfs/src/glusterfs/rbthash.h
@@ -50,9 +50,8 @@ typedef struct rbthash_table {
 } rbthash_table_t;
 
 extern rbthash_table_t *
-rbthash_table_init(glusterfs_ctx_t *ctx, int buckets, rbt_hasher_t hfunc,
-                   rbt_data_destroyer_t dfunc, unsigned long expected_entries,
-                   struct mem_pool *entrypool);
+rbthash_table_init(int buckets, rbt_hasher_t hfunc, rbt_data_destroyer_t dfunc,
+                   unsigned long expected_entries, struct mem_pool *entrypool);
 
 extern int
 rbthash_insert(rbthash_table_t *tbl, void *data, void *key, int keylen);

--- a/libglusterfs/src/glusterfs/statedump.h
+++ b/libglusterfs/src/glusterfs/statedump.h
@@ -78,7 +78,7 @@ void
 gf_proc_dump_cleanup(void);
 
 void
-gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx);
+gf_proc_dump_info(int signum);
 
 int
 gf_proc_dump_add_section(char *key, ...)
@@ -107,7 +107,7 @@ void
 gf_proc_dump_mem_info_to_dict(dict_t *dict);
 
 void
-gf_proc_dump_mempool_info_to_dict(glusterfs_ctx_t *ctx, dict_t *dict);
+gf_proc_dump_mempool_info_to_dict(dict_t *dict);
 
 void
 glusterd_init(int sig);

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -379,7 +379,7 @@ syncop_create_frame(xlator_t *this)
     int ngrps = -1;
     struct syncopctx *opctx = NULL;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         return NULL;
 

--- a/libglusterfs/src/glusterfs/timer.h
+++ b/libglusterfs/src/glusterfs/timer.h
@@ -45,12 +45,11 @@ typedef struct _gf_timer gf_timer_t;
 typedef struct _gf_timer_registry gf_timer_registry_t;
 
 gf_timer_t *
-gf_timer_call_after(glusterfs_ctx_t *ctx, struct timespec delta,
-                    gf_timer_cbk_t cbk, void *data);
+gf_timer_call_after(struct timespec delta, gf_timer_cbk_t cbk, void *data);
 
 int32_t
-gf_timer_call_cancel(glusterfs_ctx_t *ctx, gf_timer_t *event);
+gf_timer_call_cancel(gf_timer_t *event);
 
 void
-gf_timer_registry_destroy(glusterfs_ctx_t *ctx);
+gf_timer_registry_destroy();
 #endif /* _TIMER_H */

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -809,7 +809,6 @@ struct _xlator {
 
     /* Misc */
     eh_t *history; /* event history context */
-    glusterfs_ctx_t *ctx;
     glusterfs_graph_t *graph; /* not set for fuse */
     inode_table_t *itable;
     char init_succeeded;

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -808,7 +808,7 @@ struct _xlator {
     } stats[GF_FOP_MAXVALUE] __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
 
     /* Misc */
-    eh_t *history; /* event history context */
+    eh_t *history;            /* event history context */
     glusterfs_graph_t *graph; /* not set for fuse */
     inode_table_t *itable;
     char init_succeeded;
@@ -971,7 +971,7 @@ int32_t
 xlator_dynload(xlator_t *xl);
 
 xlator_t *
-file_to_xlator_tree(glusterfs_ctx_t *ctx, FILE *fp);
+file_to_xlator_tree(FILE *fp);
 
 int
 xlator_notify(xlator_t *this, int32_t event, void *data, ...);
@@ -1050,10 +1050,10 @@ enum gf_hdsk_event_notify_op {
 gf_boolean_t
 is_graph_topology_equal(glusterfs_graph_t *graph1, glusterfs_graph_t *graph2);
 int
-glusterfs_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx);
+glusterfs_volfile_reconfigure(FILE *newvolfile_fp);
 
 int
-gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
+gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp,
                        const char *oldvolfile);
 
 int
@@ -1076,7 +1076,7 @@ int
 copy_opts_to_child(xlator_t *src, xlator_t *dst, char *glob);
 
 int
-glusterfs_delete_volfile_checksum(glusterfs_ctx_t *ctx, const char *volfile_id);
+glusterfs_delete_volfile_checksum(const char *volfile_id);
 int
 xlator_memrec_free(xlator_t *xl);
 

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -223,13 +223,12 @@ glusterfs_graph_set_first(glusterfs_graph_t *graph, xlator_t *xl)
 }
 
 int
-glusterfs_graph_insert(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
-                       const char *type, const char *name,
-                       gf_boolean_t autoload)
+glusterfs_graph_insert(glusterfs_graph_t *graph, const char *type,
+                       const char *name, gf_boolean_t autoload)
 {
     xlator_t *ixl = NULL;
 
-    if (!ctx->root) {
+    if (!global_ctx->root) {
         gf_msg("glusterfs", GF_LOG_ERROR, 0, LG_MSG_VOLUME_ERROR,
                "volume \"%s\" can be added from command line only "
                "on client side",
@@ -271,78 +270,77 @@ err:
 }
 
 int
-glusterfs_graph_acl(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_acl(glusterfs_graph_t *graph)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
 
-    cmd_args = &ctx->cmd_args;
+    cmd_args = &global_ctx->cmd_args;
 
     if (!cmd_args->acl)
         return 0;
 
-    ret = glusterfs_graph_insert(graph, ctx, "system/posix-acl",
+    ret = glusterfs_graph_insert(graph, "system/posix-acl",
                                  "posix-acl-autoload", 1);
     return ret;
 }
 
 int
-glusterfs_graph_worm(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_worm(glusterfs_graph_t *graph)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
 
-    cmd_args = &ctx->cmd_args;
+    cmd_args = &global_ctx->cmd_args;
 
     if (!cmd_args->worm)
         return 0;
 
-    ret = glusterfs_graph_insert(graph, ctx, "features/worm", "worm-autoload",
-                                 1);
+    ret = glusterfs_graph_insert(graph, "features/worm", "worm-autoload", 1);
     return ret;
 }
 
 int
-glusterfs_graph_meta(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_meta(glusterfs_graph_t *graph)
 {
     int ret = 0;
 
-    if (!ctx->root)
+    if (!global_ctx->root)
         return 0;
 
-    ret = glusterfs_graph_insert(graph, ctx, "meta", "meta-autoload", 1);
+    ret = glusterfs_graph_insert(graph, "meta", "meta-autoload", 1);
     return ret;
 }
 
 int
-glusterfs_graph_mac_compat(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_mac_compat(glusterfs_graph_t *graph)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
 
-    cmd_args = &ctx->cmd_args;
+    cmd_args = &global_ctx->cmd_args;
 
     if (cmd_args->mac_compat == GF_OPTION_DISABLE)
         return 0;
 
-    ret = glusterfs_graph_insert(graph, ctx, "features/mac-compat",
+    ret = glusterfs_graph_insert(graph, "features/mac-compat",
                                  "mac-compat-autoload", 1);
 
     return ret;
 }
 
 int
-glusterfs_graph_gfid_access(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_gfid_access(glusterfs_graph_t *graph)
 {
     int ret = 0;
     cmd_args_t *cmd_args = NULL;
 
-    cmd_args = &ctx->cmd_args;
+    cmd_args = &global_ctx->cmd_args;
 
     if (!cmd_args->aux_gfid_mount)
         return 0;
 
-    ret = glusterfs_graph_insert(graph, ctx, "features/gfid-access",
+    ret = glusterfs_graph_insert(graph, "features/gfid-access",
                                  "gfid-access-autoload", 1);
     return ret;
 }
@@ -541,10 +539,8 @@ glusterfs_graph_parent_up(glusterfs_graph_t *graph)
 }
 
 int
-glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
-                        char *volume_name)
+glusterfs_graph_prepare(glusterfs_graph_t *graph, char *volume_name)
 {
-    xlator_t *trav = NULL;
     int ret = 0;
 
     /* XXX: CHECKSUM */
@@ -575,13 +571,13 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     }
 
     /* XXX: WORM VOLUME */
-    ret = glusterfs_graph_worm(graph, ctx);
+    ret = glusterfs_graph_worm(graph);
     if (ret) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs graph worm failed");
         return -1;
     }
-    ret = glusterfs_graph_acl(graph, ctx);
+    ret = glusterfs_graph_acl(graph);
     if (ret) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs graph ACL failed");
@@ -589,7 +585,7 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     }
 
     /* XXX: MAC COMPAT */
-    ret = glusterfs_graph_mac_compat(graph, ctx);
+    ret = glusterfs_graph_mac_compat(graph);
     if (ret) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs graph mac compat failed");
@@ -597,7 +593,7 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     }
 
     /* XXX: gfid-access */
-    ret = glusterfs_graph_gfid_access(graph, ctx);
+    ret = glusterfs_graph_gfid_access(graph);
     if (ret) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs graph 'gfid-access' failed");
@@ -605,7 +601,7 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     }
 
     /* XXX: topmost xlator */
-    ret = glusterfs_graph_meta(graph, ctx);
+    ret = glusterfs_graph_meta(graph);
     if (ret) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs graph meta failed");
@@ -617,10 +613,10 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
 
     fill_uuid(graph->graph_uuid, sizeof(graph->graph_uuid), graph->dob);
 
-    graph->id = ctx->graph_id++;
+    graph->id = global_ctx->graph_id++;
 
     /* XXX: --xlator-option additions */
-    gf_add_cmdline_options(graph, &ctx->cmd_args);
+    gf_add_cmdline_options(graph, &global_ctx->cmd_args);
 
     return 0;
 }
@@ -747,7 +743,7 @@ glusterfs_reachable_leaves(xlator_t *base, dict_t *leaves)
 }
 
 int
-glusterfs_graph_activate(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
+glusterfs_graph_activate(glusterfs_graph_t *graph)
 {
     int ret = 0;
     xlator_t *root = NULL;
@@ -782,18 +778,18 @@ glusterfs_graph_activate(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx)
 
     /* XXX: log full graph (_gf_dump_details) */
 
-    list_add(&graph->list, &ctx->graphs);
-    ctx->active = graph;
+    list_add(&graph->list, &global_ctx->graphs);
+    global_ctx->active = graph;
 
     /* XXX: attach to root and set active pointer */
-    if (ctx->root) {
-        ret = xlator_notify(ctx->root, GF_EVENT_GRAPH_NEW, graph);
+    if (global_ctx->root) {
+        ret = xlator_notify(global_ctx->root, GF_EVENT_GRAPH_NEW, graph);
         if (ret) {
             gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_EVENT_NOTIFY_FAILED,
                    "graph new notification failed");
             return ret;
         }
-        ((xlator_t *)ctx->root)->next = graph->top;
+        ((xlator_t *)global_ctx->root)->next = graph->top;
     }
 
     /* XXX: perform parent up */
@@ -903,20 +899,14 @@ out:
  * occurred during the operation
  */
 int
-glusterfs_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx)
+glusterfs_volfile_reconfigure(FILE *newvolfile_fp)
 {
     glusterfs_graph_t *oldvolfile_graph = NULL;
     glusterfs_graph_t *newvolfile_graph = NULL;
 
     int ret = -1;
 
-    if (!ctx) {
-        gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, 0, LG_MSG_CTX_NULL,
-               "ctx is NULL");
-        goto out;
-    }
-
-    oldvolfile_graph = ctx->active;
+    oldvolfile_graph = global_ctx->active;
     if (!oldvolfile_graph) {
         ret = 1;
         goto out;
@@ -928,7 +918,7 @@ glusterfs_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx)
         goto out;
     }
 
-    glusterfs_graph_prepare(newvolfile_graph, ctx, ctx->cmd_args.volume_name);
+    glusterfs_graph_prepare(newvolfile_graph, global_ctx->cmd_args.volume_name);
 
     if (!is_graph_topology_equal(oldvolfile_graph, newvolfile_graph)) {
         ret = 1;
@@ -964,7 +954,7 @@ out:
  */
 
 int
-gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
+gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp,
                        const char *oldvolfile)
 {
     glusterfs_graph_t *oldvolfile_graph = NULL;
@@ -985,13 +975,7 @@ gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
         goto out;
     }
 
-    if (!ctx) {
-        gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, 0, LG_MSG_CTX_NULL,
-               "ctx is NULL");
-        goto out;
-    }
-
-    oldvolfile_graph = ctx->active;
+    oldvolfile_graph = global_ctx->active;
     if (!oldvolfile_graph) {
         active_graph_found = _gf_false;
         gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, 0, LG_MSG_ACTIVE_GRAPH_NULL,
@@ -1041,7 +1025,7 @@ gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
         goto out;
     }
 
-    glusterfs_graph_prepare(newvolfile_graph, ctx, ctx->cmd_args.volume_name);
+    glusterfs_graph_prepare(newvolfile_graph, global_ctx->cmd_args.volume_name);
 
     if (!is_graph_topology_equal(oldvolfile_graph, newvolfile_graph)) {
         ret = 1;
@@ -1301,7 +1285,7 @@ glusterfs_graph_attach(glusterfs_graph_t *orig_graph, char *path,
     }
 
     /* TODO memory leaks everywhere need to free graph in case of error */
-    if (glusterfs_graph_prepare(graph, global_ctx, xl->name)) {
+    if (glusterfs_graph_prepare(graph, xl->name)) {
         gf_log(this->name, GF_LOG_WARNING,
                "failed to prepare graph for xlator %s", xl->name);
         return -EIO;
@@ -1332,14 +1316,13 @@ glusterfs_graph_attach(glusterfs_graph_t *orig_graph, char *path,
     return 0;
 }
 int
-glusterfs_muxsvc_cleanup_parent(glusterfs_ctx_t *ctx,
-                                glusterfs_graph_t *parent_graph)
+glusterfs_muxsvc_cleanup_parent(glusterfs_graph_t *parent_graph)
 {
     if (parent_graph) {
         if (parent_graph->first) {
             xlator_destroy(parent_graph->first);
         }
-        ctx->active = NULL;
+        global_ctx->active = NULL;
         GF_FREE(parent_graph);
         parent_graph = NULL;
     }
@@ -1394,7 +1377,8 @@ glusterfs_graph_cleanup(void *arg)
     pthread_mutex_lock(&global_ctx->notify_lock);
     {
         while (global_ctx->notifying)
-            pthread_cond_wait(&global_ctx->notify_cond, &global_ctx->notify_lock);
+            pthread_cond_wait(&global_ctx->notify_cond,
+                              &global_ctx->notify_lock);
     }
     pthread_mutex_unlock(&global_ctx->notify_lock);
 
@@ -1409,8 +1393,7 @@ out:
 }
 
 glusterfs_graph_t *
-glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
-                                    char *type)
+glusterfs_muxsvc_setup_parent_graph(char *name, char *type)
 {
     glusterfs_graph_t *parent_graph = NULL;
     xlator_t *ixl = NULL;
@@ -1422,7 +1405,7 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
 
     INIT_LIST_HEAD(&parent_graph->list);
 
-    ctx->active = parent_graph;
+    global_ctx->active = parent_graph;
     ixl = GF_CALLOC(1, sizeof(*ixl), gf_common_mt_xlator_t);
     if (!ixl)
         goto out;
@@ -1450,14 +1433,14 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
 
     gettimeofday(&parent_graph->dob, NULL);
     fill_uuid(parent_graph->graph_uuid, 128, parent_graph->dob);
-    parent_graph->id = ctx->graph_id++;
+    parent_graph->id = global_ctx->graph_id++;
     ret = 0;
 out:
     if (ixl)
         xlator_destroy(ixl);
 
     if (ret) {
-        glusterfs_muxsvc_cleanup_parent(ctx, parent_graph);
+        glusterfs_muxsvc_cleanup_parent(parent_graph);
         parent_graph = NULL;
     }
     return parent_graph;
@@ -1479,7 +1462,7 @@ glusterfs_svc_mux_pidfile_cleanup(gf_volfile_t *volfile_obj)
 }
 
 int
-glusterfs_process_svc_detach(glusterfs_ctx_t *ctx, gf_volfile_t *volfile_obj)
+glusterfs_process_svc_detach(gf_volfile_t *volfile_obj)
 {
     xlator_t *last_xl = NULL;
     glusterfs_graph_t *graph = NULL;
@@ -1490,12 +1473,12 @@ glusterfs_process_svc_detach(glusterfs_ctx_t *ctx, gf_volfile_t *volfile_obj)
     int ret = -1;
     xlator_t *xl = NULL;
 
-    if (!ctx || !ctx->active || !volfile_obj)
+    if (!global_ctx || !global_ctx->active || !volfile_obj)
         goto out;
 
-    pthread_mutex_lock(&ctx->cleanup_lock);
+    pthread_mutex_lock(&global_ctx->cleanup_lock);
     {
-        parent_graph = ctx->active;
+        parent_graph = global_ctx->active;
         graph = volfile_obj->graph;
         if (!graph)
             goto unlock;
@@ -1522,7 +1505,7 @@ glusterfs_process_svc_detach(glusterfs_ctx_t *ctx, gf_volfile_t *volfile_obj)
         ret = 0;
     }
 unlock:
-    pthread_mutex_unlock(&ctx->cleanup_lock);
+    pthread_mutex_unlock(&global_ctx->cleanup_lock);
 out:
     if (!ret) {
         list_del_init(&volfile_obj->volfile_list);
@@ -1661,8 +1644,7 @@ out:
     return ret;
 }
 int
-glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
-                                   char *volfile_id, char *checksum,
+glusterfs_process_svc_attach_volfp(FILE *fp, char *volfile_id, char *checksum,
                                    dict_t *dict)
 {
     glusterfs_graph_t *graph = NULL;
@@ -1676,9 +1658,7 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
         0,
     };
 
-    if (!ctx)
-        goto out;
-    parent_graph = ctx->active;
+    parent_graph = global_ctx->active;
     graph = glusterfs_graph_construct(fp);
     if (!graph) {
         gf_msg("glusterfsd", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_ATTACH_FAILED,
@@ -1700,7 +1680,7 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
     graph->leaf_count = glusterfs_count_leaves(glusterfs_root(graph));
     xl = graph->first;
     /* TODO memory leaks everywhere need to free graph in case of error */
-    if (glusterfs_graph_prepare(graph, ctx, xl->name)) {
+    if (glusterfs_graph_prepare(graph, xl->name)) {
         gf_msg("glusterfsd", GF_LOG_WARNING, EINVAL, LG_MSG_GRAPH_ATTACH_FAILED,
                "failed to prepare graph for xlator %s", xl->name);
         ret = -1;
@@ -1718,7 +1698,7 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
     }
 
     if (!parent_graph) {
-        parent_graph = glusterfs_muxsvc_setup_parent_graph(ctx, "glustershd",
+        parent_graph = glusterfs_muxsvc_setup_parent_graph("glustershd",
                                                            "debug/io-stats");
         if (!parent_graph)
             goto out;
@@ -1751,7 +1731,7 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
     snprintf(volfile_obj->vol_id, sizeof(volfile_obj->vol_id), "%s",
              volfile_id);
 
-    if (strcmp(ctx->cmd_args.process_name, "glustershd") == 0) {
+    if (strcmp(global_ctx->cmd_args.process_name, "glustershd") == 0) {
         ret = glusterfs_update_mux_pid(dict, volfile_obj);
         if (ret == -1) {
             GF_FREE(volfile_obj);
@@ -1761,12 +1741,12 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
 
     graph->used = 1;
     parent_graph->id++;
-    list_add(&graph->list, &ctx->graphs);
+    list_add(&graph->list, &global_ctx->graphs);
     INIT_LIST_HEAD(&volfile_obj->volfile_list);
     volfile_obj->graph = graph;
     memcpy(volfile_obj->volfile_checksum, checksum,
            sizeof(volfile_obj->volfile_checksum));
-    list_add_tail(&volfile_obj->volfile_list, &ctx->volfile_list);
+    list_add_tail(&volfile_obj->volfile_list, &global_ctx->volfile_list);
     gf_log_dump_graph(fp, graph);
     graph = NULL;
 
@@ -1787,13 +1767,13 @@ out:
             }
         }
         if (clean_graph)
-            glusterfs_muxsvc_cleanup_parent(ctx, clean_graph);
+            glusterfs_muxsvc_cleanup_parent(clean_graph);
     }
     return ret;
 }
 
 int
-glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
+glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp,
                                   gf_volfile_t *volfile_obj, char *checksum,
                                   dict_t *dict)
 {
@@ -1802,12 +1782,6 @@ glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
     char vol_id[NAME_MAX + 1];
 
     int ret = -1;
-
-    if (!ctx) {
-        gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, 0, LG_MSG_CTX_NULL,
-               "ctx is NULL");
-        goto out;
-    }
 
     /* Change the message id */
     if (!volfile_obj) {
@@ -1828,13 +1802,13 @@ glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
     }
     newvolfile_graph->last_xl = glusterfs_get_last_xlator(newvolfile_graph);
 
-    glusterfs_graph_prepare(newvolfile_graph, ctx, newvolfile_graph->first);
+    glusterfs_graph_prepare(newvolfile_graph, newvolfile_graph->first);
 
     if (!is_graph_topology_equal(oldvolfile_graph, newvolfile_graph)) {
         ret = snprintf(vol_id, sizeof(vol_id), "%s", volfile_obj->vol_id);
         if (ret < 0)
             goto out;
-        ret = glusterfs_process_svc_detach(ctx, volfile_obj);
+        ret = glusterfs_process_svc_detach(volfile_obj);
         if (ret) {
             gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, EINVAL,
                    LG_MSG_GRAPH_CLEANUP_FAILED,
@@ -1843,7 +1817,7 @@ glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
             goto out;
         }
         volfile_obj = NULL;
-        ret = glusterfs_process_svc_attach_volfp(ctx, newvolfile_fp, vol_id,
+        ret = glusterfs_process_svc_attach_volfp(newvolfile_fp, vol_id,
                                                  checksum, dict);
         goto out;
     }

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1853,19 +1853,16 @@ inode_table_ctx_free(inode_table_t *table)
 }
 
 void
-inode_table_destroy_all(glusterfs_ctx_t *ctx)
+inode_table_destroy_all()
 {
     glusterfs_graph_t *trav_graph = NULL, *tmp = NULL;
     xlator_t *tree = NULL;
     inode_table_t *inode_table = NULL;
 
-    if (ctx == NULL)
-        goto out;
-
     /* TODO: Traverse ctx->graphs with in ctx->lock and also the other
      * graph additions and traversals in ctx->lock.
      */
-    list_for_each_entry_safe(trav_graph, tmp, &ctx->graphs, list)
+    list_for_each_entry_safe(trav_graph, tmp, &global_ctx->graphs, list)
     {
         tree = trav_graph->first;
         inode_table = tree->itable;
@@ -1873,7 +1870,7 @@ inode_table_destroy_all(glusterfs_ctx_t *ctx)
         if (inode_table)
             inode_table_destroy(inode_table);
     }
-out:
+
     return;
 }
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1210,7 +1210,7 @@ inode_invalidate(inode_t *inode)
      * The root xlator is not in the graph but it can define an invalidate
      * handler.
      */
-    xl = inode->table->xl->ctx->root;
+    xl = global_ctx->root;
     if (xl && xl->cbks->invalidate) {
         old_THIS = THIS;
         THIS = xl;

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -129,7 +129,7 @@ gf_mem_acct_enabled(void)
     xlator_t *x = THIS;
     /* Low-level __gf_xxx() may be called
        before ctx is initialized. */
-    return x->ctx && x->ctx->mem_acct_enable;
+    return global_ctx && global_ctx->mem_acct_enable;
 }
 
 void *
@@ -639,11 +639,11 @@ mem_pool_destroy(struct mem_pool *pool)
         return;
 
     /* remove this pool from the owner (glusterfs_ctx_t) */
-    LOCK(&pool->ctx->lock);
+    LOCK(&global_ctx->lock);
     {
         list_del(&pool->owner);
     }
-    UNLOCK(&pool->ctx->lock);
+    UNLOCK(&global_ctx->lock);
 
     /* free this pool, but keep the mem_pool_shared */
     GF_FREE(pool);
@@ -701,7 +701,6 @@ mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
     if (!new)
         return NULL;
 
-    new->ctx = ctx;
     new->sizeof_type = sizeof_type;
     new->count = count;
     new->name = name;
@@ -714,11 +713,11 @@ mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
 #endif
     INIT_LIST_HEAD(&new->owner);
 
-    LOCK(&ctx->lock);
+    LOCK(&global_ctx->lock);
     {
         list_add(&new->owner, &ctx->mempool_list);
     }
-    UNLOCK(&ctx->lock);
+    UNLOCK(&global_ctx->lock);
 
     return new;
 }

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -18,19 +18,11 @@
 #include "glusterfs/libglusterfs-messages.h"
 
 void
-gf_mem_acct_enable_set(void *data)
+gf_mem_acct_enable_set(void)
 {
-    glusterfs_ctx_t *ctx = NULL;
+    global_ctx->mem_acct_enable = 1;
 
-    REQUIRE(data != NULL);
-
-    ctx = data;
-
-    GF_ASSERT(ctx != NULL);
-
-    ctx->mem_acct_enable = 1;
-
-    ENSURE(1 == ctx->mem_acct_enable);
+    ENSURE(1 == global_ctx->mem_acct_enable);
 
     return;
 }
@@ -126,10 +118,7 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 static bool
 gf_mem_acct_enabled(void)
 {
-    xlator_t *x = THIS;
-    /* Low-level __gf_xxx() may be called
-       before ctx is initialized. */
-    return global_ctx && global_ctx->mem_acct_enable;
+    return global_ctx->mem_acct_enable;
 }
 
 void *
@@ -365,8 +354,7 @@ free:
 #if defined(GF_DISABLE_MEMPOOL)
 
 struct mem_pool *
-mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
-                unsigned long count, char *name)
+mem_pool_new_fn(unsigned long sizeof_type, unsigned long count, char *name)
 {
     return (struct mem_pool *)(sizeof_type);
 }
@@ -657,8 +645,7 @@ mem_pool_destroy(struct mem_pool *pool)
 }
 
 struct mem_pool *
-mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
-                unsigned long count, char *name)
+mem_pool_new_fn(unsigned long sizeof_type, unsigned long count, char *name)
 {
     unsigned long extra_size, size;
     unsigned int power;
@@ -715,7 +702,7 @@ mem_pool_new_fn(glusterfs_ctx_t *ctx, unsigned long sizeof_type,
 
     LOCK(&global_ctx->lock);
     {
-        list_add(&new->owner, &ctx->mempool_list);
+        list_add(&new->owner, &global_ctx->mempool_list);
     }
     UNLOCK(&global_ctx->lock);
 

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -20,7 +20,7 @@ dump_mem_acct_details(xlator_t *xl, int fd)
     struct mem_acct_rec *mem_rec;
     int i = 0;
 
-    if (!xl || !xl->mem_acct || (xl->ctx->active != xl->graph))
+    if (!xl || !xl->mem_acct || (global_ctx->active != xl->graph))
         return;
 
     dprintf(fd, "# %s.%s.total.num_types %d\n", xl->type, xl->name,
@@ -88,7 +88,7 @@ dump_latency_and_count(xlator_t *xl, int fd)
     }
 
     /* Need 'fuse' data, and don't need all the old graph info */
-    if ((xl != xl->ctx->root) && (xl->ctx->active != xl->graph))
+    if ((xl != global_ctx->root) && (global_ctx->active != xl->graph))
         return;
 
     for (index = 0; index < GF_FOP_MAXVALUE; index++) {

--- a/libglusterfs/src/rbthash.c
+++ b/libglusterfs/src/rbthash.c
@@ -79,9 +79,8 @@ err:
  */
 
 rbthash_table_t *
-rbthash_table_init(glusterfs_ctx_t *ctx, int buckets, rbt_hasher_t hfunc,
-                   rbt_data_destroyer_t dfunc, unsigned long expected_entries,
-                   struct mem_pool *entrypool)
+rbthash_table_init(int buckets, rbt_hasher_t hfunc, rbt_data_destroyer_t dfunc,
+                   unsigned long expected_entries, struct mem_pool *entrypool)
 {
     rbthash_table_t *newtab = NULL;
     int ret = -1;
@@ -112,8 +111,7 @@ rbthash_table_init(glusterfs_ctx_t *ctx, int buckets, rbt_hasher_t hfunc,
     }
 
     if (expected_entries) {
-        newtab->entrypool = mem_pool_new_ctx(ctx, rbthash_entry_t,
-                                             expected_entries);
+        newtab->entrypool = mem_pool_new_ctx(rbthash_entry_t, expected_entries);
         if (!newtab->entrypool) {
             goto free_buckets;
         }

--- a/libglusterfs/src/stack.c
+++ b/libglusterfs/src/stack.c
@@ -42,9 +42,8 @@ create_frame(xlator_t *xl, call_pool_t *pool)
     list_add(&frame->frames, &stack->myframes);
 
     stack->pool = pool;
-    stack->ctx = xl->ctx;
 
-    if (frame->root->ctx->measure_latency) {
+    if (global_ctx->measure_latency) {
         timespec_now(&stack->tv);
         memcpy(&frame->begin, &stack->tv, sizeof(stack->tv));
     }
@@ -113,7 +112,7 @@ gf_proc_dump_call_frame(call_frame_t *call_frame, const char *key_buf, ...)
     memcpy(&my_frame, call_frame, sizeof(my_frame));
     UNLOCK(&call_frame->lock);
 
-    if (my_frame.root->ctx->measure_latency) {
+    if (global_ctx->measure_latency) {
         gf_time_fmt(timestr, sizeof(timestr), my_frame.begin.tv_sec,
                     gf_timefmt_FT);
         len = strlen(timestr);
@@ -280,7 +279,7 @@ gf_proc_dump_call_frame_to_dict(call_frame_t *call_frame, char *prefix,
     if (ret)
         return;
 
-    if (tmp_frame.root->ctx->measure_latency) {
+    if (global_ctx->measure_latency) {
         snprintf(key, sizeof(key), "%s.timings", prefix);
         snprintf(msg, sizeof(msg),
                  "%ld.%" GF_PRI_SNSECONDS " -> %ld.%" GF_PRI_SNSECONDS,

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -492,7 +492,6 @@ gf_proc_dump_dict_info(glusterfs_ctx_t *ctx)
 static void
 gf_proc_dump_single_xlator_info(xlator_t *trav)
 {
-    glusterfs_ctx_t *ctx = trav->ctx;
     char itable_key[1024] = {
         0,
     };
@@ -500,13 +499,13 @@ gf_proc_dump_single_xlator_info(xlator_t *trav)
     if (trav->cleanup_starting)
         return;
 
-    if (ctx->measure_latency)
+    if (global_ctx->measure_latency)
         gf_proc_dump_xl_latency_info(trav);
 
     gf_proc_dump_xlator_mem_info(trav);
 
     if (GF_PROC_DUMP_IS_XL_OPTION_ENABLED(inode) && (trav->itable)) {
-        snprintf(itable_key, sizeof(itable_key), "%d.%s.itable", ctx->graph_id,
+        snprintf(itable_key, sizeof(itable_key), "%d.%s.itable", global_ctx->graph_id,
                  trav->name);
     }
 

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -314,7 +314,7 @@ _run_dir_scan_task(call_frame_t *frame, xlator_t *subvol, loc_t *parent,
     scan_data->qlen = qlen;
     scan_data->retval = retval;
 
-    ret = synctask_new(subvol->ctx->env, _dir_scan_job_fn, _dir_scan_job_fn_cbk,
+    ret = synctask_new(global_ctx->env, _dir_scan_job_fn, _dir_scan_job_fn_cbk,
                        frame, scan_data);
 out:
     if (ret < 0) {

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -336,7 +336,7 @@ synctask_wake(struct synctask *task)
     pthread_mutex_lock(&env->mutex);
     {
         if (task->timer != NULL) {
-            if (gf_timer_call_cancel(task->xl->ctx, task->timer) != 0) {
+            if (gf_timer_call_cancel(global_ctx, task->timer) != 0) {
                 goto unlock;
             }
 
@@ -453,7 +453,7 @@ synctask_create(struct syncenv *env, size_t stacksize, synctask_fn_t fn,
 
     newtask->frame = frame;
     if (!frame) {
-        newtask->opframe = create_frame(this, this->ctx->pool);
+        newtask->opframe = create_frame(this, global_ctx->pool);
         if (!newtask->opframe)
             goto err;
         set_lk_owner_from_ptr(&newtask->opframe->root->lk_owner,
@@ -653,7 +653,7 @@ synctask_timer(void *data)
 
     pthread_mutex_lock(&task->env->mutex);
 
-    gf_timer_call_cancel(task->xl->ctx, task->timer);
+    gf_timer_call_cancel(global_ctx, task->timer);
     task->timer = NULL;
 
     __synctask_wake(task);
@@ -699,7 +699,7 @@ synctask_switchto(struct synctask *task)
             __wait(task);
 
             if (task->delta != NULL) {
-                task->timer = gf_timer_call_after(task->xl->ctx, *task->delta,
+                task->timer = gf_timer_call_after(global_ctx, *task->delta,
                                                   synctask_timer, task);
             }
         }

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -336,7 +336,7 @@ synctask_wake(struct synctask *task)
     pthread_mutex_lock(&env->mutex);
     {
         if (task->timer != NULL) {
-            if (gf_timer_call_cancel(global_ctx, task->timer) != 0) {
+            if (gf_timer_call_cancel(task->timer) != 0) {
                 goto unlock;
             }
 
@@ -653,7 +653,7 @@ synctask_timer(void *data)
 
     pthread_mutex_lock(&task->env->mutex);
 
-    gf_timer_call_cancel(global_ctx, task->timer);
+    gf_timer_call_cancel(task->timer);
     task->timer = NULL;
 
     __synctask_wake(task);
@@ -699,8 +699,8 @@ synctask_switchto(struct synctask *task)
             __wait(task);
 
             if (task->delta != NULL) {
-                task->timer = gf_timer_call_after(global_ctx, *task->delta,
-                                                  synctask_timer, task);
+                task->timer = gf_timer_call_after(*task->delta, synctask_timer,
+                                                  task);
             }
         }
 

--- a/libglusterfs/src/unittest/log_mock.c
+++ b/libglusterfs/src/unittest/log_mock.c
@@ -47,6 +47,6 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
 }
 
 void
-gf_log_globals_init(void *data, gf_loglevel_t level)
+gf_log_globals_init(gf_loglevel_t level)
 {
 }

--- a/libglusterfs/src/unittest/mem_pool_unittest.c
+++ b/libglusterfs/src/unittest/mem_pool_unittest.c
@@ -64,7 +64,7 @@ helper_xlator_init(uint32_t num_types)
     assert_non_null(xl->mem_acct);
 
     xl->ctx = test_calloc(1, sizeof(glusterfs_ctx_t));
-    assert_non_null(xl->ctx);
+    assert_non_null(global_ctx);
 
     for (i = 0; i < num_types; i++) {
         ret = LOCK_INIT(&(xl->mem_acct->rec[i].lock));
@@ -119,7 +119,7 @@ test_gf_mem_acct_enable_set(void **state)
 
     memset(&test_ctx, 0, sizeof(test_ctx));
     assert_true(NULL == test_ctx.process_uuid);
-    gf_mem_acct_enable_set((void *)&test_ctx);
+    gf_mem_acct_enable_set();
     assert_true(1 == test_ctx.mem_acct_enable);
     assert_true(NULL == test_ctx.process_uuid);
 }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -724,9 +724,6 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
     if (!xl)
         return -1;
 
-    if (!global_ctx)
-        return -1;
-
     if (!global_ctx->mem_acct_enable)
         return 0;
 
@@ -824,7 +821,7 @@ xlator_members_free(xlator_t *xl)
 
     GF_FREE(xl->name);
     GF_FREE(xl->type);
-    if (!(global_ctx && global_ctx->cmd_args.vgtool != _gf_none) && xl->dlhandle)
+    if (!(global_ctx->cmd_args.vgtool != _gf_none) && xl->dlhandle)
         dlclose(xl->dlhandle);
     if (xl->options)
         dict_unref(xl->options);
@@ -957,7 +954,7 @@ xlator_mem_cleanup(xlator_t *this)
     glusterfs_graph_t *graph = NULL;
     gf_boolean_t graph_cleanup = _gf_false;
 
-    if (this->call_cleanup || !global_ctx)
+    if (this->call_cleanup)
         return;
 
     this->call_cleanup = 1;
@@ -1366,7 +1363,7 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
         gf_smsg("glusterfs", gf_log_get_loglevel(), 0, LG_MSG_SET_LOG_LEVEL,
                 "new-value=%d", log_level, "old-value=%d",
                 gf_log_get_loglevel(), NULL);
-        gf_log_set_loglevel(global_ctx, log_level);
+        gf_log_set_loglevel(log_level);
         ret = 0;
         goto out;
     }
@@ -1456,12 +1453,12 @@ copy_opts_to_child(xlator_t *src, xlator_t *dst, char *glob)
 }
 
 int
-glusterfs_delete_volfile_checksum(glusterfs_ctx_t *ctx, const char *volfile_id)
+glusterfs_delete_volfile_checksum(const char *volfile_id)
 {
     gf_volfile_t *volfile_tmp = NULL;
     gf_volfile_t *volfile_obj = NULL;
 
-    list_for_each_entry(volfile_tmp, &ctx->volfile_list, volfile_list)
+    list_for_each_entry(volfile_tmp, &global_ctx->volfile_list, volfile_list)
     {
         if (!strcmp(volfile_id, volfile_tmp->vol_id)) {
             list_del_init(&volfile_tmp->volfile_list);

--- a/rpc/rpc-lib/src/autoscale-threads.c
+++ b/rpc/rpc-lib/src/autoscale-threads.c
@@ -12,9 +12,9 @@
 #include "rpcsvc.h"
 
 void
-rpcsvc_autoscale_threads(glusterfs_ctx_t *ctx, rpcsvc_t *rpc, int incr)
+rpcsvc_autoscale_threads(rpcsvc_t *rpc, int incr)
 {
-    struct event_pool *pool = ctx->event_pool;
+    struct event_pool *pool = global_ctx->event_pool;
     int thread_count = pool->eventthreadcount;
 
     pool->auto_thread_count += incr;

--- a/rpc/rpc-lib/src/mgmt-pmap.c
+++ b/rpc/rpc-lib/src/mgmt-pmap.c
@@ -65,7 +65,7 @@ out:
 }
 
 int
-rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brickname)
+rpc_clnt_mgmt_pmap_signout(char *brickname)
 {
     int ret = 0;
     pmap_signout_req req = {
@@ -83,8 +83,8 @@ rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brickname)
     struct iobref *iobref = NULL;
     ssize_t xdr_size = 0;
 
-    frame = create_frame(THIS, ctx->pool);
-    cmd_args = &ctx->cmd_args;
+    frame = create_frame(THIS, global_ctx->pool);
+    cmd_args = &global_ctx->cmd_args;
 
     if (!cmd_args->brick_port && (!cmd_args->brick_name || !brickname)) {
         gf_log("fsd-mgmt", GF_LOG_DEBUG,
@@ -116,7 +116,7 @@ rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brickname)
     }
 
     xdr_size = xdr_sizeof((xdrproc_t)xdr_pmap_signout_req, &req);
-    iobuf = iobuf_get2(ctx->iobuf_pool, xdr_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
     if (!iobuf) {
         goto out;
     };
@@ -134,9 +134,9 @@ rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brickname)
     }
     iov.iov_len = ret;
 
-    ret = rpc_clnt_submit(ctx->mgmt, &clnt_pmap_signout_prog, GF_PMAP_SIGNOUT,
-                          mgmt_pmap_signout_cbk, &iov, 1, NULL, 0, iobref,
-                          frame, NULL, 0, NULL, 0, NULL);
+    ret = rpc_clnt_submit(global_ctx->mgmt, &clnt_pmap_signout_prog,
+                          GF_PMAP_SIGNOUT, mgmt_pmap_signout_cbk, &iov, 1, NULL,
+                          0, iobref, frame, NULL, 0, NULL, 0, NULL);
 out:
     if (iobref)
         iobref_unref(iobref);

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -56,7 +56,7 @@ __rpc_clnt_rearm_ping_timer(struct rpc_clnt *rpc, gf_timer_cbk_t cbk)
     timeout.tv_nsec = 0;
 
     rpc_clnt_ref(rpc);
-    timer = gf_timer_call_after(global_ctx, timeout, cbk, (void *)rpc);
+    timer = gf_timer_call_after(timeout, cbk, (void *)rpc);
     if (timer == NULL) {
         gf_log(trans->name, GF_LOG_WARNING, "unable to setup ping timer");
 
@@ -82,7 +82,7 @@ rpc_clnt_remove_ping_timer_locked(struct rpc_clnt *rpc)
     if (conn->ping_timer) {
         timer = conn->ping_timer;
         conn->ping_timer = NULL;
-        gf_timer_call_cancel(global_ctx, timer);
+        gf_timer_call_cancel(timer);
         conn->ping_started = 0;
         return 1;
     }

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -56,7 +56,7 @@ __rpc_clnt_rearm_ping_timer(struct rpc_clnt *rpc, gf_timer_cbk_t cbk)
     timeout.tv_nsec = 0;
 
     rpc_clnt_ref(rpc);
-    timer = gf_timer_call_after(rpc->ctx, timeout, cbk, (void *)rpc);
+    timer = gf_timer_call_after(global_ctx, timeout, cbk, (void *)rpc);
     if (timer == NULL) {
         gf_log(trans->name, GF_LOG_WARNING, "unable to setup ping timer");
 
@@ -82,7 +82,7 @@ rpc_clnt_remove_ping_timer_locked(struct rpc_clnt *rpc)
     if (conn->ping_timer) {
         timer = conn->ping_timer;
         conn->ping_timer = NULL;
-        gf_timer_call_cancel(rpc->ctx, timer);
+        gf_timer_call_cancel(global_ctx, timer);
         conn->ping_started = 0;
         return 1;
     }
@@ -254,7 +254,7 @@ rpc_clnt_ping(struct rpc_clnt *rpc)
     local = GF_MALLOC(sizeof(struct ping_local), gf_common_ping_local_t);
     if (!local)
         return ret;
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame) {
         GF_FREE(local);
         return ret;

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -254,6 +254,6 @@ int
 rpc_clnt_disable(struct rpc_clnt *rpc);
 
 int
-rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brick_name);
+rpc_clnt_mgmt_pmap_signout(char *brick_name);
 
 #endif /* !_RPC_CLNT_H */

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -181,7 +181,6 @@ typedef struct rpc_clnt {
 
     struct mem_pool *saved_frames_pool;
 
-    glusterfs_ctx_t *ctx;
     gf_atomic_t refcount;
     xlator_t *owner;
     int auth_value;

--- a/rpc/rpc-lib/src/rpc-transport.c
+++ b/rpc/rpc-lib/src/rpc-transport.c
@@ -164,7 +164,7 @@ rpc_transport_cleanup(rpc_transport_t *trans)
 }
 
 rpc_transport_t *
-rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
+rpc_transport_load(dict_t *options, char *trans_name)
 {
     struct rpc_transport *trans = NULL, *return_trans = NULL;
     char *name = NULL;
@@ -179,7 +179,6 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
     gf_boolean_t success = _gf_false;
 
     GF_VALIDATE_OR_GOTO("rpc-transport", options, fail);
-    GF_VALIDATE_OR_GOTO("rpc-transport", ctx, fail);
     GF_VALIDATE_OR_GOTO("rpc-transport", trans_name, fail);
 
     trans = GF_CALLOC(1, sizeof(struct rpc_transport),
@@ -191,7 +190,6 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
     if (!trans->name)
         goto fail;
 
-    trans->ctx = ctx;
     type = str;
 
     /* Backward compatibility */

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -173,7 +173,6 @@ struct rpc_transport {
     void *mydata;
     pthread_mutex_t lock;
     gf_atomic_t refcount;
-    glusterfs_ctx_t *ctx;
     dict_t *options;
     char *name;
     void *dnscache;
@@ -262,7 +261,7 @@ int32_t
 rpc_transport_submit_reply(rpc_transport_t *this, rpc_transport_reply_t *reply);
 
 rpc_transport_t *
-rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *name);
+rpc_transport_load(dict_t *options, char *name);
 
 rpc_transport_t *
 rpc_transport_ref(rpc_transport_t *trans);

--- a/rpc/rpc-lib/src/rpcsvc-common.h
+++ b/rpc/rpc-lib/src/rpcsvc-common.h
@@ -47,7 +47,6 @@ typedef struct rpcsvc_state {
 
     uid_t anonuid;
     gid_t anongid;
-    glusterfs_ctx_t *ctx;
 
     /* list of connections which will listen for incoming connections */
     struct list_head listeners;

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -342,7 +342,7 @@ rpcsvc_program_actor(rpcsvc_request_t *req)
         goto err;
     }
 
-    if (svc->xl->ctx->measure_latency) {
+    if (global_ctx->measure_latency) {
         timespec_now(&req->begin);
     }
 
@@ -807,7 +807,7 @@ rpcsvc_handle_rpc_call(rpcsvc_t *svc, rpc_transport_t *trans,
         }
 
         if (req->synctask) {
-            ret = synctask_new(THIS->ctx->env, (synctask_fn_t)actor_fn,
+            ret = synctask_new(global_ctx->env, (synctask_fn_t)actor_fn,
                                rpcsvc_check_and_reply_error, NULL, req);
         } else if (req->ownthread) {
             value = pthread_getspecific(req->prog->req_queue_key);
@@ -1182,7 +1182,7 @@ rpcsvc_callback_build_record(rpcsvc_t *rpc, int prognum, int progver,
      */
     xdr_size = xdr_sizeof((xdrproc_t)xdr_callmsg, &request);
 
-    request_iob = iobuf_get2(rpc->ctx->iobuf_pool, (xdr_size + payload));
+    request_iob = iobuf_get2(global_ctx->iobuf_pool, (xdr_size + payload));
     if (!request_iob) {
         goto out;
     }

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -512,8 +512,7 @@ rpcsvc_register_portmap_enabled(rpcsvc_t *svc);
  * Called in main.
  */
 extern rpcsvc_t *
-rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
-            uint32_t poolcount);
+rpcsvc_init(xlator_t *xl, dict_t *options, uint32_t poolcount);
 
 extern int
 rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options);
@@ -685,7 +684,7 @@ rpcsvc_vector_sizer
 rpcsvc_get_program_vector_sizer(rpcsvc_t *svc, uint32_t prognum,
                                 uint32_t progver, int procnum);
 void
-rpcsvc_autoscale_threads(glusterfs_ctx_t *ctx, rpcsvc_t *rpc, int incr);
+rpcsvc_autoscale_threads(rpcsvc_t *rpc, int incr);
 
 extern int
 rpcsvc_destroy(rpcsvc_t *svc);

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -2531,7 +2531,8 @@ socket_event_poll_in(rpc_transport_t *this, gf_boolean_t notify_handled)
     }
 
     if (notify_handled && (ret >= 0))
-        gf_event_handled(global_ctx->event_pool, priv->sock, priv->idx, priv->gen);
+        gf_event_handled(global_ctx->event_pool, priv->sock, priv->idx,
+                         priv->gen);
 
     if (pollin) {
         rpc_transport_ref(this);
@@ -3098,7 +3099,6 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
          */
         if (new_sockaddr.ss_family != AF_UNIX)
             new_trans->options = dict_ref(this->options);
-        new_trans->ctx = global_ctx;
 
         ret = socket_init(new_trans);
 
@@ -3121,7 +3121,6 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
         new_trans->ops = this->ops;
         new_trans->init = this->init;
         new_trans->fini = this->fini;
-        new_trans->ctx = global_ctx;
         new_trans->xl = this->xl;
         new_trans->mydata = this->mydata;
         new_trans->notify = this->notify;
@@ -3177,8 +3176,8 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
 
             if (ret >= 0) {
                 new_priv->idx = gf_event_register(
-                    global_ctx->event_pool, new_sock, socket_event_handler, new_trans,
-                    1, 0, new_trans->notify_poller_death);
+                    global_ctx->event_pool, new_sock, socket_event_handler,
+                    new_trans, 1, 0, new_trans->notify_poller_death);
                 if (new_priv->idx == -1) {
                     ret = -1;
                     gf_log(this->name, GF_LOG_ERROR,

--- a/tests/basic/logchecks.c
+++ b/tests/basic/logchecks.c
@@ -113,11 +113,10 @@ main(int argc, char *argv[])
 
     unlink(GF_LOG_CONTROL_FILE);
     creat(GF_LOG_CONTROL_FILE, O_RDONLY);
-    ctx = glusterfs_ctx_new();
-    if (!ctx)
+    if (!glusterfs_ctx_new())
         return -1;
 
-    ret = glusterfs_globals_init(ctx);
+    ret = glusterfs_globals_init();
     if (ret) {
         printf("Error from glusterfs_globals_init [%s]\n", strerror(errno));
         return ret;
@@ -125,8 +124,6 @@ main(int argc, char *argv[])
 
     /* Pre init test, message should not be printed */
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_19);
-
-    THIS->ctx = ctx;
 
     /* TEST 1: messages before initializing the log, goes to stderr
      * and syslog based on criticality */
@@ -137,7 +134,7 @@ main(int argc, char *argv[])
 
     /* TEST 2: messages post initialization, goes to glusterlog and
      * syslog based on severity */
-    ret = gf_log_init(ctx, TEST_FILENAME, "logchecks");
+    ret = gf_log_init(TEST_FILENAME, "logchecks");
     if (ret != 0) {
         printf("Error from gf_log_init [%s]\n", strerror(errno));
         return -1;
@@ -168,14 +165,14 @@ main(int argc, char *argv[])
 
     /* TEST 6: Change level */
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_11);
-    gf_log_set_loglevel(ctx, GF_LOG_CRITICAL);
+    gf_log_set_loglevel(GF_LOG_CRITICAL);
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_15);
     go_log();
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_11);
 
     /* Reset to run with syslog */
     gf_log_set_logformat(gf_logformat_withmsgid);
-    gf_log_set_loglevel(ctx, GF_LOG_INFO);
+    gf_log_set_loglevel(GF_LOG_INFO);
 
     /* Run tests with logger changed to syslog */
     /* TEST 7: No more gluster logs */

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -640,8 +640,8 @@ __afr_lock_heal_synctask(xlator_t *this, afr_private_t *priv, int child)
     if (!frame)
         return -1;
 
-    ret = synctask_new(global_ctx->env, afr_lock_heal, afr_lock_heal_done, frame,
-                       frame);
+    ret = synctask_new(global_ctx->env, afr_lock_heal, afr_lock_heal_done,
+                       frame, frame);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_LK_HEAL_DOM,
                "Failed to launch lock heal synctask");
@@ -1399,7 +1399,7 @@ afr_spb_choice_timeout_cancel(xlator_t *this, inode_t *inode)
         }
         ctx->spb_choice = -1;
         if (ctx->timer) {
-            gf_timer_call_cancel(global_ctx, ctx->timer);
+            gf_timer_call_cancel(ctx->timer);
             ctx->timer = NULL;
         }
         ret = 0;
@@ -1502,7 +1502,7 @@ afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque)
          */
         if (ctx->timer) {
             if (ctx->spb_choice == -1) {
-                if (!gf_timer_call_cancel(global_ctx, ctx->timer)) {
+                if (!gf_timer_call_cancel(ctx->timer)) {
                     ctx->timer = NULL;
                     timer_cancelled = _gf_true;
                 }
@@ -1522,7 +1522,7 @@ afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque)
         }
 
     reset_timer:
-        ret = gf_timer_call_cancel(global_ctx, ctx->timer);
+        ret = gf_timer_call_cancel(ctx->timer);
         if (ret != 0) {
             /* We need to bail out now instead of launching a new
              * timer. Otherwise the cbk of the previous timer event
@@ -1537,8 +1537,8 @@ afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque)
         timer_reset = _gf_true;
 
     set_timer:
-        ctx->timer = gf_timer_call_after(global_ctx, delta,
-                                         afr_set_split_brain_choice_cbk, inode);
+        ctx->timer = gf_timer_call_after(delta, afr_set_split_brain_choice_cbk,
+                                         inode);
         if (!ctx->timer) {
             ctx->spb_choice = old_spb_choice;
             ret = -1;
@@ -4248,7 +4248,7 @@ afr_wakeup_same_fd_delayed_op(xlator_t *this, afr_lock_t *lock, fd_t *fd)
         local = list_entry(lock->post_op.next, afr_local_t,
                            transaction.owner_list);
         if (fd == local->fd) {
-            if (gf_timer_call_cancel(global_ctx, lock->delay_timer)) {
+            if (gf_timer_call_cancel(lock->delay_timer)) {
                 local = NULL;
             } else {
                 lock->delay_timer = NULL;
@@ -5827,7 +5827,7 @@ __afr_launch_notify_timer(xlator_t *this, afr_private_t *priv)
     gf_msg_debug(this->name, 0, "Initiating child-down timer");
     delay.tv_sec = 10;
     delay.tv_nsec = 0;
-    priv->timer = gf_timer_call_after(global_ctx, delay, afr_notify_cbk, this);
+    priv->timer = gf_timer_call_after(delay, afr_notify_cbk, this);
     if (priv->timer == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_TIMER_CREATE_FAIL,
                "Cannot create timer for delayed initialization");
@@ -6389,7 +6389,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
         have_heard_from_all = __get_heard_from_all_status(this);
         if (!had_heard_from_all && have_heard_from_all) {
             if (priv->timer) {
-                gf_timer_call_cancel(global_ctx, priv->timer);
+                gf_timer_call_cancel(priv->timer);
                 priv->timer = NULL;
             }
             /* This is the first event which completes aggregation

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -1502,7 +1502,7 @@ afr_handle_heal_xattrs(call_frame_t *frame, xlator_t *this, loc_t *loc,
         }
         data->frame = frame;
         data->loc = loc;
-        ret = synctask_new(this->ctx->env, afr_get_split_brain_status,
+        ret = synctask_new(global_ctx->env, afr_get_split_brain_status,
                            afr_get_split_brain_status_cbk, NULL, data);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN_STATUS,

--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -1419,7 +1419,7 @@ afr_handle_split_brain_commands(xlator_t *this, call_frame_t *frame, loc_t *loc,
         data->frame = frame;
         loc_copy(&local->loc, loc);
         data->loc = &local->loc;
-        ret = synctask_new(this->ctx->env, afr_can_set_split_brain_choice,
+        ret = synctask_new(global_ctx->env, afr_can_set_split_brain_choice,
                            afr_set_split_brain_choice, NULL, data);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN_STATUS,
@@ -1522,7 +1522,7 @@ afr_handle_empty_brick(xlator_t *this, call_frame_t *frame, loc_t *loc,
         loc_copy(&data->loc, loc);
         data->empty_index = empty_index;
         data->op_type = op_type;
-        ret = synctask_new(this->ctx->env, _afr_handle_empty_brick,
+        ret = synctask_new(global_ctx->env, _afr_handle_empty_brick,
                            _afr_handle_empty_brick_cbk, NULL, data);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN_STATUS,

--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -299,7 +299,7 @@ afr_fix_open(fd_t *fd, xlator_t *this)
     if (!call_count)
         goto out;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -247,7 +247,7 @@ afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
                "Failed to create ta_frame");
         goto out;
     }
-    ret = synctask_new(this->ctx->env, afr_ta_read_txn, afr_ta_read_txn_done,
+    ret = synctask_new(global_ctx->env, afr_ta_read_txn, afr_ta_read_txn_done,
                        ta_frame, frame);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_THIN_ARB,

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -396,7 +396,7 @@ out:
                  "subvol=%s;type=gfid;file="
                  "<gfid:%s>/%s>;count=2;child-%d=%s;gfid-%d=%s;"
                  "child-%d=%s;gfid-%d=%s",
-                 this->ctx->cmd_args.client_pid, this->name, uuid_utoa(pargfid),
+                 global_ctx->cmd_args.client_pid, this->name, uuid_utoa(pargfid),
                  bname, child_idx, priv->children[child_idx]->name, child_idx,
                  uuid_utoa_r(replies[child_idx].poststat.ia_gfid, g1), src_idx,
                  priv->children[src_idx]->name, src_idx,
@@ -2336,7 +2336,7 @@ afr_selfheal_unlocked_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
                      "subvol=%s;"
                      "type=file;gfid=%s;"
                      "ia_type-%d=%s;ia_type-%d=%s",
-                     this->ctx->cmd_args.client_pid, this->name,
+                     global_ctx->cmd_args.client_pid, this->name,
                      uuid_utoa(replies[i].poststat.ia_gfid), first_idx,
                      gf_inode_type_to_str(first.ia_type), i,
                      gf_inode_type_to_str(replies[i].poststat.ia_type));
@@ -2449,7 +2449,7 @@ afr_frame_create(xlator_t *this, int32_t *op_errno)
     afr_local_t *local = NULL;
     pid_t pid = GF_CLIENT_PID_SELF_HEALD;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         if (op_errno)
             *op_errno = ENOMEM;
@@ -2678,7 +2678,7 @@ afr_heal_synctask(xlator_t *this, afr_local_t *local)
     call_frame_t *heal_frame = NULL;
 
     heal_frame = local->heal_frame;
-    ret = synctask_new(this->ctx->env, afr_refresh_selfheal_wrap,
+    ret = synctask_new(global_ctx->env, afr_refresh_selfheal_wrap,
                        afr_refresh_heal_done, heal_frame, heal_frame);
     if (ret < 0)
         /* Heal not launched. Will be queued when the next inode

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -568,7 +568,7 @@ __afr_selfheal_data_finalize_source(
                      "client-pid=%d;"
                      "subvol=%s;type=data;"
                      "file=%s",
-                     this->ctx->cmd_args.client_pid, this->name,
+                     global_ctx->cmd_args.client_pid, this->name,
                      uuid_utoa(inode->gfid));
             return -EIO;
         }

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -422,7 +422,7 @@ afr_selfheal_detect_gfid_and_type_mismatch(xlator_t *this,
                      "subvol=%s;type=file;"
                      "file=<gfid:%s>/%s>;count=2;child-%d=%s;type-"
                      "%d=%s;child-%d=%s;type-%d=%s",
-                     this->ctx->cmd_args.client_pid, this->name,
+                     global_ctx->cmd_args.client_pid, this->name,
                      uuid_utoa(pargfid), bname, i, priv->children[i]->name, i,
                      gf_inode_type_to_str(replies[i].poststat.ia_type), src_idx,
                      priv->children[src_idx]->name, src_idx,

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -299,7 +299,7 @@ __afr_selfheal_metadata_finalize_source(call_frame_t *frame, xlator_t *this,
                      "client-pid=%d;"
                      "subvol=%s;"
                      "type=metadata;file=%s",
-                     this->ctx->cmd_args.client_pid, this->name,
+                     global_ctx->cmd_args.client_pid, this->name,
                      uuid_utoa(inode->gfid));
             return -EIO;
         }

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -198,7 +198,7 @@ afr_selfheal_name_type_mismatch_check(xlator_t *this, struct afr_reply *replies,
                          "file=<gfid:%s>/%s;count=2;"
                          "child-%d=%s;type-%d=%s;child-%d=%s;"
                          "type-%d=%s",
-                         this->ctx->cmd_args.client_pid, this->name,
+                         global_ctx->cmd_args.client_pid, this->name,
                          uuid_utoa(pargfid), bname, i, priv->children[i]->name,
                          i, gf_inode_type_to_str(inode_type1), type_idx,
                          priv->children[type_idx]->name, type_idx,

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -2611,7 +2611,7 @@ afr_changelog_post_op(call_frame_t *frame, xlator_t *this)
 
         GF_ASSERT(lock->delay_timer == NULL);
         lock->delay_timer = gf_timer_call_after(
-            global_ctx, delta, afr_delayed_changelog_wake_up_cbk, local);
+            delta, afr_delayed_changelog_wake_up_cbk, local);
         if (!lock->delay_timer) {
             lock->release = _gf_true;
         } else {
@@ -2700,7 +2700,7 @@ __afr_eager_lock_handle(afr_local_t *local, gf_boolean_t *take_lock,
             lock->release = _gf_true;
         } else if (lock->delay_timer) {
             lock->release = _gf_true;
-            if (gf_timer_call_cancel(global_ctx, lock->delay_timer)) {
+            if (gf_timer_call_cancel(lock->delay_timer)) {
                 /* It will be put in frozen list
                  * in the code flow below*/
             } else {
@@ -2719,7 +2719,7 @@ __afr_eager_lock_handle(afr_local_t *local, gf_boolean_t *take_lock,
 
     if (lock->delay_timer) {
         *take_lock = _gf_false;
-        if (gf_timer_call_cancel(global_ctx, lock->delay_timer)) {
+        if (gf_timer_call_cancel(lock->delay_timer)) {
             list_add_tail(&local->transaction.wait_list, &lock->frozen);
         } else {
             *timer_local = list_entry(lock->post_op.next, afr_local_t,

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -1234,7 +1234,7 @@ afr_ta_post_op_synctask(xlator_t *this, afr_local_t *local)
                "Failed to create ta_frame");
         goto err;
     }
-    ret = synctask_new(this->ctx->env, afr_ta_post_op_do, afr_ta_post_op_done,
+    ret = synctask_new(global_ctx->env, afr_ta_post_op_do, afr_ta_post_op_done,
                        ta_frame, local);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_THIN_ARB,
@@ -2611,7 +2611,7 @@ afr_changelog_post_op(call_frame_t *frame, xlator_t *this)
 
         GF_ASSERT(lock->delay_timer == NULL);
         lock->delay_timer = gf_timer_call_after(
-            this->ctx, delta, afr_delayed_changelog_wake_up_cbk, local);
+            global_ctx, delta, afr_delayed_changelog_wake_up_cbk, local);
         if (!lock->delay_timer) {
             lock->release = _gf_true;
         } else {
@@ -2700,7 +2700,7 @@ __afr_eager_lock_handle(afr_local_t *local, gf_boolean_t *take_lock,
             lock->release = _gf_true;
         } else if (lock->delay_timer) {
             lock->release = _gf_true;
-            if (gf_timer_call_cancel(this->ctx, lock->delay_timer)) {
+            if (gf_timer_call_cancel(global_ctx, lock->delay_timer)) {
                 /* It will be put in frozen list
                  * in the code flow below*/
             } else {
@@ -2719,7 +2719,7 @@ __afr_eager_lock_handle(afr_local_t *local, gf_boolean_t *take_lock,
 
     if (lock->delay_timer) {
         *take_lock = _gf_false;
-        if (gf_timer_call_cancel(this->ctx, lock->delay_timer)) {
+        if (gf_timer_call_cancel(global_ctx, lock->delay_timer)) {
             list_add_tail(&local->transaction.wait_list, &lock->frozen);
         } else {
             *timer_local = list_entry(lock->post_op.next, afr_local_t,

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -735,7 +735,7 @@ fini(xlator_t *this)
 
     LOCK(&priv->lock);
     if (priv->timer != NULL) {
-        gf_timer_call_cancel(this->ctx, priv->timer);
+        gf_timer_call_cancel(global_ctx, priv->timer);
         priv->timer = NULL;
     }
     UNLOCK(&priv->lock);

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -735,7 +735,7 @@ fini(xlator_t *this)
 
     LOCK(&priv->lock);
     if (priv->timer != NULL) {
-        gf_timer_call_cancel(global_ctx, priv->timer);
+        gf_timer_call_cancel(priv->timer);
         priv->timer = NULL;
     }
     UNLOCK(&priv->lock);

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -635,7 +635,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
         else
             goto done;
 
-        heal_frame = create_frame(this, this->ctx->pool);
+        heal_frame = create_frame(this, global_ctx->pool);
         if (heal_frame) {
             heal_local = dht_local_init(heal_frame, &loc, NULL, 0);
             if (!heal_local)
@@ -649,7 +649,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
             heal_local->inode = inode_ref(loc.inode);
             heal_local->main_frame = main_frame;
             FRAME_SU_DO(heal_frame, dht_local_t);
-            ret = synctask_new(this->ctx->env, dht_heal_full_path,
+            ret = synctask_new(global_ctx->env, dht_heal_full_path,
                                dht_heal_full_path_done, heal_frame, heal_frame);
             if (!ret) {
                 loc_wipe(&loc);
@@ -890,7 +890,7 @@ dht_common_mark_mdsxattr(call_frame_t *frame, int *errst,
            To wind a call parallel need to create a new frame
         */
         if (mark_during_fresh_lookup) {
-            xattr_frame = create_frame(this, this->ctx->pool);
+            xattr_frame = create_frame(this, global_ctx->pool);
             if (!xattr_frame) {
                 ret = -1;
                 goto out;
@@ -1270,7 +1270,7 @@ dht_dir_xattr_heal(xlator_t *this, dht_local_t *local, int *op_errno)
     }
 
     gf_uuid_unparse(local->gfid, gfid_local);
-    copy = create_frame(this, this->ctx->pool);
+    copy = create_frame(this, global_ctx->pool);
     if (copy) {
         copy_local = dht_local_init(copy, &(local->loc), NULL, 0);
         if (!copy_local) {
@@ -1286,7 +1286,7 @@ dht_dir_xattr_heal(xlator_t *this, dht_local_t *local, int *op_errno)
             gf_uuid_copy(copy_local->loc.gfid, local->gfid);
             copy_local->mds_subvol = local->mds_subvol;
             FRAME_SU_DO(copy, dht_local_t);
-            ret = synctask_new(this->ctx->env, dht_dir_heal_xattrs,
+            ret = synctask_new(global_ctx->env, dht_dir_heal_xattrs,
                                dht_dir_heal_xattrs_done, copy, copy);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, ENOMEM,
@@ -8074,7 +8074,7 @@ dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (op_ret == -1) {
         /* Remove the linkto if exists */
         if (local->linked) {
-            cleanup_frame = create_frame(this, this->ctx->pool);
+            cleanup_frame = create_frame(this, global_ctx->pool);
             if (cleanup_frame) {
                 cleanup_local = dht_local_init(cleanup_frame, &local->loc2,
                                                NULL, 0);
@@ -8084,7 +8084,7 @@ dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                 }
                 cleanup_local->link_subvol = local->link_subvol;
                 FRAME_SU_DO(cleanup_frame, dht_local_t);
-                ret = synctask_new(this->ctx->env, dht_remove_stale_linkto,
+                ret = synctask_new(global_ctx->env, dht_remove_stale_linkto,
                                    dht_remove_stale_linkto_cbk, cleanup_frame,
                                    cleanup_frame);
             }

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -113,7 +113,7 @@ dht_get_du_info_for_subvol(xlator_t *this, int subvol_idx)
     };
 
     conf = this->private;
-    pool = this->ctx->pool;
+    pool = global_ctx->pool;
 
     statfs_frame = create_frame(this, pool);
     if (!statfs_frame) {

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -557,7 +557,7 @@ dht_check_and_open_fd_on_subvol(xlator_t *this, call_frame_t *frame)
     */
     local = frame->local;
 
-    ret = synctask_new(this->ctx->env, dht_check_and_open_fd_on_subvol_task,
+    ret = synctask_new(global_ctx->env, dht_check_and_open_fd_on_subvol_task,
                        dht_check_and_open_fd_on_subvol_complete, frame, frame);
 
     if (ret) {
@@ -1503,7 +1503,7 @@ dht_rebalance_complete_check(xlator_t *this, call_frame_t *frame)
 {
     int ret = -1;
 
-    ret = synctask_new(this->ctx->env, dht_migration_complete_check_task,
+    ret = synctask_new(global_ctx->env, dht_migration_complete_check_task,
                        dht_migration_complete_check_done, frame, frame);
     return ret;
 }
@@ -1781,7 +1781,7 @@ dht_rebalance_in_progress_check(xlator_t *this, call_frame_t *frame)
 {
     int ret = -1;
 
-    ret = synctask_new(this->ctx->env, dht_rebalance_inprogress_task,
+    ret = synctask_new(global_ctx->env, dht_rebalance_inprogress_task,
                        dht_inprogress_check_done, frame, frame);
     return ret;
 }

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4423,7 +4423,7 @@ out:
     LOCK(&defrag->lock);
     {
         gf_defrag_status_get(conf, status, _gf_true);
-        if (global_ctx && global_ctx->notify)
+        if (global_ctx->notify)
             global_ctx->notify(GF_EN_DEFRAG_STATUS, status);
         if (status)
             dict_unref(status);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2388,7 +2388,7 @@ dht_start_rebalance_task(xlator_t *this, call_frame_t *frame)
     syncop_frame->root->pid = GF_CLIENT_PID_DEFRAG;
     set_lk_owner_from_ptr(&syncop_frame->root->lk_owner, syncop_frame->root);
 
-    ret = synctask_new(this->ctx->env, rebalance_task,
+    ret = synctask_new(global_ctx->env, rebalance_task,
                        rebalance_task_completion, syncop_frame, frame);
 out:
     if ((ret < 0) && syncop_frame) {
@@ -2400,13 +2400,10 @@ out:
 int
 gf_listener_stop(xlator_t *this)
 {
-    glusterfs_ctx_t *ctx = NULL;
     cmd_args_t *cmd_args = NULL;
     int ret = 0;
 
-    ctx = this->ctx;
-    GF_ASSERT(ctx);
-    cmd_args = &ctx->cmd_args;
+    cmd_args = &global_ctx->cmd_args;
     if (cmd_args->sock_file) {
         ret = sys_unlink(cmd_args->sock_file);
         if (ret && (ENOENT == errno)) {
@@ -2786,7 +2783,7 @@ gf_defrag_migrate_single_file(void *opaque)
 
     old_THIS = THIS;
     THIS = this;
-    statfs_frame = create_frame(this, this->ctx->pool);
+    statfs_frame = create_frame(this, global_ctx->pool);
     if (!statfs_frame) {
         gf_msg(this->name, GF_LOG_ERROR, DHT_MSG_NO_MEMORY, ENOMEM,
                "Insufficient memory. Frame creation failed");
@@ -4224,7 +4221,6 @@ gf_defrag_start_crawl(void *data)
     dict_t *fix_layout = NULL;
     dict_t *migrate_data = NULL;
     dict_t *status = NULL;
-    glusterfs_ctx_t *ctx = NULL;
     call_frame_t *statfs_frame = NULL;
     xlator_t *old_THIS = NULL;
     int ret = -1;
@@ -4244,10 +4240,6 @@ gf_defrag_start_crawl(void *data)
 
     this = data;
     if (!this)
-        goto exit;
-
-    ctx = this->ctx;
-    if (!ctx)
         goto exit;
 
     conf = this->private;
@@ -4280,7 +4272,7 @@ gf_defrag_start_crawl(void *data)
     old_THIS = THIS;
     THIS = this;
 
-    statfs_frame = create_frame(this, this->ctx->pool);
+    statfs_frame = create_frame(this, global_ctx->pool);
     if (!statfs_frame) {
         gf_msg(this->name, GF_LOG_ERROR, DHT_MSG_NO_MEMORY, ENOMEM,
                "Insufficient memory. Frame creation failed");
@@ -4431,8 +4423,8 @@ out:
     LOCK(&defrag->lock);
     {
         gf_defrag_status_get(conf, status, _gf_true);
-        if (ctx && ctx->notify)
-            ctx->notify(GF_EN_DEFRAG_STATUS, status);
+        if (global_ctx && global_ctx->notify)
+            global_ctx->notify(GF_EN_DEFRAG_STATUS, status);
         if (status)
             dict_unref(status);
         defrag->is_exiting = 1;
@@ -4483,7 +4475,7 @@ gf_defrag_start(void *data)
     if (!defrag)
         goto out;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -4495,7 +4487,7 @@ gf_defrag_start(void *data)
 
     old_THIS = THIS;
     THIS = this;
-    ret = synctask_new(this->ctx->env, gf_defrag_start_crawl, gf_defrag_done,
+    ret = synctask_new(global_ctx->env, gf_defrag_start_crawl, gf_defrag_done,
                        frame, this);
 
     if (ret)

--- a/xlators/cluster/dht/src/unittest/dht_layout_unittest.c
+++ b/xlators/cluster/dht/src/unittest/dht_layout_unittest.c
@@ -38,9 +38,6 @@ helper_xlator_init(uint32_t num_types)
                                sizeof(struct mem_acct_rec) + num_types);
     assert_non_null(xl->mem_acct);
 
-    xl->ctx = test_calloc(1, sizeof(glusterfs_ctx_t));
-    assert_non_null(xl->ctx);
-
     for (i = 0; i < num_types; i++) {
         ret = LOCK_INIT(&(xl->mem_acct.rec[i].lock));
         assert_false(ret);

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -1990,7 +1990,7 @@ ec_lock_timer_cancel(xlator_t *xl, ec_lock_t *lock)
     timer_link = lock->timer->data;
     GF_ASSERT(timer_link != NULL);
 
-    if (gf_timer_call_cancel(xl->ctx, lock->timer) < 0) {
+    if (gf_timer_call_cancel(global_ctx, lock->timer) < 0) {
         /* It's too late to avoid the execution of the timer callback.
          * Since we need to be sure that the callback has access to all
          * needed resources, we cannot resume the execution of the
@@ -2641,7 +2641,7 @@ ec_unlock_timer_del(ec_lock_link_t *link)
                   list_empty(&lock->owners) && list_empty(&lock->waiting) &&
                   list_empty(&lock->frozen));
 
-        gf_timer_call_cancel(link->fop->xl->ctx, lock->timer);
+        gf_timer_call_cancel(global_ctx, lock->timer);
         lock->timer = NULL;
 
         /* Any fop being processed from now on, will need to wait
@@ -2726,7 +2726,7 @@ ec_lock_delay_create(ec_lock_link_t *link)
 
     delay.tv_sec = ec_eager_lock_timeout(fop->xl->private, lock);
     delay.tv_nsec = 0;
-    lock->timer = gf_timer_call_after(fop->xl->ctx, delay, ec_unlock_timer_cbk,
+    lock->timer = gf_timer_call_after(global_ctx, delay, ec_unlock_timer_cbk,
                                       link);
     if (lock->timer == NULL) {
         gf_msg(fop->xl->name, GF_LOG_WARNING, ENOMEM,

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -1990,7 +1990,7 @@ ec_lock_timer_cancel(xlator_t *xl, ec_lock_t *lock)
     timer_link = lock->timer->data;
     GF_ASSERT(timer_link != NULL);
 
-    if (gf_timer_call_cancel(global_ctx, lock->timer) < 0) {
+    if (gf_timer_call_cancel(lock->timer) < 0) {
         /* It's too late to avoid the execution of the timer callback.
          * Since we need to be sure that the callback has access to all
          * needed resources, we cannot resume the execution of the
@@ -2641,7 +2641,7 @@ ec_unlock_timer_del(ec_lock_link_t *link)
                   list_empty(&lock->owners) && list_empty(&lock->waiting) &&
                   list_empty(&lock->frozen));
 
-        gf_timer_call_cancel(global_ctx, lock->timer);
+        gf_timer_call_cancel(lock->timer);
         lock->timer = NULL;
 
         /* Any fop being processed from now on, will need to wait
@@ -2726,8 +2726,7 @@ ec_lock_delay_create(ec_lock_link_t *link)
 
     delay.tv_sec = ec_eager_lock_timeout(fop->xl->private, lock);
     delay.tv_nsec = 0;
-    lock->timer = gf_timer_call_after(global_ctx, delay, ec_unlock_timer_cbk,
-                                      link);
+    lock->timer = gf_timer_call_after(delay, ec_unlock_timer_cbk, link);
     if (lock->timer == NULL) {
         gf_msg(fop->xl->name, GF_LOG_WARNING, ENOMEM,
                EC_MSG_UNLOCK_DELAY_FAILED, "Unable to delay an unlock");

--- a/xlators/cluster/ec/src/ec-data.c
+++ b/xlators/cluster/ec/src/ec-data.c
@@ -135,7 +135,7 @@ ec_fop_data_allocate(call_frame_t *frame, xlator_t *this, int32_t id,
     if (frame != NULL) {
         fop->frame = copy_frame(frame);
     } else {
-        fop->frame = create_frame(this, this->ctx->pool);
+        fop->frame = create_frame(this, global_ctx->pool);
     }
     if (fop->frame == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, EC_MSG_NO_MEMORY,

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -2583,7 +2583,7 @@ ec_heal_do(xlator_t *this, void *data, loc_t *loc, int32_t partial)
     if (fop->req_frame && !ec->shd.iamshd)
         blocking = _gf_true;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 
@@ -2742,7 +2742,7 @@ ec_launch_heal(ec_t *ec, ec_fop_data_t *fop)
     int ret = 0;
     call_frame_t *frame = NULL;
 
-    frame = create_frame(ec->xl, ec->xl->ctx->pool);
+    frame = create_frame(ec->xl, global_ctx->pool);
     if (!frame) {
         ret = -1;
         goto out;
@@ -2755,7 +2755,7 @@ ec_launch_heal(ec_t *ec, ec_fop_data_t *fop)
     /*Mark the fops as internal*/
     frame->root->pid = GF_CLIENT_PID_SELF_HEALD;
 
-    ret = synctask_new(ec->xl->ctx->env, ec_synctask_heal_wrap, ec_heal_done,
+    ret = synctask_new(global_ctx->env, ec_synctask_heal_wrap, ec_heal_done,
                        frame, fop);
 out:
     if (ret < 0) {
@@ -2991,7 +2991,7 @@ ec_launch_replace_heal(ec_t *ec)
 {
     int ret = -1;
 
-    ret = synctask_new(ec->xl->ctx->env, ec_replace_brick_heal_wrap,
+    ret = synctask_new(global_ctx->env, ec_replace_brick_heal_wrap,
                        ec_replace_heal_done, NULL, ec);
 
     if (ret < 0) {
@@ -3324,7 +3324,7 @@ ec_get_heal_info(xlator_t *this, loc_t *entry_loc, dict_t **dict_rsp)
         need_heal = EC_HEAL_MUST;
         goto set_heal;
     }
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         goto out;
     }

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -139,7 +139,7 @@ ec_buffer_alloc(xlator_t *xl, size_t size, struct iobref **piobref, void **ptr)
     struct iobuf *iobuf = NULL;
     int32_t ret = -ENOMEM;
 
-    iobuf = iobuf_get_page_aligned(xl->ctx->iobuf_pool, size,
+    iobuf = iobuf_get_page_aligned(global_ctx->iobuf_pool, size,
                                    EC_METHOD_WORD_SIZE);
     if (iobuf == NULL) {
         goto out;

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -76,7 +76,7 @@ ec_update_write(ec_fop_data_t *fop, uintptr_t mask, off_t offset, uint64_t size)
     if (iobref == NULL) {
         goto out;
     }
-    iobuf = iobuf_get(fop->xl->ctx->iobuf_pool);
+    iobuf = iobuf_get(global_ctx->iobuf_pool);
     if (iobuf == NULL) {
         goto out;
     }

--- a/xlators/cluster/ec/src/ec-method.c
+++ b/xlators/cluster/ec/src/ec-method.c
@@ -307,8 +307,7 @@ ec_method_init(xlator_t *xl, ec_matrix_list_t *list, uint32_t columns,
     INIT_LIST_HEAD(&list->lru);
     int32_t err;
 
-    list->pool = mem_pool_new_fn(global_ctx,
-                                 sizeof(ec_matrix_t) +
+    list->pool = mem_pool_new_fn(sizeof(ec_matrix_t) +
                                      sizeof(ec_matrix_row_t) * columns +
                                      sizeof(uint32_t) * columns * columns,
                                  128, "ec_matrix_t");

--- a/xlators/cluster/ec/src/ec-method.c
+++ b/xlators/cluster/ec/src/ec-method.c
@@ -307,7 +307,7 @@ ec_method_init(xlator_t *xl, ec_matrix_list_t *list, uint32_t columns,
     INIT_LIST_HEAD(&list->lru);
     int32_t err;
 
-    list->pool = mem_pool_new_fn(xl->ctx,
+    list->pool = mem_pool_new_fn(global_ctx,
                                  sizeof(ec_matrix_t) +
                                      sizeof(ec_matrix_row_t) * columns +
                                      sizeof(uint32_t) * columns * columns,

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -157,7 +157,7 @@ __ec_destroy_private(xlator_t *this)
         LOCK(&ec->lock);
 
         if (ec->timer != NULL) {
-            gf_timer_call_cancel(this->ctx, ec->timer);
+            gf_timer_call_cancel(global_ctx, ec->timer);
             ec->timer = NULL;
         }
 
@@ -328,7 +328,7 @@ ec_up(xlator_t *this, ec_t *ec)
     char str1[32], str2[32];
 
     if (ec->timer != NULL) {
-        gf_timer_call_cancel(this->ctx, ec->timer);
+        gf_timer_call_cancel(global_ctx, ec->timer);
         ec->timer = NULL;
     }
 
@@ -347,7 +347,7 @@ ec_down(xlator_t *this, ec_t *ec)
     char str1[32], str2[32];
 
     if (ec->timer != NULL) {
-        gf_timer_call_cancel(this->ctx, ec->timer);
+        gf_timer_call_cancel(global_ctx, ec->timer);
         ec->timer = NULL;
     }
 
@@ -378,7 +378,7 @@ ec_notify_cbk(void *data)
             goto unlock;
         }
 
-        gf_timer_call_cancel(ec->xl->ctx, ec->timer);
+        gf_timer_call_cancel(global_ctx, ec->timer);
         ec->timer = NULL;
 
         /* The timeout has expired, so any subvolume that has not
@@ -428,7 +428,7 @@ ec_launch_notify_timer(xlator_t *this, ec_t *ec)
     gf_msg_debug(this->name, 0, "Initiating child-down timer");
     delay.tv_sec = 10;
     delay.tv_nsec = 0;
-    ec->timer = gf_timer_call_after(this->ctx, delay, ec_notify_cbk, ec);
+    ec->timer = gf_timer_call_after(global_ctx, delay, ec_notify_cbk, ec);
     if (ec->timer == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, EC_MSG_TIMER_CREATE_FAIL,
                "Cannot create timer "

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -157,7 +157,7 @@ __ec_destroy_private(xlator_t *this)
         LOCK(&ec->lock);
 
         if (ec->timer != NULL) {
-            gf_timer_call_cancel(global_ctx, ec->timer);
+            gf_timer_call_cancel(ec->timer);
             ec->timer = NULL;
         }
 
@@ -328,7 +328,7 @@ ec_up(xlator_t *this, ec_t *ec)
     char str1[32], str2[32];
 
     if (ec->timer != NULL) {
-        gf_timer_call_cancel(global_ctx, ec->timer);
+        gf_timer_call_cancel(ec->timer);
         ec->timer = NULL;
     }
 
@@ -347,7 +347,7 @@ ec_down(xlator_t *this, ec_t *ec)
     char str1[32], str2[32];
 
     if (ec->timer != NULL) {
-        gf_timer_call_cancel(global_ctx, ec->timer);
+        gf_timer_call_cancel(ec->timer);
         ec->timer = NULL;
     }
 
@@ -378,7 +378,7 @@ ec_notify_cbk(void *data)
             goto unlock;
         }
 
-        gf_timer_call_cancel(global_ctx, ec->timer);
+        gf_timer_call_cancel(ec->timer);
         ec->timer = NULL;
 
         /* The timeout has expired, so any subvolume that has not
@@ -428,7 +428,7 @@ ec_launch_notify_timer(xlator_t *this, ec_t *ec)
     gf_msg_debug(this->name, 0, "Initiating child-down timer");
     delay.tv_sec = 10;
     delay.tv_nsec = 0;
-    ec->timer = gf_timer_call_after(global_ctx, delay, ec_notify_cbk, ec);
+    ec->timer = gf_timer_call_after(delay, ec_notify_cbk, ec);
     if (ec->timer == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, EC_MSG_TIMER_CREATE_FAIL,
                "Cannot create timer "

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -2932,7 +2932,7 @@ conditional_dump(dict_t *dict, char *key, data_t *value, void *data)
 
     /* Don't do this on 'brick-side', only do this on client side */
     /* Addresses CVE-2018-14659 */
-    if (this->ctx->process_mode != GF_CLIENT_PROCESS) {
+    if (global_ctx->process_mode != GF_CLIENT_PROCESS) {
         gf_log(this->name, GF_LOG_DEBUG,
                "taking io-stats dump using setxattr not permitted on brick."
                " Use 'gluster profile' instead");
@@ -3668,20 +3668,17 @@ ios_set_log_format_code(struct ios_conf *conf, char *dump_format_str)
 void
 xlator_set_loglevel(xlator_t *this, int log_level)
 {
-    glusterfs_ctx_t *ctx = NULL;
     glusterfs_graph_t *active = NULL;
     xlator_t *top = NULL;
     xlator_t *trav = this;
 
-    ctx = this->ctx;
-    GF_ASSERT(ctx);
-    active = ctx->active;
+    active = global_ctx->active;
     top = active->first;
 
     if (log_level == -1)
         return;
 
-    if (ctx->cmd_args.brick_mux) {
+    if (global_ctx->cmd_args.brick_mux) {
         /* Set log-level for all brick xlators */
         top->loglevel = log_level;
 
@@ -3694,7 +3691,7 @@ xlator_set_loglevel(xlator_t *this, int log_level)
             trav = trav->next;
         }
     } else {
-        gf_log_set_loglevel(this->ctx, log_level);
+        gf_log_set_loglevel(global_ctx, log_level);
     }
 }
 
@@ -3977,7 +3974,7 @@ init(xlator_t *this)
     if (log_str) {
         log_level = glusterd_check_log_level(log_str);
         if (DEFAULT_LOG_LEVEL != log_level)
-            gf_log_set_loglevel(this->ctx, log_level);
+            gf_log_set_loglevel(global_ctx, log_level);
     }
 
     GF_OPTION_INIT("logger", logger_str, str, out);

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3691,7 +3691,7 @@ xlator_set_loglevel(xlator_t *this, int log_level)
             trav = trav->next;
         }
     } else {
-        gf_log_set_loglevel(global_ctx, log_level);
+        gf_log_set_loglevel(log_level);
     }
 }
 
@@ -3974,7 +3974,7 @@ init(xlator_t *this)
     if (log_str) {
         log_level = glusterd_check_log_level(log_str);
         if (DEFAULT_LOG_LEVEL != log_level)
-            gf_log_set_loglevel(global_ctx, log_level);
+            gf_log_set_loglevel(log_level);
     }
 
     GF_OPTION_INIT("logger", logger_str, str, out);

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -3411,7 +3411,7 @@ init(xlator_t *this)
     }
 
 setloglevel:
-    gf_log_set_loglevel(this->ctx, conf->trace_log_level);
+    gf_log_set_loglevel(global_ctx, conf->trace_log_level);
     this->private = conf;
     ret = 0;
 out:

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -3411,7 +3411,7 @@ init(xlator_t *this)
     }
 
 setloglevel:
-    gf_log_set_loglevel(global_ctx, conf->trace_log_level);
+    gf_log_set_loglevel(conf->trace_log_level);
     this->private = conf;
     ret = 0;
 out:

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -429,7 +429,7 @@ __barrier_disable(xlator_t *this, struct list_head *queue)
     GF_ASSERT(priv);
 
     if (priv->timer) {
-        ret = gf_timer_call_cancel(this->ctx, priv->timer);
+        ret = gf_timer_call_cancel(global_ctx, priv->timer);
         priv->timer = NULL;
     }
 
@@ -443,7 +443,7 @@ __barrier_enable(xlator_t *this, barrier_priv_t *priv)
 {
     int ret = -1;
 
-    priv->timer = gf_timer_call_after(this->ctx, priv->timeout, barrier_timeout,
+    priv->timer = gf_timer_call_after(global_ctx, priv->timeout, barrier_timeout,
                                       (void *)this);
     if (!priv->timer) {
         gf_log(this->name, GF_LOG_CRITICAL,

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -429,7 +429,7 @@ __barrier_disable(xlator_t *this, struct list_head *queue)
     GF_ASSERT(priv);
 
     if (priv->timer) {
-        ret = gf_timer_call_cancel(global_ctx, priv->timer);
+        ret = gf_timer_call_cancel(priv->timer);
         priv->timer = NULL;
     }
 
@@ -443,7 +443,7 @@ __barrier_enable(xlator_t *this, barrier_priv_t *priv)
 {
     int ret = -1;
 
-    priv->timer = gf_timer_call_after(global_ctx, priv->timeout, barrier_timeout,
+    priv->timer = gf_timer_call_after(priv->timeout, barrier_timeout,
                                       (void *)this);
     if (!priv->timer) {
         gf_log(this->name, GF_LOG_CRITICAL,

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1135,7 +1135,7 @@ br_enact_signer(xlator_t *this, br_child_t *child, br_stub_init_t *stub)
 
     br_fill_brick_spec(brick, stub->export);
     ret = gf_changelog_register_generic(brick, 1, 1,
-                                        this->ctx->cmd_args.log_file, -1, this);
+                                        global_ctx->cmd_args.log_file, -1, this);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, BRB_MSG_REGISTER_FAILED, NULL);
         goto dealloc;
@@ -2014,7 +2014,7 @@ init(xlator_t *this)
     INIT_LIST_HEAD(&priv->bricks);
     INIT_LIST_HEAD(&priv->signing);
 
-    priv->timer_wheel = glusterfs_ctx_tw_get(this->ctx);
+    priv->timer_wheel = glusterfs_ctx_tw_get(global_ctx);
     if (!priv->timer_wheel) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_TIMER_WHEEL_UNAVAILABLE,
                 NULL);
@@ -2081,7 +2081,7 @@ fini(xlator_t *this)
     this->private = NULL;
     GF_FREE(priv);
 
-    glusterfs_ctx_tw_put(this->ctx);
+    glusterfs_ctx_tw_put(global_ctx);
 
     return;
 }

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -3337,7 +3337,7 @@ br_stub_send_ipc_fop(xlator_t *this, fd_t *fd, unsigned long releaseversion,
         goto dealloc_dict;
     }
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, BRS_MSG_CREATE_FRAME_FAILED,
                 NULL);

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -428,10 +428,10 @@ static int
 gf_changelog_setup_logging(xlator_t *this, char *logfile, int loglevel)
 {
     /* passing ident as NULL means to use default ident for syslog */
-    if (gf_log_init(global_ctx, logfile, NULL))
+    if (gf_log_init(logfile, NULL))
         return -1;
 
-    gf_log_set_loglevel(global_ctx, (loglevel == -1) ? GF_LOG_INFO : loglevel);
+    gf_log_set_loglevel((loglevel == -1) ? GF_LOG_INFO : loglevel);
     return 0;
 }
 

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -185,25 +185,6 @@ free_pool:
     return -1;
 }
 
-/* TODO: cleanup ctx defaults */
-void
-gf_changelog_cleanup_this(xlator_t *this)
-{
-    glusterfs_ctx_t *ctx = NULL;
-
-    if (!this)
-        return;
-
-    ctx = this->ctx;
-    syncenv_destroy(ctx->env);
-    free(ctx);
-
-    this->private = NULL;
-    this->ctx = NULL;
-
-    mem_pools_fini();
-}
-
 static int
 gf_changelog_init_context()
 {
@@ -216,7 +197,6 @@ gf_changelog_init_context()
     if (glusterfs_globals_init(ctx))
         goto free_ctx;
 
-    THIS->ctx = ctx;
     if (gf_changelog_ctx_defaults_init(ctx))
         goto free_ctx;
 
@@ -227,7 +207,6 @@ gf_changelog_init_context()
 
 free_ctx:
     free(ctx);
-    THIS->ctx = NULL;
 error_return:
     return -1;
 }
@@ -449,10 +428,10 @@ static int
 gf_changelog_setup_logging(xlator_t *this, char *logfile, int loglevel)
 {
     /* passing ident as NULL means to use default ident for syslog */
-    if (gf_log_init(this->ctx, logfile, NULL))
+    if (gf_log_init(global_ctx, logfile, NULL))
         return -1;
 
-    gf_log_set_loglevel(this->ctx, (loglevel == -1) ? GF_LOG_INFO : loglevel);
+    gf_log_set_loglevel(global_ctx, (loglevel == -1) ? GF_LOG_INFO : loglevel);
     return 0;
 }
 
@@ -465,14 +444,12 @@ gf_changelog_set_primary(xlator_t *primary, void *xl)
     gf_private_t *priv = NULL;
 
     this = xl;
-    if (!this || !this->ctx) {
+    if (!this) {
         ret = gf_changelog_init_primary();
         if (ret)
             return -1;
         this = THIS;
     }
-
-    primary->ctx = this->ctx;
 
     INIT_LIST_HEAD(&primary->volume_options);
     SAVE_THIS(THIS);

--- a/xlators/features/changelog/src/changelog-barrier.c
+++ b/xlators/features/changelog/src/changelog-barrier.c
@@ -101,7 +101,7 @@ __chlog_barrier_disable(xlator_t *this, struct list_head *queue)
     GF_ASSERT(priv);
 
     if (priv->timer) {
-        gf_timer_call_cancel(global_ctx, priv->timer);
+        gf_timer_call_cancel(priv->timer);
         priv->timer = NULL;
     }
 
@@ -116,8 +116,8 @@ __chlog_barrier_enable(xlator_t *this, changelog_priv_t *priv)
 {
     int ret = -1;
 
-    priv->timer = gf_timer_call_after(global_ctx, priv->timeout,
-                                      chlog_barrier_timeout, (void *)this);
+    priv->timer = gf_timer_call_after(priv->timeout, chlog_barrier_timeout,
+                                      (void *)this);
     if (!priv->timer) {
         gf_smsg(this->name, GF_LOG_CRITICAL, 0,
                 CHANGELOG_MSG_TIMEOUT_ADD_FAILED, NULL);

--- a/xlators/features/changelog/src/changelog-barrier.c
+++ b/xlators/features/changelog/src/changelog-barrier.c
@@ -101,7 +101,7 @@ __chlog_barrier_disable(xlator_t *this, struct list_head *queue)
     GF_ASSERT(priv);
 
     if (priv->timer) {
-        gf_timer_call_cancel(this->ctx, priv->timer);
+        gf_timer_call_cancel(global_ctx, priv->timer);
         priv->timer = NULL;
     }
 
@@ -116,7 +116,7 @@ __chlog_barrier_enable(xlator_t *this, changelog_priv_t *priv)
 {
     int ret = -1;
 
-    priv->timer = gf_timer_call_after(this->ctx, priv->timeout,
+    priv->timer = gf_timer_call_after(global_ctx, priv->timeout,
                                       chlog_barrier_timeout, (void *)this);
     if (!priv->timer) {
         gf_smsg(this->name, GF_LOG_CRITICAL, 0,

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1116,7 +1116,7 @@ changelog_local_init(xlator_t *this, inode_t *inode, uuid_t gfid,
     }
 
     if (xtra_records) {
-        iobuf = iobuf_get2(this->ctx->iobuf_pool,
+        iobuf = iobuf_get2(global_ctx->iobuf_pool,
                            xtra_records * CHANGELOG_OPT_RECORD_LEN);
         if (!iobuf)
             goto out;

--- a/xlators/features/changelog/src/changelog-rpc-common.c
+++ b/xlators/features/changelog/src/changelog-rpc-common.c
@@ -26,8 +26,6 @@
 void *
 changelog_rpc_poller(void *arg)
 {
-    xlator_t *this = arg;
-
     (void)gf_event_dispatch(global_ctx->event_pool);
     return NULL;
 }
@@ -195,7 +193,7 @@ __changelog_rpc_serialize_reply(rpcsvc_request_t *req, void *arg,
     ssize_t rsp_size = 0;
 
     rsp_size = xdr_sizeof(xdrproc, arg);
-    iob = iobuf_get2(req->svc->ctx->iobuf_pool, rsp_size);
+    iob = iobuf_get2(global_ctx->iobuf_pool, rsp_size);
     if (!iob)
         goto error_return;
 
@@ -314,7 +312,7 @@ changelog_rpc_server_init(xlator_t *this, char *sockfile, void *cbkdata,
     if (ret)
         goto dealloc_dict;
 
-    rpc = rpcsvc_init(this, global_ctx, options, 8);
+    rpc = rpcsvc_init(this, options, 8);
     if (rpc == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_RPC_START_ERROR,
                 NULL);

--- a/xlators/features/changelog/src/changelog-rpc-common.c
+++ b/xlators/features/changelog/src/changelog-rpc-common.c
@@ -28,7 +28,7 @@ changelog_rpc_poller(void *arg)
 {
     xlator_t *this = arg;
 
-    (void)gf_event_dispatch(this->ctx->event_pool);
+    (void)gf_event_dispatch(global_ctx->event_pool);
     return NULL;
 }
 
@@ -108,7 +108,7 @@ changelog_rpc_sumbit_req(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
 
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, xdr_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iobuf) {
             goto out;
         };
@@ -162,7 +162,7 @@ changelog_invoke_rpc(xlator_t *this, struct rpc_clnt *rpc,
     if (!this || !prog)
         goto error_return;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_CREATE_FRAME_FAILED,
                 NULL);
@@ -314,7 +314,7 @@ changelog_rpc_server_init(xlator_t *this, char *sockfile, void *cbkdata,
     if (ret)
         goto dealloc_dict;
 
-    rpc = rpcsvc_init(this, this->ctx, options, 8);
+    rpc = rpcsvc_init(this, global_ctx, options, 8);
     if (rpc == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_RPC_START_ERROR,
                 NULL);

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -400,7 +400,7 @@ aws_write_callback(void *dlbuf, size_t size, size_t nitems, void *mainframe)
     dliov.iov_base = (void *)dlbuf;
     dliov.iov_len = tsize;
 
-    ret = iobuf_copy(this->ctx->iobuf_pool, &dliov, 1, &iobref, &iobuf, &iov);
+    ret = iobuf_copy(global_ctx->iobuf_pool, &dliov, 1, &iobref, &iobuf, &iov);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "iobuf_copy failed");
         goto out;

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -115,7 +115,7 @@ cdc_alloc_iobuf_and_init_vec(xlator_t *this, cdc_priv_t *priv, cdc_info_t *ci,
 
     alloc_len = size ? size : ci->buffer_size;
 
-    iobuf = iobuf_get2(this->ctx->iobuf_pool, alloc_len);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, alloc_len);
     if (!iobuf)
         goto out;
 

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1752,7 +1752,7 @@ index_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
         dict_get(xdata, "get-gfid-type")) {
         args.parent = fd->inode;
         args.entries = &entries;
-        ret = synctask_new(this->ctx->env, index_get_gfid_type, NULL, NULL,
+        ret = synctask_new(global_ctx->env, index_get_gfid_type, NULL, NULL,
                            &args);
     }
 done:
@@ -1860,7 +1860,7 @@ index_rmdir_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
         }
     } else {
         args.path = index_subdir;
-        ret = synctask_new(this->ctx->env, index_wipe_index_subdir, NULL, NULL,
+        ret = synctask_new(global_ctx->env, index_wipe_index_subdir, NULL, NULL,
                            &args);
     }
 

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -928,7 +928,7 @@ leases_init_priv(xlator_t *this)
     GF_ASSERT(priv);
 
     if (!priv->timer_wheel) {
-        priv->timer_wheel = glusterfs_ctx_tw_get(this->ctx);
+        priv->timer_wheel = glusterfs_ctx_tw_get(global_ctx);
         if (!priv->timer_wheel) {
             ret = -1;
             goto out;
@@ -1038,7 +1038,7 @@ fini(xlator_t *this)
     }
 
     if (priv->timer_wheel) {
-        glusterfs_ctx_tw_put(this->ctx);
+        glusterfs_ctx_tw_put(global_ctx);
     }
 
     GF_FREE(priv);

--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1124,7 +1124,7 @@ mq_synctask1(xlator_t *this, synctask_fn_t task, gf_boolean_t spawn, loc_t *loc,
     }
 
     if (spawn) {
-        ret = synctask_new1(this->ctx->env, 1024 * 16, task,
+        ret = synctask_new1(global_ctx->env, 1024 * 16, task,
                             mq_synctask_cleanup, NULL, args);
         if (ret) {
             gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -664,7 +664,7 @@ marker_create_frame(xlator_t *this, marker_local_t *local)
 {
     call_frame_t *frame = NULL;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
 
     if (!frame)
         return -1;
@@ -1750,7 +1750,7 @@ marker_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         goto err;
 
     local->frame = frame;
-    local->lk_frame = create_frame(this, this->ctx->pool);
+    local->lk_frame = create_frame(this, global_ctx->pool);
     if (local->lk_frame == NULL)
         goto err;
 
@@ -2521,7 +2521,7 @@ marker_do_xattr_cleanup(call_frame_t *frame, xlator_t *this, dict_t *xdata,
     MARKER_INIT_LOCAL(frame, local);
 
     loc_copy(&local->loc, loc);
-    ret = synctask_new(this->ctx->env, quota_xattr_cleaner,
+    ret = synctask_new(global_ctx->env, quota_xattr_cleaner,
                        quota_xattr_cleaner_cbk, frame, xdata);
     if (ret) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/namespace/src/namespace.c
+++ b/xlators/features/namespace/src/namespace.c
@@ -409,7 +409,7 @@ set_ns_from_fd(const char *fn, call_frame_t *frame, xlator_t *this, fd_t *fd)
         gf_log(this->name, GF_LOG_DEBUG, "    %s winding, looking for path",   \
                uuid_utoa(inode->gfid));                                        \
                                                                                \
-        new_frame = create_frame(this, this->ctx->pool);                       \
+        new_frame = create_frame(this, global_ctx->pool);                       \
         if (!new_frame) {                                                      \
             gf_log(this->name, GF_LOG_ERROR,                                   \
                    "Cannot allocate new call frame.");                         \

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -50,8 +50,8 @@ __gf_quiesce_start_timer(xlator_t *this, quiesce_priv_t *priv)
         timeout.tv_sec = priv->timeout;
         timeout.tv_nsec = 0;
 
-        priv->timer = gf_timer_call_after(global_ctx, timeout,
-                                          gf_quiesce_timeout, (void *)this);
+        priv->timer = gf_timer_call_after(timeout, gf_quiesce_timeout,
+                                          (void *)this);
         if (priv->timer == NULL) {
             gf_log(this->name, GF_LOG_ERROR, "Cannot create timer");
         }

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -50,7 +50,7 @@ __gf_quiesce_start_timer(xlator_t *this, quiesce_priv_t *priv)
         timeout.tv_sec = priv->timeout;
         timeout.tv_nsec = 0;
 
-        priv->timer = gf_timer_call_after(this->ctx, timeout,
+        priv->timer = gf_timer_call_after(global_ctx, timeout,
                                           gf_quiesce_timeout, (void *)this);
         if (priv->timer == NULL) {
             gf_log(this->name, GF_LOG_ERROR, "Cannot create timer");
@@ -186,7 +186,7 @@ __gf_quiesce_perform_failover(xlator_t *this)
         goto out;
     }
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_msg_debug(this->name, 0, "failed to create the frame");
         ret = -1;

--- a/xlators/features/quota/src/quota-enforcer-client.c
+++ b/xlators/features/quota/src/quota-enforcer-client.c
@@ -64,7 +64,7 @@ quota_enforcer_submit_request(void *req, call_frame_t *frame,
 
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, xdr_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iobuf) {
             goto out;
         }
@@ -210,7 +210,7 @@ out:
 
             retry_delay.tv_sec = 5;
             retry_delay.tv_nsec = 0;
-            timer = gf_timer_call_after(this->ctx, retry_delay,
+            timer = gf_timer_call_after(global_ctx, retry_delay,
                                         _quota_enforcer_lookup, (void *)frame);
             if (timer == NULL) {
                 gf_log(this->name, GF_LOG_WARNING,

--- a/xlators/features/quota/src/quota-enforcer-client.c
+++ b/xlators/features/quota/src/quota-enforcer-client.c
@@ -210,8 +210,8 @@ out:
 
             retry_delay.tv_sec = 5;
             retry_delay.tv_nsec = 0;
-            timer = gf_timer_call_after(global_ctx, retry_delay,
-                                        _quota_enforcer_lookup, (void *)frame);
+            timer = gf_timer_call_after(retry_delay, _quota_enforcer_lookup,
+                                        (void *)frame);
             if (timer == NULL) {
                 gf_log(this->name, GF_LOG_WARNING,
                        "failed to "

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -879,7 +879,7 @@ quota_build_ancestry(inode_t *inode, quota_ancestry_built_t ancestry_cbk,
     if (fd == NULL)
         goto err;
 
-    new_frame = create_frame(this, this->ctx->pool);
+    new_frame = create_frame(this, global_ctx->pool);
     if (new_frame == NULL)
         goto err;
 

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -37,7 +37,7 @@ quotad_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
      */
     if (arg && xdrproc) {
         xdr_size = xdr_sizeof(xdrproc, arg);
-        iob = iobuf_get2(req->svc->ctx->iobuf_pool, xdr_size);
+        iob = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iob) {
             gf_log_callingfn(THIS->name, GF_LOG_ERROR, "Failed to get iobuf");
             goto ret;
@@ -437,7 +437,7 @@ quotad_aggregator_init(xlator_t *this)
         goto out;
 
     /* RPC related */
-    priv->rpcsvc = rpcsvc_init(this, global_ctx, this->options, 0);
+    priv->rpcsvc = rpcsvc_init(this, this->options, 0);
     if (priv->rpcsvc == NULL) {
         gf_msg(this->name, GF_LOG_WARNING, 0, Q_MSG_RPCSVC_INIT_FAILED,
                "creation of rpcsvc failed");

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -437,7 +437,7 @@ quotad_aggregator_init(xlator_t *this)
         goto out;
 
     /* RPC related */
-    priv->rpcsvc = rpcsvc_init(this, this->ctx, this->options, 0);
+    priv->rpcsvc = rpcsvc_init(this, global_ctx, this->options, 0);
     if (priv->rpcsvc == NULL) {
         gf_msg(this->name, GF_LOG_WARNING, 0, Q_MSG_RPCSVC_INIT_FAILED,
                "creation of rpcsvc failed");

--- a/xlators/features/quota/src/quotad-helpers.c
+++ b/xlators/features/quota/src/quotad-helpers.c
@@ -36,7 +36,7 @@ get_quotad_aggregator_state(xlator_t *this, rpcsvc_request_t *req)
 
     state->itable = active_subvol->itable;
 
-    state->pool = this->ctx->pool;
+    state->pool = global_ctx->pool;
 
     return state;
 }

--- a/xlators/features/quota/src/quotad-helpers.c
+++ b/xlators/features/quota/src/quotad-helpers.c
@@ -36,8 +36,6 @@ get_quotad_aggregator_state(xlator_t *this, rpcsvc_request_t *req)
 
     state->itable = active_subvol->itable;
 
-    state->pool = global_ctx->pool;
-
     return state;
 }
 
@@ -63,11 +61,10 @@ quotad_aggregator_alloc_frame(rpcsvc_request_t *req)
     GF_VALIDATE_OR_GOTO("server", req, out);
     GF_VALIDATE_OR_GOTO("server", req->trans, out);
     GF_VALIDATE_OR_GOTO("server", req->svc, out);
-    GF_VALIDATE_OR_GOTO("server", req->svc->ctx, out);
 
     this = req->svc->xl;
 
-    frame = create_frame(this, req->svc->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame)
         goto out;
 

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -987,7 +987,7 @@ shard_initiate_evicted_inode_fsync(xlator_t *this, inode_t *inode)
     fd_t *anon_fd = NULL;
     call_frame_t *fsync_frame = NULL;
 
-    fsync_frame = create_frame(this, this->ctx->pool);
+    fsync_frame = create_frame(this, global_ctx->pool);
     if (!fsync_frame) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, SHARD_MSG_MEMALLOC_FAILED,
                "Failed to create new frame "
@@ -1544,7 +1544,7 @@ shard_start_background_deletion(xlator_t *this)
     if (!i_cleanup)
         return 0;
 
-    cleanup_frame = create_frame(this, this->ctx->pool);
+    cleanup_frame = create_frame(this, global_ctx->pool);
     if (!cleanup_frame) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, SHARD_MSG_MEMALLOC_FAILED,
                "Failed to create "
@@ -1555,7 +1555,7 @@ shard_start_background_deletion(xlator_t *this)
 
     set_lk_owner_from_ptr(&cleanup_frame->root->lk_owner, cleanup_frame->root);
 
-    ret = synctask_new(this->ctx->env, shard_delete_shards,
+    ret = synctask_new(global_ctx->env, shard_delete_shards,
                        shard_delete_shards_cbk, cleanup_frame, cleanup_frame);
     if (ret < 0) {
         gf_msg(this->name, GF_LOG_WARNING, errno,
@@ -4310,7 +4310,7 @@ shard_acquire_entrylk(call_frame_t *frame, xlator_t *this, inode_t *inode,
     call_frame_t *entrylk_frame = NULL;
 
     local = frame->local;
-    entrylk_frame = create_frame(this, this->ctx->pool);
+    entrylk_frame = create_frame(this, global_ctx->pool);
     if (!entrylk_frame) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, SHARD_MSG_MEMALLOC_FAILED,
                "Failed to create new frame "
@@ -4431,7 +4431,7 @@ shard_acquire_inodelk(call_frame_t *frame, xlator_t *this, loc_t *loc)
     shard_inodelk_t *int_inodelk = NULL;
 
     local = frame->local;
-    lk_frame = create_frame(this, this->ctx->pool);
+    lk_frame = create_frame(this, global_ctx->pool);
     if (!lk_frame) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, SHARD_MSG_MEMALLOC_FAILED,
                "Failed to create new frame "
@@ -5260,7 +5260,7 @@ shard_post_lookup_readv_handler(call_frame_t *frame, xlator_t *this)
             0,
         };
 
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, local->req_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, local->req_size);
         if (!iobuf)
             goto err;
 
@@ -5291,7 +5291,7 @@ shard_post_lookup_readv_handler(call_frame_t *frame, xlator_t *this)
     if (!local->inode_list)
         goto err;
 
-    iobuf = iobuf_get2(this->ctx->iobuf_pool, local->total_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, local->total_size);
     if (!iobuf)
         goto err;
 

--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -524,13 +524,13 @@ __svs_initialise_snapshot_volume(xlator_t *this, const char *name,
      * If the volfile server in global context is NULL, then localhost
      * is tried (like before).
      */
-    if (this->ctx->cmd_args.volfile_server) {
-        volfile_server = gf_strdup(this->ctx->cmd_args.volfile_server);
+    if (global_ctx->cmd_args.volfile_server) {
+        volfile_server = gf_strdup(global_ctx->cmd_args.volfile_server);
         if (!volfile_server) {
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM,
                    SVS_MSG_VOLFILE_SERVER_GET_FAIL,
                    "failed to copy volfile server %s. ",
-                   this->ctx->cmd_args.volfile_server);
+                   global_ctx->cmd_args.volfile_server);
             ret = -1;
             goto out;
         }

--- a/xlators/features/snapview-server/src/snapview-server-mgmt.c
+++ b/xlators/features/snapview-server/src/snapview-server-mgmt.c
@@ -159,9 +159,8 @@ out:
 }
 
 int
-svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
-                        rpc_clnt_prog_t *prog, int procnum, fop_cbk_fn_t cbkfn,
-                        xdrproc_t xdrproc)
+svs_mgmt_submit_request(void *req, call_frame_t *frame, rpc_clnt_prog_t *prog,
+                        int procnum, fop_cbk_fn_t cbkfn, xdrproc_t xdrproc)
 {
     int ret = -1;
     int count = 0;
@@ -174,7 +173,6 @@ svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
 
     GF_VALIDATE_OR_GOTO("snapview-server", frame, out);
     GF_VALIDATE_OR_GOTO("snapview-server", req, out);
-    GF_VALIDATE_OR_GOTO("snapview-server", ctx, out);
     GF_VALIDATE_OR_GOTO("snapview-server", prog, out);
 
     GF_ASSERT(frame->this);
@@ -190,7 +188,7 @@ svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
 
-        iobuf = iobuf_get2(ctx->iobuf_pool, xdr_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iobuf) {
             goto out;
         }
@@ -211,8 +209,8 @@ svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
         count = 1;
     }
 
-    ret = rpc_clnt_submit(ctx->mgmt, prog, procnum, cbkfn, &iov, count, NULL, 0,
-                          iobref, frame, NULL, 0, NULL, 0, NULL);
+    ret = rpc_clnt_submit(global_ctx->mgmt, prog, procnum, cbkfn, &iov, count,
+                          NULL, 0, iobref, frame, NULL, 0, NULL, 0, NULL);
 
 out:
     if (iobref)
@@ -476,7 +474,7 @@ svs_get_snapshot_list(xlator_t *this)
     }
 
     ret = svs_mgmt_submit_request(
-        &req, frame, global_ctx, &svs_clnt_handshake_prog, GF_HNDSK_GET_SNAPSHOT_INFO,
+        &req, frame, &svs_clnt_handshake_prog, GF_HNDSK_GET_SNAPSHOT_INFO,
         mgmt_get_snapinfo_cbk, (xdrproc_t)xdr_gf_getsnap_name_uuid_req);
 
     if (ret) {

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -2319,7 +2319,7 @@ svs_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     glfd = sfd->fd;
 
-    iobuf = iobuf_get2(this->ctx->iobuf_pool, size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, size);
     if (!iobuf) {
         op_ret = -1;
         op_errno = ENOMEM;
@@ -2640,16 +2640,11 @@ void
 fini(xlator_t *this)
 {
     svs_private_t *priv = NULL;
-    glusterfs_ctx_t *ctx = NULL;
     int ret = 0;
 
     GF_ASSERT(this);
     priv = this->private;
     this->private = NULL;
-    ctx = this->ctx;
-    if (!ctx)
-        gf_msg(this->name, GF_LOG_ERROR, 0, SVS_MSG_INVALID_GLFS_CTX,
-               "Invalid ctx found");
 
     if (priv) {
         ret = LOCK_DESTROY(&priv->snaplist_lock);

--- a/xlators/features/snapview-server/src/snapview-server.h
+++ b/xlators/features/snapview-server/src/snapview-server.h
@@ -121,9 +121,8 @@
     } while (0)
 
 int
-svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
-                        rpc_clnt_prog_t *prog, int procnum, fop_cbk_fn_t cbkfn,
-                        xdrproc_t xdrproc);
+svs_mgmt_submit_request(void *req, call_frame_t *frame, rpc_clnt_prog_t *prog,
+                        int procnum, fop_cbk_fn_t cbkfn, xdrproc_t xdrproc);
 
 int
 svs_get_snapshot_list(xlator_t *this);

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -347,7 +347,7 @@ rename_trash_directory(xlator_t *this)
 
     priv = this->private;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (frame == NULL) {
         gf_log(this->name, GF_LOG_ERROR, "failed to create frame");
         ret = ENOMEM;
@@ -731,7 +731,7 @@ create_or_rename_trash_directory(xlator_t *this)
 
     priv = this->private;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (frame == NULL) {
         gf_log(this->name, GF_LOG_ERROR, "failed to create frame");
         ret = ENOMEM;
@@ -771,7 +771,7 @@ create_internalop_directory(xlator_t *this)
 
     priv = this->private;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (frame == NULL) {
         gf_log(this->name, GF_LOG_ERROR, "failed to create frame");
         ret = ENOMEM;

--- a/xlators/meta/src/active-link.c
+++ b/xlators/meta/src/active-link.c
@@ -17,7 +17,7 @@
 static int
 active_link_fill(xlator_t *this, inode_t *inode, strfd_t *strfd)
 {
-    strprintf(strfd, "%s", this->ctx->active->graph_uuid);
+    strprintf(strfd, "%s", global_ctx->active->graph_uuid);
 
     return 0;
 }

--- a/xlators/meta/src/cmdline-file.c
+++ b/xlators/meta/src/cmdline-file.c
@@ -19,9 +19,9 @@
 static int
 cmdline_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
 {
-    if (this->ctx->cmdlinestr)
+    if (global_ctx->cmdlinestr)
         strprintf(strfd, "{ \n  \"Cmdlinestr\": \"%s\"\n}",
-                  this->ctx->cmdlinestr);
+                  global_ctx->cmdlinestr);
     return strfd->size;
 }
 

--- a/xlators/meta/src/frames-file.c
+++ b/xlators/meta/src/frames-file.c
@@ -28,7 +28,7 @@ frames_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
     if (!this || !file || !strfd)
         return -1;
 
-    pool = this->ctx->pool;
+    pool = global_ctx->pool;
 
     strprintf(strfd, "{ \n\t\"Stack\": [\n");
 

--- a/xlators/meta/src/graph-dir.c
+++ b/xlators/meta/src/graph-dir.c
@@ -71,7 +71,7 @@ glusterfs_graph_lookup(xlator_t *this, const char *graph_uuid)
     glusterfs_graph_t *graph = NULL;
     glusterfs_graph_t *tmp = NULL;
 
-    list_for_each_entry(tmp, &this->ctx->graphs, list)
+    list_for_each_entry(tmp, &global_ctx->graphs, list)
     {
         if (strcmp(graph_uuid, tmp->graph_uuid) == 0) {
             graph = tmp;

--- a/xlators/meta/src/graphs-dir.c
+++ b/xlators/meta/src/graphs-dir.c
@@ -33,7 +33,7 @@ graphs_dir_fill(xlator_t *this, inode_t *dir, struct meta_dirent **dp)
     int i = 0;
     struct meta_dirent *dirents = NULL;
 
-    list_for_each_entry(graph, &this->ctx->graphs, list) { graphs_count++; }
+    list_for_each_entry(graph, &global_ctx->graphs, list) { graphs_count++; }
 
     dirents = GF_CALLOC(sizeof(*dirents), graphs_count + 3,
                         gf_meta_mt_dirents_t);
@@ -41,7 +41,7 @@ graphs_dir_fill(xlator_t *this, inode_t *dir, struct meta_dirent **dp)
         return -1;
 
     i = 0;
-    list_for_each_entry(graph, &this->ctx->graphs, list)
+    list_for_each_entry(graph, &global_ctx->graphs, list)
     {
         dirents[i].name = gf_strdup(graph->graph_uuid);
         dirents[i].type = IA_IFDIR;

--- a/xlators/meta/src/logfile-link.c
+++ b/xlators/meta/src/logfile-link.c
@@ -17,7 +17,7 @@
 static int
 logfile_link_fill(xlator_t *this, inode_t *inode, strfd_t *strfd)
 {
-    strprintf(strfd, "%s", this->ctx->log.filename);
+    strprintf(strfd, "%s", global_ctx->log.filename);
 
     return 0;
 }

--- a/xlators/meta/src/loglevel-file.c
+++ b/xlators/meta/src/loglevel-file.c
@@ -30,7 +30,7 @@ loglevel_file_write(xlator_t *this, fd_t *fd, struct iovec *iov, int count)
 
     level = strtol(iov[0].iov_base, NULL, 0);
     if (level >= GF_LOG_NONE && level <= GF_LOG_TRACE)
-        gf_log_set_loglevel(global_ctx, level);
+        gf_log_set_loglevel(level);
 
     return iov_length(iov, count);
 }

--- a/xlators/meta/src/loglevel-file.c
+++ b/xlators/meta/src/loglevel-file.c
@@ -18,7 +18,7 @@
 static int
 loglevel_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
 {
-    strprintf(strfd, "%d\n", this->ctx->log.loglevel);
+    strprintf(strfd, "%d\n", global_ctx->log.loglevel);
 
     return strfd->size;
 }
@@ -30,7 +30,7 @@ loglevel_file_write(xlator_t *this, fd_t *fd, struct iovec *iov, int count)
 
     level = strtol(iov[0].iov_base, NULL, 0);
     if (level >= GF_LOG_NONE && level <= GF_LOG_TRACE)
-        gf_log_set_loglevel(this->ctx, level);
+        gf_log_set_loglevel(global_ctx, level);
 
     return iov_length(iov, count);
 }

--- a/xlators/meta/src/measure-file.c
+++ b/xlators/meta/src/measure-file.c
@@ -18,7 +18,7 @@
 static int
 measure_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
 {
-    strprintf(strfd, "%d\n", this->ctx->measure_latency);
+    strprintf(strfd, "%d\n", global_ctx->measure_latency);
 
     return strfd->size;
 }
@@ -29,7 +29,7 @@ measure_file_write(xlator_t *this, fd_t *fd, struct iovec *iov, int count)
     long int num = -1;
 
     num = strtol(iov[0].iov_base, NULL, 0);
-    this->ctx->measure_latency = !!num;
+    global_ctx->measure_latency = !!num;
 
     return iov_length(iov, count);
 }

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -129,7 +129,7 @@ meta_default_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     if (!meta_fd->size)
         meta_file_fill(this, fd);
 
-    iobuf = iobuf_get2(this->ctx->iobuf_pool, size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, size);
     if (!iobuf)
         return default_readv_failure_cbk(frame, ENOMEM);
 

--- a/xlators/meta/src/process_uuid-file.c
+++ b/xlators/meta/src/process_uuid-file.c
@@ -19,7 +19,7 @@
 static int
 process_uuid_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
 {
-    strprintf(strfd, "%s\n", this->ctx->process_uuid);
+    strprintf(strfd, "%s\n", global_ctx->process_uuid);
     return strfd->size;
 }
 

--- a/xlators/meta/src/xlator-dir.c
+++ b/xlators/meta/src/xlator-dir.c
@@ -88,7 +88,7 @@ meta_xlator_dir_hook(call_frame_t *frame, xlator_t *this, loc_t *loc,
 int
 meta_root_hook(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
-    meta_ctx_set(loc->inode, this, this->ctx->root);
+    meta_ctx_set(loc->inode, this, global_ctx->root);
 
     meta_ops_set(loc->inode, this, &xlator_dir_ops);
 

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -294,7 +294,7 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
     }
     runinit(&runner);
 
-    if (this->ctx->cmd_args.vgtool != _gf_none) {
+    if (global_ctx->cmd_args.vgtool != _gf_none) {
         len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s",
                        svc->proc.logdir, svc->proc.logfile);
         if ((len < 0) || (len >= PATH_MAX)) {
@@ -302,7 +302,7 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
             goto out;
         }
 
-        if (this->ctx->cmd_args.vgtool == _gf_memcheck)
+        if (global_ctx->cmd_args.vgtool == _gf_memcheck)
             runner_add_args(&runner, "valgrind", "--leak-check=full",
                             "--trace-children=yes", "--track-origins=yes",
                             NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -3497,7 +3497,7 @@ glusterd_friend_rpc_create(xlator_t *this, glusterd_peerinfo_t *peerinfo,
     /* Enable encryption for the client connection if management encryption
      * is enabled
      */
-    if (this->ctx->secure_mgmt) {
+    if (global_ctx->secure_mgmt) {
         ret = dict_set_nstrn(options, "transport.socket.ssl-enabled",
                              SLEN("transport.socket.ssl-enabled"), "on",
                              SLEN("on"));
@@ -3507,7 +3507,7 @@ glusterd_friend_rpc_create(xlator_t *this, glusterd_peerinfo_t *peerinfo,
             goto out;
         }
 
-        this->ctx->ssl_cert_depth = glusterfs_read_secure_access_file();
+        global_ctx->ssl_cert_depth = glusterfs_read_secure_access_file();
     }
 
     ret = glusterd_rpc_create(&peerinfo->rpc, options, glusterd_peer_rpc_notify,
@@ -6238,7 +6238,6 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
     glusterd_peerctx_t *peerctx = NULL;
     gf_boolean_t quorum_action = _gf_false;
     glusterd_volinfo_t *volinfo = NULL;
-    glusterfs_ctx_t *ctx = NULL;
 
     uuid_t uuid;
 
@@ -6259,9 +6258,7 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
         default:
             break;
     }
-    ctx = this->ctx;
-    GF_VALIDATE_OR_GOTO(this->name, ctx, out);
-    if (ctx->cleanup_started) {
+    if (global_ctx->cleanup_started) {
         gf_log(this->name, GF_LOG_INFO,
                "glusterd already received a SIGTERM, "
                "dropping the event %d for peer %s",

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -2234,7 +2234,7 @@ glusterd_mgmt_handshake(xlator_t *this, glusterd_peerctx_t *peerctx)
     dict_t *req_dict = NULL;
     int ret = -1;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg("glusterd", GF_LOG_WARNING, errno, GD_MSG_FRAME_CREATE_FAIL,
                 NULL);
@@ -2513,7 +2513,7 @@ glusterd_peer_dump_version(xlator_t *this, struct rpc_clnt *rpc,
     glusterd_peerinfo_t *peerinfo = NULL;
     int ret = -1;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg(this->name, GF_LOG_WARNING, errno, GD_MSG_FRAME_CREATE_FAIL,
                 NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -588,7 +588,7 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
         goto out;
     }
 
-    mgmt_lock_timer_ctx = mgmt_lock_timer_xl->ctx;
+    mgmt_lock_timer_ctx = global_ctx;
     if (!mgmt_lock_timer_ctx) {
         GF_FREE(mgmt_lock_timer);
         goto out;
@@ -681,7 +681,7 @@ out:
         mgmt_lock_timer_xl = mgmt_lock_timer->xl;
         GF_VALIDATE_OR_GOTO(this->name, mgmt_lock_timer_xl, ret_function);
 
-        mgmt_lock_timer_ctx = mgmt_lock_timer_xl->ctx;
+        mgmt_lock_timer_ctx = global_ctx;
         GF_VALIDATE_OR_GOTO(this->name, mgmt_lock_timer_ctx, ret_function);
 
         timer = mgmt_lock_timer->timer;
@@ -804,7 +804,7 @@ glusterd_mgmt_v3_unlock(const char *name, uuid_t uuid, char *type)
         mgmt_lock_timer_xl = mgmt_lock_timer->xl;
         GF_VALIDATE_OR_GOTO(this->name, mgmt_lock_timer_xl, out);
 
-        mgmt_lock_timer_ctx = mgmt_lock_timer_xl->ctx;
+        mgmt_lock_timer_ctx = global_ctx;
         GF_VALIDATE_OR_GOTO(this->name, mgmt_lock_timer_ctx, out);
         ret = 0;
 

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -263,11 +263,11 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
              "rebalance");
     runinit(&runner);
 
-    if (this->ctx->cmd_args.vgtool != _gf_none) {
+    if (global_ctx->cmd_args.vgtool != _gf_none) {
         snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s-rebalance.log",
                  priv->logdir, volinfo->volname);
 
-        if (this->ctx->cmd_args.vgtool == _gf_memcheck)
+        if (global_ctx->cmd_args.vgtool == _gf_memcheck)
             runner_add_args(&runner, "valgrind", "--leak-check=full",
                             "--trace-children=yes", "--track-origins=yes",
                             NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -1683,7 +1683,7 @@ glusterd_rpc_friend_update(call_frame_t *frame, xlator_t *this, void *data)
 
     gf_uuid_copy(req.uuid, MY_UUID);
 
-    dummy_frame = create_frame(this, this->ctx->pool);
+    dummy_frame = create_frame(this, global_ctx->pool);
     ret = glusterd_submit_request(peerinfo->rpc, &req, dummy_frame,
                                   peerinfo->peer, GLUSTERD_FRIEND_UPDATE, NULL,
                                   this, glusterd_friend_update_cbk,
@@ -1717,7 +1717,7 @@ glusterd_cluster_lock(call_frame_t *frame, xlator_t *this, void *data)
 
     glusterd_get_uuid(&req.uuid);
 
-    dummy_frame = create_frame(this, this->ctx->pool);
+    dummy_frame = create_frame(this, global_ctx->pool);
     if (!dummy_frame)
         goto out;
 
@@ -1782,7 +1782,7 @@ glusterd_mgmt_v3_lock_peers(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     if (!frame)
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
 
     if (!frame) {
         ret = -1;
@@ -1858,7 +1858,7 @@ glusterd_mgmt_v3_unlock_peers(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     if (!frame)
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
 
     if (!frame) {
         ret = -1;
@@ -1903,7 +1903,7 @@ glusterd_cluster_unlock(call_frame_t *frame, xlator_t *this, void *data)
 
     glusterd_get_uuid(&req.uuid);
 
-    dummy_frame = create_frame(this, this->ctx->pool);
+    dummy_frame = create_frame(this, global_ctx->pool);
     if (!dummy_frame)
         goto out;
 
@@ -1969,7 +1969,7 @@ glusterd_stage_op(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     if (!frame)
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
 
     if (!frame) {
         ret = -1;
@@ -2044,7 +2044,7 @@ glusterd_commit_op(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     if (!frame)
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
 
     if (!frame) {
         ret = -1;
@@ -2248,7 +2248,7 @@ glusterd_brick_op(call_frame_t *frame, xlator_t *this, void *data)
 
     cds_list_for_each_entry(pending_node, &opinfo.pending_bricks, list)
     {
-        dummy_frame = create_frame(this, this->ctx->pool);
+        dummy_frame = create_frame(this, global_ctx->pool);
         if (!dummy_frame)
             continue;
 

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -335,7 +335,7 @@ glusterd_ac_friend_add(glusterd_friend_sm_event_t *event, void *ctx)
     }
     proc = &peerinfo->peer->proctable[GLUSTERD_FRIEND_ADD];
     if (proc->fn) {
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
         if (!frame) {
             RCU_READ_UNLOCK;
             goto out;
@@ -389,7 +389,7 @@ glusterd_ac_friend_probe(glusterd_friend_sm_event_t *event, void *ctx)
     }
     proc = &peerinfo->peer->proctable[GLUSTERD_PROBE_QUERY];
     if (proc->fn) {
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
         if (!frame) {
             gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_FRAME_CREATE_FAIL,
                     NULL);
@@ -510,7 +510,7 @@ glusterd_ac_send_friend_remove_req(glusterd_friend_sm_event_t *event,
     }
     proc = &peerinfo->peer->proctable[GLUSTERD_FRIEND_REMOVE];
     if (proc->fn) {
-        frame = create_frame(this, this->ctx->pool);
+        frame = create_frame(this, global_ctx->pool);
         if (!frame) {
             gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_FRAME_CREATE_FAIL,
                     NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -298,7 +298,7 @@ glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags)
     }
     runinit(&runner);
 
-    if (this->ctx->cmd_args.vgtool != _gf_none) {
+    if (global_ctx->cmd_args.vgtool != _gf_none) {
         len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-snapd.log",
                        svc->proc.logdir);
         if ((len < 0) || (len >= PATH_MAX)) {
@@ -307,7 +307,7 @@ glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags)
             goto out;
         }
 
-        if (this->ctx->cmd_args.vgtool == _gf_memcheck)
+        if (global_ctx->cmd_args.vgtool == _gf_memcheck)
             runner_add_args(&runner, "valgrind", "--leak-check=full",
                             "--trace-children=yes", "--track-origins=yes",
                             NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -6473,7 +6473,7 @@ glusterd_schedule_brick_snapshot(dict_t *dict, dict_t *rsp_dict,
             snap_args->args = &args;
 
             ret = synctask_new(
-                this->ctx->env, glusterd_take_brick_snapshot_task,
+                global_ctx->env, glusterd_take_brick_snapshot_task,
                 glusterd_take_brick_snapshot_cbk, NULL, snap_args);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_CREATION_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -1569,14 +1569,11 @@ glusterd_store_volinfo(glusterd_volinfo_t *volinfo,
                        glusterd_volinfo_ver_ac_t ac)
 {
     int32_t ret = -1;
-    glusterfs_ctx_t *ctx = NULL;
     xlator_t *this = THIS;
 
-    ctx = this->ctx;
-    GF_ASSERT(ctx);
     GF_ASSERT(volinfo);
 
-    pthread_mutex_lock(&ctx->cleanup_lock);
+    pthread_mutex_lock(&global_ctx->cleanup_lock);
     pthread_mutex_lock(&volinfo->store_volinfo_lock);
     {
         glusterd_perform_volinfo_version_action(volinfo, ac);
@@ -1615,7 +1612,7 @@ glusterd_store_volinfo(glusterd_volinfo_t *volinfo,
     }
 unlock:
     pthread_mutex_unlock(&volinfo->store_volinfo_lock);
-    pthread_mutex_unlock(&ctx->cleanup_lock);
+    pthread_mutex_unlock(&global_ctx->cleanup_lock);
 
     if (ret)
         glusterd_store_volume_cleanup_tmp(volinfo);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -774,7 +774,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     brick_req.dict.dict_val = NULL;
     brick_req.dict.dict_len = 0;
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_FRAME_CREATE_FAIL,
                 NULL);
@@ -843,7 +843,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     }
 
     req_size = xdr_sizeof((xdrproc_t)xdr_gd1_mgmt_brick_op_req, req);
-    iobuf = iobuf_get2(rpc->ctx->iobuf_pool, req_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, req_size);
     if (!iobuf) {
         goto err;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -179,7 +179,7 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
 
         runinit(&runner);
 
-        if (this->ctx->cmd_args.vgtool != _gf_none) {
+        if (global_ctx->cmd_args.vgtool != _gf_none) {
             len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s.log",
                            svc->proc.logdir, svc->name);
             if ((len < 0) || (len >= PATH_MAX)) {
@@ -187,7 +187,7 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
                 goto unlock;
             }
 
-            if (this->ctx->cmd_args.vgtool == _gf_memcheck)
+            if (global_ctx->cmd_args.vgtool == _gf_memcheck)
                 runner_add_args(&runner, "valgrind", "--leak-check=full",
                                 "--trace-children=yes", "--track-origins=yes",
                                 NULL);
@@ -215,7 +215,7 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
             runner_add_arg(&runner, daemon_log_level);
         }
 
-        if (this->ctx->cmd_args.global_threading) {
+        if (global_ctx->cmd_args.global_threading) {
             runner_add_arg(&runner, "--global-threading");
         }
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -169,7 +169,7 @@ gd_syncop_submit_request(struct rpc_clnt *rpc, void *req, void *local,
         goto out;
 
     req_size = xdr_sizeof(xdrproc, req);
-    iobuf = iobuf_get2(rpc->ctx->iobuf_pool, req_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, req_size);
     if (!iobuf)
         goto out;
 
@@ -177,7 +177,7 @@ gd_syncop_submit_request(struct rpc_clnt *rpc, void *req, void *local,
     if (!iobref)
         goto out;
 
-    frame = create_frame(THIS, THIS->ctx->pool);
+    frame = create_frame(THIS, global_ctx->pool);
     if (!frame)
         goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -582,7 +582,7 @@ glusterd_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
      * be serialized.
      */
     rsp_size = xdr_sizeof(xdrproc, arg);
-    iob = iobuf_get2(req->svc->ctx->iobuf_pool, rsp_size);
+    iob = iobuf_get2(global_ctx->iobuf_pool, rsp_size);
     if (!iob) {
         gf_msg("glusterd", GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
                "Failed to get iobuf");
@@ -2096,7 +2096,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
         conn = &rpc->conn;
         pthread_mutex_lock(&conn->lock);
         if (conn->reconnect) {
-            (void)gf_timer_call_cancel(global_ctx, conn->reconnect);
+            (void)gf_timer_call_cancel(conn->reconnect);
             conn->reconnect = NULL;
         }
         pthread_mutex_unlock(&conn->lock);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -519,7 +519,7 @@ glusterd_submit_request(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
     if (req) {
         req_size = xdr_sizeof(xdrproc, req);
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, req_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, req_size);
         if (!iobuf) {
             goto out;
         };
@@ -2096,7 +2096,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
         conn = &rpc->conn;
         pthread_mutex_lock(&conn->lock);
         if (conn->reconnect) {
-            (void)gf_timer_call_cancel(rpc->ctx, conn->reconnect);
+            (void)gf_timer_call_cancel(global_ctx, conn->reconnect);
             conn->reconnect = NULL;
         }
         pthread_mutex_unlock(&conn->lock);
@@ -2121,7 +2121,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
 retry:
     runinit(&runner);
 
-    if (this->ctx->cmd_args.vgtool != _gf_none) {
+    if (global_ctx->cmd_args.vgtool != _gf_none) {
         /* Run bricks with valgrind. */
         if (volinfo->logdir) {
             len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s-%s.log",
@@ -2136,7 +2136,7 @@ retry:
             goto out;
         }
 
-        if (this->ctx->cmd_args.vgtool == _gf_memcheck)
+        if (global_ctx->cmd_args.vgtool == _gf_memcheck)
             runner_add_args(&runner, "valgrind", "--leak-check=full",
                             "--trace-children=yes", "--track-origins=yes",
                             NULL);
@@ -2226,7 +2226,7 @@ retry:
         }
     }
 
-    if (this->ctx->cmd_args.logger == gf_logger_syslog) {
+    if (global_ctx->cmd_args.logger == gf_logger_syslog) {
         runner_argprintf(&runner, "--logger=syslog");
     }
 
@@ -6056,7 +6056,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
     }
 
     req_size = xdr_sizeof((xdrproc_t)xdr_gd1_mgmt_brick_op_req, req);
-    iobuf = iobuf_get2(rpc->ctx->iobuf_pool, req_size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, req_size);
     if (!iobuf) {
         goto err;
     }
@@ -6070,7 +6070,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
         goto free_iobref;
     }
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_FRAME_CREATE_FAIL,
                 NULL);
@@ -12874,7 +12874,7 @@ glusterd_launch_synctask(synctask_fn_t fn, void *opaque)
 
     /* synclock_lock must be called from within synctask, @fn must call it
      * before it starts with its work*/
-    ret = synctask_new(this->ctx->env, fn, gd_default_synctask_cbk, NULL,
+    ret = synctask_new(global_ctx->env, fn, gd_default_synctask_cbk, NULL,
                        opaque);
     if (ret)
         gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_SPAWN_SVCS_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -123,8 +123,6 @@ xlator_instantiate_va(const char *type, const char *format, va_list arg)
     xl->name = volname;
     CDS_INIT_LIST_HEAD(&xl->volume_options);
 
-    xl->ctx = this->ctx;
-
     return xl;
 
 error:

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1145,7 +1145,7 @@ glusterd_init_uds_listener(xlator_t *this)
     if (ret)
         goto out;
 
-    rpc = rpcsvc_init(this, global_ctx, options, 8);
+    rpc = rpcsvc_init(this, options, 8);
     if (rpc == NULL) {
         ret = -1;
         goto out;
@@ -1783,7 +1783,7 @@ init(xlator_t *this)
     ret = glusterd_rpcsvc_options_build(this->options);
     if (ret)
         goto out;
-    rpc = rpcsvc_init(this, global_ctx, this->options, 64);
+    rpc = rpcsvc_init(this, this->options, 64);
     if (rpc == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_INIT_FAIL,
                "failed to init rpc");

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -282,7 +282,7 @@ glusterd_client_statedump_submit_req(char *volname, char *target_ip, char *pid)
                              trans->peerinfo.identifier);
                 rpcsvc_request_submit(conf->rpc, trans, &glusterd_cbk_prog,
                                       GF_CBK_STATEDUMP, &statedump_req,
-                                      this->ctx, (xdrproc_t)xdr_gf_statedump);
+                                      global_ctx, (xdrproc_t)xdr_gf_statedump);
             }
         }
     }
@@ -1145,7 +1145,7 @@ glusterd_init_uds_listener(xlator_t *this)
     if (ret)
         goto out;
 
-    rpc = rpcsvc_init(this, this->ctx, options, 8);
+    rpc = rpcsvc_init(this, global_ctx, options, 8);
     if (rpc == NULL) {
         ret = -1;
         goto out;
@@ -1783,7 +1783,7 @@ init(xlator_t *this)
     ret = glusterd_rpcsvc_options_build(this->options);
     if (ret)
         goto out;
-    rpc = rpcsvc_init(this, this->ctx, this->options, 64);
+    rpc = rpcsvc_init(this, global_ctx, this->options, 64);
     if (rpc == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_INIT_FAIL,
                "failed to init rpc");
@@ -1800,7 +1800,7 @@ init(xlator_t *this)
     /* Enable encryption for the TCP listener is management encryption is
      * enabled
      */
-    if (this->ctx->secure_mgmt) {
+    if (global_ctx->secure_mgmt) {
         ret = dict_set_str(this->options, "transport.socket.ssl-enabled", "on");
         if (ret != 0) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
@@ -1811,7 +1811,7 @@ init(xlator_t *this)
          * This is the only place where we want secure_srvr to reflect
          * the management-plane setting.
          */
-        this->ctx->secure_srvr = MGMT_SSL_ALWAYS;
+        global_ctx->secure_srvr = MGMT_SSL_ALWAYS;
     }
 
     /*
@@ -1947,7 +1947,7 @@ init(xlator_t *this)
     }
 
     /* Set option to run bricks on valgrind if enabled in glusterd.vol */
-    this->ctx->cmd_args.vgtool = vgtool;
+    global_ctx->cmd_args.vgtool = vgtool;
     ret = dict_get_str(this->options, "run-with-valgrind", &valgrind_str);
     if (ret < 0) {
         gf_msg_debug(this->name, 0, "cannot get run-with-valgrind value");
@@ -1956,11 +1956,11 @@ init(xlator_t *this)
         gf_boolean_t vg = _gf_false;
 
         if (!strcmp(valgrind_str, "memcheck"))
-            this->ctx->cmd_args.vgtool = _gf_memcheck;
+            global_ctx->cmd_args.vgtool = _gf_memcheck;
         else if (!strcmp(valgrind_str, "drd"))
-            this->ctx->cmd_args.vgtool = _gf_drd;
+            global_ctx->cmd_args.vgtool = _gf_drd;
         else if (!gf_string2boolean(valgrind_str, &vg))
-            this->ctx->cmd_args.vgtool = (vg ? _gf_memcheck : _gf_none);
+            global_ctx->cmd_args.vgtool = (vg ? _gf_memcheck : _gf_none);
         else
             gf_msg(this->name, GF_LOG_WARNING, EINVAL, GD_MSG_INVALID_ENTRY,
                    "run-with-valgrind is neither boolean"
@@ -2097,7 +2097,7 @@ init(xlator_t *this)
     GF_OPTION_INIT("event-threads", workers, int32, out);
     if (workers > 0 && workers != conf->workers) {
         conf->workers = workers;
-        ret = gf_event_reconfigure_threads(this->ctx->event_pool, workers);
+        ret = gf_event_reconfigure_threads(global_ctx->event_pool, workers);
         if (ret)
             goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -769,18 +769,18 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
     } while (0)
 
 #define RCU_READ_LOCK                                                          \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
+    pthread_mutex_lock(&(global_ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_lock();                                                       \
     }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    pthread_mutex_unlock(&(global_ctx)->cleanup_lock);
 
 #define RCU_READ_UNLOCK                                                        \
-    pthread_mutex_lock(&(THIS->ctx)->cleanup_lock);                            \
+    pthread_mutex_lock(&(global_ctx)->cleanup_lock);                            \
     {                                                                          \
         rcu_read_unlock();                                                     \
     }                                                                          \
-    pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
+    pthread_mutex_unlock(&(global_ctx)->cleanup_lock);
 
 #define GLUSTERD_DUMP_PEERS(head, member, xpeers)                              \
     do {                                                                       \

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -394,7 +394,6 @@ typedef struct {
 } fuse_resolve_t;
 
 typedef struct {
-    void *pool;
     xlator_t *this;
     xlator_t *active_subvol;
     inode_table_t *itable;

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -130,7 +130,7 @@ get_fuse_state(xlator_t *this, fuse_in_header_t *finh)
     state->active_subvol = active_subvol;
     state->itable = active_subvol->itable;
 
-    state->pool = this->ctx->pool;
+    state->pool = global_ctx->pool;
     state->finh = finh;
     state->this = this;
 

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -130,7 +130,6 @@ get_fuse_state(xlator_t *this, fuse_in_header_t *finh)
     state->active_subvol = active_subvol;
     state->itable = active_subvol->itable;
 
-    state->pool = global_ctx->pool;
     state->finh = finh;
     state->this = this;
 
@@ -370,7 +369,7 @@ get_call_frame_for_req(fuse_state_t *state)
     xlator_t *this = NULL;
     fuse_private_t *priv = NULL;
 
-    pool = state->pool;
+    pool = global_ctx->pool;
     finh = state->finh;
     this = state->this;
     priv = this->private;

--- a/xlators/mount/fuse/src/fuse-resolve.c
+++ b/xlators/mount/fuse/src/fuse-resolve.c
@@ -472,7 +472,7 @@ fuse_resolve_fd(fuse_state_t *state)
         resolve->op_ret = -1;
         resolve->op_errno = EBADF;
     } else if (state->active_subvol != active_subvol) {
-        ret = synctask_new(state->this->ctx->env, fuse_migrate_fd_task, NULL,
+        ret = synctask_new(global_ctx->env, fuse_migrate_fd_task, NULL,
                            NULL, state);
 
         fd_migration_error = fuse_migrate_fd_error(state->this, basefd);

--- a/xlators/nfs/server/src/acl3.c
+++ b/xlators/nfs/server/src/acl3.c
@@ -168,7 +168,7 @@ acl3svc_submit_reply(rpcsvc_request_t *req, void *arg, acl3_serializer sfunc)
     /* First, get the io buffer into which the reply in arg will
      * be serialized.
      */
-    iob = iobuf_get(nfs3->iobpool);
+    iob = iobuf_get(global_ctx->iobuf_pool);
     if (!iob) {
         gf_msg(GF_ACL, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to get iobuf");

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -102,7 +102,7 @@ mnt3svc_submit_reply(rpcsvc_request_t *req, void *arg, mnt3_serializer sfunc)
      * be serialized.
      */
     /* TODO: use 'xdrproc_t' instead of 'sfunc' to get the xdr-size */
-    iob = iobuf_get(ms->iobpool);
+    iob = iobuf_get(global_ctx->iobuf_pool);
     if (!iob) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to get iobuf");
@@ -2878,7 +2878,7 @@ __mnt3udp_get_export_subdir_inode(struct svc_req *req, char *subdir,
      * refer bugzilla for more details :
      * https://bugzilla.redhat.com/show_bug.cgi?id=1161573
      */
-    fs = glfs_new_from_ctx(exp->vol->ctx);
+    fs = glfs_new_from_ctx(global_ctx);
     if (!fs)
         return NULL;
 
@@ -3618,7 +3618,6 @@ mnt3_init_state(xlator_t *nfsx)
         return NULL;
     }
 
-    ms->iobpool = nfsx->ctx->iobuf_pool;
     ms->nfsx = nfsx;
     INIT_LIST_HEAD(&ms->exportlist);
     ret = mnt3_init_options(ms, nfsx->options);

--- a/xlators/nfs/server/src/mount3.h
+++ b/xlators/nfs/server/src/mount3.h
@@ -128,9 +128,6 @@ struct mount3_state {
     /* The NFS state that this belongs to */
     struct nfs_state *nfs;
 
-    /* The buffers for all network IO are got from this pool. */
-    struct iobuf_pool *iobpool;
-
     /* List of exports, can be volumes or directories in those volumes. */
     struct list_head exportlist;
 

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -193,7 +193,7 @@ nfs_create_frame(xlator_t *xl, nfs_user_t *nfu)
     if ((!xl) || (!nfu) || (nfu->ngrps > NFS_NGROUPS))
         return NULL;
 
-    frame = create_frame(xl, (call_pool_t *)xl->ctx->pool);
+    frame = create_frame(xl, global_ctx->pool);
     if (!frame)
         goto err;
     if (call_stack_alloc_groups(frame->root, nfu->ngrps) != 0) {

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -1088,7 +1088,7 @@ nfs_init_state(xlator_t *this)
         nfs->enable_nlm = _gf_false;
     }
 
-    nfs->rpcsvc = rpcsvc_init(this, global_ctx, this->options, fopspoolsize);
+    nfs->rpcsvc = rpcsvc_init(this, this->options, fopspoolsize);
     if (!nfs->rpcsvc) {
         ret = -1;
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_RPC_INIT_FAIL,

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -1088,7 +1088,7 @@ nfs_init_state(xlator_t *this)
         nfs->enable_nlm = _gf_false;
     }
 
-    nfs->rpcsvc = rpcsvc_init(this, this->ctx, this->options, fopspoolsize);
+    nfs->rpcsvc = rpcsvc_init(this, global_ctx, this->options, fopspoolsize);
     if (!nfs->rpcsvc) {
         ret = -1;
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_RPC_INIT_FAIL,
@@ -1115,7 +1115,7 @@ nfs_init_state(xlator_t *this)
 
     GF_OPTION_INIT("nfs.event-threads", nfs->event_threads, uint32,
                    free_foppool);
-    gf_event_reconfigure_threads(this->ctx->event_pool, nfs->event_threads);
+    gf_event_reconfigure_threads(global_ctx->event_pool, nfs->event_threads);
 
     this->private = (void *)nfs;
     INIT_LIST_HEAD(&nfs->versions);
@@ -1338,7 +1338,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
 
     GF_OPTION_RECONF("nfs.event-threads", nfs->event_threads, options, uint32,
                      out);
-    gf_event_reconfigure_threads(this->ctx->event_pool, nfs->event_threads);
+    gf_event_reconfigure_threads(global_ctx->event_pool, nfs->event_threads);
 
     ret = 0;
 out:

--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -1576,7 +1576,7 @@ nfs3_log_common_call(uint32_t xid, char *op, struct nfs3_fh *fh)
 {
     char fhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
 
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
@@ -1588,7 +1588,7 @@ nfs3_log_fh_entry_call(uint32_t xid, char *op, struct nfs3_fh *fh, char *name)
 {
     char fhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
     gf_msg_debug(GF_NFS3, 0, "XID: %x, %s: args: %s, name: %s", xid, op, fhstr,
@@ -1602,7 +1602,7 @@ nfs3_log_rename_call(uint32_t xid, struct nfs3_fh *src, char *sname,
     char sfhstr[1024];
     char dfhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(src, sfhstr, sizeof(sfhstr));
     nfs3_fh_to_str(dst, dfhstr, sizeof(dfhstr));
@@ -1622,7 +1622,7 @@ nfs3_log_create_call(uint32_t xid, struct nfs3_fh *fh, char *name,
     char unchkd[] = "UNCHECKED";
     char guarded[] = "GUARDED";
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
     if (mode == EXCLUSIVE)
@@ -1648,7 +1648,7 @@ nfs3_log_mknod_call(uint32_t xid, struct nfs3_fh *fh, char *name, int type)
     char sock[] = "SOCK";
     char fifo[] = "FIFO";
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
     if (type == NF3CHR)
@@ -1671,7 +1671,7 @@ nfs3_log_symlink_call(uint32_t xid, struct nfs3_fh *fh, char *name, char *tgt)
 {
     char fhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
     gf_msg_debug(GF_NFS3, 0,
@@ -1687,7 +1687,7 @@ nfs3_log_link_call(uint32_t xid, struct nfs3_fh *fh, char *name,
     char dfhstr[1024];
     char tfhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, dfhstr, sizeof(dfhstr));
     nfs3_fh_to_str(tgt, tfhstr, sizeof(tfhstr));
@@ -1703,7 +1703,7 @@ nfs3_log_rw_call(uint32_t xid, char *op, struct nfs3_fh *fh, offset3 offt,
 {
     char fhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
     if (stablewrite == -1)
@@ -3297,7 +3297,7 @@ nfs3_log_common_res(uint32_t xid, int op, nfsstat3 stat, int pstat,
     char errstr[1024];
     int ll = nfs3_loglevel(op, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, nfs3op_strings[op].str, stat, pstat, errstr,
                         sizeof(errstr));
@@ -3315,7 +3315,7 @@ nfs3_log_readlink_res(uint32_t xid, nfsstat3 stat, int pstat, char *linkpath,
     char errstr[1024];
     int ll = nfs3_loglevel(NFS3_READLINK, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
 
     nfs3_stat_to_errstr(xid, "READLINK", stat, pstat, errstr, sizeof(errstr));
@@ -3336,7 +3336,7 @@ nfs3_log_read_res(uint32_t xid, nfsstat3 stat, int pstat, count3 count,
     int ll = GF_LOG_DEBUG;
 
     ll = nfs3_loglevel(NFS3_READ, stat);
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, "READ", stat, pstat, errstr, sizeof(errstr));
     if (vec)
@@ -3373,7 +3373,7 @@ nfs3_log_write_res(uint32_t xid, nfsstat3 stat, int pstat, count3 count,
     char errstr[1024];
     int ll = nfs3_loglevel(NFS3_WRITE, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
 
     nfs3_stat_to_errstr(xid, "WRITE", stat, pstat, errstr, sizeof(errstr));
@@ -3399,7 +3399,7 @@ nfs3_log_newfh_res(uint32_t xid, int op, nfsstat3 stat, int pstat,
     char fhstr[1024];
     int ll = nfs3_loglevel(op, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, nfs3op_strings[op].str, stat, pstat, errstr,
                         sizeof(errstr));
@@ -3419,7 +3419,7 @@ nfs3_log_readdir_res(uint32_t xid, nfsstat3 stat, int pstat, uint64_t cverf,
     char errstr[1024];
     int ll = nfs3_loglevel(NFS3_READDIR, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, "READDIR", stat, pstat, errstr, sizeof(errstr));
     if (ll == GF_LOG_DEBUG)
@@ -3441,7 +3441,7 @@ nfs3_log_readdirp_res(uint32_t xid, nfsstat3 stat, int pstat, uint64_t cverf,
     char errstr[1024];
     int ll = nfs3_loglevel(NFS3_READDIRP, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, "READDIRPLUS", stat, pstat, errstr,
                         sizeof(errstr));
@@ -3464,7 +3464,7 @@ nfs3_log_commit_res(uint32_t xid, nfsstat3 stat, int pstat, uint64_t wverf,
     char errstr[1024];
     int ll = nfs3_loglevel(NFS3_COMMIT, stat);
 
-    if (THIS->ctx->log.loglevel < ll)
+    if (global_ctx->log.loglevel < ll)
         return;
     nfs3_stat_to_errstr(xid, "COMMIT", stat, pstat, errstr, sizeof(errstr));
     if (ll == GF_LOG_DEBUG)
@@ -3481,7 +3481,7 @@ nfs3_log_readdir_call(uint32_t xid, struct nfs3_fh *fh, count3 dircount,
 {
     char fhstr[1024];
 
-    if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
+    if (global_ctx->log.loglevel < GF_LOG_DEBUG)
         return;
 
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -361,7 +361,7 @@ nfs3_funge_webnfs_zerolen_fh(rpcsvc_request_t *req, struct nfs3_state *nfs3st,
     }
 
     /* glfs_resolve_at copied from UDP MNT support */
-    fs = glfs_new_from_ctx(fungexl->ctx);
+    fs = glfs_new_from_ctx(global_ctx);
     if (!fs) {
         gf_msg_trace(GF_NFS3, 0, "failed to create glfs instance");
         ret = -ENOENT;
@@ -610,7 +610,7 @@ nfs3_serialize_reply(rpcsvc_request_t *req, void *arg, nfs3_serializer sfunc,
      */
     /* TODO: get rid of 'sfunc' and use 'xdrproc_t' so we
        can have 'xdr_sizeof' */
-    iob = iobuf_get(nfs3->iobpool);
+    iob = iobuf_get(global_ctx->iobuf_pool);
     if (!iob) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to get iobuf");
@@ -2401,7 +2401,7 @@ nfs3svc_write(rpcsvc_request_t *req)
     }
 
     /* To ensure that the iobuf for the current record does not
-     * get returned to the iobpool, we need to keep a reference for
+     * get returned to the iobuf pool, we need to keep a reference for
      * ourselves because the RPC call handler who called us will unref its
      * own ref of the record's iobuf when it is done handling the request.
      */
@@ -5629,11 +5629,9 @@ nfs3_init_state(xlator_t *nfsx)
         goto ret;
     }
 
-    nfs3->iobpool = nfsx->ctx->iobuf_pool;
-
     localpool = nfs->memfactor * GF_NFS_CONCURRENT_OPS_MULT;
     gf_msg_trace(GF_NFS3, 0, "local pool: %d", localpool);
-    nfs3->localpool = mem_pool_new_ctx(nfsx->ctx, nfs3_call_state_t, localpool);
+    nfs3->localpool = mem_pool_new_ctx(nfs3_call_state_t, localpool);
     if (!nfs3->localpool) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "local mempool creation failed");

--- a/xlators/nfs/server/src/nfs3.h
+++ b/xlators/nfs/server/src/nfs3.h
@@ -119,11 +119,6 @@ typedef struct nfs3_state {
      */
     xlator_t *nfsx;
 
-    /* The iob pool from which memory allocations are made for receiving
-     * and sending network messages.
-     */
-    struct iobuf_pool *iobpool;
-
     /* List of child subvolumes for the NFSv3 protocol.
      * Right now, is simply referring to the list of children in nfsx above.
      */

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -468,7 +468,7 @@ nlm4svc_submit_reply(rpcsvc_request_t *req, void *arg, nlm4_serializer sfunc)
     /* First, get the io buffer into which the reply in arg will
      * be serialized.
      */
-    iob = iobuf_get(nfs3->iobpool);
+    iob = iobuf_get(global_ctx->iobuf_pool);
     if (!iob) {
         gf_msg(GF_NLM, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to get iobuf");
@@ -660,7 +660,7 @@ nlm4_file_open_and_resume(nfs3_call_state_t *cs, nlm4_resume_fn_t resume)
 
     cs->fd = fd;
 
-    frame = create_frame(cs->nfsx, cs->nfsx->ctx->pool);
+    frame = create_frame(cs->nfsx, global_ctx->pool);
     if (!frame) {
         gf_msg(GF_NLM, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "unable to create frame");
@@ -1183,7 +1183,7 @@ nlm4svc_send_granted(struct nlm4_notify_args *ncf)
     testargs.exclusive = cs->args.nlm4_lockargs.exclusive;
     testargs.alock = cs->args.nlm4_lockargs.alock;
 
-    iobuf = iobuf_get(cs->nfs3state->iobpool);
+    iobuf = iobuf_get(global_ctx->iobuf_pool);
     if (!iobuf) {
         gf_msg(GF_NLM, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to get iobuf");
@@ -2722,7 +2722,7 @@ nlm4svc_init(xlator_t *nfsx)
     timeout.tv_sec = nlm_grace_period;
     timeout.tv_nsec = 0;
 
-    gf_timer_call_after(nfsx->ctx, timeout, nlm_grace_period_over, NULL);
+    gf_timer_call_after(timeout, nlm_grace_period_over, NULL);
     nlm4_inited = _gf_true;
 
     if (options)

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1146,7 +1146,7 @@ ioc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     {
         if (!ioc_inode->cache.page_table) {
             ioc_inode->cache.page_table = rbthash_table_init(
-                global_ctx, IOC_PAGE_TABLE_BUCKET_COUNT, ioc_hashfn, NULL, 0,
+                IOC_PAGE_TABLE_BUCKET_COUNT, ioc_hashfn, NULL, 0,
                 table->mem_pool);
 
             if (ioc_inode->cache.page_table == NULL) {

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1146,7 +1146,7 @@ ioc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     {
         if (!ioc_inode->cache.page_table) {
             ioc_inode->cache.page_table = rbthash_table_init(
-                this->ctx, IOC_PAGE_TABLE_BUCKET_COUNT, ioc_hashfn, NULL, 0,
+                global_ctx, IOC_PAGE_TABLE_BUCKET_COUNT, ioc_hashfn, NULL, 0,
                 table->mem_pool);
 
             if (ioc_inode->cache.page_table == NULL) {
@@ -1735,7 +1735,6 @@ init(xlator_t *this)
     dict_t *xl_options = NULL;
     uint32_t index = 0;
     int32_t ret = -1;
-    glusterfs_ctx_t *ctx = NULL;
     data_t *data = 0;
     uint32_t num_pages = 0;
 
@@ -1759,7 +1758,7 @@ init(xlator_t *this)
     }
 
     table->xl = this;
-    table->page_size = this->ctx->page_size;
+    table->page_size = global_ctx->page_size;
 
     GF_OPTION_INIT("pass-through", this->pass_through, bool, out);
 
@@ -1834,8 +1833,7 @@ init(xlator_t *this)
 
     ret = 0;
 
-    ctx = this->ctx;
-    ioc_log2_page_size = log_base2(ctx->page_size);
+    ioc_log2_page_size = log_base2(global_ctx->page_size);
 
 out:
     if (ret == -1) {

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -3561,7 +3561,7 @@ mdc_register_xattr_inval(xlator_t *this)
         goto out;
     }
 
-    frame = create_frame(this, this->ctx->pool);
+    frame = create_frame(this, global_ctx->pool);
     if (!frame) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, MD_CACHE_MSG_NO_MEMORY,
                "failed to create the frame");
@@ -3579,7 +3579,7 @@ mdc_register_xattr_inval(xlator_t *this)
 
     data->this = this;
     data->xattr = xattr;
-    ret = synctask_new(this->ctx->env, mdc_send_xattrs, mdc_send_xattrs_cbk,
+    ret = synctask_new(global_ctx->env, mdc_send_xattrs, mdc_send_xattrs_cbk,
                        frame, data);
     if (ret < 0) {
         gf_msg(this->name, GF_LOG_WARNING, errno,

--- a/xlators/performance/nl-cache/src/nl-cache.c
+++ b/xlators/performance/nl-cache/src/nl-cache.c
@@ -655,7 +655,7 @@ nlc_fini(xlator_t *this)
     conf = this->private;
     GF_FREE(conf);
 
-    glusterfs_ctx_tw_put(this->ctx);
+    glusterfs_ctx_tw_put(global_ctx);
 
     return;
 }
@@ -731,7 +731,7 @@ nlc_init(xlator_t *this)
     INIT_LIST_HEAD(&conf->lru);
     conf->last_child_down = gf_time();
 
-    conf->timer_wheel = glusterfs_ctx_tw_get(this->ctx);
+    conf->timer_wheel = glusterfs_ctx_tw_get(global_ctx);
     if (!conf->timer_wheel) {
         gf_msg(this->name, GF_LOG_ERROR, 0, NLC_MSG_NO_TIMER_WHEEL,
                "Initing the global timer wheel failed");

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -742,7 +742,7 @@ qr_readv_cached(call_frame_t *frame, qr_inode_t *qr_inode, size_t size,
 
         op_ret = min(size, (qr_inode->size - offset));
 
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, op_ret);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, op_ret);
         if (!iobuf) {
             op_ret = -1;
             goto unlock;

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -1126,7 +1126,7 @@ init(xlator_t *this)
         goto out;
     }
 
-    conf->page_size = this->ctx->page_size;
+    conf->page_size = global_ctx->page_size;
 
     GF_OPTION_INIT("page-size", conf->page_size, size_uint64, out);
 

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -1142,7 +1142,7 @@ wb_fulfill_head(wb_inode_t *wb_inode, wb_request_t *head)
             goto err;
     }
 
-    frame = create_frame(wb_inode->this, wb_inode->this->ctx->pool);
+    frame = create_frame(wb_inode->this, global_ctx->pool);
     if (!frame)
         goto err;
 
@@ -1324,7 +1324,7 @@ __wb_collapse_small_writes(wb_conf_t *conf, wb_request_t *holder,
         req_len = iov_length(req->stub->args.vector, req->stub->args.count);
 
         required_size = max((conf->page_size), (holder_len + req_len));
-        iobuf = iobuf_get2(req->wb_inode->this->ctx->iobuf_pool, required_size);
+        iobuf = iobuf_get2(global_ctx->iobuf_pool, required_size);
         if (iobuf == NULL) {
             goto out;
         }

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -876,7 +876,7 @@ client_fdctx_destroy(xlator_t *this, clnt_fd_ctx_t *fdctx)
     else
         goto out;
 
-    fr = create_frame(this, this->ctx->pool);
+    fr = create_frame(this, global_ctx->pool);
     if (fr == NULL) {
         goto out;
     }

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -3187,7 +3187,7 @@ client3_3_lookup(call_frame_t *frame, xlator_t *this, void *data)
             /* TODO: what is the size we should send ? */
             /* This change very much depends on quick-read
                changes */
-            rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+            rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
             if (rsp_iobuf == NULL) {
                 goto unwind;
             }
@@ -3453,7 +3453,7 @@ client3_3_readlink(call_frame_t *frame, xlator_t *this, void *data)
         goto unwind;
     }
 
-    rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+    rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
     if (rsp_iobuf == NULL) {
         goto unwind;
     }
@@ -4015,7 +4015,7 @@ client3_3_readv(call_frame_t *frame, xlator_t *this, void *data)
     }
     local = frame->local;
 
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, args->size);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, args->size);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -4554,7 +4554,7 @@ client3_3_fgetxattr(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     /* TODO: what is the size we should send ? */
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, 8 * GF_UNIT_KB);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, 8 * GF_UNIT_KB);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -4654,7 +4654,7 @@ client3_3_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     /* TODO: what is the size we should send ? */
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, 8 * GF_UNIT_KB);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, 8 * GF_UNIT_KB);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -4775,7 +4775,7 @@ client3_3_xattrop(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     /* TODO: what is the size we should send ? */
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, 8 * GF_UNIT_KB);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, 8 * GF_UNIT_KB);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -4880,7 +4880,7 @@ client3_3_fxattrop(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     /* TODO: what is the size we should send ? */
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, 8 * GF_UNIT_KB);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, 8 * GF_UNIT_KB);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -5395,7 +5395,7 @@ client3_3_readdir(call_frame_t *frame, xlator_t *this, void *data)
         /* TODO: what is the size we should send ? */
         /* This iobuf will live for only receiving the response,
            so not harmful */
-        rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+        rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
         if (rsp_iobuf == NULL) {
             goto unwind;
         }
@@ -5505,7 +5505,7 @@ client3_3_readdirp(call_frame_t *frame, xlator_t *this, void *data)
         /* TODO: what is the size we should send ? */
         /* This iobuf will live for only receiving the response,
            so not harmful */
-        rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+        rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
         if (rsp_iobuf == NULL) {
             goto unwind;
         }

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -3027,7 +3027,7 @@ client4_0_lookup(call_frame_t *frame, xlator_t *this, void *data)
             /* TODO: what is the size we should send ? */
             /* This change very much depends on quick-read
                changes */
-            rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+            rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
             if (rsp_iobuf == NULL) {
                 goto unwind;
             }
@@ -3825,7 +3825,7 @@ client4_0_readv(call_frame_t *frame, xlator_t *this, void *data)
     }
     local = frame->local;
 
-    rsp_iobuf = iobuf_get2(this->ctx->iobuf_pool, args->size);
+    rsp_iobuf = iobuf_get2(global_ctx->iobuf_pool, args->size);
     if (rsp_iobuf == NULL) {
         op_errno = ENOMEM;
         goto unwind;
@@ -4997,7 +4997,7 @@ client4_0_readdir(call_frame_t *frame, xlator_t *this, void *data)
         /* TODO: what is the size we should send ? */
         /* This iobuf will live for only receiving the response,
            so not harmful */
-        rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+        rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
         if (rsp_iobuf == NULL) {
             goto unwind;
         }
@@ -5108,7 +5108,7 @@ client4_0_readdirp(call_frame_t *frame, xlator_t *this, void *data)
         /* TODO: what is the size we should send ? */
         /* This iobuf will live for only receiving the response,
            so not harmful */
-        rsp_iobuf = iobuf_get(this->ctx->iobuf_pool);
+        rsp_iobuf = iobuf_get(global_ctx->iobuf_pool);
         if (rsp_iobuf == NULL) {
             goto unwind;
         }

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -244,7 +244,6 @@ server_setvolume(rpcsvc_request_t *req)
     rpc_transport_t *xprt = NULL;
     int32_t fop_version = 0;
     int32_t mgmt_version = 0;
-    glusterfs_ctx_t *ctx = NULL;
     struct _child_status *tmp = NULL;
     char *subdir_mount = NULL;
     char *client_name = NULL;
@@ -259,7 +258,6 @@ server_setvolume(rpcsvc_request_t *req)
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
     }
-    ctx = THIS->ctx;
 
     this = req->svc->xl;
     /* this is to ensure config_params is populated with the first brick
@@ -298,20 +296,20 @@ server_setvolume(rpcsvc_request_t *req)
         goto fail;
     }
 
-    LOCK(&ctx->volfile_lock);
+    LOCK(&global_ctx->volfile_lock);
     {
         xl = get_xlator_by_name(this, name);
         if (!xl) {
             xlator_in_graph = _gf_false;
             xl = this;
         }
-        if (ctx->cleanup_starting) {
+        if (global_ctx->cleanup_starting) {
             cleanup_starting = _gf_true;
             op_ret = -1;
             op_errno = ENOENT;
         }
     }
-    UNLOCK(&ctx->volfile_lock);
+    UNLOCK(&global_ctx->volfile_lock);
     if (!xl || cleanup_starting) {
         ret = gf_asprintf(&msg, "remote-subvolume \"%s\" is not found", name);
         if (-1 == ret) {
@@ -647,7 +645,7 @@ server_setvolume(rpcsvc_request_t *req)
     }
     UNLOCK(&conf->itable_lock);
 
-    ret = dict_set_str(reply, "process-uuid", this->ctx->process_uuid);
+    ret = dict_set_str(reply, "process-uuid", global_ctx->process_uuid);
     if (ret)
         gf_msg_debug(this->name, 0, "failed to set 'process-uuid'");
 

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -302,7 +302,7 @@ do_fd_cleanup(xlator_t *this, client_t *client, fdentry_t *fdentries,
         fd = fdentries[i].fd;
 
         if (fd != NULL) {
-            tmp_frame = create_frame(this, this->ctx->pool);
+            tmp_frame = create_frame(this, global_ctx->pool);
             if (tmp_frame == NULL) {
                 goto out;
             }
@@ -482,7 +482,7 @@ get_frame_from_request(rpcsvc_request_t *req)
     client = req->trans->xl_private;
     this = req->trans->xl;
     priv = this->private;
-    clienttable = this->ctx->clienttable;
+    clienttable = global_ctx->clienttable;
 
     for (i = 0; i < clienttable->max_clients; i++) {
         tmp_client = clienttable->cliententries[i].client;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -429,12 +429,11 @@ server_alloc_frame(rpcsvc_request_t *req)
     GF_VALIDATE_OR_GOTO("server", req, out);
     GF_VALIDATE_OR_GOTO("server", req->trans, out);
     GF_VALIDATE_OR_GOTO("server", req->svc, out);
-    GF_VALIDATE_OR_GOTO("server", req->svc->ctx, out);
 
     client = req->trans->xl_private;
     GF_VALIDATE_OR_GOTO("server", client, out);
 
-    frame = create_frame(client->this, req->svc->ctx->pool);
+    frame = create_frame(client->this, global_ctx->pool);
     if (!frame)
         goto out;
 

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -4899,9 +4899,9 @@ server3_3_readdirp(rpcsvc_request_t *req)
      * and transport layer can send msgs bigger than current page-size.
      */
     headers_size = sizeof(struct rpc_msg) + sizeof(gfs3_readdir_rsp);
-    if ((frame->this->ctx->page_size < args.size) ||
-        ((frame->this->ctx->page_size - args.size) < headers_size)) {
-        state->size = frame->this->ctx->page_size - headers_size;
+    if ((global_ctx->page_size < args.size) ||
+        ((global_ctx->page_size - args.size) < headers_size)) {
+        state->size = global_ctx->page_size - headers_size;
     } else {
         state->size = args.size;
     }
@@ -4954,9 +4954,9 @@ server3_3_readdir(rpcsvc_request_t *req)
      * and transport layer can send msgs bigger than current page-size.
      */
     headers_size = sizeof(struct rpc_msg) + sizeof(gfs3_readdir_rsp);
-    if ((frame->this->ctx->page_size < args.size) ||
-        ((frame->this->ctx->page_size - args.size) < headers_size)) {
-        state->size = frame->this->ctx->page_size - headers_size;
+    if ((global_ctx->page_size < args.size) ||
+        ((global_ctx->page_size - args.size) < headers_size)) {
+        state->size = global_ctx->page_size - headers_size;
     } else {
         state->size = args.size;
     }

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -4717,9 +4717,9 @@ server4_0_readdirp(rpcsvc_request_t *req)
      * and transport layer can send msgs bigger than current page-size.
      */
     headers_size = sizeof(struct rpc_msg) + sizeof(gfx_readdir_rsp);
-    if ((frame->this->ctx->page_size < args.size) ||
-        ((frame->this->ctx->page_size - args.size) < headers_size)) {
-        state->size = frame->this->ctx->page_size - headers_size;
+    if ((global_ctx->page_size < args.size) ||
+        ((global_ctx->page_size - args.size) < headers_size)) {
+        state->size = global_ctx->page_size - headers_size;
     } else {
         state->size = args.size;
     }
@@ -4767,9 +4767,9 @@ server4_0_readdir(rpcsvc_request_t *req)
      * and transport layer can send msgs bigger than current page-size.
      */
     headers_size = sizeof(struct rpc_msg) + sizeof(gfx_readdir_rsp);
-    if ((frame->this->ctx->page_size < args.size) ||
-        ((frame->this->ctx->page_size - args.size) < headers_size)) {
-        state->size = frame->this->ctx->page_size - headers_size;
+    if ((global_ctx->page_size < args.size) ||
+        ((global_ctx->page_size - args.size) < headers_size)) {
+        state->size = global_ctx->page_size - headers_size;
     } else {
         state->size = args.size;
     }

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -45,7 +45,7 @@ gfs_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
      */
     if (arg && xdrproc) {
         xdr_size = xdr_sizeof(xdrproc, arg);
-        iob = iobuf_get2(req->svc->ctx->iobuf_pool, xdr_size);
+        iob = iobuf_get2(global_ctx->iobuf_pool, xdr_size);
         if (!iob) {
             gf_msg_callingfn(THIS->name, GF_LOG_ERROR, ENOMEM, PS_MSG_NO_MEMORY,
                              "Failed to get iobuf");
@@ -661,7 +661,7 @@ server_graph_janitor_threads(void *data)
         }
     }
     if (victim_found)
-        glusterfs_delete_volfile_checksum(global_ctx, victim->volfile_id);
+        glusterfs_delete_volfile_checksum(victim->volfile_id);
     UNLOCK(&global_ctx->volfile_lock);
     if (!victim_found) {
         gf_log(this->name, GF_LOG_ERROR,
@@ -691,7 +691,7 @@ server_graph_janitor_threads(void *data)
             }
         }
         UNLOCK(&global_ctx->volfile_lock);
-        rpcsvc_autoscale_threads(global_ctx, conf->rpc, -1);
+        rpcsvc_autoscale_threads(conf->rpc, -1);
     }
 
 out:
@@ -1214,7 +1214,7 @@ server_init(xlator_t *this)
         conf->dync_auth = ret;
 
     /* RPC related */
-    conf->rpc = rpcsvc_init(this, global_ctx, this->options, 0);
+    conf->rpc = rpcsvc_init(this, this->options, 0);
     if (conf->rpc == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_RPCSVC_CREATE_FAILED, NULL);
         ret = -1;
@@ -1740,10 +1740,10 @@ server_notify(xlator_t *this, int32_t event, void *data, ...)
                     }
                 }
                 if (victim_found)
-                    glusterfs_delete_volfile_checksum(global_ctx, victim->volfile_id);
+                    glusterfs_delete_volfile_checksum(victim->volfile_id);
                 UNLOCK(&global_ctx->volfile_lock);
 
-                rpc_clnt_mgmt_pmap_signout(global_ctx, victim_name);
+                rpc_clnt_mgmt_pmap_signout(victim_name);
 
                 if (!xprt_found && victim_found) {
                     server_call_xlator_mem_cleanup(this, victim_name);

--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -217,7 +217,7 @@ posix_aio_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto err;
     }
 
-    paiocb->iobuf = iobuf_get2(this->ctx->iobuf_pool, size);
+    paiocb->iobuf = iobuf_get2(global_ctx->iobuf_pool, size);
     if (!paiocb->iobuf) {
         op_errno = ENOMEM;
         goto err;

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2381,8 +2381,8 @@ posix_ctx_disk_thread_proc(void *data)
 
             timespec_now_realtime(&sleep_till);
             sleep_till.tv_sec += 5;
-            (void)pthread_cond_timedwait(&global_ctx->xl_cond, &global_ctx->xl_lock,
-                                         &sleep_till);
+            (void)pthread_cond_timedwait(&global_ctx->xl_cond,
+                                         &global_ctx->xl_lock, &sleep_till);
         }
     }
     pthread_mutex_unlock(&global_ctx->xl_lock);

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1367,17 +1367,16 @@ out:
 static void
 posix_add_fd_to_cleanup(xlator_t *this, struct posix_fd *pfd)
 {
-    glusterfs_ctx_t *ctx = this->ctx;
     struct posix_private *priv = this->private;
 
     pfd->xl = this;
-    pthread_mutex_lock(&ctx->fd_lock);
+    pthread_mutex_lock(&global_ctx->fd_lock);
     {
-        list_add_tail(&pfd->list, &ctx->janitor_fds);
+        list_add_tail(&pfd->list, &global_ctx->janitor_fds);
         priv->rel_fdcount++;
-        pthread_cond_signal(&ctx->fd_cond);
+        pthread_cond_signal(&global_ctx->fd_cond);
     }
-    pthread_mutex_unlock(&ctx->fd_lock);
+    pthread_mutex_unlock(&global_ctx->fd_lock);
 }
 
 int32_t
@@ -1706,7 +1705,7 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto out;
     }
 
-    iobuf = iobuf_get_page_aligned(this->ctx->iobuf_pool, size, ALIGN_SIZE);
+    iobuf = iobuf_get_page_aligned(global_ctx->iobuf_pool, size, ALIGN_SIZE);
     if (!iobuf) {
         op_errno = ENOMEM;
         goto out;

--- a/xlators/storage/posix/src/posix-io-uring.c
+++ b/xlators/storage/posix/src/posix-io-uring.c
@@ -218,7 +218,7 @@ posix_io_uring_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto err;
     }
 
-    iobuf = iobuf_get2(this->ctx->iobuf_pool, size);
+    iobuf = iobuf_get2(global_ctx->iobuf_pool, size);
     if (!iobuf) {
         op_errno = ENOMEM;
         goto err;


### PR DESCRIPTION
In the patch https://github.com/gluster/glusterfs/pull/1614
we have introduced a global_ctx to access a ctx variable.
With the help of this global_ctx variable now it is not
require to call THIS to access ctx and avoid unnecessary
resource consumption to call THIS.

Fixes: #1874
Change-Id: I1ceb193dddf92754f20905379c92ac7b8f89e1fb
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

