### PR TITLE
afr: remove memcpy() + ntoh32() pattern

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -1576,7 +1576,6 @@ afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
     int i = 0;
     int idx = afr_index_for_transaction_type(type);
     void *pending_raw = NULL;
-    int pending[3];
     int ret = 0;
 
     priv = this->private;
@@ -1585,9 +1584,8 @@ afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
         ret = dict_get_ptr(xdata, priv->pending_key[i], &pending_raw);
         if (ret) /* no pending flags */
             continue;
-        memcpy(pending, pending_raw, sizeof(pending));
 
-        if (ntoh32(pending[idx]))
+        if (*((int *)pending_raw + idx))
             accused[i] = 1;
     }
 
@@ -3303,7 +3301,6 @@ afr_is_pending_set(xlator_t *this, dict_t *xdata, int type)
     int idx = -1;
     afr_private_t *priv = NULL;
     void *pending_raw = NULL;
-    int *pending_int = NULL;
     int i = 0;
 
     priv = this->private;
@@ -3311,9 +3308,7 @@ afr_is_pending_set(xlator_t *this, dict_t *xdata, int type)
 
     if (dict_get_ptr(xdata, AFR_DIRTY, &pending_raw) == 0) {
         if (pending_raw) {
-            pending_int = pending_raw;
-
-            if (ntoh32(pending_int[idx]))
+            if (*((int *)pending_raw + idx))
                 return _gf_true;
         }
     }
@@ -3323,9 +3318,7 @@ afr_is_pending_set(xlator_t *this, dict_t *xdata, int type)
             continue;
         if (!pending_raw)
             continue;
-        pending_int = pending_raw;
-
-        if (ntoh32(pending_int[idx]))
+        if (*((int *)pending_raw + idx))
             return _gf_true;
     }
 
@@ -7858,8 +7851,6 @@ afr_ta_dict_contains_pending_xattr(dict_t *dict, afr_private_t *priv, int child)
     ret = dict_get_ptr(dict, priv->pending_key[child], (void *)&pending);
     if (ret == 0) {
         for (i = 0; i < AFR_NUM_CHANGE_LOGS; i++) {
-            /* Not doing a ntoh32(pending) as we just want to check
-             * if it is non-zero or not. */
             if (pending[i]) {
                 return _gf_true;
             }

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -733,9 +733,6 @@ afr_selfheal_fill_dirty(xlator_t *this, int *dirty, int subvol, int idx,
                         dict_t *xdata)
 {
     void *pending_raw = NULL;
-    int pending[3] = {
-        0,
-    };
 
     if (!dirty)
         return 0;
@@ -746,9 +743,7 @@ afr_selfheal_fill_dirty(xlator_t *this, int *dirty, int subvol, int idx,
     if (!pending_raw)
         return -1;
 
-    memcpy(pending, pending_raw, sizeof(pending));
-
-    dirty[subvol] = ntoh32(pending[idx]);
+    dirty[subvol] = ntoh32(*((int *)pending_raw + idx));
 
     return 0;
 }
@@ -759,9 +754,6 @@ afr_selfheal_fill_matrix(xlator_t *this, int **matrix, int subvol, int idx,
 {
     int i = 0;
     void *pending_raw = NULL;
-    int pending[3] = {
-        0,
-    };
     afr_private_t *priv = NULL;
 
     priv = this->private;
@@ -776,9 +768,7 @@ afr_selfheal_fill_matrix(xlator_t *this, int **matrix, int subvol, int idx,
         if (!pending_raw)
             continue;
 
-        memcpy(pending, pending_raw, sizeof(pending));
-
-        matrix[subvol][i] = ntoh32(pending[idx]);
+        matrix[subvol][i] = ntoh32(*((int *)pending_raw + idx));
     }
 
     return 0;

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -532,9 +532,6 @@ static gf_boolean_t
 is_full_heal_marker_present(xlator_t *this, dict_t *xdata, int idx)
 {
     int i = 0;
-    int pending[3] = {
-        0,
-    };
     void *pending_raw = NULL;
     afr_private_t *priv = NULL;
 
@@ -554,8 +551,7 @@ is_full_heal_marker_present(xlator_t *this, dict_t *xdata, int idx)
         if (!pending_raw)
             continue;
 
-        memcpy(pending, pending_raw, sizeof(pending));
-        if (ntoh32(pending[idx]))
+        if (*((int *)pending_raw + idx))
             return _gf_true;
     }
 

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -673,9 +673,6 @@ afr_shd_ta_unset_xattrs(xlator_t *this, loc_t *loc, dict_t **xdata, int healer)
     gf_boolean_t need_xattrop = _gf_false;
     void *pending_raw = NULL;
     int *raw = NULL;
-    int pending[AFR_NUM_CHANGE_LOGS] = {
-        0,
-    };
     int i = 0;
     int j = 0;
     int val = 0;
@@ -704,9 +701,8 @@ afr_shd_ta_unset_xattrs(xlator_t *this, loc_t *loc, dict_t **xdata, int healer)
             goto out;
         }
 
-        memcpy(pending, pending_raw, sizeof(pending));
         for (j = 0; j < AFR_NUM_CHANGE_LOGS; j++) {
-            val = ntoh32(pending[j]);
+            val = ntoh32(*((int *)pending_raw + j));
             if (val) {
                 if (i == healer) {
                     gf_msg(this->name, GF_LOG_INFO, 0, AFR_MSG_THIN_ARB,


### PR DESCRIPTION
-Remove memcpy and/or byte order conversions when fetching values from
the dictionary.

Fixes: #504
Change-Id: Idf2367bac8cc592c419a11ea751495e1c664ec4d
Reported-by: Yaniv Kaul <ykaul@redhat.com>
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

