### PR TITLE
doc: Remove the unneeded backslash for glusterfs manpage

### DIFF
--- a/doc/glusterfs.8
+++ b/doc/glusterfs.8
@@ -124,7 +124,7 @@ Set fuse module's congestion threshold to N (the default is 48).
 \fB\-\-direct\-io\-mode=BOOL|auto\fR
 Specify fuse direct I/O strategy (the default is auto).
 .TP
-\fB\-\-dump-fuse=PATH\f\R
+\fB\-\-dump-fuse=PATH\fR
 Dump fuse traffic to PATH
 .TP
 \fB\-\-entry\-timeout=SECONDS\fR


### PR DESCRIPTION
Remove the unneeded backslash for glusterfs manpage, so
we can get "PATH" instead of "PATHR":

--dump-fuse=PATHR   ->   --dump-fuse=PATH

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>

