### PR TITLE
Removing unused memory allocation

### DIFF
--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -20,7 +20,6 @@ enum gf_common_mem_types_ {
     gf_common_mt_fdtable_t, /* used only in one location */
     gf_common_mt_fd_ctx,    /* used only in one location */
     gf_common_mt_gf_dirent_t,
-    gf_common_mt_inode_t,   /* used only in one location */
     gf_common_mt_inode_ctx, /* used only in one location */
     gf_common_mt_list_head,
     gf_common_mt_inode_table_t, /* used only in one location */
@@ -55,16 +54,8 @@ enum gf_common_mem_types_ {
     gf_common_mt_rpc_trans_pollin_t,  /* used only in one location */
     gf_common_mt_rpc_trans_reqinfo_t, /* used only in one location */
     gf_common_mt_glusterfs_graph_t,
-    gf_common_mt_rdma_private_t,       /* used only in one location */
-    gf_common_mt_rpc_transport_t,      /* used only in one location */
-    gf_common_mt_rdma_post_t,          /* used only in one location */
-    gf_common_mt_qpent,                /* used only in one location */
-    gf_common_mt_rdma_device_t,        /* used only in one location */
-    gf_common_mt_rdma_arena_mr,        /* used only in one location */
-    gf_common_mt_sge,                  /* used only in one location */
     gf_common_mt_rpcclnt_cb_program_t, /* used only in one location */
     gf_common_mt_libxl_marker_local,   /* used only in one location */
-    gf_common_mt_graph_buf,            /* used only in one location */
     gf_common_mt_trie_trie,            /* used only in one location */
     gf_common_mt_trie_data,            /* used only in one location */
     gf_common_mt_trie_node,            /* used only in one location */
@@ -96,7 +87,6 @@ enum gf_common_mem_types_ {
     gf_common_mt_strfd_data_t,       /* used only in one location */
     gf_common_mt_regex_t,            /* used only in one location */
     gf_common_mt_ereg,               /* used only in one location */
-    gf_common_mt_wr,                 /* used only in one location */
     gf_common_mt_dnscache,           /* used only in one location */
     gf_common_mt_dnscache_entry,     /* used only in one location */
     gf_common_mt_parser_t,           /* used only in one location */
@@ -115,12 +105,8 @@ enum gf_common_mem_types_ {
     gf_common_mt_syncenv,   /* used only in one location */
     gf_common_mt_scan_data, /* used only in one location */
     gf_common_list_node,
-    gf_mt_default_args_t,     /* used only in one location */
-    gf_mt_default_args_cbk_t, /* used only in one location */
     /*used for compound fops*/
-    gf_mt_compound_req_t, /* used only in one location */
-    gf_mt_compound_rsp_t, /* used only in one location */
-    gf_common_mt_tw_ctx,  /* used only in one location */
+    gf_common_mt_tw_ctx, /* used only in one location */
     gf_common_mt_tw_timer_list,
     /*lock migration*/
     gf_common_mt_lock_mig,

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -52,7 +52,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_afr_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_afr_mt_end);
 
     if (ret != 0) {
         return ret;

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -231,7 +231,7 @@ mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_dht_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_dht_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_NO_MEMORY,

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -205,7 +205,7 @@ __ec_destroy_private(xlator_t *this)
 int32_t
 mem_acct_init(xlator_t *this)
 {
-    if (xlator_mem_acct_init(this, ec_mt_end + 1) != 0) {
+    if (xlator_mem_acct_init(this, ec_mt_end) != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, EC_MSG_NO_MEMORY,
                "Memory accounting initialization "
                "failed.");

--- a/xlators/debug/delay-gen/src/delay-gen.c
+++ b/xlators/debug/delay-gen/src/delay-gen.c
@@ -561,7 +561,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_delay_gen_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_delay_gen_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -1411,7 +1411,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_error_gen_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_error_gen_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3820,7 +3820,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_io_stats_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_io_stats_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -3233,7 +3233,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_trace_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_trace_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/arbiter/src/arbiter.c
+++ b/xlators/features/arbiter/src/arbiter.c
@@ -281,7 +281,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_arbiter_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_arbiter_mt_end);
     if (ret)
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting "

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -575,7 +575,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_barrier_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_barrier_mt_end);
     if (ret)
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting "

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1503,7 +1503,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_br_stub_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_br_stub_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, BRB_MSG_MEM_ACNT_FAILED, NULL);

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -53,7 +53,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_br_stub_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_br_stub_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, BRS_MSG_MEM_ACNT_FAILED, NULL);

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -2237,7 +2237,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_changelog_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_changelog_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_WARNING, ENOMEM,

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -216,7 +216,7 @@ mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_libaws_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_libaws_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "Memory accounting init failed");

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
@@ -29,7 +29,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_libcvlt_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_libcvlt_mt_end);
 
     if (ret != 0) {
         return ret;

--- a/xlators/features/cloudsync/src/cloudsync.c
+++ b/xlators/features/cloudsync/src/cloudsync.c
@@ -271,7 +271,7 @@ cs_mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("cloudsync", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_cs_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_cs_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "Memory accounting init failed");

--- a/xlators/features/gfid-access/src/gfid-access.c
+++ b/xlators/features/gfid-access/src/gfid-access.c
@@ -1269,7 +1269,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_gfid_access_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_gfid_access_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_WARNING,

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -2316,7 +2316,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_index_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_index_mt_end);
 
     return ret;
 }

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -907,7 +907,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_leases_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_leases_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, LEASE_MSG_NO_MEM,

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -3927,7 +3927,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_locks_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_locks_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -3178,7 +3178,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_marker_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_marker_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -2482,7 +2482,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_quiesce_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_quiesce_mt_end);
 
     return ret;
 }

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -4938,7 +4938,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_quota_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_quota_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,

--- a/xlators/features/quota/src/quotad.c
+++ b/xlators/features/quota/src/quotad.c
@@ -30,7 +30,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_quota_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_quota_mt_end);
 
     if (0 != ret) {
         gf_log(this->name, GF_LOG_WARNING,

--- a/xlators/features/read-only/src/read-only.c
+++ b/xlators/features/read-only/src/read-only.c
@@ -16,7 +16,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_read_only_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_read_only_mt_end);
     if (ret)
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting "

--- a/xlators/features/read-only/src/worm.c
+++ b/xlators/features/read-only/src/worm.c
@@ -20,7 +20,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_read_only_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_read_only_mt_end);
     if (ret)
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting "

--- a/xlators/features/selinux/src/selinux.c
+++ b/xlators/features/selinux/src/selinux.c
@@ -199,7 +199,7 @@ mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("selinux", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_selinux_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_selinux_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SL_MSG_MEM_ACCT_INIT_FAILED,

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -7091,7 +7091,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_shard_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_shard_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_MEM_ACCT_INIT_FAILED,

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -2561,7 +2561,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_svc_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_svc_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, SVC_MSG_MEM_ACNT_FAILED, NULL);

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -2560,7 +2560,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_svs_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_svs_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_WARNING, 0, SVS_MSG_MEM_ACNT_FAILED,

--- a/xlators/features/thin-arbiter/src/thin-arbiter.c
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.c
@@ -561,7 +561,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_ta_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_ta_mt_end);
     if (ret)
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting "

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -2399,7 +2399,7 @@ mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("trash", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_trash_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_trash_mt_end);
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,
                "Memory accounting init"

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -2117,7 +2117,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_upcall_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_upcall_mt_end);
 
     if (ret != 0) {
         gf_msg("upcall", GF_LOG_WARNING, 0, UPCALL_MSG_NO_MEMORY,

--- a/xlators/features/utime/src/utime.c
+++ b/xlators/features/utime/src/utime.c
@@ -126,7 +126,7 @@ gf_utime_priv(xlator_t *this)
 int32_t
 mem_acct_init(xlator_t *this)
 {
-    if (xlator_mem_acct_init(this, utime_mt_end + 1) != 0) {
+    if (xlator_mem_acct_init(this, utime_mt_end) != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, UTIME_MSG_NO_MEMORY,
                "Memory accounting initialization failed.");
         return -1;

--- a/xlators/meta/src/meta.c
+++ b/xlators/meta/src/meta.c
@@ -195,7 +195,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_meta_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_meta_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR, "Memory accounting init failed");

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -364,7 +364,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_gld_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_gld_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6595,7 +6595,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_fuse_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_fuse_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -708,7 +708,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_nfs_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_nfs_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1609,7 +1609,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_ioc_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_ioc_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM,

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -909,7 +909,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_iot_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_iot_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, IO_THREADS_MSG_NO_MEMORY,

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -3672,7 +3672,7 @@ out:
 int32_t
 mdc_mem_acct_init(xlator_t *this)
 {
-    return xlator_mem_acct_init(this, gf_mdc_mt_end + 1);
+    return xlator_mem_acct_init(this, gf_mdc_mt_end);
 }
 
 int

--- a/xlators/performance/nl-cache/src/nl-cache.c
+++ b/xlators/performance/nl-cache/src/nl-cache.c
@@ -665,7 +665,7 @@ nlc_mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_nlc_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_nlc_mt_end);
     return ret;
 }
 

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -912,7 +912,7 @@ mem_acct_init(xlator_t *this)
 {
     int ret = -1;
 
-    ret = xlator_mem_acct_init(this, gf_ob_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_ob_mt_end);
 
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, OPEN_BEHIND_MSG_NO_MEMORY,

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -1132,7 +1132,7 @@ qr_mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_qr_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_qr_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, QUICK_READ_MSG_NO_MEMORY,

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -1066,7 +1066,7 @@ mem_acct_init(xlator_t *this)
         goto out;
     }
 
-    ret = xlator_mem_acct_init(this, gf_ra_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_ra_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, READ_AHEAD_MSG_NO_MEMORY,

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -1181,7 +1181,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         goto out;
 
-    ret = xlator_mem_acct_init(this, gf_rda_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_rda_mt_end);
 
     if (ret != 0)
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, READDIR_AHEAD_MSG_NO_MEMORY,

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -3012,7 +3012,7 @@ mem_acct_init(xlator_t *this)
         goto out;
     }
 
-    ret = xlator_mem_acct_init(this, gf_wb_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_wb_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, WRITE_BEHIND_MSG_NO_MEMORY,
@@ -3191,15 +3191,13 @@ struct volume_options options[] = {
         .op_version = {GD_OP_VERSION_6_0},
         .flags = OPT_FLAG_SETTABLE,
     },
-    {
-        .key = {"pass-through"},
-        .type = GF_OPTION_TYPE_BOOL,
-        .default_value = "false",
-        .op_version = {GD_OP_VERSION_9_0},
-        .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_CLIENT_OPT,
-        .tags = {"write-behind"},
-        .description = "Enable/disable write-behind pass-through"
-    },
+    {.key = {"pass-through"},
+     .type = GF_OPTION_TYPE_BOOL,
+     .default_value = "false",
+     .op_version = {GD_OP_VERSION_9_0},
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_CLIENT_OPT,
+     .tags = {"write-behind"},
+     .description = "Enable/disable write-behind pass-through"},
     {.key = {"flush-behind"},
      .type = GF_OPTION_TYPE_BOOL,
      .default_value = "on",

--- a/xlators/playground/template/src/template.c
+++ b/xlators/playground/template/src/template.c
@@ -17,7 +17,7 @@ template_mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("template", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_template_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_template_mt_end);
 
     if (ret != 0) {
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, TEMPLATE_MSG_NO_MEMORY,

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2431,7 +2431,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_client_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_client_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, PC_MSG_NO_MEMORY, NULL);

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -726,7 +726,7 @@ server_mem_acct_init(xlator_t *this)
 
     GF_VALIDATE_OR_GOTO("server", this, out);
 
-    ret = xlator_mem_acct_init(this, gf_server_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_server_mt_end);
 
     if (ret != 0) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, PS_MSG_NO_MEMORY, NULL);

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -236,7 +236,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_posix_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_posix_mt_end);
 
     if (ret != 0) {
         return ret;

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -28,7 +28,7 @@ mem_acct_init(xlator_t *this)
     if (!this)
         return ret;
 
-    ret = xlator_mem_acct_init(this, gf_posix_acl_mt_end + 1);
+    ret = xlator_mem_acct_init(this, gf_posix_acl_mt_end);
 
     if (ret != 0) {
         gf_log(this->name, GF_LOG_ERROR,


### PR DESCRIPTION
Removing extra unused type.
Removing leftovers from the RDMA

Fixes: #904

Change-Id: Id5d28622120578b7076d112e355ad8df116021dd
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

