### PR TITLE
tests: ./tests/bugs/replicate/bug-921231.t is continuously failing

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -5477,7 +5477,7 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
         }
         if (profile_info[i].fop_hits) {
             cli_out(
-                "%10.2lf %10.2lf us %10.2lf us %10.2lf us"
+                "%10.2lf %10.2lf ns %10.2lf ns %10.2lf ns"
                 " %14" PRId64 " %11s",
                 profile_info[i].percentage_avg_latency,
                 profile_info[i].avg_latency, profile_info[i].min_latency,

--- a/tests/bugs/replicate/bug-921231.t
+++ b/tests/bugs/replicate/bug-921231.t
@@ -25,7 +25,7 @@ write_to_file &
 write_to_file &
 wait
 #Test if the MAX [F]INODELK fop latency is of the order of seconds.
-inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 TEST [ -z $inodelk_max_latency ]
 
 cleanup;


### PR DESCRIPTION
The test case (./tests/bugs/replicate/bug-921231.t )
is continuously failing.The test case is failing because
inodelk_max_latency is showing wrong value in profile.
The value is not correct because recently the profile
timestamp is changed from microsec to nanosec from
the patch #1833.

Fixes: #2005
Change-Id: Ieb683836938d986b56f70b2380103efe95657821
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

