### PR TITLE
core: Reduce calls to THIS wherever possible

### DIFF
--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -1152,7 +1152,8 @@ glfsh_gather_heal_info(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
             !strstr(xl->name, "-ta-")) {
             heal_xl = _get_ancestor(xl, heal_op);
             if (heal_xl) {
-                old_THIS = THIS;
+                if (!old_THIS)
+                    old_THIS = THIS;
                 THIS = heal_xl;
                 ret = glfsh_print_pending_heals(
                     fs, top_subvol, rootloc, xl, heal_op,

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -462,22 +462,26 @@ fd_destroy(fd_t *fd, gf_boolean_t bound)
         for (i = 0; i < fd->xl_count; i++) {
             if (fd->_ctx[i].key) {
                 xl = fd->_ctx[i].xl_key;
-                old_THIS = THIS;
-                THIS = xl;
-                if (!xl->call_cleanup && xl->cbks->releasedir)
+                if (!xl->call_cleanup && xl->cbks->releasedir) {
+                    if (!old_THIS)
+                        old_THIS = THIS;
+                    THIS = xl;
                     xl->cbks->releasedir(xl, fd);
-                THIS = old_THIS;
+                    THIS = old_THIS;
+                }
             }
         }
     } else {
         for (i = 0; i < fd->xl_count; i++) {
             if (fd->_ctx[i].key) {
                 xl = fd->_ctx[i].xl_key;
-                old_THIS = THIS;
-                THIS = xl;
-                if (!xl->call_cleanup && xl->cbks->release)
+                if (!xl->call_cleanup && xl->cbks->release) {
+                    if (!old_THIS)
+                        old_THIS = THIS;
+                    THIS = xl;
                     xl->cbks->release(xl, fd);
-                THIS = old_THIS;
+                    THIS = old_THIS;
+                }
             }
         }
     }


### PR DESCRIPTION
In few functions 'THIS' is called inside a loop and saved for later
use in 'old_THIS'. Instead we can call 'THIS' only when 'old_THIS'
is NULL and reuse that itself to reduce redundant calls.

Change-Id: Ie5d4e5fe42bd4df02d101b4c199759cb84e6aee1
Fixes: #1755
Signed-off-by: karthik-us <ksubrahm@redhat.com>

