### PR TITLE
ec: cleanup healing code

### DIFF
--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -562,30 +562,19 @@ struct _ec_matrix_list {
 };
 
 struct _ec_heal {
-    struct list_head list;
     gf_lock_t lock;
     xlator_t *xl;
     ec_fop_data_t *fop;
     void *data;
-    ec_fop_data_t *lookup;
     loc_t loc;
-    struct iatt iatt;
-    char *symlink;
     fd_t *fd;
-    int32_t partial;
     int32_t done;
     int32_t error;
-    gf_boolean_t nameheal;
-    uintptr_t available;
     uintptr_t good;
     uintptr_t bad;
-    uintptr_t open;
-    uintptr_t fixed;
     uint64_t offset;
     uint64_t size;
     uint64_t total_size;
-    uint64_t version[2];
-    uint64_t raw_size;
 };
 
 struct subvol_healer {


### PR DESCRIPTION
Drop unused 'struct ec_heal' leftovers and simplify related bits.

Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Fixes: #2014

