### PR TITLE
doc: Updated release 9.0 notes

### DIFF
--- a/doc/release-notes/9.0.md
+++ b/doc/release-notes/9.0.md
@@ -16,7 +16,7 @@ A full list of bugs that have been addressed is included further below.
 ([reference](https://www.gluster.org/release-schedule/))
 
 2. Release 9 will receive maintenance updates around the 30th of every month
-for the first 3 months post release (i.e Feb'21, Mar'21, Apr'21). Post the
+for the first 3 months post release (i.e Mar'21, Apr'21, May'21). Post the
 initial 3 months, it will receive maintenance updates every 2 months till EOL.
 
 
@@ -25,11 +25,10 @@ initial 3 months, it will receive maintenance updates every 2 months till EOL.
 
 ### Highlights
 
-- Added support for:
+Added support for:
 
-  - io uring in Gluster
-  - support running with up to 5000 volumes
-  
+  - io_uring in Gluster (io_uring support in kernel required)
+  - support running with up to 5000 volumes (Testing done on: 5k volumes on 3 nodes, brick_mux was enabled with default configuration)  
 
 
 ### Features


### PR DESCRIPTION
Added
* io_uring requires kernel support
* 5k volume was tested on 3 nodes with brick mux enabled

Updates: #1868

Change-Id: Ib76548398ca6099f5c7c68a091aa1a4fcb5de536
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

