### PR TITLE
Dereference after null reference (CID:1124543)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1948,7 +1948,7 @@ gd_validate_peer_op_version(xlator_t *this, glusterd_peerinfo_t *peerinfo,
     if (!this) {
         gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_XLATOR_NOT_DEFINED,
                 NULL);
-        goto out;
+        return ret;
     }
 
     if (!peerinfo) {

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1945,12 +1945,6 @@ gd_validate_peer_op_version(xlator_t *this, glusterd_peerinfo_t *peerinfo,
         goto out;
     }
 
-    if (!this) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_XLATOR_NOT_DEFINED,
-                NULL);
-        return ret;
-    }
-
     if (!peerinfo) {
         gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_INVALID_ARGUMENT, NULL);
         goto out;


### PR DESCRIPTION
'this' pointer was being dereferenced after null check. This change avoids it.

Change-Id: I7dedee44c08df481d2a037eb601f3d5c4d9284f5
Updates: #1060
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>

