### PR TITLE
AFR - fixing coverity issue (Argument cannot be negative) 

### DIFF
--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -360,7 +360,7 @@ enum gf_internal_fop_indicator {
 #define GF_CHECK_XATTR_KEY_AND_GOTO(key, cmpkey, errval, lbl)                  \
     do {                                                                       \
         if (key && strcmp(key, cmpkey) == 0) {                                 \
-            errval = -EINVAL;                                                  \
+            errval = EINVAL;                                                   \
             goto lbl;                                                          \
         }                                                                      \
     } while (0)

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -1581,7 +1581,6 @@ afr_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
      * Heal daemons don't have IO threads ... and as a result they
      * send this getxattr down and eventually crash :(
      */
-    op_errno = -1;
     GF_CHECK_XATTR_KEY_AND_GOTO(name, IO_THREADS_QUEUE_SIZE_KEY, op_errno, out);
 
     /*
@@ -1609,6 +1608,7 @@ no_name:
 out:
     if (ret < 0)
         AFR_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
+
     return 0;
 }
 


### PR DESCRIPTION
CID 1430124

A negative value is being passed to a parameter hat cannot be negative.
Modified the value which is being passed.

Change-Id: I06dca105f7a78ae16145b0876910851fb631e366
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

