### PR TITLE
tests: fix tests/bugs/nfs/bug-1053579.t

### DIFF
--- a/tests/bugs/nfs/bug-1053579.t
+++ b/tests/bugs/nfs/bug-1053579.t
@@ -4,6 +4,8 @@
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../nfs.rc
 
+SCRIPT_TIMEOUT=500
+
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 function create_files() {


### PR DESCRIPTION
On NFS the number of groups associated to a user that can be passed
to the server is limited. This test created a user with 200 groups
and checked that a file owned by the latest created group couldn't
be accessed, under the assumption that the last group won't be passed
to the server.

However there's no guarantee on how the list of groups is generated,
so the latest created group could be passed as one of the initial
groups, making the allowing access to the file and causing the test
to fail (because it was expecting to not be possible).

Given that there's no way to be sure which groups will be passed, this
patch changes the test so that a check is done for each group the user
belongs to. Then we check that there have been some successes and some
failures.

Once 'manage-gids' is set, we do the same, but this time the number of
failures must be 0.

Fixes: #2033
Change-Id: Ide06da2861fcade2166372d1f3e9eb4ff2dd5f58
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

