### PR TITLE
glusterd: do not allow changing storage.linux-aio for running volume

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -1196,24 +1196,33 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
             key = key_fixed;
             keylen = strlen(key_fixed);
         }
-#ifdef HAVE_LIBURING
-        if (len_strcmp(key, keylen, "storage.linux-io_uring")) {
-            if (volinfo == NULL) {
-                snprintf(errstr, sizeof(errstr), "vol info is NULL for %s.",
-                         volname);
-                ret = -1;
-                goto out;
-            }
-            if (volinfo->status == GLUSTERD_STATUS_STARTED) {
+
+#ifdef HAVE_LIBAIO
+        if (len_strcmp(key, keylen, "storage.linux-aio")) {
+            if (volinfo && volinfo->status == GLUSTERD_STATUS_STARTED) {
                 snprintf(errstr, sizeof(errstr),
-                         "Changing this option is "
-                         "not supported when volume is in started state. "
-                         "Please stop the volume.");
+                         "Changing 'storage.linux-aio' is not"
+                         " supported when the volume is in started"
+                         " state. Please stop the volume first.");
                 ret = -1;
                 goto out;
             }
         }
-#endif
+#endif /* HAVE_LIBAIO */
+
+#ifdef HAVE_LIBURING
+        if (len_strcmp(key, keylen, "storage.linux-io_uring")) {
+            if (volinfo && volinfo->status == GLUSTERD_STATUS_STARTED) {
+                snprintf(errstr, sizeof(errstr),
+                         "Changing 'storage.linux-io_uring' is not"
+                         " supported when the volume is in started"
+                         " state. Please stop the volume first.");
+                ret = -1;
+                goto out;
+            }
+        }
+#endif /* HAVE_LIBURING */
+
         if (len_strcmp(key, keylen, "cluster.granular-entry-heal")) {
             /* For granular entry-heal, if the set command was
              * invoked through volume-set CLI, then allow the


### PR DESCRIPTION
Do not allow changing storage.linux-aio for running volume,
cleanup nearby storage.linux-io_uring error message as well.

Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Updates: #2039

