### PR TITLE
Revert "skip the lock when refcount is not zero"

### DIFF
--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -543,17 +543,20 @@ fd_unref(fd_t *fd)
         return;
     }
 
-    refcount = GF_ATOMIC_DEC(fd->refcount);
-    if (refcount == 0) {
-        LOCK(&fd->inode->lock);
-        {
+    LOCK(&fd->inode->lock);
+    {
+        refcount = GF_ATOMIC_DEC(fd->refcount);
+        if (refcount == 0) {
             if (!list_empty(&fd->inode_list)) {
                 list_del_init(&fd->inode_list);
                 fd->inode->active_fd_count--;
                 bound = _gf_true;
             }
         }
-        UNLOCK(&fd->inode->lock);
+    }
+    UNLOCK(&fd->inode->lock);
+
+    if (refcount == 0) {
         fd_destroy(fd, bound);
     }
 


### PR DESCRIPTION
This reverts commit 50e953e2450b5183988c12e87bdfbc997e0ad8a8.

Fixes: #2052
Change-Id: Ic0670a63423b5d79c3d48001e18910b1dbf7e98d

