### PR TITLE
call-stub: remove unused fields

### DIFF
--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -16,20 +16,17 @@
 #include "glusterfs/libglusterfs-messages.h"
 
 static call_stub_t *
-stub_new(call_frame_t *frame, const char wind, const glusterfs_fop_t fop)
+stub_new(call_frame_t *frame, const uint32_t wind, const glusterfs_fop_t fop)
 {
     call_stub_t *new = NULL;
 
-    GF_VALIDATE_OR_GOTO("call-stub", frame, out);
-
-    new = mem_get0(frame->this->ctx->stub_mem_pool);
+    new = GF_CALLOC(1, sizeof(call_stub_t), gf_common_mt_char);
     GF_VALIDATE_OR_GOTO("call-stub", new, out);
 
-    new->frame = frame;
-    new->wind = wind;
-    new->fop = fop;
-    new->stub_mem_pool = frame->this->ctx->stub_mem_pool;
     INIT_LIST_HEAD(&new->list);
+    new->frame = frame;
+    new->fop = fop;
+    new->wind = wind;
 
     INIT_LIST_HEAD(&new->args_cbk.entries);
 out:
@@ -2368,9 +2365,7 @@ call_stub_destroy(call_stub_t *stub)
     else
         call_stub_wipe_args_cbk(stub);
 
-    stub->stub_mem_pool = NULL;
-
-    mem_put(stub);
+    GF_FREE(stub);
 out:
     return;
 }

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -20,10 +20,6 @@
 typedef struct _call_stub {
     struct list_head list;
     call_frame_t *frame;
-    struct mem_pool *stub_mem_pool; /* pointer to stub mempool in ctx_t */
-    uint32_t jnl_meta_len;
-    uint32_t jnl_data_len;
-    void (*serialize)(struct _call_stub *, char *, char *);
     union {
         fop_lookup_t lookup;
         fop_stat_t stat;
@@ -136,8 +132,8 @@ typedef struct _call_stub {
         fop_copy_file_range_cbk_t copy_file_range;
     } fn_cbk;
     glusterfs_fop_t fop;
-    gf_boolean_t poison;
-    char wind;
+    uint32_t poison;
+    uint32_t wind;
     default_args_t args;
     default_args_cbk_t args_cbk;
 } call_stub_t;


### PR DESCRIPTION
- Cleaned up the call stub structure from some unused fields.
- Moved some members from char/boolean to uint32_t.
- Reordered initialization according to member order
- Moved from mempool to regular GF_CALLOC/GF_FREE to avoid long
unneeded indirection.

Overall, it causes all members to be on the same cacheline.
In my tests, I'm getting higher performance of up to 10-15% (but
I'm testing only a simple fio randrw on my local machine) initially.

Fixes: #2054
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

