### PR TITLE
features/locks - Fixing a segfault

### DIFF
--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -434,6 +434,8 @@ pl_inode_get(xlator_t *this, inode_t *inode, pl_local_t *local)
     pl_inode_t *pl_inode = NULL;
     int ret = 0;
 
+    GF_VALIDATE_OR_GOTO("posix-locks", inode, out);
+
     LOCK(&inode->lock);
     {
         ret = __inode_ctx_get(inode, this, &tmp_pl_inode);
@@ -490,6 +492,7 @@ unlock:
         pl_fetch_mlock_info_from_disk(this, pl_inode, local);
     }
 
+out:
     return pl_inode;
 }
 


### PR DESCRIPTION
A NULL indoe was passed to the method pl_inode_get, which resulted in a
segfault. This patch will prevent a segfault in case a NULL inode is
being passed to the method.

Fixes: 2058
Change-Id: I7a809c1d2dcc3a5115dc667324f81178e25ac0d5
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

