### PR TITLE
configure: add linux-io_uring flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1444,13 +1444,28 @@ if test -n "$LIBAIO"; then
 fi
 
 BUILD_LIBURING=no
-AC_CHECK_HEADERS([liburing.h])
-AC_CHECK_LIB([uring],[io_uring_queue_init],[LIBURING="-luring"])
+case $host_os in
+    linux*)
+        AC_ARG_ENABLE([linux_io_uring],
+                      AC_HELP_STRING([--disable-linux-io_uring],
+                      [Disable io-uring in POSIX xlator.]))
 
-if test -n "$LIBURING"; then
-   AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled])
-   BUILD_LIBURING=yes
-fi
+        # Don't build on our jenkins CentOS 7 machines. We can remove this
+        # centOS7 variable when we start using CentOS Stream where liburing is available.
+        if test "x$ac_cv_file__etc_redhat_release" = "xyes"; then
+            if grep "release 7" /etc/centos-release; then
+                centOS7=yes
+            fi
+        fi
+        if test "x$enable_linux_io_uring" != "xno" -a "x$centOS7" != "xyes"; then
+            AC_CHECK_HEADERS([liburing.h],
+                             [AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled]) LIBURING="-luring"],
+                             AC_MSG_ERROR([Install liburing library and headers or use --disable-linux-io_uring]))
+            BUILD_LIBURING=yes
+        fi
+        ;;
+esac
+
 dnl gnfs section
 BUILD_GNFS="no"
 RPCBIND_SERVICE=""

--- a/configure.ac
+++ b/configure.ac
@@ -1450,14 +1450,7 @@ case $host_os in
                       AC_HELP_STRING([--disable-linux-io_uring],
                       [Disable io-uring in POSIX xlator.]))
 
-        # Don't build on our jenkins CentOS 7 machines. We can remove this
-        # centOS7 variable when we start using CentOS Stream where liburing is available.
-        if test "x$ac_cv_file__etc_redhat_release" = "xyes"; then
-            if grep "release 7" /etc/centos-release; then
-                centOS7=yes
-            fi
-        fi
-        if test "x$enable_linux_io_uring" != "xno" -a "x$centOS7" != "xyes"; then
+        if test "x$enable_linux_io_uring" != "xno" ; then
             AC_CHECK_HEADERS([liburing.h],
                              [AC_DEFINE(HAVE_LIBURING, 1, [io-uring based POSIX enabled]) LIBURING="-luring"],
                              AC_MSG_ERROR([Install liburing library and headers or use --disable-linux-io_uring]))

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -53,6 +53,16 @@
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --with ipv6default
 %{?_with_ipv6default:%global _with_ipv6default --with-ipv6-default}
 
+# linux-io_uring
+# If you wish to compile an rpm without linux-io_uring support...
+# rpmbuild -ta  @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --disable-linux-io_uring
+%{?_without_linux_io_uring:%global _without_linux_io_uring --disable-linux-io_uring}
+
+# Disable linux-io_uring on unsupported distros.
+%if ( 0%{?fedora} && 0%{?fedora} <= 32 ) || ( 0%{?rhel} && 0%{?rhel} <= 7 )
+%global _without_linux_io_uring --disable-linux-io_uring
+%endif
+
 # libtirpc
 # if you wish to compile an rpm without TIRPC (i.e. use legacy glibc rpc)
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without libtirpc
@@ -135,6 +145,7 @@
 %if 0%{?_without_server:1}
 %global _without_events --disable-events
 %global _without_georeplication --disable-georeplication
+%global _without_linux_io_uring --disable-linux-io_uring
 %global _with_gnfs %{nil}
 %global _without_ocf --without-ocf
 %endif
@@ -278,6 +289,10 @@ BuildRequires:    libattr-devel
 
 %if (0%{?_with_firewalld:1})
 BuildRequires:    firewalld
+%endif
+
+%if ( 0%{!?_without_linux_io_uring:1} )
+BuildRequires:    liburing-devel
 %endif
 
 Obsoletes:        %{name}-common < %{version}-%{release}
@@ -843,6 +858,7 @@ done
         %{?_without_server} \
         %{?_without_syslog} \
         %{?_with_ipv6default} \
+        %{?_without_linux_io_uring} \
         %{?_without_libtirpc}
 
 # fix hardening and remove rpath in shlibs
@@ -1623,6 +1639,9 @@ exit 0
 %endif
 
 %changelog
+* Fri Jan 29 2021 Ravishankar N <ravishankar@redhat.com>
+- add liburing-devel as a requirement.
+
 * Thu Nov 26 2020 Shwetha K Acharya <sacharya@redhat.com>
 - Add tar as dependency to georeplication rpm for RHEL version >= 8.3
 


### PR DESCRIPTION
By default, if liburing is not present on the machine where gluster rpms are
being built, then the built rpm won't have the feature present in posix.so.
While this is obviously displayed in the ./configure's summary, it means the
feature won't work on a target machine where the rpm is installed, even if the
target has Linux kernel >=5.1 and liburing installed.

I think it is better to have a configure option `--enable-linux-io_uring` which
is on by default. That way, the build machines will error out by default and
will either need to `./configure --disable-linux-io_uring` to compile sucessfully (or) install the
library and headers on the build machine.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>

