### PR TITLE
tests: fix gfapi async callback prototypes

### DIFF
--- a/tests/basic/ec/ec-fast-fgetxattr.c
+++ b/tests/basic/ec/ec-fast-fgetxattr.c
@@ -30,8 +30,8 @@ fill_iov(struct iovec *iov, char fillchar, int count)
 }
 
 void
-write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         fprintf(stderr, "glfs_write failed");

--- a/tests/basic/gfapi/gfapi-async-calls-test.c
+++ b/tests/basic/gfapi/gfapi-async-calls-test.c
@@ -87,8 +87,8 @@ out:
 }
 
 void
-pwritev_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                  struct stat *poststat, void *cookie)
+pwritev_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                  struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_pwritev failed");
@@ -122,8 +122,8 @@ out:
 }
 
 void
-pwrite_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                 struct stat *poststat, void *cookie)
+pwrite_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                 struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_pwrite_cbk failed");
@@ -150,8 +150,8 @@ pwrite_async(glfs_fd_t *glfd)
 }
 
 void
-writev_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                 struct stat *poststat, void *cookie)
+writev_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                 struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_writev_cbk failed");
@@ -185,8 +185,8 @@ out:
 }
 
 void
-write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_write_cbk failed");
@@ -213,8 +213,8 @@ write_async(glfs_fd_t *glfd)
 }
 
 void
-preadv_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                 struct stat *poststat, void *cookie)
+preadv_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                 struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_preadv_cbk failed");
@@ -248,8 +248,8 @@ out:
 }
 
 void
-pread_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+pread_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_pread_cbk failed");
@@ -275,8 +275,8 @@ pread_async(glfs_fd_t *glfd)
 }
 
 void
-readv_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+readv_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_readv_cbk failed");
@@ -309,8 +309,8 @@ out:
 }
 
 void
-read_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-               struct stat *poststat, void *cookie)
+read_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+               struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_read_cbk failed");
@@ -335,8 +335,8 @@ read_async(glfs_fd_t *glfd)
 }
 
 void
-fsync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+fsync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_fsync_async_cbk failed");
@@ -346,8 +346,8 @@ fsync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
 }
 
 void
-fdatasync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                    struct stat *poststat, void *cookie)
+fdatasync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                    struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_fdatasync_async_cbk failed");
@@ -357,8 +357,8 @@ fdatasync_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
 }
 
 void
-ftruncate_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                    struct stat *poststat, void *cookie)
+ftruncate_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                    struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         LOG_ERR("glfs_ftruncate_async_cbk failed");


### PR DESCRIPTION
Consistently use 'struct glfs_stat *' instead of 'struct stat *'
to avoid warnings reported with -Wincompatible-pointer-types.

Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Updates: #1000

