### PR TITLE
libglusterfs: annotate synctasks with valgrind API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,6 +432,19 @@ case x$enable_valgrind in
     ;;
 esac
 
+if test "x$VALGRIND_TOOL" != xno; then
+   AC_MSG_CHECKING([whether valgrind API can be used])
+   AC_COMPILE_IFELSE(
+   [AC_LANG_PROGRAM([
+      [#include <valgrind/valgrind.h>]],
+      [[VALGRIND_STACK_DEREGISTER(VALGRIND_STACK_REGISTER(0, 0))]])],
+      [HAVE_VALGRIND_API=yes], [HAVE_VALGRIND_API=no])
+   AC_MSG_RESULT([$HAVE_VALGRIND_API])
+   if test x$HAVE_VALGRIND_API = "xyes"; then
+      AC_DEFINE(HAVE_VALGRIND_API, 1, [Define if valgrind API can be used.])
+   fi
+fi
+
 AC_ARG_WITH([previous-options],
         [AS_HELP_STRING([--with-previous-options],
                         [read config.status for configure options])

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -83,6 +83,10 @@ struct synctask {
     } tsan;
 #endif
 
+#ifdef HAVE_VALGRIND_API
+    unsigned stackid;
+#endif
+
     ucontext_t ctx;
     struct syncproc *proc;
 
@@ -101,6 +105,10 @@ struct syncproc {
         void *fiber;
         char name[TSAN_THREAD_NAMELEN];
     } tsan;
+#endif
+
+#ifdef HAVE_VALGRIND_API
+    unsigned stackid;
 #endif
 
     ucontext_t sched;

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -15,6 +15,10 @@
 #include <sanitizer/tsan_interface.h>
 #endif
 
+#ifdef HAVE_VALGRIND_API
+#include <valgrind/valgrind.h>
+#endif
+
 int
 syncopctx_setfsuid(void *uid)
 {
@@ -370,6 +374,10 @@ synctask_destroy(struct synctask *task)
     __tsan_destroy_fiber(task->tsan.fiber);
 #endif
 
+#ifdef HAVE_VALGRIND_API
+    VALGRIND_STACK_DEREGISTER(task->stackid);
+#endif
+
     GF_FREE(task);
 }
 
@@ -485,6 +493,12 @@ synctask_create(struct syncenv *env, size_t stacksize, synctask_fn_t fn,
     snprintf(newtask->tsan.name, TSAN_THREAD_NAMELEN, "<synctask of %s>",
              this->name);
     __tsan_set_fiber_name(newtask->tsan.fiber, newtask->tsan.name);
+#endif
+
+#ifdef HAVE_VALGRIND_API
+    newtask->stackid = VALGRIND_STACK_REGISTER(
+        newtask->ctx.uc_stack.ss_sp,
+        newtask->ctx.uc_stack.ss_sp + newtask->ctx.uc_stack.ss_size);
 #endif
 
     newtask->state = SYNCTASK_INIT;
@@ -691,6 +705,27 @@ synctask_switchto(struct synctask *task)
     pthread_mutex_unlock(&env->mutex);
 }
 
+#ifdef HAVE_VALGRIND_API
+
+static unsigned
+__valgrind_register_current_stack(void)
+{
+    pthread_attr_t attr;
+    size_t stacksize;
+    void *stack;
+    int ret;
+
+    ret = pthread_getattr_np(pthread_self(), &attr);
+    GF_ASSERT(ret == 0);
+
+    ret = pthread_attr_getstack(&attr, &stack, &stacksize);
+    GF_ASSERT(ret == 0);
+
+    return VALGRIND_STACK_REGISTER(stack, stack + stacksize);
+}
+
+#endif /* HAVE_VALGRIND_API */
+
 void *
 syncenv_processor(void *thdata)
 {
@@ -706,12 +741,20 @@ syncenv_processor(void *thdata)
     __tsan_set_fiber_name(proc->tsan.fiber, proc->tsan.name);
 #endif
 
+#ifdef HAVE_VALGRIND_API
+    proc->stackid = __valgrind_register_current_stack();
+#endif
+
     while ((task = syncenv_task(proc)) != NULL) {
         synctask_switchto(task);
     }
 
 #ifdef HAVE_TSAN_API
     __tsan_destroy_fiber(proc->tsan.fiber);
+#endif
+
+#ifdef HAVE_VALGRIND_API
+    VALGRIND_STACK_DEREGISTER(proc->stackid);
 #endif
 
     return NULL;


### PR DESCRIPTION
If --enable-valgrind[=memcheck,drd] is specified and API headers
are detected, annotate synctask context initialization and context
switch with valgrind API.

Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Fixes: #2075

