### PR TITLE
Glustereventsd Default port

### DIFF
--- a/events/src/eventsconfig.json
+++ b/events/src/eventsconfig.json
@@ -1,5 +1,5 @@
 {
     "log-level": "INFO",
-    "port": 24009,
+    "port": 55555,
     "disable-events-log": false
 }

--- a/extras/firewalld/glusterfs.xml
+++ b/extras/firewalld/glusterfs.xml
@@ -4,7 +4,7 @@
 <description>Default ports for gluster-distributed storage</description>
 <port protocol="tcp" port="24007"/>    <!--For glusterd -->
 <port protocol="tcp" port="24008"/>    <!--For glusterd RDMA port management -->
-<port protocol="tcp" port="24009"/>    <!--For glustereventsd -->
+<port protocol="tcp" port="55555"/>    <!--For glustereventsd -->
 <port protocol="tcp" port="38465"/>    <!--Gluster NFS service -->
 <port protocol="tcp" port="38466"/>    <!--Gluster NFS service -->
 <port protocol="tcp" port="38467"/>    <!--Gluster NFS service -->

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -26,7 +26,7 @@
 #include "glusterfs/events.h"
 
 #define EVENT_HOST "127.0.0.1"
-#define EVENT_PORT 24009
+#define EVENT_PORT 55555
 
 int
 _gf_event(eventtypes_t event, const char *fmt, ...)


### PR DESCRIPTION
Issue : The default port of glustereventsd is currently 24009
which is preventing glustereventsd from binding to the UDP port
due to selinux policies.

Fix: Changing the default port to be bound by chanding it to something
in the ephemeral range.

Change-Id: Idf10e92e80ab0eaf294face0549a6e912be8fc35
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>
Fixes: #2080

