### PR TITLE
dht: don't parse decommissioned-bricks option when in decommission

### DIFF
--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -299,6 +299,7 @@ dht_decommissioned_remove(xlator_t *this, dht_conf_t *conf)
             conf->decommission_subvols_cnt--;
         }
     }
+    conf->decommission_in_progress = 0;
 }
 
 static void
@@ -493,9 +494,11 @@ dht_reconfigure(xlator_t *this, dict_t *options)
     }
 
     if (dict_get_str(options, "decommissioned-bricks", &temp_str) == 0) {
-        ret = dht_parse_decommissioned_bricks(this, conf, temp_str);
-        if (ret == -1)
-            goto out;
+        if (!(conf->decommission_in_progress)) {
+            ret = dht_parse_decommissioned_bricks(this, conf, temp_str);
+            if (ret == -1)
+                goto out;
+        }
     } else {
         dht_decommissioned_remove(this, conf);
     }


### PR DESCRIPTION
Scenario:
1. decommission start: the option decommissioned-bricks is added to the vol file 
    and being parsed by dht.
2. another configuration change (like setting a new loglevel): the decommissioned-bricks option 
    still exists on the vol file and being parsed again, this leads to invalid data.    

Fix:  
Prevent the parsing of "decommissioned-bricks" when decommission is running. 
This counts on the fact that once a decommission is running it cannot be started again.

Fixes: #1992
Change-Id: I7a016750e2f865aee4cd620bd9033ec19421d47d
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

