### PR TITLE
glusterd: fix for starting brick on new port

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -4103,7 +4103,7 @@ threadid_func(CRYPTO_THREADID *id)
      */
     CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 }
-#else /* older openssl */
+#else  /* older openssl */
 static unsigned long
 legacy_threadid_func(void)
 {
@@ -4359,7 +4359,7 @@ ssl_setup_connection_params(rpc_transport_t *this)
                        "DH ciphers are disabled.",
                        dh_param, ERR_error_string(err, NULL));
             }
-#else /* HAVE_OPENSSL_DH_H */
+#else  /* HAVE_OPENSSL_DH_H */
             BIO_free(bio);
             gf_log(this->name, GF_LOG_ERROR, "OpenSSL has no DH support");
 #endif /* HAVE_OPENSSL_DH_H */
@@ -4386,7 +4386,7 @@ ssl_setup_connection_params(rpc_transport_t *this)
                        "ECDH ciphers are disabled.",
                        ec_curve, ERR_error_string(err, NULL));
             }
-#else /* HAVE_OPENSSL_ECDH_H */
+#else  /* HAVE_OPENSSL_ECDH_H */
             gf_log(this->name, GF_LOG_ERROR, "OpenSSL has no ECDH support");
 #endif /* HAVE_OPENSSL_ECDH_H */
         }

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -949,6 +949,12 @@ __socket_server_bind(rpc_transport_t *this)
                 if (errno == EADDRINUSE) {
                     gf_log(this->name, GF_LOG_ERROR, "Port is already in use");
                     ret = -EADDRINUSE;
+
+                    /* TODO: Remove this delay. It was added only to address
+                     * failures in the regression test suite, In a real
+                     * situation, if a port is in use when the process starts,
+                     * it most likely will remain in use during 10 seconds as
+                     * well.*/
                     sleep(1);
                     retries--;
                 } else {
@@ -958,7 +964,7 @@ __socket_server_bind(rpc_transport_t *this)
                 break;
             }
         }
-        if (ret != 0)
+        if (ret < 0)
             goto out;
 
         if (getsockname(priv->sock, SA(&this->myinfo.sockaddr),
@@ -4097,7 +4103,7 @@ threadid_func(CRYPTO_THREADID *id)
      */
     CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 }
-#else  /* older openssl */
+#else /* older openssl */
 static unsigned long
 legacy_threadid_func(void)
 {
@@ -4353,7 +4359,7 @@ ssl_setup_connection_params(rpc_transport_t *this)
                        "DH ciphers are disabled.",
                        dh_param, ERR_error_string(err, NULL));
             }
-#else  /* HAVE_OPENSSL_DH_H */
+#else /* HAVE_OPENSSL_DH_H */
             BIO_free(bio);
             gf_log(this->name, GF_LOG_ERROR, "OpenSSL has no DH support");
 #endif /* HAVE_OPENSSL_DH_H */
@@ -4380,7 +4386,7 @@ ssl_setup_connection_params(rpc_transport_t *this)
                        "ECDH ciphers are disabled.",
                        ec_curve, ERR_error_string(err, NULL));
             }
-#else  /* HAVE_OPENSSL_ECDH_H */
+#else /* HAVE_OPENSSL_ECDH_H */
             gf_log(this->name, GF_LOG_ERROR, "OpenSSL has no ECDH support");
 #endif /* HAVE_OPENSSL_ECDH_H */
         }

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -948,6 +948,7 @@ __socket_server_bind(rpc_transport_t *this)
                        this->myinfo.identifier, strerror(errno));
                 if (errno == EADDRINUSE) {
                     gf_log(this->name, GF_LOG_ERROR, "Port is already in use");
+                    ret = -EADDRINUSE;
                     sleep(1);
                     retries--;
                 } else {
@@ -957,19 +958,9 @@ __socket_server_bind(rpc_transport_t *this)
                 break;
             }
         }
-    } else {
-        ret = bind(priv->sock, (struct sockaddr *)&this->myinfo.sockaddr,
-                   this->myinfo.sockaddr_len);
+        if(ret != 0)
+            goto out;
 
-        if (ret != 0) {
-            gf_log(this->name, GF_LOG_ERROR, "binding to %s failed: %s",
-                   this->myinfo.identifier, strerror(errno));
-            if (errno == EADDRINUSE) {
-                gf_log(this->name, GF_LOG_ERROR, "Port is already in use");
-            }
-        }
-    }
-    if (AF_UNIX != SA(&this->myinfo.sockaddr)->sa_family) {
         if (getsockname(priv->sock, SA(&this->myinfo.sockaddr),
                         &this->myinfo.sockaddr_len) != 0) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -984,6 +975,17 @@ __socket_server_bind(rpc_transport_t *this)
             gf_log(this->name, GF_LOG_INFO,
                    "process started listening on port (%d)",
                    cmd_args->brick_port);
+        }
+    } else {
+        ret = bind(priv->sock, (struct sockaddr *)&this->myinfo.sockaddr,
+                   this->myinfo.sockaddr_len);
+
+        if (ret != 0) {
+            gf_log(this->name, GF_LOG_ERROR, "binding to %s failed: %s",
+                   this->myinfo.identifier, strerror(errno));
+            if (errno == EADDRINUSE) {
+                gf_log(this->name, GF_LOG_ERROR, "Port is already in use");
+            }
         }
     }
 

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -958,7 +958,7 @@ __socket_server_bind(rpc_transport_t *this)
                 break;
             }
         }
-        if(ret != 0)
+        if (ret != 0)
             goto out;
 
         if (getsockname(priv->sock, SA(&this->myinfo.sockaddr),

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2053,7 +2053,6 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
     rpc_clnt_connection_t *conn = NULL;
     int pid = -1;
     int32_t len = 0;
-    int errno_tmp = 0;
     glusterd_brick_proc_t *brick_proc = NULL;
     char *inet_family = NULL;
     char *global_threading = NULL;
@@ -2114,7 +2113,6 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
         goto out;
     }
 
-    errno_tmp = errno;
     /* Build the exp_path, before starting the glusterfsd even in
        valgrind mode. Otherwise all the glusterfsd processes start
        writing the valgrind log to the same file.
@@ -2272,11 +2270,9 @@ retry:
     if (wait) {
         synclock_unlock(&priv->big_lock);
         ret = runner_run(&runner);
-        if (ret)
-            ret = errno_tmp;
         synclock_lock(&priv->big_lock);
 
-        if (ret == EADDRINUSE) {
+        if (ret == -EADDRINUSE) {
             /* retry after getting a new port */
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    GD_MSG_SRC_BRICK_PORT_UNAVAIL,


### PR DESCRIPTION
The Errno set by the runner code was not correct when the bind() fails to assign an already occupied port in the __socket_server_bind().

Fix:
Updated the code to return the correct errno from the __socket_server_bind() if the bind() fails due to `EADDRINUSE` error.
And, use the returned errno from `runner_run()` to retry allocating a new port to the brick process.

Fixes: #1101 

Change-Id: If124337f41344a04f050754e402490529ef4ecdc
Signed-off-by: nik-redhat <nladha@redhat.com>

