### PR TITLE
Fix comments format, remove 'is a folder' warning

### DIFF
--- a/tests/geo-rep.rc
+++ b/tests/geo-rep.rc
@@ -1,4 +1,4 @@
-// clang-format off
+# clang-format off
 GEO_REP_TIMEOUT=120
 CHECK_MOUNT_TIMEOUT=50
 #check for mount point

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -1,4 +1,4 @@
-// clang-format off
+# clang-format off
 checkpoint_time="$(date +%s%N)"
 
 M0=${M0:=/mnt/glusterfs/0};   # 0th mount point for FUSE


### PR DESCRIPTION
// is for C and C++, shell use #. Vim syntax coloration is
misleading.

This displayed in each jenkins log:
  ./tests/00-geo-rep/../include.rc: line 1: //: is a folder

Likely no impact besides a wrong warning.

Fix #2093

