### PR TITLE
Removal of force option in snapshot create

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -4300,7 +4300,6 @@ out:
 }
 
 /* snapshot create <snapname> <vol-name(s)> [description <description>]
- *                                           [force]
  * @arg-0, dict     : Request Dictionary to be sent to server side.
  * @arg-1, words    : Contains individual words of CLI command.
  * @arg-2, wordcount: Contains number of words present in the CLI command.
@@ -4317,6 +4316,7 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
     char key[PATH_MAX] = "";
     char *snapname = NULL;
     unsigned int cmdi = 2;
+    int flags = 0;
     /* cmdi is command index, here cmdi is "2" (gluster snapshot create)*/
 
     GF_ASSERT(words);
@@ -4463,6 +4463,16 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
     ret = 0;
 
 out:
+    if (ret == 0) {
+        /*Adding force flag in either of the case i.e force set
+         * or unset*/
+        ret = dict_set_int32(dict, "flags", flags);
+        if (ret) {
+            gf_log("cli", GF_LOG_ERROR,
+                   "Could not save "
+                   "snap force option");
+        }
+    }
     return ret;
 }
 

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -4317,7 +4317,6 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
     char key[PATH_MAX] = "";
     char *snapname = NULL;
     unsigned int cmdi = 2;
-    int flags = 0;
     /* cmdi is command index, here cmdi is "2" (gluster snapshot create)*/
 
     GF_ASSERT(words);
@@ -4448,23 +4447,14 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
             goto out;
         i++;
         /* point the index to next word.
-         * As description might be follwed by force option.
-         * Before that, check if wordcount limit is reached
+         * Check if wordcount limit is reached
+         * If wordcount limit is not reached then
+         * it is invalid syntax as the command ends with description.
          */
     }
 
-    if (strcmp(words[i], "force") == 0) {
-        flags = GF_CLI_FLAG_OP_FORCE;
-
-    } else {
-        ret = -1;
-        cli_err("Invalid Syntax.");
-        gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
-        goto out;
-    }
-
-    /* Check if the command has anything after "force" keyword */
-    if (++i < wordcount) {
+    /* Check if the command has anything after the description */
+    if (i < wordcount) {
         ret = -1;
         gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
         goto out;
@@ -4473,16 +4463,6 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
     ret = 0;
 
 out:
-    if (ret == 0) {
-        /*Adding force flag in either of the case i.e force set
-         * or unset*/
-        ret = dict_set_int32(dict, "flags", flags);
-        if (ret) {
-            gf_log("cli", GF_LOG_ERROR,
-                   "Could not save "
-                   "snap force option");
-        }
-    }
     return ret;
 }
 

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -4452,13 +4452,15 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
          */
     }
 
+    /*TODO: the below force option should be completely removed after a
+            couple of releases as it is deprecated.*/
     if (strcmp(words[i], "force") == 0) {
-        ret = -1;
-        cli_err(
-            "\'force\' option is deprecated and"
-            "should not be used while creating snapshot");
-        gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
-        goto out;
+        cli_out(
+            "Warning: \'force\' option is deprecated and "
+            "should not be used in the future while "
+            "creating snapshot. Snapshot create command will "
+            "only execute if all the bricks used in creating "
+            "the snapshot are online.");
     } else {
         ret = -1;
         cli_err("Invalid Syntax.");
@@ -4466,7 +4468,7 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
         goto out;
     }
 
-    /* Check if the command has anything after the description */
+    /* Check if the command has anything after the force */
     if (++i < wordcount) {
         ret = -1;
         gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -4447,14 +4447,27 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
             goto out;
         i++;
         /* point the index to next word.
-         * Check if wordcount limit is reached
-         * If wordcount limit is not reached then
-         * it is invalid syntax as the command ends with description.
+         * As description might be follwed by force option which is deprecated.
+         * Before that, check if wordcount limit is reached
          */
     }
 
+    if (strcmp(words[i], "force") == 0) {
+        ret = -1;
+        cli_err(
+            "\'force\' option is deprecated and"
+            "should not be used while creating snapshot");
+        gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
+        goto out;
+    } else {
+        ret = -1;
+        cli_err("Invalid Syntax.");
+        gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
+        goto out;
+    }
+
     /* Check if the command has anything after the description */
-    if (i < wordcount) {
+    if (++i < wordcount) {
         ret = -1;
         gf_log("cli", GF_LOG_ERROR, "Invalid Syntax");
         goto out;

--- a/cli/src/cli-cmd-snapshot.c
+++ b/cli/src/cli-cmd-snapshot.c
@@ -71,7 +71,7 @@ struct cli_cmd snapshot_cmds[] = {
     {"snapshot help", cli_cmd_snapshot_help_cbk,
      "display help for snapshot commands"},
     {"snapshot create <snapname> <volname> [no-timestamp] "
-     "[description <description>] [force]",
+     "[description <description>]",
      cli_cmd_snapshot_cbk, "Snapshot Create."},
     {"snapshot clone <clonename> <snapname>", cli_cmd_snapshot_cbk,
      "Snapshot Clone."},

--- a/tests/bugs/snapshot/bug-1090042.t
+++ b/tests/bugs/snapshot/bug-1090042.t
@@ -20,7 +20,7 @@ TEST !  $CLI snapshot create ${V0}_snap1 $V0 no-timestamp;
 TEST !  snapshot_exists 0 ${V0}_snap1;
 
 #With changes introduced in BZ #1184344 force snap create should fail too
-TEST  ! $CLI snapshot create ${V0}_snap1 $V0 no-timestamp force;
+TEST  ! $CLI snapshot create ${V0}_snap1 $V0 no-timestamp;
 TEST  ! snapshot_exists 0 ${V0}_snap1;
 
 cleanup;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -1927,31 +1927,21 @@ glusterd_snap_create_clone_common_prevalidate(
         }
 
         if (!glusterd_is_brick_started(brickinfo)) {
-            if (!clone && (flags & GF_CLI_FLAG_OP_FORCE)) {
-                gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_BRICK_DISCONNECTED,
-                       "brick %s:%s is not started", brickinfo->hostname,
-                       brickinfo->path);
-                brick_order++;
-                brick_count++;
-                continue;
-            }
             if (!clone) {
                 snprintf(err_str, PATH_MAX,
                          "One or more bricks are not running. "
                          "Please run volume status command to see "
                          "brick status.\n"
+                         "All bricks have to be online to take a snapshot."
                          "Please start the stopped brick "
-                         "and then issue snapshot create "
-                         "command or use [force] option in "
-                         "snapshot create to override this "
-                         "behavior.");
-                gf_smsg(this->name, GF_LOG_ERROR, errno,
-                        GD_MSG_BRICK_NOT_RUNNING,
-                        "Please run volume status command to see brick "
-                        "status.Please start the stopped brick and then issue "
-                        "snapshot create command or use 'force' option in "
-                        "snapshot create to override this behavior.",
-                        NULL);
+                         "and then issue snapshot create command.");
+                gf_smsg(
+                    this->name, GF_LOG_ERROR, errno, GD_MSG_BRICK_NOT_RUNNING,
+                    "Please run volume status command to see brick "
+                    "status. All bricks have to be online to take a snapshot."
+                    "Please start the stopped brick and then issue "
+                    "snapshot create command.",
+                    NULL);
             } else {
                 snprintf(err_str, PATH_MAX,
                          "One or more bricks are not running. "


### PR DESCRIPTION
The force option does fails for snapshot create
command even though the quorum is satisfied and is redundant.
The changes removes the force option for snapshot create command
and checks if all bricks are online instead of checking for quorum
for creating a snapshot.

Fixes: #2099
Change-Id: I45d866e67052fef982a60aebe8dec069e78015bd
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>

