### PR TITLE
cluster/afr: Change default self-heal-window-size to 1MB

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -350,6 +350,12 @@ afr_selfheal_data_do(call_frame_t *frame, xlator_t *this, fd_t *fd, int source,
     }
 
     block = 128 * 1024 * priv->data_self_heal_window_size;
+    if (HAS_HOLES((&replies[source].poststat))) {
+        /*Reduce the possibility of data-block allocations in case of files
+         * with holes. Correct way to fix it would be to use seek fop while
+         * healing data*/
+        block = 128 * 1024;
+    }
 
     type = afr_data_self_heal_type_get(priv, healed_sinks, source, replies);
 

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -946,12 +946,12 @@ struct volume_options options[] = {
      .type = GF_OPTION_TYPE_INT,
      .min = 1,
      .max = 1024,
-     .default_value = "1",
+     .default_value = "8",
      .op_version = {1},
      .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
      .tags = {"replicate"},
-     .description = "Maximum number blocks per file for which self-heal "
-                    "process would be applied simultaneously."},
+     .description = "Maximum number of 128KB blocks per file for which "
+                    "self-heal process would be applied simultaneously."},
     {.key = {"metadata-self-heal"},
      .type = GF_OPTION_TYPE_BOOL,
      .default_value = "off",


### PR DESCRIPTION
At the moment self-heal-window-size is 128KB. This leads to healing data
in 128KB chunks. With the growth of data and the avg file sizes
nowadays, 1MB seems like a better default.

Change-Id: I70c42c83b16c7adb53d6b5762969e878477efb5c
Fixes: #2067
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

