### PR TITLE
Stirng not null terminated

### DIFF
--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -10,11 +10,11 @@
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/param.h> /* for PATH_MAX */
+#include <unistd.h>
 
 /* NOTE (USE_LIBGLUSTERFS):
  * ------------------------
@@ -24,14 +24,14 @@
  * We unconditionally pass then while building gsyncd binary.
  */
 #ifdef USE_LIBGLUSTERFS
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/globals.h>
 #include <glusterfs/defaults.h>
+#include <glusterfs/globals.h>
+#include <glusterfs/glusterfs.h>
 #endif
 
+#include "procdiggy.h"
 #include <glusterfs/common-utils.h>
 #include <glusterfs/run.h>
-#include "procdiggy.h"
 
 #define _GLUSTERD_CALLED_ "_GLUSTERD_CALLED_"
 #define _GSYNCD_DISPATCHED_ "_GSYNCD_DISPATCHED_"
@@ -246,6 +246,9 @@ invoke_rsync(int argc, char **argv)
     ret = sys_readlink(path, buf, sizeof(buf));
     if (ret == -1 || ret == sizeof(buf))
         goto error;
+
+    buf[ret] = '\0';
+
     if (strcmp(argv[argc - 1], "/") == 0 /* root dir cannot be a target */ ||
         (strcmp(argv[argc - 1], path) /* match against gluster target */ &&
          strcmp(argv[argc - 1], buf) /* match against file target */) != 0) {

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -187,7 +187,9 @@ sys_readdir(DIR *dir, struct dirent *de)
 ssize_t
 sys_readlink(const char *path, char *buf, size_t bufsiz)
 {
-    return FS_RET_CHECK(readlink(path, buf, bufsiz), errno);
+    int sz = readlink(path, buf, bufsiz);
+    buf[sz] = '\0';
+    return FS_RET_CHECK(sz, errno);
 }
 
 int
@@ -362,7 +364,9 @@ sys_writev(int fd, const struct iovec *iov, int iovcnt)
 ssize_t
 sys_read(int fd, void *buf, size_t count)
 {
-    return FS_RET_CHECK(read(fd, buf, count), errno);
+    int sz = read(fd, buf, count);
+    buf[sz] = '\0';
+    return FS_RET_CHECK(sz, errno);
 }
 
 ssize_t

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -187,9 +187,7 @@ sys_readdir(DIR *dir, struct dirent *de)
 ssize_t
 sys_readlink(const char *path, char *buf, size_t bufsiz)
 {
-    int sz = readlink(path, buf, bufsiz);
-    buf[sz] = '\0';
-    return FS_RET_CHECK(sz, errno);
+    return FS_RET_CHECK(readlink(path, buf, bufsiz), errno);
 }
 
 int

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -364,9 +364,7 @@ sys_writev(int fd, const struct iovec *iov, int iovcnt)
 ssize_t
 sys_read(int fd, void *buf, size_t count)
 {
-    int sz = read(fd, buf, count);
-    buf[sz] = '\0';
-    return FS_RET_CHECK(sz, errno);
+    return FS_RET_CHECK(read(fd, buf, count), errno);
 }
 
 ssize_t


### PR DESCRIPTION
CID: 1214629,1274235,1430115,1437648

Null character is added at the end of buffer which corrects the
issue.

Change-Id: I8f7016520ffd41b2c68fe3c7f053e0e04f306c84
Updates: #1060
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>

