### PR TITLE
cluster/dht: Allow fix-layout only on directories (#2109)

### DIFF
--- a/tests/bugs/distribute/disallow-fixlayout-on-files.t
+++ b/tests/bugs/distribute/disallow-fixlayout-on-files.t
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume info
+
+#Create a distributed volume
+TEST $CLI volume create $V0 $H0:$B0/${V0}1;
+TEST $CLI volume set $V0 cluster.lookup-optimize off
+TEST $CLI volume start $V0
+
+# Mount FUSE
+TEST glusterfs -s $H0 --volfile-id $V0 $M0
+
+#Create files
+TEST mkdir $M0/foo
+TEST touch $M0/foo/a
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+TEST $CLI volume add-brick $V0 $H0:$B0/${V0}2
+
+TEST glusterfs -s $H0 --volfile-id $V0 $M0
+TEST setfattr -n distribute.fix.layout -v "yes" $M0
+TEST setfattr -n distribute.fix.layout -v "yes" $M0/foo
+TEST ! setfattr -n distribute.fix.layout -v "yes" $M0/foo/a
+TEST ls $M0 #Test that the mount didn't crash
+
+cleanup;

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -5907,6 +5907,10 @@ dht_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr,
 
     tmp = dict_get(xattr, GF_XATTR_FIX_LAYOUT_KEY);
     if (tmp) {
+        if (!IA_ISDIR(loc->inode->ia_type)) {
+            op_errno = ENOTSUP;
+            goto err;
+        }
         ret = dict_get_uint32(xattr, "new-commit-hash", &new_hash);
         if (ret == 0) {
             gf_msg_debug(this->name, 0,


### PR DESCRIPTION
Problem:
fix-layout operation assumes that the path passed is directory i.e.
layout->cnt == conf->subvolume_cnt. This will lead to a crash when
fix-layout is attempted on a file.

Fix:
Disallow fix-layout on files

fixes: #2107
Change-Id: I2116b8773059f67e3260e9207e20eab3de711417
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

