### PR TITLE
change to an option for time checking storage.reserve

### DIFF
--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -123,6 +123,7 @@
 #define GD_OP_VERSION_8_0 80000 /* Op-version for GlusterFS 8.0 */
 
 #define GD_OP_VERSION_9_0 90000 /* Op-version for GlusterFS 9.0 */
+#define GD_OP_VERSION_9_1 90100 /* Op-version for GlusterFS 9.1 */
 
 #define GD_OP_VERSION_10_0 100000 /* Op-version for GlusterFS 10.0 */
 

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -754,6 +754,7 @@ struct _glusterfs_ctx {
     struct list_head diskth_xl;
     pthread_mutex_t xl_lock;
     pthread_cond_t xl_cond;
+    /* add disk reserve internal for check thread*/
     pthread_t disk_space_check;
     uint32_t disk_reserve_check_interval;
     gf_boolean_t cleanup_starting;

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -755,7 +755,7 @@ struct _glusterfs_ctx {
     pthread_mutex_t xl_lock;
     pthread_cond_t xl_cond;
     pthread_t disk_space_check;
-
+    uint32_t disk_reserve_check_interval;
     gf_boolean_t cleanup_starting;
     gf_boolean_t destroy_ctx;
     char volume_id[GF_UUID_BUF_SIZE]; /* Used only in protocol/client */

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -2387,6 +2387,11 @@ struct volopt_map_entry glusterd_volopt_map[] = {
         .op_version = GD_OP_VERSION_3_13_0,
     },
     {
+        .key = "storage.reserve-check-interval",
+        .voltype = "storage/posix",
+        .op_version = GD_OP_VERSION_4_0_0,
+    },
+    {
         .option = "health-check-timeout",
         .key = "storage.health-check-timeout",
         .type = NO_DOC,

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -2389,7 +2389,7 @@ struct volopt_map_entry glusterd_volopt_map[] = {
     {
         .key = "storage.reserve-check-interval",
         .voltype = "storage/posix",
-        .op_version = GD_OP_VERSION_4_0_0,
+        .op_version = GD_OP_VERSION_9_1,
     },
     {
         .option = "health-check-timeout",

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -884,7 +884,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
         .validate_fn = validate_defrag_throttle_option,
         .flags = VOLOPT_FLAG_CLIENT_OPT,
     },
-
     {
         .key = "cluster.lock-migration",
         .voltype = "cluster/distribute",
@@ -894,7 +893,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
         .validate_fn = validate_lock_migration_option,
         .flags = VOLOPT_FLAG_CLIENT_OPT,
     },
-
     {
         .key = "cluster.force-migration",
         .voltype = "cluster/distribute",
@@ -1777,9 +1775,7 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .value = "on",
      .op_version = 2,
      .description = "enable/disable open-behind translator in the volume.",
-     .flags = VOLOPT_FLAG_CLIENT_OPT | VOLOPT_FLAG_XLATOR_OPT
-
-    },
+     .flags = VOLOPT_FLAG_CLIENT_OPT | VOLOPT_FLAG_XLATOR_OPT},
     {.key = "performance.quick-read",
      .voltype = "performance/quick-read",
      .option = "!perf",
@@ -1864,7 +1860,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .option = "cache-invalidation",
      .op_version = GD_OP_VERSION_3_9_0,
      .flags = VOLOPT_FLAG_CLIENT_OPT},
-
     {.key = "performance.global-cache-invalidation",
      .voltype = "performance/md-cache",
      .option = "global-cache-invalidation",
@@ -1880,7 +1875,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .validate_fn = validate_uss,
      .description = "enable/disable User Serviceable Snapshots on the "
                     "volume."},
-
     {.key = "features.snapshot-directory",
      .voltype = "features/snapview-client",
      .op_version = GD_OP_VERSION_3_6_0,
@@ -1890,7 +1884,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .description = "Entry point directory for entering snapshot world. "
                     "Value can have only [0-9a-z-_] and starts with "
                     "dot (.) and cannot exceed 255 character"},
-
     {.key = "features.show-snapshot-directory",
      .voltype = "features/snapview-client",
      .op_version = GD_OP_VERSION_3_6_0,
@@ -1898,7 +1891,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .flags = VOLOPT_FLAG_CLIENT_OPT | VOLOPT_FLAG_XLATOR_OPT,
      .description = "show entry point in readdir output of "
                     "snapdir-entry-path which is set by samba"},
-
     {.key = "features.tag-namespaces",
      .voltype = "features/namespace",
      .op_version = GD_OP_VERSION_4_1_0,
@@ -3102,7 +3094,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
                        "access-control xlator in volume",
         .type = NO_DOC,
     },
-
     {.key = "cluster.use-anonymous-inode",
      .voltype = "cluster/replicate",
      .op_version = GD_OP_VERSION_9_0,

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -418,6 +418,9 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     old_disk_reserve = priv->disk_reserve;
     GF_OPTION_RECONF("reserve", priv->disk_reserve, options, percent_or_size,
                      out);
+    // reload  config  to reserve check  for check thread
+    GF_OPTION_RECONF("reserve-check-interval", priv->disk_reserve_check_interval, options, uint32,
+                     out);
     /* option can be any one of percent or bytes */
     priv->disk_unit = 0;
     if (priv->disk_reserve < 100.0)
@@ -1120,7 +1123,8 @@ posix_init(xlator_t *this)
     _private->disk_space_full = 0;
 
     GF_OPTION_INIT("reserve", _private->disk_reserve, percent_or_size, out);
-
+    // add disk reserve internal seconds for reserve check
+    GF_OPTION_INIT("reserve-check-interval", _private->disk_reserve_check_interval, uint32, out);
     /* option can be any one of percent or bytes */
     _private->disk_unit = 0;
     pthread_cond_init(&_private->fd_cond, NULL);
@@ -1448,6 +1452,14 @@ struct volume_options posix_options[] = {
      .description = "Percentage/Size of disk space to be reserved."
                     " Set to 0 to disable",
      .op_version = {GD_OP_VERSION_3_13_0},
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
+    {.key = {"reserve-check-interval"},
+     .type = GF_OPTION_TYPE_INT,
+     .min = 1,
+     .default_value = "5",
+     .validate = GF_OPT_VALIDATE_MIN,
+     .description =  "Interval in second to check disk reserve",
+     .op_version = {GD_OP_VERSION_4_0_0},
      .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
     {.key = {"batch-fsync-mode"},
      .type = GF_OPTION_TYPE_STR,

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -342,9 +342,9 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     int32_t create_mask = -1;
     int32_t create_directory_mask = -1;
     double old_disk_reserve = 0.0;
-
+    glusterfs_ctx_t *ctx = NULL;
     priv = this->private;
-
+    ctx = this->ctx;
     GF_OPTION_RECONF("brick-uid", uid, options, int32, out);
     GF_OPTION_RECONF("brick-gid", gid, options, int32, out);
     if (uid != -1 || gid != -1)
@@ -418,8 +418,8 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     old_disk_reserve = priv->disk_reserve;
     GF_OPTION_RECONF("reserve", priv->disk_reserve, options, percent_or_size,
                      out);
-    GF_OPTION_RECONF("reserve-check-interval", priv->disk_reserve_check_interval, options, uint32,
-                     out);
+    GF_OPTION_RECONF("reserve-check-interval", ctx->disk_reserve_check_interval,
+                     options, uint32, out);
     /* option can be any one of percent or bytes */
     priv->disk_unit = 0;
     if (priv->disk_reserve < 100.0)
@@ -674,7 +674,7 @@ posix_init(xlator_t *this)
     };
     int hdirfd = -1;
     char value;
-
+    glusterfs_ctx_t *ctx = this->ctx;
     dir_data = dict_get(this->options, "directory");
 
     if (this->children) {
@@ -1122,7 +1122,8 @@ posix_init(xlator_t *this)
     _private->disk_space_full = 0;
 
     GF_OPTION_INIT("reserve", _private->disk_reserve, percent_or_size, out);
-    GF_OPTION_INIT("reserve-check-interval", _private->disk_reserve_check_interval, uint32, out);
+    GF_OPTION_INIT("reserve-check-interval", ctx->disk_reserve_check_interval,
+                   uint32, out);
     /* option can be any one of percent or bytes */
     _private->disk_unit = 0;
     pthread_cond_init(&_private->fd_cond, NULL);
@@ -1456,7 +1457,7 @@ struct volume_options posix_options[] = {
      .min = 1,
      .default_value = "5",
      .validate = GF_OPT_VALIDATE_MIN,
-     .description =  "Interval in second to check disk reserve",
+     .description = "Interval in second to check disk reserve",
      .op_version = {GD_OP_VERSION_9_1},
      .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
     {.key = {"batch-fsync-mode"},

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -418,7 +418,6 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     old_disk_reserve = priv->disk_reserve;
     GF_OPTION_RECONF("reserve", priv->disk_reserve, options, percent_or_size,
                      out);
-    // reload  config  to reserve check  for check thread
     GF_OPTION_RECONF("reserve-check-interval", priv->disk_reserve_check_interval, options, uint32,
                      out);
     /* option can be any one of percent or bytes */
@@ -1123,7 +1122,6 @@ posix_init(xlator_t *this)
     _private->disk_space_full = 0;
 
     GF_OPTION_INIT("reserve", _private->disk_reserve, percent_or_size, out);
-    // add disk reserve internal seconds for reserve check
     GF_OPTION_INIT("reserve-check-interval", _private->disk_reserve_check_interval, uint32, out);
     /* option can be any one of percent or bytes */
     _private->disk_unit = 0;
@@ -1459,7 +1457,7 @@ struct volume_options posix_options[] = {
      .default_value = "5",
      .validate = GF_OPT_VALIDATE_MIN,
      .description =  "Interval in second to check disk reserve",
-     .op_version = {GD_OP_VERSION_4_0_0},
+     .op_version = {GD_OP_VERSION_9_1},
      .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
     {.key = {"batch-fsync-mode"},
      .type = GF_OPTION_TYPE_STR,

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2355,13 +2355,16 @@ posix_ctx_disk_thread_proc(void *data)
     glusterfs_ctx_t *ctx = NULL;
     uint32_t interval = 0;
     struct posix_diskxl *pthis = NULL;
-    xlator_t *this = NULL;
+    xlator_t *this = data;
     struct timespec sleep_till = {
         0,
     };
-
-    ctx = data;
-
+    priv = this->private;
+    ctx = this->ctx;
+    gf_msg_debug("glusterfs_ctx", 0,
+                 "Ctx disk-space thread started, "
+                 "interval = %d seconds",
+                 priv->disk_reserve_check_interval);
     pthread_mutex_lock(&ctx->xl_lock);
     {
         while (ctx->diskxl_count > 0) {
@@ -2372,7 +2375,7 @@ posix_ctx_disk_thread_proc(void *data)
 
                 THIS = this = pthis->xl;
                 priv = this->private;
-
+                
                 posix_disk_space_check(priv);
 
                 pthread_mutex_lock(&ctx->xl_lock);
@@ -2415,7 +2418,7 @@ posix_spawn_disk_space_check_thread(xlator_t *this)
     {
         if (ctx->diskxl_count++ == 0) {
             ret = gf_thread_create(&ctx->disk_space_check, NULL,
-                                   posix_ctx_disk_thread_proc, ctx,
+                                   posix_ctx_disk_thread_proc, this,
                                    "posixctxres");
 
             if (ret) {

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2361,12 +2361,6 @@ posix_ctx_disk_thread_proc(void *data)
     };
 
     ctx = data;
-    interval = 5;
-
-    gf_msg_debug("glusterfs_ctx", 0,
-                 "Ctx disk-space thread started, "
-                 "interval = %d seconds",
-                 interval);
 
     pthread_mutex_lock(&ctx->xl_lock);
     {
@@ -2389,7 +2383,7 @@ posix_ctx_disk_thread_proc(void *data)
             }
 
             timespec_now_realtime(&sleep_till);
-            sleep_till.tv_sec += 5;
+            sleep_till.tv_sec += priv->disk_reserve_check_interval;
             (void)pthread_cond_timedwait(&ctx->xl_cond, &ctx->xl_lock,
                                          &sleep_till);
         }

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -202,8 +202,6 @@ struct posix_private {
     pthread_t health_check;
 
     double disk_reserve;
-    /* seconds for check disk reversion  */
-    uint32_t disk_reserve_check_interval;
     pthread_t disk_space_check;
     uint32_t disk_space_full;
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -202,6 +202,8 @@ struct posix_private {
     pthread_t health_check;
 
     double disk_reserve;
+    /* seconds for check disk reversion  */
+    uint32_t disk_reserve_check_interval;
     pthread_t disk_space_check;
     uint32_t disk_space_full;
 


### PR DESCRIPTION
storage/posix: change to an option for time checking storage.reserve (#2120)

Change-Id: 66e34de17b1e6e308a5b648fc2232f543047b40d
Fixes: #2120
Signed-off-by: perrynzhou <perrynzhou@gmail.com>

code detail:
- https://github.com/gluster/glusterfs/commit/4c13280c813694f9eb1ad2cb1d864098ea01a006
- https://github.com/gluster/glusterfs/commit/573d133f463dd8dde5c6fad98fa91b827682c348

