### PR TITLE
stack.h/c: remove unused variable and reorder struct

### DIFF
--- a/libglusterfs/src/stack.c
+++ b/libglusterfs/src/stack.c
@@ -127,7 +127,6 @@ gf_proc_dump_call_frame(call_frame_t *call_frame, const char *key_buf, ...)
     }
 
     gf_proc_dump_write("frame", "%p", call_frame);
-    gf_proc_dump_write("ref_count", "%d", my_frame.ref_count);
     gf_proc_dump_write("translator", "%s", my_frame.this->name);
     gf_proc_dump_write("complete", "%d", my_frame.complete);
 
@@ -270,11 +269,6 @@ gf_proc_dump_call_frame_to_dict(call_frame_t *call_frame, char *prefix,
         return;
     memcpy(&tmp_frame, call_frame, sizeof(tmp_frame));
     UNLOCK(&call_frame->lock);
-
-    snprintf(key, sizeof(key), "%s.refcount", prefix);
-    ret = dict_set_int32(dict, key, tmp_frame.ref_count);
-    if (ret)
-        return;
 
     snprintf(key, sizeof(key), "%s.translator", prefix);
     ret = dict_set_dynstr(dict, key, gf_strdup(tmp_frame.this->name));

--- a/xlators/meta/src/frames-file.c
+++ b/xlators/meta/src/frames-file.c
@@ -50,8 +50,6 @@ frames_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
                     strprintf(strfd, "\t\t\t\"Creation_time\": %d.%09d,\n",
                               (int)frame->begin.tv_sec,
                               (int)frame->begin.tv_nsec);
-                strprintf(strfd, " \t\t\t\"Refcount\": %d,\n",
-                          frame->ref_count);
                 if (frame->parent)
                     strprintf(strfd, "\t\t\t\"Parent\": \"%s\",\n",
                               frame->parent->this->name);


### PR DESCRIPTION
- Removed unused ref_count variable
- Reordered the struct to get related variables closer together.
- Changed 'complete' from a '_Bool' to a 'int32_t'

Before:
```
struct _call_frame {
        call_stack_t *             root;                 /*     0     8 */
        call_frame_t *             parent;               /*     8     8 */
        struct list_head           frames;               /*    16    16 */
        void *                     local;                /*    32     8 */
        xlator_t *                 this;                 /*    40     8 */
        ret_fn_t                   ret;                  /*    48     8 */
        int32_t                    ref_count;            /*    56     4 */

        /* XXX 4 bytes hole, try to pack */

        /* --- cacheline 1 boundary (64 bytes) --- */
        gf_lock_t                  lock;                 /*    64    40 */
        void *                     cookie;               /*   104     8 */
        _Bool                      complete;             /*   112     1 */

        /* XXX 3 bytes hole, try to pack */

        glusterfs_fop_t            op;                   /*   116     4 */
        struct timespec            begin;                /*   120    16 */
        /* --- cacheline 2 boundary (128 bytes) was 8 bytes ago --- */
        struct timespec            end;                  /*   136    16 */
        const char  *              wind_from;            /*   152     8 */
        const char  *              wind_to;              /*   160     8 */
        const char  *              unwind_from;          /*   168     8 */
        const char  *              unwind_to;            /*   176     8 */

        /* size: 184, cachelines: 3, members: 17 */
        /* sum members: 177, holes: 2, sum holes: 7 */
        /* last cacheline: 56 bytes */
```

After:
```
struct _call_frame {
        call_stack_t *             root;                 /*     0     8 */
        call_frame_t *             parent;               /*     8     8 */
        struct list_head           frames;               /*    16    16 */
        struct timespec            begin;                /*    32    16 */
        struct timespec            end;                  /*    48    16 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        void *                     local;                /*    64     8 */
        gf_lock_t                  lock;                 /*    72    40 */
        void *                     cookie;               /*   112     8 */
        xlator_t *                 this;                 /*   120     8 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        ret_fn_t                   ret;                  /*   128     8 */
        glusterfs_fop_t            op;                   /*   136     4 */
        int32_t                    complete;             /*   140     4 */
        const char  *              wind_from;            /*   144     8 */
        const char  *              wind_to;              /*   152     8 */
        const char  *              unwind_from;          /*   160     8 */
        const char  *              unwind_to;            /*   168     8 */

        /* size: 176, cachelines: 3, members: 16 */
        /* last cacheline: 48 bytes */
```

Fixes: #2130
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

