### PR TITLE
list.h: remove offensive language, introduce _list_del()

### DIFF
--- a/libglusterfs/src/glusterfs/list.h
+++ b/libglusterfs/src/glusterfs/list.h
@@ -78,13 +78,16 @@ _list_del(struct list_head *old)
     old->prev->next = old->next;
 }
 
+#define LIST_POISON1 ((void *)0xdead000000000100)
+#define LIST_POISON2 ((void *)0xdead000000000122)
+
 static inline void
 list_del(struct list_head *old)
 {
     _list_del(old);
 
-    old->next = (void *)0x00100100;
-    old->prev = (void *)0x00200200;
+    old->next = (struct list_head *)LIST_POISON1;
+    old->prev = (struct list_head *)LIST_POISON2;
 }
 
 static inline void

--- a/libglusterfs/src/glusterfs/list.h
+++ b/libglusterfs/src/glusterfs/list.h
@@ -66,21 +66,31 @@ list_add_order(struct list_head *new, struct list_head *head,
     list_add(new, pos);
 }
 
+/* Delete a list entry by making the prev/next entries
+   point to each other.
+
+   This is only for internal list manipulation where we know
+   the prev/next entries already! */
+static inline void
+_list_del(struct list_head *old)
+{
+    old->next->prev = old->prev;
+    old->prev->next = old->next;
+}
+
 static inline void
 list_del(struct list_head *old)
 {
-    old->prev->next = old->next;
-    old->next->prev = old->prev;
+    _list_del(old);
 
-    old->next = (void *)0xbabebabe;
-    old->prev = (void *)0xcafecafe;
+    old->next = (void *)0x00100100;
+    old->prev = (void *)0x00200200;
 }
 
 static inline void
 list_del_init(struct list_head *old)
 {
-    old->prev->next = old->next;
-    old->next->prev = old->prev;
+    _list_del(old);
 
     old->next = old;
     old->prev = old;
@@ -89,14 +99,14 @@ list_del_init(struct list_head *old)
 static inline void
 list_move(struct list_head *list, struct list_head *head)
 {
-    list_del(list);
+    _list_del(list);
     list_add(list, head);
 }
 
 static inline void
 list_move_tail(struct list_head *list, struct list_head *head)
 {
-    list_del(list);
+    _list_del(list);
     list_add_tail(list, head);
 }
 


### PR DESCRIPTION
1. Replace offensive variables with the values the Linux kernel uses.
2. Introduce an internal function - _list_del() that can be used
when list->next and list->prev are going to be assigned later on.

(too bad in the code we do not have enough uses of list_move() and
list_move_tail(), btw. Would have contributed also to code readability)

Fixes: #2025
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

