### PR TITLE
tests: Handle nanosecond duration in profile info

### DIFF
--- a/tests/bugs/glusterfs/bug-895235.t
+++ b/tests/bugs/glusterfs/bug-895235.t
@@ -16,7 +16,7 @@ TEST glusterfs --entry-timeout=0 --attribute-timeout=0 -s $H0 --volfile-id=$V0 $
 
 TEST gluster volume profile $V0 start
 TEST dd of=$M0/a if=/dev/zero bs=1024k count=1 oflag=append
-finodelk_max_latency=$($CLI volume profile $V0 info | grep FINODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+finodelk_max_latency=$($CLI volume profile $V0 info | grep FINODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 
 TEST [ -z $finodelk_max_latency ]
 

--- a/tests/bugs/replicate/bug-1297695.t
+++ b/tests/bugs/replicate/bug-1297695.t
@@ -38,6 +38,6 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 write_to_file &
 #Test if the MAX [F]INODELK fop latency is of the order of seconds.
 EXPECT "^1$" get_pending_heal_count $V0
-inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 TEST [ -z $inodelk_max_latency ]
 cleanup

--- a/tests/bugs/replicate/bug-888174.t
+++ b/tests/bugs/replicate/bug-888174.t
@@ -32,7 +32,7 @@ do
         echo hi > $M0/a
 done
 #Test if the MAX INODELK fop latency is of the order of seconds.
-inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+inodelk_max_latency=$($CLI volume profile $V0 info | grep INODELK | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 
 TEST [ -z $inodelk_max_latency ]
 

--- a/tests/features/delay-gen.t
+++ b/tests/features/delay-gen.t
@@ -28,10 +28,10 @@ TEST $GFS -s $H0 --volfile-id $V0 $M0
 TEST dd if=/dev/zero of=$M0/1 count=1 bs=128k oflag=sync
 
 #Write should take at least a second
-write_max_latency=$($CLI volume profile $V0 info | grep WRITE | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+write_max_latency=$($CLI volume profile $V0 info | grep WRITE | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 
 #Create should not take a second
-create_max_latency=$($CLI volume profile $V0 info | grep CREATE | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{7,}")
+create_max_latency=$($CLI volume profile $V0 info | grep CREATE | awk 'BEGIN {max = 0} {if ($6 > max) max=$6;} END {print max}' | cut -d. -f 1 | egrep "[0-9]{10,}")
 
 TEST [ ! -z $write_max_latency ];
 TEST [ -z $create_max_latency ];


### PR DESCRIPTION
Problem:
volume profile info now prints duration in nano seconds. Tests were
written when the duration was printed in micro seconds. This leads to
spurious failures.

Fix:
Change tests to handle nano second durations

fixes: #2134
Change-Id: I94722be87000a485d98c8b0f6d8b7e1a526b07e7
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

