### PR TITLE
CID: 1422183 Unused ret value

### DIFF
--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1685,9 +1685,7 @@ mq_initiate_quota_task(void *opaque)
             goto out;
         }
 
-        if (prev_dirty == 0) {
-            ret = mq_mark_dirty(this, &parent_loc, 0);
-        } else {
+        if (prev_dirty != 0) {
             ret = mq_inode_ctx_get(parent_loc.inode, this, &parent_ctx);
             if (ret == 0)
                 mq_set_ctx_dirty_status(parent_ctx, _gf_false);


### PR DESCRIPTION
**CID: 1422183**
Unused `ret` value: `ret` is overwritten before getting used.
Change: Removed the equals 0 condition and only updating the ret value if != 0.

Change-Id: I30edca3c9f591f4f953298745ec99c9e0f718e83
Updates: #1060
Signed-off-by: aujjwal-redhat <aujjwal@redhat.com>

