### PR TITLE
gfapi: avoid crash while logging message.

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1538,7 +1538,7 @@ glfs_pwritev_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
         ret = -1;
         errno = EINVAL;
         gf_smsg(THIS->name, GF_LOG_ERROR, errno, API_MSG_INVALID_ARG,
-                "size >= %llu is not allowed", GF_UNIT_GB, NULL);
+                "Data size too large", "size = %llu", GF_UNIT_GB, NULL);
         goto out;
     }
 


### PR DESCRIPTION
Breaking parameter into two different parameter
to avoid a crash.

fixes: #2138

Change-Id: Idd5f3631488c1d892748f83e6847fb6fd2d0802a
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

