### PR TITLE
runner: moving to posix_spawnp instead of fork (#1644)

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -5145,7 +5145,8 @@ gf_fop_int(char *fop)
 }
 
 int
-close_fds_except(int *fdv, size_t count)
+close_fds_except_custom(int *fdv, size_t count, void *prm,
+                        void closer(int fd, void *prm))
 {
     int i = 0;
     size_t j = 0;
@@ -5182,7 +5183,7 @@ close_fds_except(int *fdv, size_t count)
             }
         }
         if (should_close)
-            sys_close(i);
+            closer(i, prm);
     }
     sys_closedir(d);
 #else  /* !GF_LINUX_HOST_OS */
@@ -5202,10 +5203,22 @@ close_fds_except(int *fdv, size_t count)
             }
         }
         if (should_close)
-            sys_close(i);
+            closer(i, prm);
     }
 #endif /* !GF_LINUX_HOST_OS */
     return 0;
+}
+
+static void
+closer_close(int fd, void *prm)
+{
+    sys_close(fd);
+}
+
+int
+close_fds_except(int *fdv, size_t count)
+{
+    return close_fds_except_custom(fdv, count, NULL, closer_close);
 }
 
 /**

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1139,6 +1139,10 @@ char *
 get_ip_from_addrinfo(struct addrinfo *addr, char **ip);
 
 int
+close_fds_except_custom(int *fdv, size_t count, void *prm,
+                        void closer(int fd, void *prm));
+
+int
 close_fds_except(int *fdv, size_t count);
 
 int


### PR DESCRIPTION
Removed the fork(), and implemented the
posix_spwanp() accordingly, as it provides much better
performance than fork(). More detailed description about
the benefits can be found in the description of the issue
linked below.

Updates:#810

This PR is a backport of #1644 in the devel branch.

Change-Id: I921490dcc5859e509bfe1a1d43ba3d76b54ac820
Signed-off-by: nik-redhat <nladha@redhat.com>

