### PR TITLE
runner: moving to posix_spawnp instead of fork (#1644)

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1188,6 +1188,10 @@ char *
 get_ip_from_addrinfo(struct addrinfo *addr, char **ip);
 
 int
+close_fds_except_custom(int *fdv, size_t count, void *prm,
+                        void closer(int fd, void *prm));
+
+int
 close_fds_except(int *fdv, size_t count);
 
 int


### PR DESCRIPTION
Removed the fork(), and implemented the
posix_spwanp() acccrodingly, as it provides much better
performance than fork(). More detailed description about
the benefits can be found in the description of the issue
linked below.

Updates:#810

This PR is a backport of #1644 in the devel branch.

Change-Id: I21fefc1ea2f6a3fa2e5316bec4f3467a1678d7ac
Signed-off-by: nik-redhat <nladha@redhat.com>

