### PR TITLE
BUGFIX Systemd-Unit - GlusterFS start before network is started

### DIFF
--- a/extras/systemd/glusterd.service.in
+++ b/extras/systemd/glusterd.service.in
@@ -4,8 +4,7 @@ Documentation=man:glusterd(8)
 StartLimitBurst=6
 StartLimitIntervalSec=3600
 Requires=@RPCBIND_SERVICE@
-After=network.target @RPCBIND_SERVICE@
-Before=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Problem:
glusterd is starting before network is started leading to connection issues.

Fix:
systemd-unit in centos8 to start glusterd after network is started.

fixes: #2152

