### PR TITLE
posix: fix chmod error on symlinks

### DIFF
--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -123,6 +123,9 @@ int
 sys_fchmod(int fd, mode_t mode);
 
 int
+sys_lchmod(const char *path, mode_t mode);
+
+int
 sys_chown(const char *path, uid_t owner, gid_t group);
 
 int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1045,6 +1045,7 @@ sys_fstatat
 sys_fsync
 sys_ftruncate
 sys_futimes
+sys_lchmod
 sys_lchown
 sys_lgetxattr
 sys_link

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -286,6 +286,12 @@ sys_fchmod(int fd, mode_t mode)
 }
 
 int
+sys_lchmod(const char *path, mode_t mode)
+{
+    return FS_RET_CHECK0(lchmod(path, mode), errno);
+}
+
+int
 sys_chown(const char *path, uid_t owner, gid_t group)
 {
     return FS_RET_CHECK0(chown(path, owner, group), errno);


### PR DESCRIPTION
After glibc 2.32, lchmod() is returning EOPNOTSUPP instead of ENOSYS when
called on symlinks. The man page says that the returned code is ENOTSUP.
They are the same in linux, but this patch correctly handles all errors.

Fixes: #2154
Change-Id: Ib3bb3d86d421cba3d7ec8d66b6beb131ef6e0925
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

