### PR TITLE
cluster/afr: Fix race in lockinfo (f)getxattr

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -1011,11 +1011,13 @@ afr_getxattr_lockinfo_cbk_common(call_frame_t *frame, int32_t op_ret,
                              newdict, local->xdata_rsp);
         }
 
-        dict_unref(newdict);
+        if (newdict != NULL) {
+            dict_unref(newdict);
+        }
     }
 }
 
-int32_t
+static int32_t
 afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                           int32_t op_ret, int32_t op_errno, dict_t *dict,
                           dict_t *xdata)
@@ -1026,7 +1028,7 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int32_t
+static int32_t
 afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            int32_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -915,7 +915,6 @@ afr_update_local_dicts(call_frame_t *frame, dict_t *dict, dict_t *xdata)
         UNLOCK(&frame->lock);
     }
 
-
     if (dict != NULL) {
         if (dict_copy(dict, local->dict) < 0) {
             goto done;

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -15,6 +15,8 @@
 #include <stdlib.h>
 #include <signal.h>
 
+#include <urcu/uatomic.h>
+
 #include <glusterfs/glusterfs.h>
 #include "afr.h"
 #include <glusterfs/dict.h>
@@ -866,79 +868,117 @@ afr_getxattr_quota_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int32_t
-afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *dict,
-                          dict_t *xdata)
+static int32_t
+afr_update_local_dicts(call_frame_t *frame, dict_t *dict, dict_t *xdata)
 {
-    int call_cnt = 0, len = 0;
+    afr_local_t *local;
+    dict_t *local_dict;
+    dict_t *local_xdata;
+    int32_t ret;
+
+    local = frame->local;
+    local_dict = NULL;
+    local_xdata = NULL;
+
+    ret = -ENOMEM;
+
+    if ((dict != NULL) && (local->dict == NULL)) {
+        local_dict = dict_new();
+        if (local_dict == NULL) {
+            goto done;
+        }
+    }
+
+    if ((xdata != NULL) && (local->xdata_rsp == NULL)) {
+        local_xdata = dict_new();
+        if (local_xdata == NULL) {
+            goto done;
+        }
+    }
+
+    if ((local_dict != NULL) || (local_xdata != NULL)) {
+        /* TODO: Maybe it would be better to preallocate both dicts before
+         *       sending the requests. This way we don't need to use a LOCK()
+         *       here. */
+        LOCK(&frame->lock);
+
+        if ((local_dict != NULL) && (local->dict == NULL)) {
+            local->dict = local_dict;
+            local_dict = NULL;
+        }
+
+        if ((local_xdata != NULL) && (local->xdata_rsp == NULL)) {
+            local->xdata_rsp = local_xdata;
+            local_xdata = NULL;
+        }
+
+        UNLOCK(&frame->lock);
+
+        if (dict != NULL) {
+            if (dict_copy(dict, local->dict) < 0) {
+                goto done;
+            }
+        }
+
+        if (xdata != NULL) {
+            if (dict_copy(xdata, local->xdata_rsp) < 0) {
+                goto done;
+            }
+        }
+    }
+
+    ret = 0;
+
+done:
+    if (local_dict != NULL) {
+        dict_unref(local_dict);
+    }
+
+    if (local_xdata != NULL) {
+        dict_unref(local_xdata);
+    }
+
+    return ret;
+}
+
+static void
+afr_getxattr_lockinfo_cbk_common(call_frame_t *frame, int32_t op_ret,
+                                 int32_t op_errno, dict_t *dict, dict_t *xdata,
+                                 bool fgetxattr)
+{
+    int len = 0;
     char *lockinfo_buf = NULL;
     dict_t *lockinfo = NULL, *newdict = NULL;
     afr_local_t *local = NULL;
 
-    LOCK(&frame->lock);
-    {
-        local = frame->local;
+    local = frame->local;
 
-        call_cnt = --local->call_count;
-
-        if ((op_ret < 0) || (!dict && !xdata)) {
-            goto unlock;
-        }
-
-        if (xdata) {
-            if (!local->xdata_rsp) {
-                local->xdata_rsp = dict_new();
-                if (!local->xdata_rsp) {
-                    local->op_ret = -1;
-                    local->op_errno = ENOMEM;
-                    goto unlock;
-                }
-            }
-        }
-
-        if (!dict) {
-            goto unlock;
-        }
-
+    if ((op_ret >= 0) && (dict != NULL)) {
         op_ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
                                       (void **)&lockinfo_buf, &len);
-
-        if (!lockinfo_buf) {
-            goto unlock;
-        }
-
-        if (!local->dict) {
-            local->dict = dict_new();
-            if (!local->dict) {
-                local->op_ret = -1;
-                local->op_errno = ENOMEM;
-                goto unlock;
-            }
-        }
-    }
-unlock:
-    UNLOCK(&frame->lock);
-
-    if (lockinfo_buf != NULL) {
-        lockinfo = dict_new();
-        if (lockinfo == NULL) {
-            local->op_ret = -1;
-            local->op_errno = ENOMEM;
-        } else {
-            op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
-
-            if (lockinfo && local->dict) {
-                dict_copy(lockinfo, local->dict);
+        if (lockinfo_buf != NULL) {
+            lockinfo = dict_new();
+            if (lockinfo == NULL) {
+                op_ret = -1;
+            } else {
+                op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
             }
         }
     }
 
-    if (xdata && local->xdata_rsp) {
-        dict_copy(xdata, local->xdata_rsp);
+    if ((op_ret >= 0) && ((lockinfo != NULL) || (xdata != NULL))) {
+        op_ret = afr_update_local_dicts(frame, lockinfo, xdata);
+        if (lockinfo != NULL) {
+            dict_unref(lockinfo);
+        }
     }
 
-    if (!call_cnt) {
+    if (op_ret < 0) {
+        local->op_ret = -1;
+        local->op_errno = ENOMEM;
+    }
+
+    if (uatomic_sub_return(&local->call_count, 1) == 0) {
         newdict = dict_new();
         if (!newdict) {
             local->op_ret = -1;
@@ -956,17 +996,32 @@ unlock:
         op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
                                  (void *)lockinfo_buf, len);
         if (op_ret < 0) {
+            GF_FREE(lockinfo_buf);
             local->op_ret = -1;
             local->op_errno = -op_ret;
             goto unwind;
         }
 
     unwind:
-        AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, newdict,
-                         local->xdata_rsp);
-    }
+        if (fgetxattr) {
+            AFR_STACK_UNWIND(fgetxattr, frame, local->op_ret, local->op_errno,
+                             newdict, local->xdata_rsp);
+        } else {
+            AFR_STACK_UNWIND(getxattr, frame, local->op_ret, local->op_errno,
+                             newdict, local->xdata_rsp);
+        }
 
-    dict_unref(lockinfo);
+        dict_unref(newdict);
+    }
+}
+
+int32_t
+afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                          int32_t op_ret, int32_t op_errno, dict_t *dict,
+                          dict_t *xdata)
+{
+    afr_getxattr_lockinfo_cbk_common(frame, op_ret, op_errno, dict, xdata,
+                                     false);
 
     return 0;
 }
@@ -976,102 +1031,8 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            int32_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
 {
-    int call_cnt = 0, len = 0;
-    char *lockinfo_buf = NULL;
-    dict_t *lockinfo = NULL, *newdict = NULL;
-    afr_local_t *local = NULL;
-
-    LOCK(&frame->lock);
-    {
-        local = frame->local;
-
-        call_cnt = --local->call_count;
-
-        if ((op_ret < 0) || (!dict && !xdata)) {
-            goto unlock;
-        }
-
-        if (xdata) {
-            if (!local->xdata_rsp) {
-                local->xdata_rsp = dict_new();
-                if (!local->xdata_rsp) {
-                    local->op_ret = -1;
-                    local->op_errno = ENOMEM;
-                    goto unlock;
-                }
-            }
-        }
-
-        if (!dict) {
-            goto unlock;
-        }
-
-        op_ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
-                                      (void **)&lockinfo_buf, &len);
-
-        if (!lockinfo_buf) {
-            goto unlock;
-        }
-
-        if (!local->dict) {
-            local->dict = dict_new();
-            if (!local->dict) {
-                local->op_ret = -1;
-                local->op_errno = ENOMEM;
-                goto unlock;
-            }
-        }
-    }
-unlock:
-    UNLOCK(&frame->lock);
-
-    if (lockinfo_buf != NULL) {
-        lockinfo = dict_new();
-        if (lockinfo == NULL) {
-            local->op_ret = -1;
-            local->op_errno = ENOMEM;
-        } else {
-            op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
-
-            if (lockinfo && local->dict) {
-                dict_copy(lockinfo, local->dict);
-            }
-        }
-    }
-
-    if (xdata && local->xdata_rsp) {
-        dict_copy(xdata, local->xdata_rsp);
-    }
-
-    if (!call_cnt) {
-        newdict = dict_new();
-        if (!newdict) {
-            local->op_ret = -1;
-            local->op_errno = ENOMEM;
-            goto unwind;
-        }
-
-        op_ret = dict_allocate_and_serialize(
-            local->dict, (char **)&lockinfo_buf, (unsigned int *)&len);
-        if (op_ret != 0) {
-            local->op_ret = -1;
-            goto unwind;
-        }
-
-        op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
-                                 (void *)lockinfo_buf, len);
-        if (op_ret < 0) {
-            local->op_ret = -1;
-            local->op_errno = -op_ret;
-            goto unwind;
-        }
-
-    unwind:
-        AFR_STACK_UNWIND(fgetxattr, frame, op_ret, op_errno, newdict,
-                         local->xdata_rsp);
-    }
-
-    dict_unref(lockinfo);
+    afr_getxattr_lockinfo_cbk_common(frame, op_ret, op_errno, dict, xdata,
+                                     true);
 
     return 0;
 }
@@ -1587,6 +1548,8 @@ afr_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
      * Special xattrs which need responses from all subvols
      */
     if (afr_is_special_xattr(name, &cbk, 0)) {
+        local->dict = dict_new();
+        local->xdata_rsp = dict_new();
         afr_getxattr_all_subvols(this, frame, name, loc, cbk);
         return 0;
     }


### PR DESCRIPTION
A shared dictionary was updated outside the lock after having updated
the number of remaining answers. This means that one thread may be
processing the last answer and unwinding the request before another
thread completes updating the dict.

    Thread 1                           Thread 2

    LOCK()
    call_cnt-- (=1)
    UNLOCK()
                                       LOCK()
                                       call_cnt-- (=0)
                                       UNLOCK()
                                       update_dict(dict)
                                       if (call_cnt == 0) {
                                           STACK_UNWIND(dict);
                                       }
    update_dict(dict)
    if (call_cnt == 0) {
        STACK_UNWIND(dict);
    }

The updates from thread 1 are lost.

This patch also reduces the work done inside the locked region and
reduces code duplication.

Fixes: #2161
Change-Id: Idc0d34ab19ea6031de0641f7b05c624d90fac8fa
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

