### PR TITLE
dht: manage layout version to detect potentially outdated layout due cluster change

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -88,6 +88,7 @@ struct dht_layout {
     int type;
     gf_atomic_t ref; /* use with dht_conf_t->layout_lock */
     uint32_t search_unhashed;
+    int version;
     struct {
         int err; /* 0 = normal
                     -1 = dir exists and no xattr
@@ -520,6 +521,7 @@ struct dht_conf {
     dht_layout_t **dir_layouts;
     unsigned int search_unhashed;
     int gen;
+    int global_layout_version;
     dht_du_t *du_stats;
     double min_free_disk;
     double min_free_inodes;

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -40,6 +40,7 @@ dht_layout_new(xlator_t *this, int cnt)
     if (conf) {
         layout->spread_cnt = conf->dir_spread_cnt;
         layout->gen = conf->gen;
+        layout->version = conf->global_layout_version;
     }
 
     GF_ATOMIC_INIT(layout->ref, 1);
@@ -71,7 +72,7 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
     dht_conf_t *conf = NULL;
     int oldret = -1;
     int ret = -1;
-    dht_layout_t *old_layout;
+    dht_layout_t *old_layout = NULL;
 
     conf = this->private;
     if (!conf || !layout)

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -282,6 +282,7 @@ dht_parse_decommissioned_bricks(xlator_t *this, dht_conf_t *conf,
 
     ret = 0;
     conf->decommission_in_progress = 1;
+    conf->global_layout_version++;
 out:
     GF_FREE(dup_brick);
 
@@ -299,6 +300,7 @@ dht_decommissioned_remove(xlator_t *this, dht_conf_t *conf)
             conf->decommission_subvols_cnt--;
         }
     }
+    conf->global_layout_version++;
     conf->decommission_in_progress = 0;
 }
 
@@ -500,7 +502,8 @@ dht_reconfigure(xlator_t *this, dict_t *options)
                 goto out;
         }
     } else {
-        dht_decommissioned_remove(this, conf);
+        if (conf->decommission_in_progress)
+            dht_decommissioned_remove(this, conf);
     }
 
     dht_init_regex(this, options, "rsync-hash-regex", &conf->rsync_regex,
@@ -801,6 +804,7 @@ dht_init(xlator_t *this)
     }
 
     conf->gen = 1;
+    conf->global_layout_version = 1;
 
     this->local_pool = mem_pool_new(dht_local_t, 512);
     if (!this->local_pool) {


### PR DESCRIPTION
WIP - Testing
Added the following logic:
1. dht conf holds global layout version which getting increments upon decommission start/stop
   in other cases: decommission commit or add-bricks the graph is reconstructing and the entire conf is reset.
2. each time a layout is getting sync with the disk, its version initialized with the global layout.
3. In create/mknod paths - if layout_version < global_version do a lookup on parent dir

Change-Id: I906247bec5a5996f0cb71ed4654704aef81f3ebf
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

