### PR TITLE
Glusterd: Rebalance status updation after node reboot

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -217,6 +217,7 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
     };
     char *volfileserver = NULL;
     char *localtime_logging = NULL;
+    int pid = -1;
 
     priv = this->private;
     GF_VALIDATE_OR_GOTO("glusterd", priv, out);
@@ -326,7 +327,11 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
 
     sleep(5);
 
-    ret = glusterd_rebalance_rpc_create(volinfo);
+    if (!gf_is_service_running(pidfile, &pid)) {
+        ret = glusterd_rebalance_rpc_create(volinfo);
+    } else {
+        gf_msg_debug(this->name, 0, "Rebalance process is already running.");
+    }
 
     // FIXME: this cbk is passed as NULL in all occurrences. May be
     // we never needed it.


### PR DESCRIPTION
Issue: Rebalance status is not updated for a given node
which is rebooted during rebalance.

RC: The Rebalance RPC has to be created only if the
rebalance process has started running.

Solution: The rpc creation for rebalance is invoked
only after the rebalance daemon has started running
properly.

Fixes: #1339
Change-Id: If8fe8fb3d8c4ca8416c810912b7bca6e62872c16
Signed-off-by: srijan-sivakumar <ssivakumar@redhat.com>

