### PR TITLE
logging: Avoiding a call to strerror while logging

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4745,7 +4745,7 @@ recursive_rmdir(const char *delete_path)
             ret = sys_unlink(path);
 
         if (ret) {
-            gf_msg_debug(this->name, errno, " Failed to remove %s. ", path);
+            gf_msg_debug(this->name, errno, " Failed to remove %s.", path);
         }
 
         gf_msg_debug(this->name, 0, "%s %s",

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4722,10 +4722,8 @@ recursive_rmdir(const char *delete_path)
 
     dir = sys_opendir(delete_path);
     if (!dir) {
-        gf_msg_debug(this->name, 0,
-                     "Failed to open directory %s. "
-                     "Reason : %s",
-                     delete_path, strerror(errno));
+        gf_msg_debug(this->name, errno, "Failed to open directory %s.",
+                     delete_path);
         ret = 0;
         goto out;
     }
@@ -4736,10 +4734,7 @@ recursive_rmdir(const char *delete_path)
         snprintf(path, PATH_MAX, "%s/%s", delete_path, entry->d_name);
         ret = sys_lstat(path, &st);
         if (ret == -1) {
-            gf_msg_debug(this->name, 0,
-                         "Failed to stat entry %s :"
-                         " %s",
-                         path, strerror(errno));
+            gf_msg_debug(this->name, errno, "Failed to stat entry %s", path);
             (void)sys_closedir(dir);
             goto out;
         }
@@ -4750,10 +4745,7 @@ recursive_rmdir(const char *delete_path)
             ret = sys_unlink(path);
 
         if (ret) {
-            gf_msg_debug(this->name, 0,
-                         " Failed to remove %s. "
-                         "Reason : %s",
-                         path, strerror(errno));
+            gf_msg_debug(this->name, errno, " Failed to remove %s. ", path);
         }
 
         gf_msg_debug(this->name, 0, "%s %s",
@@ -4762,16 +4754,12 @@ recursive_rmdir(const char *delete_path)
 
     ret = sys_closedir(dir);
     if (ret) {
-        gf_msg_debug(this->name, 0,
-                     "Failed to close dir %s. Reason :"
-                     " %s",
-                     delete_path, strerror(errno));
+        gf_msg_debug(this->name, errno, "Failed to close dir %s", delete_path);
     }
 
     ret = sys_rmdir(delete_path);
     if (ret) {
-        gf_msg_debug(this->name, 0, "Failed to rmdir: %s,err: %s", delete_path,
-                     strerror(errno));
+        gf_msg_debug(this->name, errno, "Failed to rmdir: %s", delete_path);
     }
 
 out:

--- a/xlators/cluster/dht/src/dht-inode-write.c
+++ b/xlators/cluster/dht/src/dht-inode-write.c
@@ -59,8 +59,8 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (op_ret == -1 && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
-        gf_msg_debug(this->name, 0, "subvolume %s returned -1 (%s)", prev->name,
-                     strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
+                     prev->name);
         goto out;
     }
 

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -1210,8 +1210,8 @@ dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
 
     if (op_ret == -1) {
-        gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
-                     strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "link/file on %s failed",
+                     prev->name);
         local->op_ret = -1;
         local->op_errno = op_errno;
         local->added_link = _gf_false;
@@ -1248,8 +1248,8 @@ dht_rename_linkto_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     src_cached = local->src_cached;
 
     if (op_ret == -1) {
-        gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
-                     strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "link/file on %s failed",
+                     prev->name);
         local->op_ret = -1;
         local->op_errno = op_errno;
     }
@@ -1298,8 +1298,8 @@ dht_rename_unlink_links_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
 
     if ((op_ret == -1) && (op_errno != ENOENT)) {
-        gf_msg_debug(this->name, 0, "unlink of %s on %s failed (%s)",
-                     local->loc2.path, prev->name, strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "unlink of %s on %s failed ",
+                     local->loc2.path, prev->name);
         local->op_ret = -1;
         local->op_errno = op_errno;
     }

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -303,9 +303,7 @@ ec_heal_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ec_trace("WRITE_CBK", cookie, "ret=%d, errno=%d", op_ret, op_errno);
 
-    gf_msg_debug(fop->xl->name, op_errno,
-                 "%s: write op_ret %d"
-                 " at %" PRIu64,
+    gf_msg_debug(fop->xl->name, op_errno, "%s: write op_ret %d at %" PRIu64,
                  uuid_utoa(heal->fd->inode->gfid), op_ret, heal->offset);
 
     ec_heal_update(cookie, 0);
@@ -1307,7 +1305,7 @@ ec_create_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
     ret = 0;
 out:
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, -ret, "%s/%s: heal failed ",
+        gf_msg_debug(ec->xl->name, -ret, "%s/%s: heal failed",
                      uuid_utoa(parent->gfid), name);
     cluster_replies_wipe(replies, ec->nodes);
     loc_wipe(&loc);
@@ -1863,7 +1861,7 @@ out:
     cluster_replies_wipe(replies, ec->nodes);
     cluster_replies_wipe(fstat_replies, ec->nodes);
     if (ret < 0) {
-        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed",
                      uuid_utoa(fd->inode->gfid));
     } else {
         gf_msg_debug(ec->xl->name, 0,
@@ -1936,7 +1934,7 @@ out:
     if (xattrs)
         dict_unref(xattrs);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed",
                      uuid_utoa(fd->inode->gfid));
     return ret;
 }
@@ -2110,7 +2108,7 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
     LOCK_DESTROY(&heal->lock);
     syncbarrier_destroy(heal->data);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed",
                      uuid_utoa(fd->inode->gfid));
     return ret;
 }
@@ -2150,7 +2148,7 @@ __ec_heal_trim_sinks(call_frame_t *frame, ec_t *ec, fd_t *fd,
 out:
     cluster_replies_wipe(replies, ec->nodes);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed",
                      uuid_utoa(fd->inode->gfid));
     return ret;
 }

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -303,11 +303,10 @@ ec_heal_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ec_trace("WRITE_CBK", cookie, "ret=%d, errno=%d", op_ret, op_errno);
 
-    gf_msg_debug(fop->xl->name, 0,
-                 "%s: write op_ret %d, op_errno %s"
+    gf_msg_debug(fop->xl->name, op_errno,
+                 "%s: write op_ret %d"
                  " at %" PRIu64,
-                 uuid_utoa(heal->fd->inode->gfid), op_ret, strerror(op_errno),
-                 heal->offset);
+                 uuid_utoa(heal->fd->inode->gfid), op_ret, heal->offset);
 
     ec_heal_update(cookie, 0);
 
@@ -337,11 +336,10 @@ ec_heal_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   heal->offset, 0, iobref, NULL);
     } else {
         if (op_ret < 0) {
-            gf_msg_debug(fop->xl->name, 0,
-                         "%s: read failed %s, failing "
+            gf_msg_debug(fop->xl->name, op_errno,
+                         "%s: read failed, failing "
                          "to heal block at %" PRIu64,
-                         uuid_utoa(heal->fd->inode->gfid), strerror(op_errno),
-                         heal->offset);
+                         uuid_utoa(heal->fd->inode->gfid), heal->offset);
             heal->bad = 0;
         }
         heal->done = 1;
@@ -1118,9 +1116,8 @@ ec_delete_stale_name(dict_t *gfid_db, char *key, data_t *d, void *data)
     dict_del(gfid_db, key);
 out:
     if (ret < 0) {
-        gf_msg_debug(ec->xl->name, 0, "%s/%s: heal failed %s",
-                     uuid_utoa(name_data->parent->gfid), name_data->name,
-                     strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s/%s: heal failed",
+                     uuid_utoa(name_data->parent->gfid), name_data->name);
     }
     cluster_replies_wipe(replies, ec->nodes);
     loc_wipe(&loc);
@@ -1310,8 +1307,8 @@ ec_create_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
     ret = 0;
 out:
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, 0, "%s/%s: heal failed %s",
-                     uuid_utoa(parent->gfid), name, strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s/%s: heal failed ",
+                     uuid_utoa(parent->gfid), name);
     cluster_replies_wipe(replies, ec->nodes);
     loc_wipe(&loc);
     loc_wipe(&srcloc);
@@ -1866,8 +1863,8 @@ out:
     cluster_replies_wipe(replies, ec->nodes);
     cluster_replies_wipe(fstat_replies, ec->nodes);
     if (ret < 0) {
-        gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
-                     uuid_utoa(fd->inode->gfid), strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+                     uuid_utoa(fd->inode->gfid));
     } else {
         gf_msg_debug(ec->xl->name, 0,
                      "%s: sources: %d, sinks: "
@@ -1939,8 +1936,8 @@ out:
     if (xattrs)
         dict_unref(xattrs);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
-                     uuid_utoa(fd->inode->gfid), strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+                     uuid_utoa(fd->inode->gfid));
     return ret;
 }
 
@@ -2113,8 +2110,8 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
     LOCK_DESTROY(&heal->lock);
     syncbarrier_destroy(heal->data);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
-                     uuid_utoa(fd->inode->gfid), strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+                     uuid_utoa(fd->inode->gfid));
     return ret;
 }
 
@@ -2153,8 +2150,8 @@ __ec_heal_trim_sinks(call_frame_t *frame, ec_t *ec, fd_t *fd,
 out:
     cluster_replies_wipe(replies, ec->nodes);
     if (ret < 0)
-        gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
-                     uuid_utoa(fd->inode->gfid), strerror(-ret));
+        gf_msg_debug(ec->xl->name, -ret, "%s: heal failed ",
+                     uuid_utoa(fd->inode->gfid));
     return ret;
 }
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -452,7 +452,7 @@ br_log_object(xlator_t *this, char *op, uuid_t gfid, int32_t op_errno)
 {
     int softerror = br_object_sign_softerror(op_errno);
     if (softerror) {
-        gf_msg_debug(this->name, op_errno, "%s() failed on object %s ", op,
+        gf_msg_debug(this->name, op_errno, "%s() failed on object %s", op,
                      uuid_utoa(gfid));
     } else {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, BRB_MSG_OP_FAILED, "op=%s",
@@ -465,7 +465,7 @@ br_log_object_path(xlator_t *this, char *op, const char *path, int32_t op_errno)
 {
     int softerror = br_object_sign_softerror(op_errno);
     if (softerror) {
-        gf_msg_debug(this->name, op_errno, "%s() failed on object %s ", op,
+        gf_msg_debug(this->name, op_errno, "%s() failed on object %s", op,
                      path);
     } else {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, BRB_MSG_OP_FAILED, "op=%s",

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -452,10 +452,8 @@ br_log_object(xlator_t *this, char *op, uuid_t gfid, int32_t op_errno)
 {
     int softerror = br_object_sign_softerror(op_errno);
     if (softerror) {
-        gf_msg_debug(this->name, 0,
-                     "%s() failed on object %s "
-                     "[reason: %s]",
-                     op, uuid_utoa(gfid), strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "%s() failed on object %s ", op,
+                     uuid_utoa(gfid));
     } else {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, BRB_MSG_OP_FAILED, "op=%s",
                 op, "gfid=%s", uuid_utoa(gfid), NULL);
@@ -467,10 +465,8 @@ br_log_object_path(xlator_t *this, char *op, const char *path, int32_t op_errno)
 {
     int softerror = br_object_sign_softerror(op_errno);
     if (softerror) {
-        gf_msg_debug(this->name, 0,
-                     "%s() failed on object %s "
-                     "[reason: %s]",
-                     op, path, strerror(op_errno));
+        gf_msg_debug(this->name, op_errno, "%s() failed on object %s ", op,
+                     path);
     } else {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, BRB_MSG_OP_FAILED, "op=%s",
                 op, "path=%s", path, NULL);

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -5010,9 +5010,7 @@ shard_common_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }
-        gf_msg_debug(this->name, op_errno,
-                     "mknod of shard %d "
-                     "failed",
+        gf_msg_debug(this->name, op_errno, "mknod of shard %d failed",
                      shard_block_num);
         goto done;
     }

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -5010,10 +5010,10 @@ shard_common_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }
-        gf_msg_debug(this->name, 0,
+        gf_msg_debug(this->name, op_errno,
                      "mknod of shard %d "
-                     "failed: %s",
-                     shard_block_num, strerror(op_errno));
+                     "failed",
+                     shard_block_num);
         goto done;
     }
 

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -954,9 +954,8 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
             op_errno = errno;
             if (errno == ENODATA) {
                 gf_msg_debug(this->name, errno,
-                             "getxattr on "
-                             "%s failed (ket: %s)",
-                             loc->path, name);
+                             "getxattr on %s failed (ket: %s)", loc->path,
+                             name);
             } else {
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
                        SVS_MSG_GETXATTR_FAILED,

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -953,10 +953,10 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
             op_ret = -1;
             op_errno = errno;
             if (errno == ENODATA) {
-                gf_msg_debug(this->name, 0,
+                gf_msg_debug(this->name, errno,
                              "getxattr on "
-                             "%s failed (ket: %s) with %s",
-                             loc->path, name, strerror(errno));
+                             "%s failed (ket: %s)",
+                             loc->path, name);
             } else {
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
                        SVS_MSG_GETXATTR_FAILED,

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -612,10 +612,8 @@ tear_down_cluster(gf_boolean_t run_teardown)
          */
         dir = sys_opendir(CONFDIR);
         if (!dir) {
-            gf_msg_debug(THIS->name, 0,
-                         "Failed to open directory %s. "
-                         "Reason : %s",
-                         CONFDIR, strerror(errno));
+            gf_msg_debug(THIS->name, errno, "Failed to open directory %s. ",
+                         CONFDIR);
             ret = 0;
             goto out;
         }
@@ -626,10 +624,8 @@ tear_down_cluster(gf_boolean_t run_teardown)
             snprintf(path, PATH_MAX, "%s/%s", CONFDIR, entry->d_name);
             ret = sys_lstat(path, &st);
             if (ret == -1) {
-                gf_msg_debug(THIS->name, 0,
-                             "Failed to stat entry %s :"
-                             " %s",
-                             path, strerror(errno));
+                gf_msg_debug(THIS->name, errno,
+                             "Failed to stat entry %s :", path);
                 goto out;
             }
 
@@ -645,10 +641,7 @@ tear_down_cluster(gf_boolean_t run_teardown)
                 ret = sys_unlink(path);
 
             if (ret) {
-                gf_msg_debug(THIS->name, 0,
-                             " Failed to remove %s. "
-                             "Reason : %s",
-                             path, strerror(errno));
+                gf_msg_debug(THIS->name, errno, " Failed to remove %s. ", path);
             }
 
             gf_msg_debug(THIS->name, 0, "%s %s",
@@ -657,20 +650,16 @@ tear_down_cluster(gf_boolean_t run_teardown)
 
         ret = sys_closedir(dir);
         if (ret) {
-            gf_msg_debug(THIS->name, 0,
-                         "Failed to close dir %s. Reason :"
-                         " %s",
-                         CONFDIR, strerror(errno));
+            gf_msg_debug(THIS->name, errno,
+                         "Failed to close dir %s. Reason :", CONFDIR);
         }
         goto exit;
     }
 
 out:
     if (dir && sys_closedir(dir)) {
-        gf_msg_debug(THIS->name, 0,
-                     "Failed to close dir %s. Reason :"
-                     " %s",
-                     CONFDIR, strerror(errno));
+        gf_msg_debug(THIS->name, errno,
+                     "Failed to close dir %s. Reason :", CONFDIR);
     }
 exit:
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -612,7 +612,7 @@ tear_down_cluster(gf_boolean_t run_teardown)
          */
         dir = sys_opendir(CONFDIR);
         if (!dir) {
-            gf_msg_debug(THIS->name, errno, "Failed to open directory %s. ",
+            gf_msg_debug(THIS->name, errno, "Failed to open directory %s.",
                          CONFDIR);
             ret = 0;
             goto out;
@@ -624,8 +624,8 @@ tear_down_cluster(gf_boolean_t run_teardown)
             snprintf(path, PATH_MAX, "%s/%s", CONFDIR, entry->d_name);
             ret = sys_lstat(path, &st);
             if (ret == -1) {
-                gf_msg_debug(THIS->name, errno,
-                             "Failed to stat entry %s :", path);
+                gf_msg_debug(THIS->name, errno, "Failed to stat entry %s",
+                             path);
                 goto out;
             }
 
@@ -641,7 +641,7 @@ tear_down_cluster(gf_boolean_t run_teardown)
                 ret = sys_unlink(path);
 
             if (ret) {
-                gf_msg_debug(THIS->name, errno, " Failed to remove %s. ", path);
+                gf_msg_debug(THIS->name, errno, "Failed to remove %s.", path);
             }
 
             gf_msg_debug(THIS->name, 0, "%s %s",
@@ -650,16 +650,14 @@ tear_down_cluster(gf_boolean_t run_teardown)
 
         ret = sys_closedir(dir);
         if (ret) {
-            gf_msg_debug(THIS->name, errno,
-                         "Failed to close dir %s. Reason :", CONFDIR);
+            gf_msg_debug(THIS->name, errno, "Failed to close dir %s", CONFDIR);
         }
         goto exit;
     }
 
 out:
     if (dir && sys_closedir(dir)) {
-        gf_msg_debug(THIS->name, errno,
-                     "Failed to close dir %s. Reason :", CONFDIR);
+        gf_msg_debug(THIS->name, errno, "Failed to close dir %s.", CONFDIR);
     }
 exit:
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -3999,7 +3999,7 @@ glusterd_restore_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
     if (ret) {
         if (errno == ENOENT) {
             ret = 0;
-            gf_msg_debug(this->name, 0, "%s not found", src_path);
+            gf_msg_debug(this->name, errno, "%s not found", src_path);
         } else
             gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                    "Stat on %s failed with %s", src_path, strerror(errno));

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -2616,8 +2616,7 @@ glusterd_do_lvm_snapshot_remove(glusterd_volinfo_t *snap_vol,
             break;
 
         gf_msg_debug(this->name, errno,
-                     "umount failed for "
-                     "path %s (brick: %s). Retry(%d)",
+                     "umount failed for path %s (brick: %s). Retry(%d)",
                      mount_pt, brickinfo->path, retry_count);
 
         /*

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -676,8 +676,7 @@ out:
         /* Revert the changes in case of failure */
         ret = sys_rmdir(pathname);
         if (ret) {
-            gf_msg_debug(this->name, 0, "Failed to rmdir: %s,err: %s", pathname,
-                         strerror(errno));
+            gf_msg_debug(this->name, errno, "Failed to rmdir: %s", pathname);
         }
 
         ret = sys_rename(delete_path, pathname);
@@ -689,8 +688,7 @@ out:
 
         ret = sys_rmdir(trashdir);
         if (ret) {
-            gf_msg_debug(this->name, 0, "Failed to rmdir: %s, Reason: %s",
-                         trashdir, strerror(errno));
+            gf_msg_debug(this->name, errno, "Failed to rmdir: %s", trashdir);
         }
     }
 
@@ -2617,10 +2615,10 @@ glusterd_do_lvm_snapshot_remove(glusterd_volinfo_t *snap_vol,
         if (!ret)
             break;
 
-        gf_msg_debug(this->name, 0,
+        gf_msg_debug(this->name, errno,
                      "umount failed for "
-                     "path %s (brick: %s): %s. Retry(%d)",
-                     mount_pt, brickinfo->path, strerror(errno), retry_count);
+                     "path %s (brick: %s). Retry(%d)",
+                     mount_pt, brickinfo->path, retry_count);
 
         /*
          * This used to be one second, but that wasn't long enough

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -1897,8 +1897,8 @@ glusterd_service_stop_nolock(const char *service, char *pidfile, int sig,
 
     if (kill(pid, 0) < 0) {
         ret = 0;
-        gf_msg_debug(this->name, 0, "%s process not running: (%d) %s", service,
-                     pid, strerror(errno));
+        gf_msg_debug(this->name, errno, "%s process not running: (%d)", service,
+                     pid);
         goto out;
     }
     gf_msg_debug(this->name, 0,
@@ -7837,10 +7837,9 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     ret = glusterd_add_inode_size_to_dict(dict, count);
 out:
     if (ret)
-        gf_msg_debug(this->name, 0,
+        gf_msg_debug(this->name, errno,
                      "Error adding brick"
-                     " detail to dict: %s",
-                     strerror(errno));
+                     " detail to dict");
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -7837,9 +7837,7 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     ret = glusterd_add_inode_size_to_dict(dict, count);
 out:
     if (ret)
-        gf_msg_debug(this->name, errno,
-                     "Error adding brick"
-                     " detail to dict");
+        gf_msg_debug(this->name, errno, "Error adding brick detail to dict");
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -2691,8 +2691,7 @@ glusterd_clearlocks_create_mount(glusterd_volinfo_t *volinfo, char **mntpt)
     tmpl = mkdtemp(template);
     if (!tmpl) {
         gf_msg_debug(THIS->name, errno,
-                     "Couldn't create temporary "
-                     "mount directory.");
+                     "Couldn't create temporary mount directory.");
         goto out;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -2690,10 +2690,9 @@ glusterd_clearlocks_create_mount(glusterd_volinfo_t *volinfo, char **mntpt)
     snprintf(template, sizeof(template), "/tmp/%s.XXXXXX", volinfo->volname);
     tmpl = mkdtemp(template);
     if (!tmpl) {
-        gf_msg_debug(THIS->name, 0,
+        gf_msg_debug(THIS->name, errno,
                      "Couldn't create temporary "
-                     "mount directory. Reason %s",
-                     strerror(errno));
+                     "mount directory.");
         goto out;
     }
 

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -417,8 +417,8 @@ out:
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
-            gf_msg_debug(this->name, 0, "remote operation failed: %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -474,10 +474,8 @@ client3_3_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -541,10 +539,8 @@ client3_3_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -945,10 +941,7 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1011,11 +1004,10 @@ out:
     if (rsp.op_ret == -1) {
         if ((op_errno == ENOTSUP) || (op_errno == ENODATA) ||
             (op_errno == ESTALE) || (op_errno == ENOENT)) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed: %s. Path: %s "
+            gf_msg_debug(this->name, op_errno,
+                         "remote operation failed. Path: %s "
                          "(%s). Key: %s",
-                         strerror(op_errno), local->loc.path,
-                         loc_gfid_utoa(&local->loc),
+                         local->loc.path, loc_gfid_utoa(&local->loc),
                          (local->name) ? local->name : "(null)");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
@@ -1083,8 +1075,7 @@ out:
     if (rsp.op_ret == -1) {
         if ((op_errno == ENOTSUP) || (op_errno == ERANGE) ||
             (op_errno == ENODATA) || (op_errno == ENOENT)) {
-            gf_msg_debug(this->name, 0, "remote operation failed: %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1781,10 +1772,7 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -327,8 +327,8 @@ out:
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
-            gf_msg_debug(this->name, 0, "remote operation failed: %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -382,10 +382,8 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -447,10 +445,8 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(gf_error_to_errno(rsp.op_errno)));
+            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+                         "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -834,10 +830,7 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -898,11 +891,10 @@ out:
     if (rsp.op_ret == -1) {
         if ((op_errno == ENOTSUP) || (op_errno == ENODATA) ||
             (op_errno == ESTALE) || (op_errno == ENOENT)) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed: %s. Path: %s "
+            gf_msg_debug(this->name, op_errno,
+                         "remote operation failed. Path: %s "
                          "(%s). Key: %s",
-                         strerror(op_errno), local->loc.path,
-                         loc_gfid_utoa(&local->loc),
+                         local->loc.path, loc_gfid_utoa(&local->loc),
                          (local->name) ? local->name : "(null)");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
@@ -971,8 +963,7 @@ out:
     if (rsp.op_ret == -1) {
         if ((op_errno == ENOTSUP) || (op_errno == ERANGE) ||
             (op_errno == ENODATA) || (op_errno == ENOENT)) {
-            gf_msg_debug(this->name, 0, "remote operation failed: %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1655,10 +1646,7 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, 0,
-                         "remote operation failed:"
-                         " %s",
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "remote operation failed");
         } else {
             gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -55,9 +55,8 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (op_ret == -1) {
         if (op_errno == ENOENT) {
-            gf_msg_debug(this->name, 0, "%s/%s: failed to resolve (%s)",
-                         uuid_utoa(resolve_loc->pargfid), resolve_loc->name,
-                         strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "%s/%s: failed to resolve",
+                         uuid_utoa(resolve_loc->pargfid), resolve_loc->name);
             if (resolve->type == RESOLVE_NOT) {
                 do {
                     inode = inode_grep(state->itable, resolve_loc->parent,
@@ -118,8 +117,8 @@ resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     if (op_ret == -1) {
         if (op_errno == ENOENT) {
-            gf_msg_debug(this->name, GF_LOG_DEBUG, "%s: failed to resolve (%s)",
-                         uuid_utoa(resolve_loc->gfid), strerror(op_errno));
+            gf_msg_debug(this->name, op_errno, "%s: failed to resolve ",
+                         uuid_utoa(resolve_loc->gfid));
         } else {
             gf_msg(this->name, GF_LOG_WARNING, op_errno,
                    PS_MSG_GFID_RESOLVE_FAILED, "%s: failed to resolve (%s)",

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -117,7 +117,7 @@ resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     if (op_ret == -1) {
         if (op_errno == ENOENT) {
-            gf_msg_debug(this->name, op_errno, "%s: failed to resolve ",
+            gf_msg_debug(this->name, op_errno, "%s: failed to resolve",
                          uuid_utoa(resolve_loc->gfid));
         } else {
             gf_msg(this->name, GF_LOG_WARNING, op_errno,

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -963,7 +963,7 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
 
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(THIS->name, 0, "%s", strerror(op_errno));
+            gf_msg_debug(THIS->name, op_errno, "Failed");
         } else {
             gf_msg(THIS->name, GF_LOG_INFO, op_errno, PS_MSG_SETXATTR_INFO,
                    "client: %s, "
@@ -1033,7 +1033,7 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             dict_foreach(state->dict, _gf_server_log_fsetxattr_failure, frame);
         }
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(THIS->name, 0, "%s", strerror(op_errno));
+            gf_msg_debug(THIS->name, op_errno, "Failed");
         } else {
             gf_msg(THIS->name, GF_LOG_INFO, op_errno, PS_MSG_SETXATTR_INFO,
                    "client: %s, "

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -898,7 +898,7 @@ server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
         }
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(THIS->name, op_errno, "Failed: ");
+            gf_msg_debug(THIS->name, op_errno, "Failed");
         } else {
             gf_smsg(THIS->name, GF_LOG_INFO, op_errno, PS_MSG_SETXATTR_INFO,
                     "client=%s", STACK_CLIENT_NAME(frame->root),

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -858,7 +858,7 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
 
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(THIS->name, 0, "%s", strerror(op_errno));
+            gf_msg_debug(THIS->name, op_errno, "Failed");
         } else {
             gf_smsg(THIS->name, GF_LOG_INFO, op_errno, PS_MSG_SETXATTR_INFO,
                     "client=%s", STACK_CLIENT_NAME(frame->root),
@@ -898,7 +898,7 @@ server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
         }
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(THIS->name, 0, "%s", strerror(op_errno));
+            gf_msg_debug(THIS->name, op_errno, "Failed: ");
         } else {
             gf_smsg(THIS->name, GF_LOG_INFO, op_errno, PS_MSG_SETXATTR_INFO,
                     "client=%s", STACK_CLIENT_NAME(frame->root),

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -1900,10 +1900,10 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         if (op_ret == -1) {
             op_errno = errno;
             if (op_errno == ENOTEMPTY) {
-                gf_msg_debug(this->name, 0,
+                gf_msg_debug(this->name, op_errno,
                              "rename of %s to"
-                             " %s failed: %s",
-                             real_oldpath, real_newpath, strerror(op_errno));
+                             " %s failed",
+                             real_oldpath, real_newpath);
             } else {
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_RENAME_FAILED,
                        "rename of %s to %s failed", real_oldpath, real_newpath);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -827,8 +827,7 @@ posix_pstat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *path,
             errno = op_errno; /*gf_msg could have changed errno*/
         } else {
             op_errno = errno;
-            gf_msg_debug(this->name, 0, "lstat failed on %s (%s)", path,
-                         strerror(errno));
+            gf_msg_debug(this->name, errno, "lstat failed on %s ", path);
             errno = op_errno; /*gf_msg could have changed errno*/
         }
         goto out;
@@ -1314,10 +1313,10 @@ posix_fhandle_pair(call_frame_t *frame, xlator_t *this, int fd, char *key,
         } else {
 #ifdef GF_DARWIN_HOST_OS
             if (errno == EINVAL) {
-                gf_msg_debug(this->name, 0,
+                gf_msg_debug(this->name, errno,
                              "fd=%d: key:%s "
-                             "error:%s",
-                             fd, key, strerror(errno));
+                             "error",
+                             fd, key);
             } else {
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                        "fd=%d: key:%s", fd, key);
@@ -1362,10 +1361,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
     /* check that it is valid directory handle */
     size = sys_lstat(hpath, &stbuf);
     if (size < 0) {
-        gf_msg_debug(this->name, 0,
-                     "%s: Handle stat failed: "
-                     "%s",
-                     hpath, strerror(errno));
+        gf_msg_debug(this->name, errno, "%s: Handle stat failed: ", hpath);
         goto out;
     }
 
@@ -1379,7 +1375,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
     size = posix_handle_path(this, gfid, NULL, newpath, sizeof(newpath));
     if (size <= 0) {
         if (errno == ENOENT) {
-            gf_msg_debug(this->name, 0, "%s: %s", newpath, strerror(ENOENT));
+            gf_msg_debug(this->name, ENOENT, "%s ", newpath);
             stale = _gf_true;
         }
         goto out;
@@ -1387,7 +1383,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
 
     size = sys_lgetxattr(newpath, GFID_XATTR_KEY, gfid_curr, 16);
     if (size < 0 && errno == ENOENT) {
-        gf_msg_debug(this->name, 0, "%s: %s", newpath, strerror(ENOENT));
+        gf_msg_debug(this->name, ENOENT, "%s ", newpath);
         stale = _gf_true;
     } else if (size == 16 && gf_uuid_compare(gfid, gfid_curr)) {
         gf_msg_debug(this->name, 0,

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1313,10 +1313,7 @@ posix_fhandle_pair(call_frame_t *frame, xlator_t *this, int fd, char *key,
         } else {
 #ifdef GF_DARWIN_HOST_OS
             if (errno == EINVAL) {
-                gf_msg_debug(this->name, errno,
-                             "fd=%d: key:%s "
-                             "error",
-                             fd, key);
+                gf_msg_debug(this->name, errno, "fd=%d: key:%s error", fd, key);
             } else {
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                        "fd=%d: key:%s", fd, key);
@@ -1361,7 +1358,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
     /* check that it is valid directory handle */
     size = sys_lstat(hpath, &stbuf);
     if (size < 0) {
-        gf_msg_debug(this->name, errno, "%s: Handle stat failed: ", hpath);
+        gf_msg_debug(this->name, errno, "%s: Handle stat failed", hpath);
         goto out;
     }
 
@@ -1375,7 +1372,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
     size = posix_handle_path(this, gfid, NULL, newpath, sizeof(newpath));
     if (size <= 0) {
         if (errno == ENOENT) {
-            gf_msg_debug(this->name, ENOENT, "%s ", newpath);
+            gf_msg_debug(this->name, ENOENT, "Failed for path: %s", newpath);
             stale = _gf_true;
         }
         goto out;
@@ -1383,7 +1380,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
 
     size = sys_lgetxattr(newpath, GFID_XATTR_KEY, gfid_curr, 16);
     if (size < 0 && errno == ENOENT) {
-        gf_msg_debug(this->name, ENOENT, "%s ", newpath);
+        gf_msg_debug(this->name, ENOENT, "Failed for path: %s", newpath);
         stale = _gf_true;
     } else if (size == 16 && gf_uuid_compare(gfid, gfid_curr)) {
         gf_msg_debug(this->name, 0,

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -186,8 +186,7 @@ posix_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = errno;
         if (op_errno == ENOENT) {
             gf_msg_debug(this->name, op_errno,
-                         "lstat on gfid-handle %s (path: %s)"
-                         "failed",
+                         "lstat on gfid-handle %s (path: %s) failed",
                          real_path ? real_path : "<null>", loc->path);
         } else {
             gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_LSTAT_FAILED,
@@ -259,7 +258,7 @@ posix_do_chmod(xlator_t *this, const char *path, struct iatt *stbuf)
      * to handle all cases. */
     if ((ret < 0) &&
         ((errno == ENOSYS) || (errno == EOPNOTSUPP) || (errno == ENOTSUP))) {
-        gf_msg_debug(this->name, errno, "%s", path);
+        gf_msg_debug(this->name, errno, "Failed for path: %s", path);
         if (is_symlink) {
             ret = 0;
             goto out;
@@ -342,7 +341,7 @@ posix_do_utimes(xlator_t *this, const char *path, struct iatt *stbuf, int valid)
 
     ret = PATH_SET_TIMESPEC_OR_TIMEVAL(path, tv);
     if ((ret == -1) && (errno == ENOSYS)) {
-        gf_msg_debug(this->name, errno, "%s ", path);
+        gf_msg_debug(this->name, errno, "Failed for path: %s", path);
         if (is_symlink) {
             ret = 0;
             goto out;
@@ -5053,13 +5052,11 @@ unlock:
         if (op_ret) {
             if (filler->real_path)
                 gf_msg_debug(this->name, -size,
-                             "dict_set_bin failed (path=%s): "
-                             "key=%s",
+                             "dict_set_bin failed (path=%s): key=%s",
                              filler->real_path, k);
             else
                 gf_msg_debug(this->name, -size,
-                             "dict_set_bin failed (gfid=%s): "
-                             "key=%s",
+                             "dict_set_bin failed (gfid=%s): key=%s",
                              uuid_utoa(filler->inode->gfid), k);
 
             op_ret = -1;

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -185,11 +185,10 @@ posix_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     if (op_ret == -1) {
         op_errno = errno;
         if (op_errno == ENOENT) {
-            gf_msg_debug(this->name, 0,
+            gf_msg_debug(this->name, op_errno,
                          "lstat on gfid-handle %s (path: %s)"
-                         "failed: %s",
-                         real_path ? real_path : "<null>", loc->path,
-                         strerror(op_errno));
+                         "failed",
+                         real_path ? real_path : "<null>", loc->path);
         } else {
             gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_LSTAT_FAILED,
                    "lstat on gfid-handle %s (path: %s) failed",
@@ -260,7 +259,7 @@ posix_do_chmod(xlator_t *this, const char *path, struct iatt *stbuf)
      * to handle all cases. */
     if ((ret < 0) &&
         ((errno == ENOSYS) || (errno == EOPNOTSUPP) || (errno == ENOTSUP))) {
-        gf_msg_debug(this->name, 0, "%s (%s)", path, strerror(errno));
+        gf_msg_debug(this->name, errno, "%s", path);
         if (is_symlink) {
             ret = 0;
             goto out;
@@ -343,7 +342,7 @@ posix_do_utimes(xlator_t *this, const char *path, struct iatt *stbuf, int valid)
 
     ret = PATH_SET_TIMESPEC_OR_TIMEVAL(path, tv);
     if ((ret == -1) && (errno == ENOSYS)) {
-        gf_msg_debug(this->name, 0, "%s (%s)", path, strerror(errno));
+        gf_msg_debug(this->name, errno, "%s ", path);
         if (is_symlink) {
             ret = 0;
             goto out;
@@ -4193,10 +4192,10 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             if (size == -1) {
                 op_errno = errno;
                 if (errno == ENODATA || errno == ENOATTR) {
-                    gf_msg_debug(this->name, 0,
+                    gf_msg_debug(this->name, op_errno,
                                  "fgetxattr"
-                                 " failed on key %s (%s)",
-                                 key, strerror(op_errno));
+                                 " failed on key %s",
+                                 key);
                 } else {
                     gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                            "fgetxattr"
@@ -5053,16 +5052,15 @@ unlock:
         op_ret = dict_set_bin(filler->xattr, k, array, count);
         if (op_ret) {
             if (filler->real_path)
-                gf_msg_debug(this->name, 0,
+                gf_msg_debug(this->name, -size,
                              "dict_set_bin failed (path=%s): "
-                             "key=%s (%s)",
-                             filler->real_path, k, strerror(-size));
+                             "key=%s",
+                             filler->real_path, k);
             else
-                gf_msg_debug(this->name, 0,
+                gf_msg_debug(this->name, -size,
                              "dict_set_bin failed (gfid=%s): "
-                             "key=%s (%s)",
-                             uuid_utoa(filler->inode->gfid), k,
-                             strerror(-size));
+                             "key=%s",
+                             uuid_utoa(filler->inode->gfid), k);
 
             op_ret = -1;
             op_errno = EINVAL;


### PR DESCRIPTION
As strerror is already printed if there is an errnum
avoiding a redundant call to it while logging.

Fixes: #782

Change-Id: I1cde45342e439f821e2d19ca8d90e54906f7a5b2
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

