### PR TITLE
glusterd: fix for gcc-10 -Wstringop-overflow compiling warning

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14776,7 +14776,9 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
         if (tmpptr == NULL)
             goto check_failed;
         addrlen = strlen(brick) - strlen(tmpptr);
-        strncpy(brick_addr, brick, addrlen);
+        if (addrlen >= 128)
+            goto check_failed;
+        memcpy(brick_addr, brick, addrlen);
         brick_addr[addrlen] = '\0';
         ret = getaddrinfo(brick_addr, NULL, NULL, &ai_info);
         if (ret != 0) {


### PR DESCRIPTION
Fix following compiling warning:

glusterd-utils.c: In function ‘glusterd_check_brick_order’:
glusterd-utils.c:14724:9: warning: ‘strncpy’ specified bound depends
on the length of the source argument [-Wstringop-overflow=]
         strncpy(brick_addr, brick, addrlen);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glusterd-utils.c:14723:19: note: length computed here
         addrlen = strlen(brick) - strlen(tmpptr);
                   ^~~~~~~~~~~~~

Fixes: #2174
Change-Id: Ief18036ad8b27d16731ef9b2252dfb836a8fa68f
Signed-off-by: Ren Lei <renlei4@zte.com.cn>

