### PR TITLE
glusterfs:the mount operation will get stuck when the vol isn't exist

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2370,6 +2370,7 @@ post_unlock:
            restart the process */
         gf_log("mgmt", GF_LOG_ERROR, "failed to fetch volume file (key:%s)",
                ctx->cmd_args.volfile_id);
+        emancipate(ctx, ret);
         cleanup_and_exit(0);
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1119,9 +1119,12 @@ fail:
     GF_FREE(brick_name);
 
     rsp.op_ret = ret;
-    if (rsp.op_ret < 0)
+    if (rsp.op_ret < 0) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MOUNT_REQ_FAIL,
                "Failed to mount the volume");
+        if (!op_errno)
+            op_errno = ENOENT;
+    }
 
     if (op_errno)
         rsp.op_errno = gf_errno_to_error(op_errno);


### PR DESCRIPTION
when passing wrong volume-name which doesn't exits, it will get stuck.
The errno is 0 inited in glusterd-handshake.c. After initing the errno,
the process blocks in gf_fuse_umount.

