### PR TITLE
glusterd: Resolve use after free bug

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -149,11 +149,10 @@ glusterd_defrag_unref(glusterd_defrag_info_t *defrag)
     LOCK(&defrag->lock);
     {
         refcnt = --defrag->refcnt;
-        if (refcnt <= 0)
-            GF_FREE(defrag);
     }
     UNLOCK(&defrag->lock);
-
+    if (refcnt <= 0)
+        GF_FREE(defrag);
 out:
     return refcnt;
 }


### PR DESCRIPTION
In the commit 61ae58e67567ea4de8f8efc6b70a9b1f8e0f1bea
introduced a coverity bug use object after cleanup
the object.

Cleanup memory after comeout from a critical section
Fixes: #2180

Change-Id: Iee2050c4883a0dd44b8523bb822b664462ab6041
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

