### PR TITLE
api: Fix a function name in the API doc

### DIFF
--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -335,7 +335,7 @@ glfs_fini(glfs_t *fs) __THROW GFAPI_PUBLIC(glfs_fini, 3.4.0);
 /*
   SYNOPSIS
 
-      glfs_getvol: Get the volfile associated with a 'virtual mount'
+      glfs_get_volfile: Get the volfile associated with a 'virtual mount'
 
   DESCRIPTION
 


### PR DESCRIPTION
Wrong function name was mentioned in API doc
for `glfs_get_volfile`.

Change-Id: Id2251837f53270f1f03b8a5501ea335b7995873b
Updates: #1000
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>

