### PR TITLE
afr: fix error handling in (f)getxattr of lockinfo

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -6457,6 +6457,7 @@ afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno)
     int __ret = -1;
     local->op_ret = -1;
     local->op_errno = EUCLEAN;
+    local->op_result = INT64_MIN;
 
     __ret = syncbarrier_init(&local->barrier);
     if (__ret) {

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -481,6 +481,7 @@ typedef struct _afr_local {
 
     int32_t op_ret;
     int32_t op_errno;
+    int64_t op_result;
 
     int dirty[AFR_NUM_CHANGE_LOGS];
 


### PR DESCRIPTION
Change-Id: I49782c0e0c41ff85e0060103f211542e471e1464
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

