### PR TITLE
EC - Fixing a Coverity issue (Uninitialized lock use)

### DIFF
--- a/xlators/cluster/ec/src/ec-data.c
+++ b/xlators/cluster/ec/src/ec-data.c
@@ -249,8 +249,6 @@ ec_fop_data_release(ec_fop_data_t *fop)
         fop->frame->local = NULL;
         STACK_DESTROY(fop->frame->root);
 
-        LOCK_DESTROY(&fop->lock);
-
         if (fop->xdata != NULL) {
             dict_unref(fop->xdata);
         }
@@ -280,6 +278,8 @@ ec_fop_data_release(ec_fop_data_t *fop)
         ec = fop->xl->private;
         ec_handle_last_pending_fop_completion(fop, &notify);
         ec_handle_healers_done(fop);
+
+        LOCK_DESTROY(&fop->lock);
         mem_put(fop);
         if (notify) {
             ec_pending_fops_completed(ec);


### PR DESCRIPTION
CID: 1444461

A lock is being destroyed, but in some code-flows might be used later
on, modified code-flow to make sure the destroyed lock is not being used
in all cases.

Change-Id: I9610d56d9cb8a8ab7062e9094493dba9afdd0b30
updates: #1060
Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

