### PR TITLE
socket: Resolve ssl_ctx leak for a brick while only mgmt SSL is enabled

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -1154,7 +1154,7 @@ __socket_reset(rpc_transport_t *this)
         SSL_free(priv->ssl_ssl);
         priv->ssl_ssl = NULL;
     }
-    if (priv->use_ssl && priv->ssl_ctx) {
+    if (priv->ssl_ctx) {
         SSL_CTX_free(priv->ssl_ctx);
         priv->ssl_ctx = NULL;
     }
@@ -4615,7 +4615,7 @@ fini(rpc_transport_t *this)
             SSL_free(priv->ssl_ssl);
             priv->ssl_ssl = NULL;
         }
-        if (priv->use_ssl && priv->ssl_ctx) {
+        if (priv->ssl_ctx) {
             SSL_CTX_free(priv->ssl_ctx);
             priv->ssl_ctx = NULL;
         }


### PR DESCRIPTION
Problem: While only mgmt SSL is enabled for a brick process use_ssl flag
         is false for a brick process and socket api's cleanup ssl_ctx only
         while use_ssl and ssl_ctx both are valid

Solution: To avoid a leak check only ssl_ctx, if it is valid cleanup
          ssl_ctx

> Fixes: #1196
> Change-Id: I2f4295478f4149dcb7d608ea78ee5104f28812c3
> Signed-off-by: Mohit Agrawal <moagrawal@redhat.com>
> (Reviewed on upstream link https://review.gluster.org/#/c/glusterfs/+/24366/)
> (Cherry picked from commit 9873baee34afdf0c20f5fc98a7dbf2a9f07447e2)

Fixes: #2210
Change-Id: Icc403209cbd535c8226a23654262be63b74e351e
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

