### PR TITLE
cli: syntax check for arbiter volume creation (#2207)

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -657,7 +657,8 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
             if (words[index]) {
                 if (!strcmp(words[index], "arbiter")) {
                     ret = gf_string2int(words[index + 1], &arbiter_count);
-                    if ((ret == -1) || (arbiter_count != 1)) {
+                    if ((ret == -1) || (arbiter_count != 1) ||
+                        ((replica_count < 2) || (replica_count > 3))) {
                         cli_err(
                             "For arbiter "
                             "configuration, "

--- a/tests/basic/afr/arbiter-cli.t
+++ b/tests/basic/afr/arbiter-cli.t
@@ -18,6 +18,7 @@ TEST ! $CLI volume create $V0 arbiter 1 replica 3 $H0:$B0/${V0}{0,1,2}
 
 # Incorrect values for replica and arbiter count.
 TEST ! $CLI volume create $V0  replica 3 arbiter 2 $H0:$B0/${V0}{0,1,2}
+TEST ! $CLI volume create $V0  replica 4 arbiter 1 $H0:$B0/${V0}{0,1,2,3}
 
 # Correct setup
 # Only documented value is replica=2 and arbiter=1.


### PR DESCRIPTION
commit 8e7bfd6a58b444b26cb50fb98870e77302f3b9eb changed the syntax for
arbiter volume creation to 'replica 2 arbiter 1', while still allowing
the old syntax of 'replica 3 arbiter 1'. But while doing so, it also
removed a conditional check, thereby allowing replica count > 3. This
patch fixes it.

Updates: #2192
Change-Id: Ie109325adb6d78e287e658fd5f59c26ad002e2d3
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

