### PR TITLE
afr: remove priv->root_inode

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -3874,9 +3874,6 @@ afr_discover(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     }
 
     if (__is_root_gfid(loc->inode->gfid)) {
-        if (!priv->root_inode)
-            priv->root_inode = inode_ref(loc->inode);
-
         if (priv->choose_local && !priv->did_discovery) {
             /* Logic to detect which subvolumes of AFR are
                local, in order to prefer them for reads

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -1034,7 +1034,7 @@ afr_fill_ta_loc(xlator_t *this, loc_t *loc, gf_boolean_t is_gfid_based_fop)
     afr_private_t *priv = NULL;
 
     priv = this->private;
-    loc->parent = inode_ref(priv->root_inode);
+    loc->parent = inode_ref(this->itable->root);
     gf_uuid_copy(loc->pargfid, loc->parent->gfid);
     loc->name = priv->pending_key[THIN_ARBITER_BRICK_INDEX];
     if (is_gfid_based_fop && gf_uuid_is_null(priv->ta_gfid)) {

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -662,8 +662,6 @@ init(xlator_t *this)
         goto out;
     }
 
-    priv->root_inode = NULL;
-
     ret = 0;
 out:
     return ret;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -177,8 +177,6 @@ typedef struct _afr_private {
 
     xlator_t **children;
 
-    inode_t *root_inode;
-
     int favorite_child; /* subvolume to be preferred in resolving
                                     split-brain cases */
     /* For thin-arbiter. */


### PR DESCRIPTION
priv->root_inode seems to be a remenant of pump xlator and was getting
populated in discover code path. thin-arbiter code used it to populate
loc info but it seems that in case of some daemons like quotad, the
discover path for root gfid is not hit, causing it to crash.

Fix:
root inode can be accessed via this->itable->root, so use that and
remove priv->root_inode instances from the afr code.

Fixes: #2234
Change-Id: Iec59c157f963a4dc455652a5c85a797d00cba52a
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

