### PR TITLE
cluster/dht: Provide option to disable fsync in data migration

### DIFF
--- a/tests/basic/distribute/migration-fsync.t
+++ b/tests/basic/distribute/migration-fsync.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+#This tests checks if the file migration performs fsync based on option
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}0
+TEST $CLI volume set $V0 performance.quick-read off
+TEST $CLI volume set $V0 performance.io-cache off
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume set $V0 performance.read-ahead off
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+for i in {1..100};
+do
+    echo abc > $M0/$i
+done
+
+TEST $CLI volume profile $V0 start
+TEST $CLI volume add-brick $V0 $H0:$B0/${V0}1
+TEST $CLI volume rebalance $V0 start force;
+EXPECT_WITHIN $REBALANCE_TIMEOUT "completed" rebalance_status_field $V0
+fsync_count=$($CLI volume profile $V0 info incremental | grep -w FSYNC | wc -l)
+EXPECT_NOT "^0$" echo $fsync_count
+EXPECT_NOT "^0$" rebalanced_files_field $V0
+
+TEST $CLI volume set $V0 rebalance.ensure-durability off
+TEST $CLI volume add-brick $V0 $H0:$B0/${V0}2
+TEST $CLI volume rebalance $V0 start force;
+EXPECT_WITHIN $REBALANCE_TIMEOUT "completed" rebalance_status_field $V0
+fsync_count=$($CLI volume profile $V0 info incremental | grep -w FSYNC | wc -l)
+EXPECT "^0$" echo $fsync_count
+EXPECT_NOT "^0$" rebalanced_files_field $V0
+
+cleanup

--- a/tests/bugs/glusterfs/bug-861015-index.t
+++ b/tests/bugs/glusterfs/bug-861015-index.t
@@ -8,7 +8,7 @@ cleanup;
 TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1,2,3,4,5}
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0

--- a/tests/bugs/glusterfs/bug-895235.t
+++ b/tests/bugs/glusterfs/bug-895235.t
@@ -8,7 +8,7 @@ TEST glusterd
 TEST pidof glusterd
 
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1}
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST $CLI volume set $V0 performance.write-behind off
 TEST $CLI volume set $V0 cluster.eager-lock off
 TEST $CLI volume start $V0

--- a/tests/bugs/replicate/bug-1297695.t
+++ b/tests/bugs/replicate/bug-1297695.t
@@ -22,7 +22,7 @@ TEST $CLI volume set $V0 cluster.self-heal-daemon off
 
 TEST $CLI volume start $V0
 TEST $CLI volume profile $V0 start
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0
 TEST mkdir $M0/dir
 TEST touch $M0/dir/file

--- a/tests/bugs/replicate/bug-921231.t
+++ b/tests/bugs/replicate/bug-921231.t
@@ -19,7 +19,7 @@ TEST $CLI volume set $V0 post-op-delay-secs 3
 TEST $CLI volume set $V0 client-log-level DEBUG
 TEST $CLI volume start $V0
 TEST $CLI volume profile $V0 start
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0
 write_to_file &
 write_to_file &

--- a/tests/bugs/replicate/bug-976800.t
+++ b/tests/bugs/replicate/bug-976800.t
@@ -19,7 +19,7 @@ function is_fd_open {
 TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1}
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST $CLI volume set $V0 cluster.eager-lock off
 TEST $CLI volume set $V0 flush-behind off
 TEST $CLI volume start $V0

--- a/tests/bugs/replicate/bug-979365.t
+++ b/tests/bugs/replicate/bug-979365.t
@@ -14,7 +14,7 @@ function num_fsyncs {
 TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1}
-TEST $CLI volume set $V0 ensure-durability on
+TEST $CLI volume set $V0 cluster.ensure-durability on
 TEST $CLI volume set $V0 cluster.eager-lock off
 TEST $CLI volume start $V0
 TEST $CLI volume profile $V0 start
@@ -34,7 +34,7 @@ TEST $CLI volume profile $V0 stop
 TEST $CLI volume stop $V0
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
 #Disable ensure-durability now to disable fsyncs in afr.
-TEST $CLI volume set $V0 ensure-durability off
+TEST $CLI volume set $V0 cluster.ensure-durability off
 TEST $CLI volume start $V0
 TEST kill_brick $V0 $H0 $B0/${V0}0
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -615,6 +615,8 @@ struct dht_conf {
     gf_boolean_t do_weighting;
 
     gf_boolean_t randomize_by_gfid;
+
+    gf_boolean_t ensure_durability;
 };
 typedef struct dht_conf dht_conf_t;
 

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -476,6 +476,9 @@ dht_reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("force-migration", conf->force_migration, options, bool,
                      out);
 
+    GF_OPTION_RECONF("ensure-durability", conf->ensure_durability, options,
+                     bool, out);
+
     if (conf->defrag) {
         if (dict_get_str(options, "rebal-throttle", &temp_str) == 0) {
             ret = dht_configure_throttle(this, conf, temp_str);
@@ -747,6 +750,8 @@ dht_init(xlator_t *this)
     GF_OPTION_INIT("lock-migration", conf->lock_migration_enabled, bool, err);
 
     GF_OPTION_INIT("force-migration", conf->force_migration, bool, err);
+
+    GF_OPTION_INIT("ensure-durability", conf->ensure_durability, bool, err);
 
     if (defrag) {
         defrag->lock_migration_enabled = conf->lock_migration_enabled;
@@ -1095,6 +1100,15 @@ struct volume_options dht_options[] = {
      .description = "If disabled, rebalance will not migrate files that "
                     "are being written to by an application",
      .op_version = {GD_OP_VERSION_4_0_0},
+     .level = OPT_STATUS_ADVANCED,
+     .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
+
+    {.key = {"ensure-durability"},
+     .type = GF_OPTION_TYPE_BOOL,
+     .default_value = "on",
+     .description = "If disabled, rebalance will not fsync files after "
+                    "migration",
+     .op_version = {GD_OP_VERSION_10_0},
      .level = OPT_STATUS_ADVANCED,
      .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
 

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -3103,4 +3103,9 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .op_version = GD_OP_VERSION_9_0,
      .value = "yes",
      .flags = VOLOPT_FLAG_CLIENT_OPT},
+
+    {.key = "rebalance.ensure-durability",
+     .voltype = "cluster/distribute",
+     .op_version = GD_OP_VERSION_10_0,
+     .flags = VOLOPT_FLAG_CLIENT_OPT},
     {.key = NULL}};


### PR DESCRIPTION
At the moment dht rebalance doesn't give any option to disable fsync
after data migration. Making this an option would let admins take
responsibility of data in a way that is suitable for their cluster.
Default value is still 'on', so that the behavior is intact for people
who don't care about this.

For example: If the data that is going to be migrated is already backed
up or snapshotted, there is no need for fsync to happen right after
migration which can affect active I/O on the volume from applications.

fixes: #2258
Change-Id: I7a50b8d3a2f270d79920ef306ceb6ba6451150c4
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

