### PR TITLE
CID 1412333 (#1 of 1): Copy into fixed size buffer (STRING_OVERFLOW)

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -108,23 +108,25 @@ af_unix_client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
     path_data = dict_get_sizen(this->options, "transport.socket.bind-path");
     if (path_data) {
         char *path = data_to_str(path_data);
-        if (!path || path_data->len > 108) { /* 108 = addr->sun_path length */
-            gf_log(this->name, GF_LOG_TRACE,
-                   "bind-path not specified for unix socket, "
-                   "letting connect to assign default value");
-            goto err;
-        }
-
-        addr = (struct sockaddr_un *)sockaddr;
 
         int count = 0;
+
         while (path[count] != '\0') {
             count++;
         }
 
+        addr = (struct sockaddr_un *)sockaddr;
+
         if (count <= 108) {
             strcpy(addr->sun_path, path);
             ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
+
+        } else { /* 108 = addr->sun_path length */
+
+            gf_log(this->name, GF_LOG_TRACE,
+                   "bind-path not specified for unix socket, "
+                   "letting connect to assign default value");
+            goto err;
         }
 
         if (ret == -1) {

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -108,26 +108,19 @@ af_unix_client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
     path_data = dict_get_sizen(this->options, "transport.socket.bind-path");
     if (path_data) {
         char *path = data_to_str(path_data);
-
-        int count = 0;
-
-        while (path[count] != '\0') {
-            count++;
-        }
-
-        addr = (struct sockaddr_un *)sockaddr;
-
-        if (count <= 108) {
-            strcpy(addr->sun_path, path);
-            ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
-
-        } else { /* 108 = addr->sun_path length */
-
+        if (!path || path_data->len > 108) { /* 108 = addr->sun_path length */
             gf_log(this->name, GF_LOG_TRACE,
                    "bind-path not specified for unix socket, "
                    "letting connect to assign default value");
             goto err;
         }
+
+        addr = (struct sockaddr_un *)sockaddr;
+
+        strncpy(addr->sun_path, path, sizeof(addr->sun_path));
+        addr->sun_path[sizeof(addr->sun_path) - 1] = '\0';
+
+        ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
 
         if (ret == -1) {
             gf_log(this->name, GF_LOG_ERROR,

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -126,7 +126,6 @@ af_unix_client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
             gf_log(this->name, GF_LOG_ERROR,
                    "cannot bind to unix-domain socket %d (%s)", sock,
                    strerror(errno));
-            goto err;
         }
     } else {
         gf_log(this->name, GF_LOG_TRACE,

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -116,8 +116,17 @@ af_unix_client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
         }
 
         addr = (struct sockaddr_un *)sockaddr;
-        strcpy(addr->sun_path, path);
-        ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
+
+        int count = 0;
+        while (path[count] != '\0') {
+            count++;
+        }
+
+        if (count <= 108) {
+            strcpy(addr->sun_path, path);
+            ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
+        }
+
         if (ret == -1) {
             gf_log(this->name, GF_LOG_ERROR,
                    "cannot bind to unix-domain socket %d (%s)", sock,


### PR DESCRIPTION
CID: 1412333

Description:
`path` length might overrun the 108-character fixed-size string. Added a condition to check the size of `path`.

Updates: #1060

Change-Id: I4e7c58ab3a3f6807992dfc3023c21f762bff6b32
Signed-off-by: aujjwal-redhat <aujjwal@redhat.com>

