### PR TITLE
socket: Reduce the waiting time for socket connect

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -3321,11 +3321,15 @@ connect_loop(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
         if (ret >= 0) {
             break;
         }
-        if ((errno != ENOENT) || (++connect_fails >= 5)) {
+        if ((errno != ENOENT) || (++connect_fails >= 50)) {
             break;
         }
         /* coverity[SLEEP] */
-        sleep(1);
+        if (connect_fails <= 3) {
+            usleep(10000);
+        } else {
+            usleep(100000);
+        }
     }
 
     return ret;


### PR DESCRIPTION
It's a too long time to sleep 1s waiting for unix socket ready.
10ms may be sufficient.
Reduce waiting time to improve efficiency and performance.

Fixes: #2037

Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>