### PR TITLE
extras: disable lookup-optimize in virt and block groups

### DIFF
--- a/extras/group-distributed-virt
+++ b/extras/group-distributed-virt
@@ -8,3 +8,4 @@ user.cifs=off
 client.event-threads=4
 server.event-threads=4
 performance.client-io-threads=on
+cluster.lookup-optimize=off

--- a/extras/group-gluster-block
+++ b/extras/group-gluster-block
@@ -25,3 +25,4 @@ features.shard-block-size=64MB
 user.cifs=off
 server.allow-insecure=on
 cluster.choose-local=off
+cluster.lookup-optimize=off

--- a/extras/group-virt.example
+++ b/extras/group-virt.example
@@ -22,3 +22,4 @@ server.tcp-user-timeout=20
 server.keepalive-time=10
 server.keepalive-interval=2
 server.keepalive-count=5
+cluster.lookup-optimize=off


### PR DESCRIPTION
lookup-optimize doesn't provide any benefit for virtualized
environments and gluster-block workloads, but it's known to cause
corruption in some cases when sharding is also enabled and the volume
is expanded or shrunk.

For this reason, we disable lookup-optimize by default on those
environments.

Fixes: #2253
Change-Id: I25861aa50b335556a995a9c33318dd3afb41bf71
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

