### PR TITLE
extras: upgrade script for geo-rep

### DIFF
--- a/extras/glusterfs-georep-upgrade.py
+++ b/extras/glusterfs-georep-upgrade.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+"""
+
+Copyright (c) 2020 Red Hat, Inc. <http://www.redhat.com>
+This file is part of GlusterFS.
+
+This file is licensed to you under your choice of the GNU Lesser
+General Public License, version 3 or any later version (LGPLv3 or
+later), or the GNU General Public License, version 2 (GPLv2), in all
+cases as published by the Free Software Foundation.
+
+"""
+
+import argparse
+import errno
+import os, sys
+import shutil
+from datetime import datetime
+
+def find_htime_path(brick_path):
+    dirs = []
+    htime_dir = os.path.join(brick_path, '.glusterfs/changelogs/htime')
+    for file in os.listdir(htime_dir):
+        if os.path.isfile(os.path.join(htime_dir,file)) and file.startswith("HTIME"):
+            dirs.append(os.path.join(htime_dir, file))
+        else:
+            raise FileNotFoundError("%s unavailable" % (os.path.join(htime_dir, file)))
+    return dirs
+
+def modify_htime_file(brick_path):
+    htime_file_path_list = find_htime_path(brick_path)
+
+    for htime_file_path in htime_file_path_list:
+        changelog_path = os.path.join(brick_path, '.glusterfs/changelogs')
+        temp_htime_path = os.path.join(changelog_path, 'htime/temp_htime_file')
+        with open(htime_file_path, 'r') as htime_file, open(temp_htime_path, 'w') as temp_htime_file:
+            #extract epoch times from htime file
+            paths = htime_file.read().split("\x00")
+
+            for pth in paths:
+                epoch_no = pth.split(".")[-1]
+                changelog = os.path.basename(pth)
+                #convert epoch time to year, month and day
+                if epoch_no != '':
+                    date=(datetime.fromtimestamp(float(int(epoch_no))).strftime("%Y/%m/%d"))
+                    #update paths in temp htime file
+                    temp_htime_file.write("%s/%s/%s\x00" % (changelog_path, date, changelog))
+                    #create directory in the format year/month/days
+                    path = os.path.join(changelog_path, date)
+
+                if changelog.startswith("CHANGELOG."):
+                    try:
+                        os.makedirs(path, mode = 0o600);
+                    except OSError as exc:
+                        if exc.errno == errno.EEXIST:
+                            pass
+                        else:
+                            raise
+
+                    #copy existing changelogs to new directory structure, delete old changelog files
+                    shutil.copyfile(pth, os.path.join(path, changelog))
+                    os.remove(pth)
+
+        #rename temp_htime_file with htime file
+        os.rename(htime_file_path, os.path.join('%s.bak'%htime_file_path))
+        os.rename(temp_htime_path, htime_file_path)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('brick_path', help="This upgrade script, which is to be run on\
+                         server side, takes brick path as the argument, \
+                         updates paths inside htime file and alters the directory structure \
+                         above the changelog files inorder to support new optimised format \
+                         of the directory structure as per \
+                         https://review.gluster.org/#/c/glusterfs/+/23733/")
+    args = parser.parse_args()
+    modify_htime_file(args.brick_path)

--- a/extras/glusterfs-georep-upgrade.py
+++ b/extras/glusterfs-georep-upgrade.py
@@ -49,10 +49,7 @@ def modify_htime_file(brick_path):
                     path = os.path.join(changelog_path, date)
 
                 if changelog.startswith("CHANGELOG."):
-                    try:
-                        os.makedirs(path, mode = 0o600, exist_ok = True)
-                    except OSError:
-                        raise
+                    os.makedirs(path, mode = 0o600, exist_ok = True)
 
                     #copy existing changelogs to new directory structure, delete old changelog files
                     shutil.copyfile(pth, os.path.join(path, changelog))

--- a/extras/glusterfs-georep-upgrade.py
+++ b/extras/glusterfs-georep-upgrade.py
@@ -50,12 +50,9 @@ def modify_htime_file(brick_path):
 
                 if changelog.startswith("CHANGELOG."):
                     try:
-                        os.makedirs(path, mode = 0o600);
-                    except OSError as exc:
-                        if exc.errno == errno.EEXIST:
-                            pass
-                        else:
-                            raise
+                        os.makedirs(path, mode = 0o600, exist_ok = True)
+                    except OSError:
+                        raise
 
                     #copy existing changelogs to new directory structure, delete old changelog files
                     shutil.copyfile(pth, os.path.join(path, changelog))

--- a/tests/00-geo-rep/georep-upgrade.t
+++ b/tests/00-geo-rep/georep-upgrade.t
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+
+SCRIPT_TIMEOUT=500
+
+###############################################################################################
+#Before upgrade
+###############################################################################################
+brick=/bricks/brick1
+epoch1=$(date '+%s')
+sleep 1
+epoch2=$(date '+%s')
+mkdir -p /bricks/brick1/.glusterfs/changelogs/htime
+mkdir -p /bricks/brick1/.glusterfs/changelogs
+
+#multiple htime files(changelog enable/disable scenario)
+TEST touch /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch1
+TEST touch /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2
+
+#changelog files
+TEST touch /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch1
+TEST touch /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch2
+
+htime_file1=/bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch1
+htime_file2=/bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2
+
+#data inside htime files before upgrade
+data1=/bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch1
+data2=/bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch2
+
+#data inside htime files after upgrade
+updated_data1=/bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m/%d')`/CHANGELOG.$epoch1
+updated_data2=/bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m/%d')`/CHANGELOG.$epoch2
+
+echo -n $data1>$htime_file1
+echo -n $data2>$htime_file2
+
+echo "Before upgrade:"
+EXPECT '1' echo $(grep $data1 $htime_file1 | wc -l)
+EXPECT '1' echo $(grep $data2 $htime_file2 | wc -l)
+
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch1 | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch1 | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch2 | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2 | wc -l)
+###############################################################################################
+#Upgrade
+###############################################################################################
+TEST upgrade_script=$(find / -type f -name glusterfs-georep-upgrade.py)
+TEST python3 $upgrade_script $brick
+
+###############################################################################################
+#After upgrade
+###############################################################################################
+echo "After upgrade:"
+EXPECT '1' echo $(grep $updated_data1 $htime_file1 | wc -l)
+EXPECT '1' echo $(grep $updated_data2 $htime_file2 | wc -l)
+
+#Check directory structure inside changelogs
+TEST ! ls /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch1
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch1 | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch1.bak | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y')` | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m')` | wc -l)
+EXPECT '2' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m/%d')` | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m/%d')`/CHANGELOG.$epoch1 | wc -l)
+
+TEST ! ls /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch2
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2 | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2.bak | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y')` | wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m')`| wc -l)
+EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/`echo $(date '+%Y/%m/%d')`/CHANGELOG.$epoch2 | wc -l)
+
+TEST rm -rf /bricks


### PR DESCRIPTION
The patch https://review.gluster.org/#/c/glusterfs/+/23733/( which
optimizes the changelog) introduces change in dirctory structure
which is above changelog files.
Thus, before upgrade, old version should get updated, with respect
to the corresponding changes made by the above qouted patch.

This upgrade script,
1) creates a temp htime file, with updated paths from the htime file.
   Updates temp htime file as htime file.
2) places the changelog files under the required directory structure.

Updates: #154
Change-Id: I4b5a6cb9a9266a65972b419b329bc958de8fdf8a
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

