### PR TITLE
common-ha: ensure shared_storage is mounted before setup

### DIFF
--- a/extras/ganesha/scripts/ganesha-ha.sh
+++ b/extras/ganesha/scripts/ganesha-ha.sh
@@ -195,8 +195,21 @@ setup_cluster()
     local servers=${3}
     local unclean=""
     local quorum_policy="stop"
+    local dfresult=""
 
     logger "setting up cluster ${name} with the following ${servers}"
+
+    # check that shared_storage is mounted
+    dfresult=$(df -T ${HA_VOL_MNT})
+    if [[ -z "${dfresult}" ]]; then
+        logger "gluster shared_storage is not mounted, exiting..."
+        exit 1
+    fi
+
+    if [[ "${dfresult}" != *"fuse.glusterfs"* ]]; then
+        logger "gluster shared_storage is not mounted, exiting..."
+        exit 1
+    fi
 
     # pcs cluster setup --force ${PCS9OR10_PCS_CNAME_OPTION} ${name} ${servers}
     pcs cluster setup --force ${PCS9OR10_PCS_CNAME_OPTION} ${name} --enable ${servers}


### PR DESCRIPTION
If gluster shared-storage isn't mounted, ganesha will fail to start

Change-Id: I6ed7044ea6b6c61b013ebe17088bfde311b109b7
fixes: #2278
Signed-off-by: Kaleb S KEITHLEY <kkeithle@redhat.com>

