### PR TITLE
features/shard: dont set shard inode ctx when writev still in progress

### DIFF
--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -1495,12 +1495,13 @@ shard_inode_ctx_update(inode_t *inode, xlator_t *this, dict_t *xdata,
          * set 0.
          */
 
-        shard_inode_ctx_set(inode, this, buf, size, SHARD_MASK_BLOCK_SIZE);
-    }
-    /* If the file is sharded, also set the remaining attributes,
-     * except for ia_size and ia_blocks.
-     */
-    if (size) {
+        shard_inode_ctx_set(inode, this, buf, size,
+                            SHARD_LOOKUP_MASK | SHARD_MASK_BLOCK_SIZE);
+        (void)shard_inode_ctx_invalidate(inode, this, buf);
+    } else if (size) {
+        /* If the file is sharded, also set the remaining attributes,
+         * except for ia_size and ia_blocks.
+         */
         shard_inode_ctx_set(inode, this, buf, 0, SHARD_LOOKUP_MASK);
         (void)shard_inode_ctx_invalidate(inode, this, buf);
     }

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -337,6 +337,7 @@ typedef struct shard_inode_ctx {
                             sharded */
     struct iatt stat;
     gf_boolean_t refresh;
+    gf_boolean_t i_ctx_refresh_protect;
     /* The following members of inode ctx will be applicable only to the
      * individual shards' ctx and never the base file ctx.
      */
@@ -349,7 +350,6 @@ typedef struct shard_inode_ctx {
     inode_t *inode;
     int fsync_count;
     inode_t *base_inode;
-    gf_boolean_t i_ctx_refresh_protect;
 } shard_inode_ctx_t;
 
 typedef enum {

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -349,6 +349,7 @@ typedef struct shard_inode_ctx {
     inode_t *inode;
     int fsync_count;
     inode_t *base_inode;
+    gf_boolean_t i_ctx_refresh_protect;
 } shard_inode_ctx_t;
 
 typedef enum {


### PR DESCRIPTION
features/shard: dont set shard inode ctx when writev still in progress

The refresh flag is set to indicate that the client local inode
context is invalid and needs to fetch fresh values from the server.

But this will create an issue when the write FOP is still on and if this
the flag is frequently set to true as a result of readdirp or stat then
it will end up updating the wrong value at the server at the end of write fop
while updating size xattr.

The local cache will have updated values when that client itself
doing the IO. By setting the refresh flag, the client overrides the latest
context with values from the server. This will lead to a wrong size update
on the server. 

Solution: don't update the inode_ctx if the write operation is active on that
client

Please check #2246 for further explanation.

Fixes: #2246
Change-Id: Ic9920c588b33dc091797d0ca4525840482b6bff1
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>