### PR TITLE
extras: fix for postscript failure on logrotation of snapd logs

### DIFF
--- a/extras/glusterfs-logrotate
+++ b/extras/glusterfs-logrotate
@@ -61,8 +61,6 @@
     delaycompress
     notifempty
     postrotate
-    for pid in `ps -aef | grep glusterfs | egrep "snapd" | awk '{print $2}'`; do
-        /usr/bin/kill -HUP $pid > /dev/null 2>&1 || true
-    done
+    /usr/bin/killall -HUP `pgrep -f "glusterfs.*snapd"` > /dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
Issue:
On executing the logrotate command, the postscript runs as a separate process,
and when we do a `grep` for the `snapd` process it returns the PID of that
short-term process as well, and executing a kill on that throws the error.
To check a similar error could be seen if we replace the `killall` for `bricks`
log rotation with a for loop on PIDs.

Fix:
Use the `killall` command on the list of `snapd` processes instead of
using the `kill` command to individually kill them.

Fixes: #2360 

Change-Id: Ie0fcd469d5d4f653a3dbeabbd91fb5123c4cbb47
Signed-off-by: nik-redhat <nladha@redhat.com>