### PR TITLE
tests: Fix incorrect variables in throttle-rebal.t

### DIFF
--- a/tests/basic/distribute/throttle-rebal.t
+++ b/tests/basic/distribute/throttle-rebal.t
@@ -43,9 +43,9 @@ EXPECT "aggressive" echo `$CLI volume info | grep rebal-throttle | awk '{print $
 
 EXPECT "success" set_throttle $cores
 
-#Setting thorttle number to be more than the number of cores should fail
-THORTTLE_LEVEL=$((cores+1))
-TEST echo $THORTTLE_LEVEL
+#Setting throttle number to be more than the number of cores should fail
+THROTTLE_LEVEL=$((cores+1))
+TEST echo $THROTTLE_LEVEL
 EXPECT "failed" set_throttle $THROTTLE_LEVEL
 EXPECT "$cores" echo `$CLI volume info | grep rebal-throttle | awk '{print $2}'`
 


### PR DESCRIPTION
The final test doesn't test what it means to test. It still fails as expected, but only because at this point `THROTTLE_LEVEL` is still set to `garbage`.

Easily fixed by correcting the typos in the variable names, and thus fixes https://github.com/gluster/glusterfs/issues/2315

