### PR TITLE
coverity: Removed structural dead code

### DIFF
--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -685,10 +685,8 @@ server_graph_janitor_threads(void *data)
         LOCK(&ctx->volfile_lock);
         {
             totchildcount = 0;
-            for (trav_p = &top->children; *trav_p; trav_p = &(*trav_p)->next) {
+            if (top->children)
                 totchildcount++;
-                break;
-            }
             if (!totchildcount && !ctx->destroy_ctx) {
                 ctx->destroy_ctx = _gf_true;
                 destroy_ctx = _gf_true;

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -637,7 +637,6 @@ server_graph_janitor_threads(void *data)
     xlator_list_t **trav_p = NULL;
     xlator_t *top = NULL;
     uint32_t parent_down = 0;
-    uint32_t totchildcount = 1;
     struct rpc_clnt *rpc = NULL;
 
     GF_ASSERT(data);
@@ -684,10 +683,7 @@ server_graph_janitor_threads(void *data)
         xlator_mem_cleanup(victim);
         LOCK(&ctx->volfile_lock);
         {
-            totchildcount = 0;
-            if (top->children)
-                totchildcount++;
-            if (!totchildcount && !ctx->destroy_ctx) {
+            if (!top->children && !ctx->destroy_ctx) {
                 ctx->destroy_ctx = _gf_true;
                 destroy_ctx = _gf_true;
             }
@@ -699,7 +695,7 @@ server_graph_janitor_threads(void *data)
 out:
     free(arg->victim_name);
     free(arg);
-    if (!totchildcount && destroy_ctx) {
+    if (!top->children && destroy_ctx) {
         gf_log(THIS->name, GF_LOG_INFO,
                "Going to Cleanup ctx pool memory and exit the process %s",
                ctx->cmdlinestr);

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -695,7 +695,7 @@ server_graph_janitor_threads(void *data)
 out:
     free(arg->victim_name);
     free(arg);
-    if (!top->children && destroy_ctx) {
+    if (destroy_ctx) {
         gf_log(THIS->name, GF_LOG_INFO,
                "Going to Cleanup ctx pool memory and exit the process %s",
                ctx->cmdlinestr);


### PR DESCRIPTION
Issue:
`for` loop was executed only once, leading to structural
dead code in coverity

Fix:
Updated the code to use `if` condition instead of
`for` loop for the same.

CID: 1437779
Updates: #1060

Change-Id: I2ca1d2c9d2842d586161fe971bb8c7b3444dfb2b
Signed-off-by: nik-redhat <nladha@redhat.com>

