### PR TITLE
coverity: resource leak

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5449,6 +5449,7 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
 
         if (GLUSTERD_VOL_COMP_RJT == *status) {
             ret = 0;
+            update = _gf_false;
             goto out;
         }
         if (GLUSTERD_VOL_COMP_UPDATE_REQ == *status) {
@@ -5463,11 +5464,12 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
          * first brick to come up before attaching the subsequent bricks
          * in case brick multiplexing is enabled
          */
-        glusterd_launch_synctask(glusterd_import_friend_volumes_synctask, arg);
+        ret = glusterd_launch_synctask(glusterd_import_friend_volumes_synctask,
+                                       arg);
     }
 
 out:
-    if (ret && arg) {
+    if ((ret || !update) && arg) {
         dict_unref(arg->peer_data);
         dict_unref(arg->peer_ver_data);
         GF_FREE(arg);
@@ -12920,7 +12922,7 @@ gd_default_synctask_cbk(int ret, call_frame_t *frame, void *opaque)
     return ret;
 }
 
-void
+int
 glusterd_launch_synctask(synctask_fn_t fn, void *opaque)
 {
     xlator_t *this = THIS;
@@ -12934,6 +12936,8 @@ glusterd_launch_synctask(synctask_fn_t fn, void *opaque)
         gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_SPAWN_SVCS_FAIL,
                "Failed to spawn bricks"
                " and other volume related services");
+
+    return ret;
 }
 
 /*

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -669,7 +669,7 @@ int32_t
 glusterd_take_lvm_snapshot(glusterd_brickinfo_t *brickinfo,
                            char *origin_brick_path);
 
-void
+int
 glusterd_launch_synctask(synctask_fn_t fn, void *opaque);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -936,7 +936,7 @@ out:
     return ret ? -1 : 0;
 }
 #undef RUN_GSYNCD_CMD
-#else  /* SYNCDAEMON_COMPILE */
+#else /* SYNCDAEMON_COMPILE */
 static int
 configure_syncdaemon(glusterd_conf_t *conf)
 {


### PR DESCRIPTION
Issue:
Variable `arg` is not freed before the function exits,
and leads to a resource leak.

Fix:
Free the arg variable if the status of a function call
`glusterd_compare_friend_volume` is
`GLUSTERD_VOL_COMP_UPDATE_REQ`, or if the `glusterd_launch_synctask`
fails to start the process.

And, added a check for return value on calling
`glusterd_launch_synctask` function and exit if the
thread creation fails.

CID: 1401716
Updates: #1060

Change-Id: I4abd621771f88853d8d01e9039cdee2f3d862c4f
Signed-off-by: nik-redhat <nladha@redhat.com>

