### PR TITLE
cli: Increased spacing in cli for option table

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -10478,8 +10478,8 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    cli_out("%-40s%-40s", "Option", "Value");
-    cli_out("%-40s%-40s", "------", "-----");
+    cli_out("%-40s %-39s", "Option", "Value");
+    cli_out("%-40s %-39s", "------", "-----");
     for (i = 1; i <= count; i++) {
         ret = snprintf(dict_key, sizeof dict_key, "key%d", i);
         ret = dict_get_strn(dict, dict_key, ret, &key);
@@ -10496,7 +10496,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
                    dict_key);
             goto out;
         }
-        cli_out("%-39s: %-39s", key, value);
+        cli_out("%-40s %-39s", key, value);
     }
 
 out:

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -10478,8 +10478,8 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    cli_out("%-40s%-40s", "Option", "Value");
-    cli_out("%-40s%-40s", "------", "-----");
+    cli_out("%-50s%-40s", "Option", "Value");
+    cli_out("%-50s%-40s", "------", "-----");
     for (i = 1; i <= count; i++) {
         ret = snprintf(dict_key, sizeof dict_key, "key%d", i);
         ret = dict_get_strn(dict, dict_key, ret, &key);
@@ -10496,7 +10496,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
                    dict_key);
             goto out;
         }
-        cli_out("%-40s%-40s", key, value);
+        cli_out("%-50s%-40s", key, value);
     }
 
 out:

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -10478,8 +10478,8 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    cli_out("%-50s%-40s", "Option", "Value");
-    cli_out("%-50s%-40s", "------", "-----");
+    cli_out("%-40s%-40s", "Option", "Value");
+    cli_out("%-40s%-40s", "------", "-----");
     for (i = 1; i <= count; i++) {
         ret = snprintf(dict_key, sizeof dict_key, "key%d", i);
         ret = dict_get_strn(dict, dict_key, ret, &key);
@@ -10496,7 +10496,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
                    dict_key);
             goto out;
         }
-        cli_out("%-50s%-40s", key, value);
+        cli_out("%-39s: %-39s", key, value);
     }
 
 out:


### PR DESCRIPTION
Issue:
Some options have name larger than length 40,
due to which the output of command `gluster vol get <volname> all`
mixes up the option, value for long option names.

Fix:
Added a `space` separator between option and value in cli
for `gluster vol get <volname> all`output.

Fixes: #2313

Change-Id: I841730ced074547a81171a4432d15ec9c35f39cd
Signed-off-by: nik-redhat <nladha@redhat.com>

