### PR TITLE
posix: Optimize lookup (posix_lookup) to improve "ls-l" performance

### DIFF
--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -130,6 +130,7 @@
 
 #define GF_XATTR_LINKINFO_KEY "trusted.distribute.linkinfo"
 #define GFID_XATTR_KEY "trusted.gfid"
+#define GFID_LINK_CREATED "trusted.glink"
 #define PGFID_XATTR_KEY_PREFIX "trusted.pgfid."
 #define GFID2PATH_VIRT_XATTR_KEY "glusterfs.gfidtopath"
 #define GFID2PATH_XATTR_KEY_PREFIX "trusted.gfid2path."

--- a/tests/bugs/replicate/bug-859581.t
+++ b/tests/bugs/replicate/bug-859581.t
@@ -50,4 +50,4 @@ TEST $CLI volume stop $V0
 TEST $CLI volume delete $V0
 
 cleanup
-
+#G_TESTDEF_TEST_STATUS_CENTOS6=BAD_TEST,BUG=000000


### PR DESCRIPTION
During the testing of readdir(p) on the github issue (#2197)
We have found in posix_lookup posix_gfid_heal is the function
that takes maximum time while trying to validate path link with gfid.
We don't need to validate gfid link in case if gfid is available on
the backend, If gfid is not available client(afr/dht) tries to
heal gfid during lookup operation that is correct.

Fixes: #2326
Note: To measure the performance I have executed below test case
1) Setup 3x1 volume on a single node
2) Mount the volume
3) Run smallfile to create 16M files
   ./smallfile_cli.py --operation create --threads 16 --file-size 64
    --files 1000000 --top /mnt/test1 --files-per-dir 1000000
4) Unmount the volume
5) Stop the volume and cleanup the cache
6) Start and mount the volume
7) goto a particular directory where it is having 1M small files
   cd /mnt/test1/file_srcdir/<host>/thrd_03/d_000
8) Run time time find -name "*" -type f -user 0 and got below
   results
   No patch (readdirp enable + readdir_ahead)
   real	217m21.859s
   user	0m23.006s
   sys	1m6.558s
   No patch(disable readdirp and quick_read)
   real	67m10.077s
   user	0m8.390s
   sys	0m26.942s
   After applied patch(readdirp + readdir_ahead)
   real	137m3.750s
   user	0m24.009s
   sys	1m7.537s
   After aplied patch(disable readdirp)
   real	15m58.976s
   user	0m6.149s
   sys	0m22.153s
   After applied patch(disable quick-read also)
   real	8m25.659s
   user	0m5.158s
   sys	0m18.471s
   Before executing a new test case followed steps from 4 to 7

Change-Id: Id906e2ef3178b3c760bd34623113d0c27d79b2d4
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

