### PR TITLE
group-samba: disable performance.write-behind translator.

### DIFF
--- a/extras/group-samba
+++ b/extras/group-samba
@@ -9,3 +9,4 @@ performance.nl-cache=on
 performance.nl-cache-timeout=600
 performance.readdir-ahead=on
 performance.parallel-readdir=on
+performance.write-behind=off


### PR DESCRIPTION
Fixes: #2328

From the vfs_glusterfs(8) manpage:

"The GlusterFS write-behind performance translator, when used with
Samba, could be a source of data corruption. The translator, while
processing a write call, immediately returns success but continues
writing the data to the server in the background. This can cause data
corruption when two clients relying on Samba to provide data consistency
are operating on the same file."

Guenther

Signed-off-by: Günther Deschner <gd@samba.org>

