### PR TITLE
logging: fix a relock deadlock

### DIFF
--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -580,6 +580,10 @@ void
 gf_log_globals_init(void *data, gf_loglevel_t level)
 {
     glusterfs_ctx_t *ctx = data;
+    pthread_mutexattr_t log_m_attr;
+    int ret;
+
+    ret = pthread_mutexattr_init(&log_m_attr);
 
     pthread_mutex_init(&ctx->log.logfile_mutex, NULL);
 
@@ -592,7 +596,12 @@ gf_log_globals_init(void *data, gf_loglevel_t level)
     ctx->log.timeout = GF_LOG_FLUSH_TIMEOUT_DEFAULT;
     ctx->log.localtime = GF_LOG_LOCALTIME_DEFAULT;
 
-    pthread_mutex_init(&ctx->log.log_buf_lock, NULL);
+    if (ret) {
+        pthread_mutex_init(&ctx->log.log_buf_lock, NULL);
+    } else {
+        pthread_mutexattr_settype(&log_m_attr, PTHREAD_MUTEX_RECURSIVE);
+        pthread_mutex_init(&ctx->log.log_buf_lock, &log_m_attr);
+    }
 
     INIT_LIST_HEAD(&ctx->log.lru_queue);
 


### PR DESCRIPTION
In gf_log_inject_timer_event(), got lock log.log_buf_lock. Then, under the lock, any call to gf_msg will hang the thread. Because in _gf_msg_internal(), it will relock log.log_buf_lock.

Use a PTHREAD_MUTEX_RECURSIVE type instead of the default type for this mutex to fix this deadlock.

fixes: #2330

Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>