### PR TITLE
Resource Leak Coverity Fix(CID: 1430144)

### DIFF
--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -1324,7 +1324,7 @@ br_scrubber_scale_up(xlator_t *this, struct br_scrubber *fsscrub,
                "%d/%d [total scrubber(s): %d]",
                v2, i, diff, (v1 + i));
 
-    if (scrub != NULL) {
+    if (ret && scrub) {
         GF_FREE(scrub);
     }
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -1324,6 +1324,10 @@ br_scrubber_scale_up(xlator_t *this, struct br_scrubber *fsscrub,
                "%d/%d [total scrubber(s): %d]",
                v2, i, diff, (v1 + i));
 
+    if (scrub != NULL) {
+        GF_FREE(scrub);
+    }
+
     return 0;
 
 error_return:


### PR DESCRIPTION
scrub variable is allocated memory but not freed while exiting
the function.This fix frees the scrub.

Fixes CID: 1430144
Updates: #1060
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>

Change-Id: Iab4e1de6c691d9f4fa650392e7764e6b6390048a

