### PR TITLE
Errno replaced by ret

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -88,7 +88,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get volume name");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name, "
                "while handling bitrot command");
         goto out;
@@ -97,7 +97,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get type of command");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type of cmd, "
                "while handling bitrot command");
         goto out;
@@ -196,7 +196,7 @@ glusterd_bitrot_scrub_throttle(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_str(dict, "scrub-throttle-value", &scrub_throttle);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch scrub-"
                "throttle value");
         goto out;
@@ -205,7 +205,7 @@ glusterd_bitrot_scrub_throttle(glusterd_volinfo_t *volinfo, dict_t *dict,
     option = gf_strdup(scrub_throttle);
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -233,7 +233,7 @@ glusterd_bitrot_scrub_freq(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
 
     ret = dict_get_str(dict, "scrub-frequency-value", &scrub_freq);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch scrub-"
                "freq value");
         goto out;
@@ -242,7 +242,7 @@ glusterd_bitrot_scrub_freq(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
     option = gf_strdup(scrub_freq);
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -284,7 +284,7 @@ glusterd_bitrot_scrub(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
 
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -314,7 +314,7 @@ glusterd_bitrot_expiry_time(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_uint32(dict, "expiry-time", &expiry_time);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bitrot expiry"
                " timer value.");
         goto out;
@@ -324,7 +324,7 @@ glusterd_bitrot_expiry_time(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, key, dkey);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -381,7 +381,7 @@ glusterd_bitrot_signer_threads(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_uint32(dict, "signer-threads", &signer_th_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bitrot signer thread count.");
         goto out;
     }
@@ -394,7 +394,7 @@ glusterd_bitrot_signer_threads(glusterd_volinfo_t *volinfo, dict_t *dict,
     snprintf(dkey, sizeof(dkey), "%d", signer_th_count);
     ret = dict_set_dynstr_with_alloc(volinfo->dict, key, dkey);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -438,7 +438,7 @@ glusterd_bitrot_enable(glusterd_volinfo_t *volinfo, char **op_errstr)
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_BITROT, "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -446,7 +446,7 @@ glusterd_bitrot_enable(glusterd_volinfo_t *volinfo, char **op_errstr)
     /*Once bitrot is enable scrubber should be in Active state*/
     ret = dict_set_dynstr_with_alloc(volinfo->dict, "features.scrub", "Active");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option "
                "features.scrub value");
         goto out;
@@ -474,7 +474,7 @@ glusterd_bitrot_disable(glusterd_volinfo_t *volinfo, char **op_errstr)
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_BITROT,
                                      "off");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -483,7 +483,7 @@ glusterd_bitrot_disable(glusterd_volinfo_t *volinfo, char **op_errstr)
     ret = dict_set_dynstr_with_alloc(volinfo->dict, "features.scrub",
                                      "Inactive");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set "
                "features.scrub value");
         goto out;
@@ -579,7 +579,7 @@ glusterd_op_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -592,7 +592,7 @@ glusterd_op_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type from "
                "dict");
         goto out;
@@ -707,7 +707,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -728,7 +728,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type for "
                "operation");
 
@@ -751,7 +751,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         if (!ret) {
             ret = dict_get_str(dict, "scrub-value", &scrub_cmd);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                        "Unable to "
                        "get scrub-value");
                 *op_errstr = gf_strdup(

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -88,7 +88,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get volume name");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name, "
                "while handling bitrot command");
         goto out;
@@ -97,7 +97,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get type of command");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type of cmd, "
                "while handling bitrot command");
         goto out;
@@ -196,7 +196,7 @@ glusterd_bitrot_scrub_throttle(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_str(dict, "scrub-throttle-value", &scrub_throttle);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch scrub-"
                "throttle value");
         goto out;
@@ -205,7 +205,7 @@ glusterd_bitrot_scrub_throttle(glusterd_volinfo_t *volinfo, dict_t *dict,
     option = gf_strdup(scrub_throttle);
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -233,7 +233,7 @@ glusterd_bitrot_scrub_freq(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
 
     ret = dict_get_str(dict, "scrub-frequency-value", &scrub_freq);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch scrub-"
                "freq value");
         goto out;
@@ -242,7 +242,7 @@ glusterd_bitrot_scrub_freq(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
     option = gf_strdup(scrub_freq);
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -284,7 +284,7 @@ glusterd_bitrot_scrub(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
 
     ret = dict_set_dynstr(volinfo->dict, key, option);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -314,7 +314,7 @@ glusterd_bitrot_expiry_time(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_uint32(dict, "expiry-time", &expiry_time);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bitrot expiry"
                " timer value.");
         goto out;
@@ -324,7 +324,7 @@ glusterd_bitrot_expiry_time(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, key, dkey);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -381,7 +381,7 @@ glusterd_bitrot_signer_threads(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = dict_get_uint32(dict, "signer-threads", &signer_th_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bitrot signer thread count.");
         goto out;
     }
@@ -394,7 +394,7 @@ glusterd_bitrot_signer_threads(glusterd_volinfo_t *volinfo, dict_t *dict,
     snprintf(dkey, sizeof(dkey), "%d", signer_th_count);
     ret = dict_set_dynstr_with_alloc(volinfo->dict, key, dkey);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option %s", key);
         goto out;
     }
@@ -438,7 +438,7 @@ glusterd_bitrot_enable(glusterd_volinfo_t *volinfo, char **op_errstr)
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_BITROT, "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -446,7 +446,7 @@ glusterd_bitrot_enable(glusterd_volinfo_t *volinfo, char **op_errstr)
     /*Once bitrot is enable scrubber should be in Active state*/
     ret = dict_set_dynstr_with_alloc(volinfo->dict, "features.scrub", "Active");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set option "
                "features.scrub value");
         goto out;
@@ -474,7 +474,7 @@ glusterd_bitrot_disable(glusterd_volinfo_t *volinfo, char **op_errstr)
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_BITROT,
                                      "off");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -483,7 +483,7 @@ glusterd_bitrot_disable(glusterd_volinfo_t *volinfo, char **op_errstr)
     ret = dict_set_dynstr_with_alloc(volinfo->dict, "features.scrub",
                                      "Inactive");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set "
                "features.scrub value");
         goto out;
@@ -579,7 +579,7 @@ glusterd_op_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -592,7 +592,7 @@ glusterd_op_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type from "
                "dict");
         goto out;
@@ -707,7 +707,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -728,7 +728,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_int32(dict, "type", &type);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get type for "
                "operation");
 
@@ -751,7 +751,7 @@ glusterd_op_stage_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         if (!ret) {
             ret = dict_get_str(dict, "scrub-value", &scrub_cmd);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                        "Unable to "
                        "get scrub-value");
                 *op_errstr = gf_strdup(

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -294,7 +294,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "name");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -315,7 +315,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "brick count");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -381,7 +381,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
                           replica_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "failed to set the replica-count in dict");
         goto out;
     }
@@ -392,7 +392,7 @@ brick_val:
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "bricks");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -400,7 +400,7 @@ brick_val:
     if (type != volinfo->type) {
         ret = dict_set_int32n(dict, "type", SLEN("type"), type);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "failed to set the new type in dict");
             goto out;
         }
@@ -660,7 +660,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "name");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -670,7 +670,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get brick "
                  "count");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -688,7 +688,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get cmd "
                  "ccommand");
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -696,7 +696,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
     ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
                           &replica_count);
     if (!ret) {
-        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "request to change replica-count to %d", replica_count);
         ret = gd_rmbr_validate_replica_count(volinfo, replica_count, count,
                                              err_str, sizeof(err_str));
@@ -712,7 +712,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
             ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
                                   replica_count);
             if (ret) {
-                gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                        "failed to set the replica_count "
                        "in dict");
                 goto out;
@@ -775,7 +775,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
             snprintf(err_str, sizeof(err_str), "Unable to get %s", key);
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                    err_str);
             goto out;
         }
@@ -899,7 +899,7 @@ _glusterd_restart_gsync_session(dict_t *this, char *key, data_t *value,
     ret = dict_set_dynstrn(param->rsp_dict, "secondary", SLEN("secondary"),
                            secondary_buf);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to store secondary");
         if (secondary_buf)
             GF_FREE(secondary_buf);
@@ -1041,7 +1041,7 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
             snprintf(key, sizeof(key), "brick%d.mount_dir", i);
             ret = dict_get_str(dict, key, &brick_mount_dir);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                        "%s not present", key);
                 goto out;
             }
@@ -1305,7 +1305,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -1498,7 +1498,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (!count) {
         ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get count");
             goto out;
         }
@@ -1507,7 +1507,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (!bricks) {
         ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get bricks");
             goto out;
         }
@@ -1579,7 +1579,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                 ret = dict_set_dynstr_with_alloc(rsp_dict, key,
                                                  brickinfo->mount_dir);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, ret,
+                    gf_msg(this->name, GF_LOG_ERROR, -ret,
                            GD_MSG_DICT_SET_FAILED, "Failed to set %s", key);
                     goto out;
                 }
@@ -1598,7 +1598,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
                           local_brick_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count");
         goto out;
     }
@@ -1643,7 +1643,7 @@ glusterd_remove_brick_validate_bricks(gf1_op_commands cmd, int32_t brick_count,
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
             snprintf(msg, sizeof(msg), "Unable to get %s", key);
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                     "key=%s", key, NULL);
             *errstr = gf_strdup(msg);
             goto out;
@@ -1784,7 +1784,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -1803,7 +1803,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick command");
         goto out;
     }
@@ -1811,7 +1811,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick count");
         goto out;
     }
@@ -1939,7 +1939,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
                                     SLEN(GF_REMOVE_BRICK_TID_KEY),
                                     &task_id_str);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_WARNING, ret,
+                    gf_msg(this->name, GF_LOG_WARNING, -ret,
                            GD_MSG_DICT_GET_FAILED, "Missing remove-brick-id");
                     ret = 0;
                 }
@@ -2114,7 +2114,7 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2129,14 +2129,14 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
 
     ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bricks");
         goto out;
     }
@@ -2177,7 +2177,7 @@ glusterd_post_commit_add_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2195,7 +2195,7 @@ glusterd_post_commit_replace_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2233,7 +2233,7 @@ glusterd_set_rebalance_id_for_remove_brick(dict_t *req_dict, dict_t *rsp_dict)
 
     ret = dict_get_int32n(rsp_dict, "command", SLEN("command"), &cmd);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
         goto out;
     }
@@ -2323,7 +2323,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
         goto out;
     }
@@ -2423,7 +2423,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
@@ -2440,7 +2440,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
         }
         ret = dict_set_int32n(bricks_dict, "count", SLEN("count"), count);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to save remove-brick count");
             goto out;
         }
@@ -2450,7 +2450,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
         keylen = snprintf(key, sizeof(key), "brick%d", i);
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get %s", key);
             goto out;
         }
@@ -2465,7 +2465,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
             }
             ret = dict_set_dynstrn(bricks_dict, key, keylen, brick_tmpstr);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to add brick to dict");
                 goto out;
             }
@@ -2485,7 +2485,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
                           &replica_count);
     if (!ret) {
-        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "changing replica count %d to %d on volume %s",
                volinfo->replica_count, replica_count, volinfo->volname);
         volinfo->replica_count = replica_count;
@@ -2607,7 +2607,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
                "dict");
         goto out;
@@ -2633,7 +2633,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
                     "Barrier op for volume %s not present "
                     "in dict",
                     volname);
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                *op_errstr);
         goto out;
     }
@@ -2656,7 +2656,7 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
                "dict");
         goto out;
@@ -2676,14 +2676,14 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
                     "Barrier op for volume %s not present "
                     "in dict",
                     volname);
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED, "%s",
                *op_errstr);
         goto out;
     }
 
     ret = dict_set_dynstr_with_alloc(vol->dict, "features.barrier", barrier_op);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set barrier op in"
                " volume option dict");
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -294,7 +294,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "name");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -315,7 +315,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "brick count");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -335,7 +335,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     }
 
     if (!dict_getn(dict, "force", SLEN("force"))) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get flag");
         goto out;
     }
@@ -381,7 +381,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
                           replica_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "failed to set the replica-count in dict");
         goto out;
     }
@@ -392,7 +392,7 @@ brick_val:
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "bricks");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -400,7 +400,7 @@ brick_val:
     if (type != volinfo->type) {
         ret = dict_set_int32n(dict, "type", SLEN("type"), type);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "failed to set the new type in dict");
             goto out;
         }
@@ -660,7 +660,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
                  "name");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -670,7 +670,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get brick "
                  "count");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -688,7 +688,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         snprintf(err_str, sizeof(err_str),
                  "Unable to get cmd "
                  "ccommand");
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                err_str);
         goto out;
     }
@@ -696,7 +696,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
     ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
                           &replica_count);
     if (!ret) {
-        gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                "request to change replica-count to %d", replica_count);
         ret = gd_rmbr_validate_replica_count(volinfo, replica_count, count,
                                              err_str, sizeof(err_str));
@@ -712,8 +712,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
             ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
                                   replica_count);
             if (ret) {
-                gf_msg(this->name, GF_LOG_WARNING, errno,
-                       GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
                        "failed to set the replica_count "
                        "in dict");
                 goto out;
@@ -776,8 +775,8 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
             snprintf(err_str, sizeof(err_str), "Unable to get %s", key);
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                   "%s", err_str);
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
+                   err_str);
             goto out;
         }
         gf_msg_debug(this->name, 0,
@@ -900,7 +899,7 @@ _glusterd_restart_gsync_session(dict_t *this, char *key, data_t *value,
     ret = dict_set_dynstrn(param->rsp_dict, "secondary", SLEN("secondary"),
                            secondary_buf);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Unable to store secondary");
         if (secondary_buf)
             GF_FREE(secondary_buf);
@@ -1042,7 +1041,7 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
             snprintf(key, sizeof(key), "brick%d.mount_dir", i);
             ret = dict_get_str(dict, key, &brick_mount_dir);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                        "%s not present", key);
                 goto out;
             }
@@ -1306,7 +1305,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -1499,7 +1498,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (!count) {
         ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get count");
             goto out;
         }
@@ -1508,7 +1507,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (!bricks) {
         ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get bricks");
             goto out;
         }
@@ -1580,7 +1579,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                 ret = dict_set_dynstr_with_alloc(rsp_dict, key,
                                                  brickinfo->mount_dir);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, errno,
+                    gf_msg(this->name, GF_LOG_ERROR, ret,
                            GD_MSG_DICT_SET_FAILED, "Failed to set %s", key);
                     goto out;
                 }
@@ -1599,7 +1598,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
                           local_brick_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count");
         goto out;
     }
@@ -1644,7 +1643,7 @@ glusterd_remove_brick_validate_bricks(gf1_op_commands cmd, int32_t brick_count,
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
             snprintf(msg, sizeof(msg), "Unable to get %s", key);
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                     "key=%s", key, NULL);
             *errstr = gf_strdup(msg);
             goto out;
@@ -1785,7 +1784,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -1804,7 +1803,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick command");
         goto out;
     }
@@ -1812,7 +1811,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick count");
         goto out;
     }
@@ -1940,7 +1939,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
                                     SLEN(GF_REMOVE_BRICK_TID_KEY),
                                     &task_id_str);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_WARNING, errno,
+                    gf_msg(this->name, GF_LOG_WARNING, ret,
                            GD_MSG_DICT_GET_FAILED, "Missing remove-brick-id");
                     ret = 0;
                 }
@@ -2115,7 +2114,7 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2130,14 +2129,14 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
 
     ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bricks");
         goto out;
     }
@@ -2178,7 +2177,7 @@ glusterd_post_commit_add_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2196,7 +2195,7 @@ glusterd_post_commit_replace_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -2234,7 +2233,7 @@ glusterd_set_rebalance_id_for_remove_brick(dict_t *req_dict, dict_t *rsp_dict)
 
     ret = dict_get_int32n(rsp_dict, "command", SLEN("command"), &cmd);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
         goto out;
     }
@@ -2324,7 +2323,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
         goto out;
     }
@@ -2424,7 +2423,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
@@ -2441,7 +2440,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
         }
         ret = dict_set_int32n(bricks_dict, "count", SLEN("count"), count);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to save remove-brick count");
             goto out;
         }
@@ -2451,7 +2450,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
         keylen = snprintf(key, sizeof(key), "brick%d", i);
         ret = dict_get_strn(dict, key, keylen, &brick);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get %s", key);
             goto out;
         }
@@ -2466,7 +2465,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
             }
             ret = dict_set_dynstrn(bricks_dict, key, keylen, brick_tmpstr);
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to add brick to dict");
                 goto out;
             }
@@ -2486,7 +2485,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
     ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
                           &replica_count);
     if (!ret) {
-        gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                "changing replica count %d to %d on volume %s",
                volinfo->replica_count, replica_count, volinfo->volname);
         volinfo->replica_count = replica_count;
@@ -2608,7 +2607,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
                "dict");
         goto out;
@@ -2634,7 +2633,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
                     "Barrier op for volume %s not present "
                     "in dict",
                     volname);
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                *op_errstr);
         goto out;
     }
@@ -2657,7 +2656,7 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
                "dict");
         goto out;
@@ -2677,14 +2676,14 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
                     "Barrier op for volume %s not present "
                     "in dict",
                     volname);
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, "%s",
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "%s",
                *op_errstr);
         goto out;
     }
 
     ret = dict_set_dynstr_with_alloc(vol->dict, "features.barrier", barrier_op);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set barrier op in"
                " volume option dict");
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -46,7 +46,7 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, int frame_timeout,
     ret = dict_set_int32n(options, "transport.socket.ignore-enoent",
                           SLEN("transport.socket.ignore-enoent"), 1);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=transport.socket.ignore-enoent", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -46,7 +46,7 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, int frame_timeout,
     ret = dict_set_int32n(options, "transport.socket.ignore-enoent",
                           SLEN("transport.socket.ignore-enoent"), 1);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=transport.socket.ignore-enoent", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -228,7 +228,7 @@ glusterd_check_ganesha_cmd(char *key, char *value, char **errstr, dict_t *dict)
         } else if (is_origin_glusterd(dict)) {
             ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
-                gf_msg("glusterd-ganesha", GF_LOG_ERROR, ret,
+                gf_msg("glusterd-ganesha", GF_LOG_ERROR, -ret,
                        GD_MSG_DICT_GET_FAILED, "Unable to get volume name");
                 goto out;
             }
@@ -260,7 +260,7 @@ glusterd_op_stage_set_ganesha(dict_t *dict, char **op_errstr)
 
     ret = dict_get_str(dict, "value", &value);
     if (value == NULL) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "value not present.");
         goto out;
     }
@@ -318,14 +318,14 @@ glusterd_op_set_ganesha(dict_t *dict, char **errstr)
 
     ret = dict_get_str(dict, "key", &key);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Couldn't get key in global option set");
         goto out;
     }
 
     ret = dict_get_str(dict, "value", &value);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Couldn't get value in global option set");
         goto out;
     }
@@ -340,7 +340,7 @@ glusterd_op_set_ganesha(dict_t *dict, char **errstr)
     ret = dict_set_dynstr_with_alloc(priv->opts,
                                      GLUSTERD_STORE_KEY_GANESHA_GLOBAL, value);
     if (ret) {
-        gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set"
                " nfs-ganesha in dict.");
         goto out;
@@ -485,7 +485,7 @@ ganesha_manage_export(dict_t *dict, char *value,
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -731,14 +731,14 @@ teardown(gf_boolean_t run_teardown, char **op_errstr)
         unexported, hence setting the appropriate keys */
         ret = dict_set_str(vol_opts, "features.cache-invalidation", "off");
         if (ret)
-            gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                    "Could not set features.cache-invalidation "
                    "to off for %s",
                    volinfo->volname);
 
         ret = dict_set_str(vol_opts, "ganesha.enable", "off");
         if (ret)
-            gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                    "Could not set ganesha.enable to off for %s",
                    volinfo->volname);
 

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -228,7 +228,7 @@ glusterd_check_ganesha_cmd(char *key, char *value, char **errstr, dict_t *dict)
         } else if (is_origin_glusterd(dict)) {
             ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
-                gf_msg("glusterd-ganesha", GF_LOG_ERROR, errno,
+                gf_msg("glusterd-ganesha", GF_LOG_ERROR, ret,
                        GD_MSG_DICT_GET_FAILED, "Unable to get volume name");
                 goto out;
             }
@@ -260,7 +260,7 @@ glusterd_op_stage_set_ganesha(dict_t *dict, char **op_errstr)
 
     ret = dict_get_str(dict, "value", &value);
     if (value == NULL) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "value not present.");
         goto out;
     }
@@ -318,14 +318,14 @@ glusterd_op_set_ganesha(dict_t *dict, char **errstr)
 
     ret = dict_get_str(dict, "key", &key);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Couldn't get key in global option set");
         goto out;
     }
 
     ret = dict_get_str(dict, "value", &value);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Couldn't get value in global option set");
         goto out;
     }
@@ -340,7 +340,7 @@ glusterd_op_set_ganesha(dict_t *dict, char **errstr)
     ret = dict_set_dynstr_with_alloc(priv->opts,
                                      GLUSTERD_STORE_KEY_GANESHA_GLOBAL, value);
     if (ret) {
-        gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set"
                " nfs-ganesha in dict.");
         goto out;
@@ -485,7 +485,7 @@ ganesha_manage_export(dict_t *dict, char *value,
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
@@ -731,14 +731,14 @@ teardown(gf_boolean_t run_teardown, char **op_errstr)
         unexported, hence setting the appropriate keys */
         ret = dict_set_str(vol_opts, "features.cache-invalidation", "off");
         if (ret)
-            gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
                    "Could not set features.cache-invalidation "
                    "to off for %s",
                    volinfo->volname);
 
         ret = dict_set_str(vol_opts, "ganesha.enable", "off");
         if (ret)
-            gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
                    "Could not set ganesha.enable to off for %s",
                    volinfo->volname);
 

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -145,7 +145,7 @@ __glusterd_handle_sys_exec(rpcsvc_request_t *req)
 
         ret = dict_set_dynstr(dict, "host-uuid", host_uuid);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=host-uuid", NULL);
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -145,7 +145,7 @@ __glusterd_handle_sys_exec(rpcsvc_request_t *req)
 
         ret = dict_set_dynstr(dict, "host-uuid", host_uuid);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=host-uuid", NULL);
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -390,88 +390,88 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
     keylen = snprintf(key, sizeof(key), "volume%d.name", count);
     ret = dict_set_strn(volumes, key, keylen, volinfo->volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.type", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.status", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->status);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.brick_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->brick_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.dist_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->dist_leaf_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.replica_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->replica_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.disperse_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->disperse_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.redundancy_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->redundancy_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.arbiter_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->arbiter_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.transport", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->transport_type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.thin_arbiter_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->thin_arbiter_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -484,24 +484,24 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
     keylen = snprintf(key, sizeof(key), "volume%d.volume_id", count);
     ret = dict_set_dynstrn(volumes, key, keylen, volume_id_str);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.rebalance", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->rebal.defrag_cmd);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.snap_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->snap_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -524,7 +524,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
         keylen = snprintf(key, sizeof(key), "volume%d.brick%d", count, i);
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -539,7 +539,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
         }
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -561,7 +561,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
                           count);
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -658,7 +658,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
          * not be held */
         ret = dict_get_strn(dict, "volname", SLEN("volname"), &tmp);
         if (ret) {
-            gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                    "No Volume name present. "
                    "Locks not being held.");
             goto local_locking_done;
@@ -1758,7 +1758,7 @@ __glusterd_handle_cli_list_volume(rpcsvc_request_t *req)
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -2749,15 +2749,15 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
 
     ret = dict_get_int32n(dict, "op", SLEN("op"), &op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=op", NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=op",
+                NULL);
         goto out;
     }
 
@@ -4151,7 +4151,7 @@ unlock:
         uuid_utoa_r(MY_UUID, my_uuid_str);
         ret = dict_set_strn(friends, key, keylen, my_uuid_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4160,7 +4160,7 @@ unlock:
         ret = dict_set_nstrn(friends, key, keylen, "localhost",
                              SLEN("localhost"));
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4168,7 +4168,7 @@ unlock:
         keylen = snprintf(key, sizeof(key), "friend%d.connected", count);
         ret = dict_set_int32n(friends, key, keylen, 1);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4176,7 +4176,7 @@ unlock:
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -4926,7 +4926,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
          */
         ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set count "
                    "value in the dictionary");
             goto out;
@@ -5287,21 +5287,21 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
                         brickinfo->path);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=brick-name", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(dict, "cmd", SLEN("cmd"), GF_CLI_STATUS_CLIENTS);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cmd", NULL);
         goto out;
     }
 
     ret = dict_set_strn(dict, "volname", SLEN("volname"), volinfo->volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=volname", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -390,88 +390,88 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
     keylen = snprintf(key, sizeof(key), "volume%d.name", count);
     ret = dict_set_strn(volumes, key, keylen, volinfo->volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.type", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.status", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->status);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.brick_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->brick_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.dist_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->dist_leaf_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.replica_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->replica_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.disperse_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->disperse_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.redundancy_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->redundancy_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.arbiter_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->arbiter_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.transport", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->transport_type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.thin_arbiter_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->thin_arbiter_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -484,24 +484,24 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
     keylen = snprintf(key, sizeof(key), "volume%d.volume_id", count);
     ret = dict_set_dynstrn(volumes, key, keylen, volume_id_str);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.rebalance", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->rebal.defrag_cmd);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.snap_count", count);
     ret = dict_set_int32n(volumes, key, keylen, volinfo->snap_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -524,7 +524,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
         keylen = snprintf(key, sizeof(key), "volume%d.brick%d", count, i);
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -539,7 +539,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
         }
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -561,7 +561,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
                           count);
         ret = dict_set_dynstrn(volumes, key, keylen, buf);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -658,7 +658,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
          * not be held */
         ret = dict_get_strn(dict, "volname", SLEN("volname"), &tmp);
         if (ret) {
-            gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                    "No Volume name present. "
                    "Locks not being held.");
             goto local_locking_done;
@@ -1758,7 +1758,7 @@ __glusterd_handle_cli_list_volume(rpcsvc_request_t *req)
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -2749,15 +2749,15 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
 
     ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
 
     ret = dict_get_int32n(dict, "op", SLEN("op"), &op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=op",
-                NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=op", NULL);
         goto out;
     }
 
@@ -4151,7 +4151,7 @@ unlock:
         uuid_utoa_r(MY_UUID, my_uuid_str);
         ret = dict_set_strn(friends, key, keylen, my_uuid_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4160,7 +4160,7 @@ unlock:
         ret = dict_set_nstrn(friends, key, keylen, "localhost",
                              SLEN("localhost"));
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4168,7 +4168,7 @@ unlock:
         keylen = snprintf(key, sizeof(key), "friend%d.connected", count);
         ret = dict_set_int32n(friends, key, keylen, 1);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4176,7 +4176,7 @@ unlock:
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -4926,7 +4926,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
          */
         ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set count "
                    "value in the dictionary");
             goto out;
@@ -5287,21 +5287,21 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
                         brickinfo->path);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=brick-name", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(dict, "cmd", SLEN("cmd"), GF_CLI_STATUS_CLIENTS);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cmd", NULL);
         goto out;
     }
 
     ret = dict_set_strn(dict, "volname", SLEN("volname"), volinfo->volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=volname", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1586,7 +1586,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
     ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=flags", NULL);
         op_errno = -ret;
         ret = -1;
@@ -1602,7 +1602,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         op_errno = EINVAL;
         ret = -1;
@@ -1639,7 +1639,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
         }
         ret = dict_set_dynstr(dict_rsp, "volume_id", volume_id_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=volume_id", NULL);
             op_errno = -ret;
             ret = -1;
@@ -1740,7 +1740,7 @@ __server_get_snap_info(rpcsvc_request_t *req)
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         op_errno = EINVAL;
-        gf_msg("glusterd", GF_LOG_ERROR, EINVAL, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Failed to retrieve volname");
         ret = -1;
         goto out;
@@ -1957,22 +1957,22 @@ gd_validate_peer_op_version(xlator_t *this, glusterd_peerinfo_t *peerinfo,
 
     ret = dict_get_int32(dict, GD_OP_VERSION_KEY, &peer_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GD_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GD_OP_VERSION_KEY, NULL);
         goto out;
     }
 
     ret = dict_get_int32(dict, GD_MAX_OP_VERSION_KEY, &peer_max_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GD_MAX_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GD_MAX_OP_VERSION_KEY, NULL);
         goto out;
     }
 
     ret = dict_get_int32(dict, GD_MIN_OP_VERSION_KEY, &peer_min_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GD_MIN_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GD_MIN_OP_VERSION_KEY, NULL);
         goto out;
     }
 
@@ -2256,7 +2256,7 @@ glusterd_mgmt_handshake(xlator_t *this, glusterd_peerctx_t *peerctx)
     ret = dict_set_dynstr(req_dict, GD_PEER_ID_KEY,
                           gf_strdup(uuid_utoa(MY_UUID)));
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "failed to set peer ID in dict");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1586,7 +1586,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
     ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=flags", NULL);
         op_errno = -ret;
         ret = -1;
@@ -1602,7 +1602,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         op_errno = EINVAL;
         ret = -1;
@@ -1639,7 +1639,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
         }
         ret = dict_set_dynstr(dict_rsp, "volume_id", volume_id_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=volume_id", NULL);
             op_errno = -ret;
             ret = -1;
@@ -1740,7 +1740,7 @@ __server_get_snap_info(rpcsvc_request_t *req)
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         op_errno = EINVAL;
-        gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Failed to retrieve volname");
         ret = -1;
         goto out;
@@ -1957,22 +1957,22 @@ gd_validate_peer_op_version(xlator_t *this, glusterd_peerinfo_t *peerinfo,
 
     ret = dict_get_int32(dict, GD_OP_VERSION_KEY, &peer_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GD_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GD_OP_VERSION_KEY, NULL);
         goto out;
     }
 
     ret = dict_get_int32(dict, GD_MAX_OP_VERSION_KEY, &peer_max_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GD_MAX_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GD_MAX_OP_VERSION_KEY, NULL);
         goto out;
     }
 
     ret = dict_get_int32(dict, GD_MIN_OP_VERSION_KEY, &peer_min_op_version);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GD_MIN_OP_VERSION_KEY, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GD_MIN_OP_VERSION_KEY, NULL);
         goto out;
     }
 
@@ -2256,7 +2256,7 @@ glusterd_mgmt_handshake(xlator_t *this, glusterd_peerctx_t *peerctx)
     ret = dict_set_dynstr(req_dict, GD_PEER_ID_KEY,
                           gf_strdup(uuid_utoa(MY_UUID)));
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "failed to set peer ID in dict");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.c
@@ -213,7 +213,7 @@ glusterd_hooks_set_volume_args(dict_t *dict, runner_t *runner)
 
     ret = dict_get_int32(dict, "count", &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -364,7 +364,7 @@ glusterd_hooks_run_hooks(char *hooks_path, glusterd_op_t op, dict_t *op_ctx,
 
     ret = dict_get_str(op_ctx, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_CRITICAL, -ret, GD_MSG_DICT_GET_FAILED,
                "Failed to get volname "
                "from operation context");
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.c
@@ -213,7 +213,7 @@ glusterd_hooks_set_volume_args(dict_t *dict, runner_t *runner)
 
     ret = dict_get_int32(dict, "count", &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -364,7 +364,7 @@ glusterd_hooks_run_hooks(char *hooks_path, glusterd_op_t op, dict_t *op_ctx,
 
     ret = dict_get_str(op_ctx, "volname", &volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
                "Failed to get volname "
                "from operation context");
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-log-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-log-ops.c
@@ -137,7 +137,7 @@ glusterd_op_stage_log_rotate(dict_t *dict, char **op_errstr)
     /* If no brick is specified, do log-rotate for
        all the bricks in the volume */
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=brick", NULL);
         ret = 0;
         goto out;
@@ -203,7 +203,7 @@ glusterd_op_log_rotate(dict_t *dict)
     /* If no brick is specified, do log-rotate for
        all the bricks in the volume */
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=brick", NULL);
         goto cont;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-log-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-log-ops.c
@@ -137,7 +137,7 @@ glusterd_op_stage_log_rotate(dict_t *dict, char **op_errstr)
     /* If no brick is specified, do log-rotate for
        all the bricks in the volume */
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=brick", NULL);
         ret = 0;
         goto out;
@@ -203,7 +203,7 @@ glusterd_op_log_rotate(dict_t *dict)
     /* If no brick is specified, do log-rotate for
        all the bricks in the volume */
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=brick", NULL);
         goto cont;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -1131,8 +1131,7 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
         case GD_OP_PROFILE_VOLUME: {
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_msg(this->name, GF_LOG_CRITICAL, errno,
-                       GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
                        "operation ctx");
                 goto out;
@@ -1153,8 +1152,7 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
             }
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_msg(this->name, GF_LOG_CRITICAL, errno,
-                       GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
                        "operation ctx");
                 goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -1131,7 +1131,8 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
         case GD_OP_PROFILE_VOLUME: {
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_CRITICAL, -ret,
+                       GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
                        "operation ctx");
                 goto out;
@@ -1152,7 +1153,8 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
             }
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_msg(this->name, GF_LOG_CRITICAL, ret, GD_MSG_DICT_GET_FAILED,
+                gf_msg(this->name, GF_LOG_CRITICAL, -ret,
+                       GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
                        "operation ctx");
                 goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -266,7 +266,7 @@ glusterd_set_txn_opinfo(uuid_t *txn_id, glusterd_op_info_t *opinfo)
         ret = dict_set_bin(priv->glusterd_txn_opinfo, uuid_utoa(*txn_id),
                            opinfo_obj, sizeof(glusterd_txn_opinfo_obj));
         if (ret) {
-            gf_msg_callingfn(this->name, GF_LOG_ERROR, ret,
+            gf_msg_callingfn(this->name, GF_LOG_ERROR, -ret,
                              GD_MSG_DICT_SET_FAILED,
                              "Unable to set opinfo for transaction"
                              " ID : %s",
@@ -566,13 +566,13 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
                                   (int32_t *)&heal_op);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=heal-op", NULL);
                 goto out;
             }
             ret = dict_set_int32n(dict, "xl-op", SLEN("xl-op"), heal_op);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                         "Key=xl-op", NULL);
                 goto out;
             }
@@ -590,7 +590,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
                                 brickinfo->path);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                         "Key=brick-name", NULL);
                 goto out;
             }
@@ -608,7 +608,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             brick_req->op = GLUSTERD_BRICK_XLATOR_DEFRAG;
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
                 goto out;
             }
@@ -715,7 +715,7 @@ glusterd_node_op_build_payload(glusterd_op_t op, gd1_mgmt_brick_op_req **req,
 
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
                 goto out;
             }
@@ -1109,7 +1109,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
         keystr_len = sprintf(keystr, "key%d", count);
         ret = dict_get_strn(dict, keystr, keystr_len, &key);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", keystr, NULL);
             break;
         }
@@ -1669,7 +1669,7 @@ glusterd_op_stage_sync_volume(dict_t *dict, char **op_errstr)
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
                  "retrieved from msg");
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         *op_errstr = gf_strdup(msg);
         goto out;
@@ -1752,7 +1752,7 @@ glusterd_op_stage_status_volume(dict_t *dict, char **op_errstr)
 
     ret = dict_get_uint32(dict, "cmd", &cmd);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=cmd", NULL);
         goto out;
     }
@@ -2213,8 +2213,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     }
 
@@ -2228,8 +2228,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     } else
         next_version = NULL;
@@ -2421,7 +2421,7 @@ glusterd_update_volumes_dict(glusterd_volinfo_t *volinfo)
             ret = dict_set_dynstr_with_alloc(volinfo->dict, NFS_DISABLE_MAP_KEY,
                                              "on");
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to set "
                        "option ' NFS_DISABLE_MAP_KEY ' on "
                        "volume %s",
@@ -2437,7 +2437,7 @@ glusterd_update_volumes_dict(glusterd_volinfo_t *volinfo)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "transport.address-family", "inet");
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, ret,
+                    gf_msg(this->name, GF_LOG_ERROR, -ret,
                            GD_MSG_DICT_SET_FAILED,
                            "failed to set transport."
                            "address-family on %s",
@@ -2533,7 +2533,7 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     conf = this->private;
     ret = dict_get_strn(dict, "key1", SLEN("key1"), &key);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
@@ -2669,8 +2669,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     dict_copy(conf->opts, dup_opt);
     ret = dict_set_str(dup_opt, key, value);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -2681,8 +2681,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     }
 
@@ -2696,8 +2696,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     } else
         next_version = NULL;
@@ -2708,8 +2708,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
 
     ret = dict_set_dynstr(conf->opts, key, dup_value);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     } else
         dup_value = NULL; /* Protect the allocation from GF_FREE */
@@ -2816,7 +2816,7 @@ glusterd_set_shared_storage(dict_t *dict, char *key, char *value,
 
     ret = dict_set_dynstr_with_alloc(dict, "hooks_args", hooks_args);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set"
                " hooks_args in dict.");
         goto out;
@@ -3155,7 +3155,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
                  "retrieved from msg");
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         *op_errstr = gf_strdup(msg);
         goto out;
@@ -3728,7 +3728,7 @@ glusterd_op_status_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_set_int32n(rsp_dict, "type", SLEN("type"), volinfo->type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -266,7 +266,7 @@ glusterd_set_txn_opinfo(uuid_t *txn_id, glusterd_op_info_t *opinfo)
         ret = dict_set_bin(priv->glusterd_txn_opinfo, uuid_utoa(*txn_id),
                            opinfo_obj, sizeof(glusterd_txn_opinfo_obj));
         if (ret) {
-            gf_msg_callingfn(this->name, GF_LOG_ERROR, errno,
+            gf_msg_callingfn(this->name, GF_LOG_ERROR, ret,
                              GD_MSG_DICT_SET_FAILED,
                              "Unable to set opinfo for transaction"
                              " ID : %s",
@@ -566,13 +566,13 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
                                   (int32_t *)&heal_op);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                         "Key=heal-op", NULL);
                 goto out;
             }
             ret = dict_set_int32n(dict, "xl-op", SLEN("xl-op"), heal_op);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                         "Key=xl-op", NULL);
                 goto out;
             }
@@ -590,7 +590,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
                                 brickinfo->path);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                         "Key=brick-name", NULL);
                 goto out;
             }
@@ -608,7 +608,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             brick_req->op = GLUSTERD_BRICK_XLATOR_DEFRAG;
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
                 goto out;
             }
@@ -715,7 +715,7 @@ glusterd_node_op_build_payload(glusterd_op_t op, gd1_mgmt_brick_op_req **req,
 
             ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
                 goto out;
             }
@@ -1109,7 +1109,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
         keystr_len = sprintf(keystr, "key%d", count);
         ret = dict_get_strn(dict, keystr, keystr_len, &key);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", keystr, NULL);
             break;
         }
@@ -1669,7 +1669,7 @@ glusterd_op_stage_sync_volume(dict_t *dict, char **op_errstr)
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
                  "retrieved from msg");
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         *op_errstr = gf_strdup(msg);
         goto out;
@@ -1752,7 +1752,7 @@ glusterd_op_stage_status_volume(dict_t *dict, char **op_errstr)
 
     ret = dict_get_uint32(dict, "cmd", &cmd);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=cmd", NULL);
         goto out;
     }
@@ -2213,8 +2213,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     }
 
@@ -2228,8 +2228,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     } else
         next_version = NULL;
@@ -2421,7 +2421,7 @@ glusterd_update_volumes_dict(glusterd_volinfo_t *volinfo)
             ret = dict_set_dynstr_with_alloc(volinfo->dict, NFS_DISABLE_MAP_KEY,
                                              "on");
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to set "
                        "option ' NFS_DISABLE_MAP_KEY ' on "
                        "volume %s",
@@ -2437,7 +2437,7 @@ glusterd_update_volumes_dict(glusterd_volinfo_t *volinfo)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "transport.address-family", "inet");
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, errno,
+                    gf_msg(this->name, GF_LOG_ERROR, ret,
                            GD_MSG_DICT_SET_FAILED,
                            "failed to set transport."
                            "address-family on %s",
@@ -2533,7 +2533,7 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     conf = this->private;
     ret = dict_get_strn(dict, "key1", SLEN("key1"), &key);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
@@ -2669,8 +2669,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     dict_copy(conf->opts, dup_opt);
     ret = dict_set_str(dup_opt, key, value);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -2681,8 +2681,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     }
 
@@ -2696,8 +2696,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
         goto out;
     } else
         next_version = NULL;
@@ -2708,8 +2708,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
 
     ret = dict_set_dynstr(conf->opts, key, dup_value);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     } else
         dup_value = NULL; /* Protect the allocation from GF_FREE */
@@ -2816,7 +2816,7 @@ glusterd_set_shared_storage(dict_t *dict, char *key, char *value,
 
     ret = dict_set_dynstr_with_alloc(dict, "hooks_args", hooks_args);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set"
                " hooks_args in dict.");
         goto out;
@@ -3155,7 +3155,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
                  "retrieved from msg");
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         *op_errstr = gf_strdup(msg);
         goto out;
@@ -3728,7 +3728,7 @@ glusterd_op_status_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     ret = dict_set_int32n(rsp_dict, "type", SLEN("type"), volinfo->type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -616,7 +616,7 @@ glusterd_inode_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_INODE_QUOTA,
                                      "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -664,7 +664,7 @@ glusterd_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_QUOTA, "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -680,7 +680,7 @@ glusterd_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
     ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                      "features.quota-deem-statfs", "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "setting quota-deem-statfs"
                "in volinfo failed");
         goto out;
@@ -732,7 +732,7 @@ glusterd_quota_disable(glusterd_volinfo_t *volinfo, char **op_errstr,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_QUOTA, "off");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -616,7 +616,7 @@ glusterd_inode_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_INODE_QUOTA,
                                      "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -664,7 +664,7 @@ glusterd_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_QUOTA, "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }
@@ -680,7 +680,7 @@ glusterd_quota_enable(glusterd_volinfo_t *volinfo, char **op_errstr,
     ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                      "features.quota-deem-statfs", "on");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "setting quota-deem-statfs"
                "in volinfo failed");
         goto out;
@@ -732,7 +732,7 @@ glusterd_quota_disable(glusterd_volinfo_t *volinfo, char **op_errstr,
 
     ret = dict_set_dynstr_with_alloc(volinfo->dict, VKEY_FEATURES_QUOTA, "off");
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "dict set failed");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -1456,20 +1456,20 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
     GF_ASSERT(priv);
     ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         goto out;
     }
     ret = dict_get_int32n(dict, "port", SLEN("port"), &port);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_DEBUG, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_DEBUG, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=port", NULL);
         port = GF_DEFAULT_BASE_PORT;
     }
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1541,7 +1541,7 @@ glusterd_rpc_friend_add(call_frame_t *frame, xlator_t *this, void *data)
     ret = dict_set_dynstr_with_alloc(peer_data, "hostname_in_cluster",
                                      peerinfo->hostname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Unable to add hostname of the peer");
         goto out;
     }
@@ -1752,7 +1752,7 @@ glusterd_mgmt_v3_lock_peers(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1828,7 +1828,7 @@ glusterd_mgmt_v3_unlock_peers(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1941,7 +1941,7 @@ glusterd_stage_op(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -2016,7 +2016,7 @@ glusterd_commit_op(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -1456,20 +1456,20 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
     GF_ASSERT(priv);
     ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         goto out;
     }
     ret = dict_get_int32n(dict, "port", SLEN("port"), &port);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_DEBUG, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=port", NULL);
         port = GF_DEFAULT_BASE_PORT;
     }
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1541,7 +1541,7 @@ glusterd_rpc_friend_add(call_frame_t *frame, xlator_t *this, void *data)
     ret = dict_set_dynstr_with_alloc(peer_data, "hostname_in_cluster",
                                      peerinfo->hostname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to add hostname of the peer");
         goto out;
     }
@@ -1752,7 +1752,7 @@ glusterd_mgmt_v3_lock_peers(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1828,7 +1828,7 @@ glusterd_mgmt_v3_unlock_peers(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -1941,7 +1941,7 @@ glusterd_stage_op(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }
@@ -2016,7 +2016,7 @@ glusterd_commit_op(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=peerinfo", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -89,7 +89,7 @@ glusterd_validate_quorum(xlator_t *this, glusterd_op_t op, dict_t *dict,
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         ret = 0;
         goto out;
@@ -254,8 +254,8 @@ glusterd_is_volume_in_server_quorum(glusterd_volinfo_t *volinfo)
 
     ret = dict_get_str(volinfo->dict, GLUSTERD_QUORUM_TYPE_KEY, &quorum_type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GLUSTERD_QUORUM_TYPE_KEY, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GLUSTERD_QUORUM_TYPE_KEY, NULL);
         goto out;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -89,7 +89,7 @@ glusterd_validate_quorum(xlator_t *this, glusterd_op_t op, dict_t *dict,
 
     ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         ret = 0;
         goto out;
@@ -254,8 +254,8 @@ glusterd_is_volume_in_server_quorum(glusterd_volinfo_t *volinfo)
 
     ret = dict_get_str(volinfo->dict, GLUSTERD_QUORUM_TYPE_KEY, &quorum_type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GLUSTERD_QUORUM_TYPE_KEY, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GLUSTERD_QUORUM_TYPE_KEY, NULL);
         goto out;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -171,28 +171,28 @@ glusterd_shdsvc_create_volfile(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(mod_dict, "cluster.background-self-heal-count", 0);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.background-self-heal-count", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.data-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.data-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.metadata-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.metadata-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.entry-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.entry-self-heal", NULL);
         goto out;
     }
@@ -376,7 +376,7 @@ glusterd_new_shd_svc_start(glusterd_svc_t *svc, int flags)
 
     ret = dict_set_str(cmdline, "arg", client_pid);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg", NULL);
         goto out;
     }
@@ -386,28 +386,28 @@ glusterd_new_shd_svc_start(glusterd_svc_t *svc, int flags)
      * should be put in reverse order*/
     ret = dict_set_str(cmdline, "arg4", svc->name);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg4", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg3", GD_SHD_PROCESS_NAME);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg3", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg2", glusterd_uuid_option);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg2", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg1", "--xlator-option");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg1", NULL);
         goto out;
     }
@@ -574,35 +574,35 @@ glusterd_shdsvc_reconfigure(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(mod_dict, "cluster.background-self-heal-count", 0);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.background-self-heal-count", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.data-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.data-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.metadata-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.metadata-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_int32(mod_dict, "graph-check", 1);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=graph-check", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.entry-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.entry-self-heal", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -171,28 +171,28 @@ glusterd_shdsvc_create_volfile(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(mod_dict, "cluster.background-self-heal-count", 0);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.background-self-heal-count", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.data-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.data-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.metadata-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.metadata-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.entry-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.entry-self-heal", NULL);
         goto out;
     }
@@ -376,7 +376,7 @@ glusterd_new_shd_svc_start(glusterd_svc_t *svc, int flags)
 
     ret = dict_set_str(cmdline, "arg", client_pid);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg", NULL);
         goto out;
     }
@@ -386,28 +386,28 @@ glusterd_new_shd_svc_start(glusterd_svc_t *svc, int flags)
      * should be put in reverse order*/
     ret = dict_set_str(cmdline, "arg4", svc->name);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg4", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg3", GD_SHD_PROCESS_NAME);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg3", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg2", glusterd_uuid_option);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg2", NULL);
         goto out;
     }
 
     ret = dict_set_str(cmdline, "arg1", "--xlator-option");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=arg1", NULL);
         goto out;
     }
@@ -574,35 +574,35 @@ glusterd_shdsvc_reconfigure(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(mod_dict, "cluster.background-self-heal-count", 0);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.background-self-heal-count", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.data-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.data-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.metadata-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.metadata-self-heal", NULL);
         goto out;
     }
 
     ret = dict_set_int32(mod_dict, "graph-check", 1);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=graph-check", NULL);
         goto out;
     }
 
     ret = dict_set_str(mod_dict, "cluster.entry-self-heal", "on");
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cluster.entry-self-heal", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -155,23 +155,23 @@ glusterd_broadcast_friend_delete(char *hostname, uuid_t uuid)
     keylen = snprintf(key, sizeof(key), "op");
     ret = dict_set_int32n(friends, key, keylen, ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "hostname");
     ret = dict_set_strn(friends, key, keylen, hostname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -405,14 +405,14 @@ glusterd_ac_friend_probe(glusterd_friend_sm_event_t *event, void *ctx)
         ret = dict_set_strn(dict, "hostname", SLEN("hostname"),
                             probe_ctx->hostname);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=hostname", NULL);
             goto unlock;
         }
 
         ret = dict_set_int32n(dict, "port", SLEN("port"), probe_ctx->port);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=port", NULL);
             goto unlock;
         }
@@ -589,8 +589,8 @@ glusterd_ac_send_friend_update(glusterd_friend_sm_event_t *event, void *ctx)
     ev_ctx.op = GD_FRIEND_UPDATE_ADD;
     ret = dict_set_int32n(friends, key, keylen, ev_ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto unlock;
     }
 
@@ -609,7 +609,7 @@ glusterd_ac_send_friend_update(glusterd_friend_sm_event_t *event, void *ctx)
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto unlock;
     }
@@ -705,8 +705,8 @@ glusterd_ac_update_friend(glusterd_friend_sm_event_t *event, void *ctx)
     ev_ctx.op = GD_FRIEND_UPDATE_ADD;
     ret = dict_set_int32n(friends, key, keylen, ev_ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto unlock;
     }
 
@@ -725,7 +725,7 @@ glusterd_ac_update_friend(glusterd_friend_sm_event_t *event, void *ctx)
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto unlock;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -155,23 +155,23 @@ glusterd_broadcast_friend_delete(char *hostname, uuid_t uuid)
     keylen = snprintf(key, sizeof(key), "op");
     ret = dict_set_int32n(friends, key, keylen, ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "hostname");
     ret = dict_set_strn(friends, key, keylen, hostname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -405,14 +405,14 @@ glusterd_ac_friend_probe(glusterd_friend_sm_event_t *event, void *ctx)
         ret = dict_set_strn(dict, "hostname", SLEN("hostname"),
                             probe_ctx->hostname);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=hostname", NULL);
             goto unlock;
         }
 
         ret = dict_set_int32n(dict, "port", SLEN("port"), probe_ctx->port);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=port", NULL);
             goto unlock;
         }
@@ -589,8 +589,8 @@ glusterd_ac_send_friend_update(glusterd_friend_sm_event_t *event, void *ctx)
     ev_ctx.op = GD_FRIEND_UPDATE_ADD;
     ret = dict_set_int32n(friends, key, keylen, ev_ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto unlock;
     }
 
@@ -609,7 +609,7 @@ glusterd_ac_send_friend_update(glusterd_friend_sm_event_t *event, void *ctx)
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto unlock;
     }
@@ -705,8 +705,8 @@ glusterd_ac_update_friend(glusterd_friend_sm_event_t *event, void *ctx)
     ev_ctx.op = GD_FRIEND_UPDATE_ADD;
     ret = dict_set_int32n(friends, key, keylen, ev_ctx.op);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto unlock;
     }
 
@@ -725,7 +725,7 @@ glusterd_ac_update_friend(glusterd_friend_sm_event_t *event, void *ctx)
 
     ret = dict_set_int32n(friends, "count", SLEN("count"), count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto unlock;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -5061,7 +5061,7 @@ glusterd_snap_set_unsupported_opt(
         ret = dict_set_dynstr(volinfo->dict, unsupported_opt[i].key,
                               unsupported_opt[i].value);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "dict set failed");
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -5061,7 +5061,7 @@ glusterd_snap_set_unsupported_opt(
         ret = dict_set_dynstr(volinfo->dict, unsupported_opt[i].key,
                               unsupported_opt[i].value);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "dict set failed");
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1474,7 +1474,7 @@ commit_done:
     if (op == GD_OP_STATUS_VOLUME) {
         ret = dict_get_uint32(req_dict, "cmd", &cmd);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                     "Key=cmd", NULL);
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1474,7 +1474,7 @@ commit_done:
     if (op == GD_OP_STATUS_VOLUME) {
         ret = dict_get_uint32(req_dict, "cmd", &cmd);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                     "Key=cmd", NULL);
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3001,7 +3001,7 @@ glusterd_add_bricks_hname_path_to_dict(dict_t *dict,
         ret = snprintf(key, sizeof(key), "%d-hostname", index);
         ret = dict_set_strn(dict, key, ret, brickinfo->hostname);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3009,7 +3009,7 @@ glusterd_add_bricks_hname_path_to_dict(dict_t *dict,
         ret = snprintf(key, sizeof(key), "%d-path", index);
         ret = dict_set_strn(dict, key, ret, brickinfo->path);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3134,7 +3134,7 @@ glusterd_add_volume_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = gd_add_vol_snap_details_to_dict(dict, pfx, volinfo);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "vol snap details", NULL);
         goto out;
     }
@@ -3329,8 +3329,8 @@ out:
     GF_FREE(rb_id_str);
 
     if (key[0] != '\0' && ret != 0)
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
     gf_msg_debug(this->name, 0, "Returning with %d", ret);
     return ret;
 }
@@ -3388,7 +3388,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         snprintf(key, sizeof(key) - 1, "%s.gfid%d", key_prefix, gfid_idx);
         ret = dict_set_dynstr_with_alloc(load, key, uuid_utoa(buf));
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3396,7 +3396,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         snprintf(key, sizeof(key) - 1, "%s.gfid-type%d", key_prefix, gfid_idx);
         ret = dict_set_int8(load, key, type);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3405,24 +3405,24 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
     ret = snprintf(key, sizeof(key), "%s.gfid-count", key_prefix);
     ret = dict_set_int32n(load, key, ret, gfid_idx);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     snprintf(key, sizeof(key), "%s.quota-cksum", key_prefix);
     ret = dict_set_uint32(load, key, volinfo->quota_conf_cksum);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     snprintf(key, sizeof(key), "%s.quota-version", key_prefix);
     ret = dict_set_uint32(load, key, volinfo->quota_conf_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -3755,7 +3755,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     keylen = snprintf(key, sizeof(key), "%s.name", key_prefix);
     ret = dict_get_strn(arg->peer_ver_data, key, keylen, &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -3776,7 +3776,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     keylen = snprintf(key, sizeof(key), "%s.version", key_prefix);
     ret = dict_get_int32n(arg->peer_ver_data, key, keylen, &version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -3800,7 +3800,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     snprintf(key, sizeof(key), "%s.ckusm", key_prefix);
     ret = dict_get_uint32(arg->peer_ver_data, key, &cksum);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -4329,8 +4329,8 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
     keylen = snprintf(key, sizeof(key), "%s.gfid-count", key_prefix);
     ret = dict_get_int32n(peer_data, key, keylen, &gfid_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -4343,7 +4343,7 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
                           gfid_idx);
         ret = dict_get_strn(peer_data, key, keylen, &gfid_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4414,7 +4414,7 @@ gd_import_friend_volume_rebal_dict(dict_t *dict, int count,
     ret = dict_get_int32n(dict, key, ret, &dict_count);
     if (ret) {
         /* Older peers will not have this dict */
-        gf_smsg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+        gf_smsg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
                 key, NULL);
         ret = 0;
         goto out;
@@ -5082,7 +5082,7 @@ glusterd_import_friend_volume(dict_t *peer_data, int count,
         ret = snprintf(key, sizeof(key), "volume%d.update", count);
         ret = dict_get_int32n(peer_data, key, ret, &update);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -5199,7 +5199,7 @@ glusterd_import_friend_volumes_synctask(void *opaque)
     peer_data = arg->peer_data;
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5256,7 +5256,7 @@ glusterd_import_friend_volumes(dict_t *peer_data)
 
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5282,8 +5282,8 @@ glusterd_get_global_server_quorum_ratio(dict_t *opts, double *quorum)
     ret = dict_get_strn(opts, GLUSTERD_QUORUM_RATIO_KEY,
                         SLEN(GLUSTERD_QUORUM_RATIO_KEY), &quorum_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GLUSTERD_QUORUM_RATIO_KEY, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GLUSTERD_QUORUM_RATIO_KEY, NULL);
     } else {
         ret = gf_string2percent(quorum_str, quorum);
     }
@@ -5299,8 +5299,8 @@ glusterd_get_global_opt_version(dict_t *opts, uint32_t *version)
     ret = dict_get_strn(opts, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), &version_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
     } else {
         ret = gf_string2uint(version_str, version);
     }
@@ -5345,7 +5345,7 @@ glusterd_import_global_opts(dict_t *friend_data)
                           SLEN("global-opt-count"), &count);
     if (ret) {
         // old version peer
-        gf_smsg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=global-opt-count", NULL);
         ret = 0;
         goto out;
@@ -5426,7 +5426,7 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
 
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5698,16 +5698,16 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
         ret = dict_set_nstrn(dict, key, keylen, "Scrubber Daemon",
                              SLEN("Scrubber Daemon"));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.path", count);
     ret = dict_set_dynstrn(dict, key, keylen, gf_strdup(uuid_utoa(MY_UUID)));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -5721,7 +5721,7 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
             ret = dict_get_int32n(vol_opts, "nfs.port", SLEN("nfs.port"),
                                   &port);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=nfs.port", NULL);
                 goto out;
             }
@@ -5732,24 +5732,24 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
     keylen = snprintf(key, sizeof(key), "brick%d.port", count);
     ret = dict_set_int32n(dict, key, keylen, port);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.pid", count);
     ret = dict_set_int32n(dict, key, keylen, pid);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.status", count);
     ret = dict_set_int32n(dict, key, keylen, running);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -6077,7 +6077,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
         ret = dict_set_strn(dict, GLUSTER_BRICK_GRACEFUL_CLEANUP,
                             SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), "enable");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set cluster.brick-graceful-cleanup key");
             goto err;
         }
@@ -7486,8 +7486,8 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     ret = snprintf(key, sizeof(key), "brick%d.device", count);
     ret = dict_get_strn(dict, key, ret, &device);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7502,8 +7502,8 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     ret = snprintf(key, sizeof(key), "brick%d.fs_name", count);
     ret = dict_get_strn(dict, key, ret, &fs_name);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7675,8 +7675,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_fsname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7685,8 +7685,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7779,8 +7779,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.block_size", base_key);
     ret = dict_set_uint64(dict, key, block_size);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7789,8 +7789,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.free", base_key);
     ret = dict_set_uint64(dict, key, memfree);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7799,8 +7799,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.total", base_key);
     ret = dict_set_uint64(dict, key, memtotal);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         goto out;
     }
 
@@ -7810,7 +7810,7 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
         snprintf(key, sizeof(key), "%s.total_inodes", base_key);
         ret = dict_set_uint64(dict, key, inodes_total);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -7821,7 +7821,7 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
         snprintf(key, sizeof(key), "%s.free_inodes", base_key);
         ret = dict_set_uint64(dict, key, inodes_free);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -7936,8 +7936,8 @@ glusterd_add_brick_to_dict(glusterd_volinfo_t *volinfo,
 
 out:
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
         gf_msg_debug(this->name, 0, "Returning %d", ret);
     }
 
@@ -8409,8 +8409,8 @@ glusterd_sm_tr_log_transition_add_to_dict(dict_t *dict,
 
 out:
     if (key[0] != '\0' && ret != 0)
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
-                key, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                "Key=%s", key, NULL);
     gf_msg_debug("glusterd", 0, "returning %d", ret);
     return ret;
 }
@@ -10077,7 +10077,7 @@ glusterd_append_gsync_status(dict_t *dst, dict_t *src)
 
     ret = dict_get_strn(src, "gsync-status", SLEN("gsync-status"), &stop_msg);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=gsync-status", NULL);
         ret = 0;
         goto out;
@@ -10374,7 +10374,7 @@ glusterd_profile_volume_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
 
     ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &brick_count);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         ret = 0;  // no bricks in the rsp
         goto out;
@@ -10789,14 +10789,14 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
     ret = dict_set_int32n(ctx_dict, "hot_brick_count", SLEN("hot_brick_count"),
                           hot_brick_count);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=hot_brick_count", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(ctx_dict, "type", SLEN("type"), type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
         goto out;
     }
@@ -12251,7 +12251,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
     ret = dict_get_int32n(req_dict, "rebalance-command",
                           SLEN("rebalance-command"), &cmd);
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get the cmd");
         goto out;
     }
@@ -12287,7 +12287,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
     snprintf(key, sizeof(key), "time-left-%d", i);
     ret = dict_set_uint64(op_ctx, key, volinfo->rebal.time_left);
     if (ret)
-        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "failed to set time left");
 
 out:
@@ -12983,7 +12983,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
             ret = dict_set_dynstr_with_alloc(volinfo->dict, NFS_DISABLE_MAP_KEY,
                                              "on");
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to set option '" NFS_DISABLE_MAP_KEY
                        "' on volume "
                        "%s",
@@ -13015,7 +13015,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "features.quota-deem-statfs", "on");
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, ret,
+                    gf_msg(this->name, GF_LOG_ERROR, -ret,
                            GD_MSG_DICT_SET_FAILED,
                            "Failed to set option "
                            "'features.quota-deem-statfs' "
@@ -13033,7 +13033,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "transport.address-family", addr_family);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, ret,
+                    gf_msg(this->name, GF_LOG_ERROR, -ret,
                            GD_MSG_DICT_SET_FAILED,
                            "failed to set transport."
                            "address-family on %s",
@@ -13048,7 +13048,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
         ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                          "storage.fips-mode-rchecksum", "on");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set option 'storage.fips-mode-rchecksum' "
                    "on volume %s",
                    volinfo->volname);
@@ -13062,7 +13062,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
         ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                          "cluster.granular-entry-heal", "on");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set option 'cluster.granular-entry-heal' "
                    "on volume %s",
                    volinfo->volname);
@@ -14952,7 +14952,7 @@ glusterd_add_peers_to_auth_list(char *volname)
 
     ret = dict_get_str_sizen(volinfo->dict, "auth.allow", &auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "auth allow list is not set");
         goto out;
     }
@@ -14990,14 +14990,14 @@ glusterd_add_peers_to_auth_list(char *volname)
         ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
                             new_auth_allow_list);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
             goto out;
         }
         ret = dict_set_strn(volinfo->dict, "old.auth.allow",
                             SLEN("old.auth.allow"), auth_allow_list);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set old auth.allow list");
             goto out;
         }
@@ -15033,7 +15033,7 @@ glusterd_replace_old_auth_allow_list(char *volname)
     ret = dict_get_str_sizen(volinfo->dict, "old.auth.allow",
                              &old_auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "old auth allow list is not set, no need to replace the list");
         ret = 0;
         goto out;
@@ -15043,7 +15043,7 @@ glusterd_replace_old_auth_allow_list(char *volname)
     ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
                         old_auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to replace auth.allow list");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3001,7 +3001,7 @@ glusterd_add_bricks_hname_path_to_dict(dict_t *dict,
         ret = snprintf(key, sizeof(key), "%d-hostname", index);
         ret = dict_set_strn(dict, key, ret, brickinfo->hostname);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3009,7 +3009,7 @@ glusterd_add_bricks_hname_path_to_dict(dict_t *dict,
         ret = snprintf(key, sizeof(key), "%d-path", index);
         ret = dict_set_strn(dict, key, ret, brickinfo->path);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3134,7 +3134,7 @@ glusterd_add_volume_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = gd_add_vol_snap_details_to_dict(dict, pfx, volinfo);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "vol snap details", NULL);
         goto out;
     }
@@ -3329,8 +3329,8 @@ out:
     GF_FREE(rb_id_str);
 
     if (key[0] != '\0' && ret != 0)
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
     gf_msg_debug(this->name, 0, "Returning with %d", ret);
     return ret;
 }
@@ -3388,7 +3388,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         snprintf(key, sizeof(key) - 1, "%s.gfid%d", key_prefix, gfid_idx);
         ret = dict_set_dynstr_with_alloc(load, key, uuid_utoa(buf));
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3396,7 +3396,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         snprintf(key, sizeof(key) - 1, "%s.gfid-type%d", key_prefix, gfid_idx);
         ret = dict_set_int8(load, key, type);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -3405,24 +3405,24 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
     ret = snprintf(key, sizeof(key), "%s.gfid-count", key_prefix);
     ret = dict_set_int32n(load, key, ret, gfid_idx);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     snprintf(key, sizeof(key), "%s.quota-cksum", key_prefix);
     ret = dict_set_uint32(load, key, volinfo->quota_conf_cksum);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     snprintf(key, sizeof(key), "%s.quota-version", key_prefix);
     ret = dict_set_uint32(load, key, volinfo->quota_conf_version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -3755,7 +3755,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     keylen = snprintf(key, sizeof(key), "%s.name", key_prefix);
     ret = dict_get_strn(arg->peer_ver_data, key, keylen, &volname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -3776,7 +3776,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     keylen = snprintf(key, sizeof(key), "%s.version", key_prefix);
     ret = dict_get_int32n(arg->peer_ver_data, key, keylen, &version);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -3800,7 +3800,7 @@ glusterd_compare_friend_volume(dict_t *peer_data,
     snprintf(key, sizeof(key), "%s.ckusm", key_prefix);
     ret = dict_get_uint32(arg->peer_ver_data, key, &cksum);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s is NULL in peer_ver_data", key, NULL);
         goto out;
     }
@@ -4329,8 +4329,8 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
     keylen = snprintf(key, sizeof(key), "%s.gfid-count", key_prefix);
     ret = dict_get_int32n(peer_data, key, keylen, &gfid_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -4343,7 +4343,7 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
                           gfid_idx);
         ret = dict_get_strn(peer_data, key, keylen, &gfid_str);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -4414,8 +4414,8 @@ gd_import_friend_volume_rebal_dict(dict_t *dict, int count,
     ret = dict_get_int32n(dict, key, ret, &dict_count);
     if (ret) {
         /* Older peers will not have this dict */
-        gf_smsg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                key, NULL);
         ret = 0;
         goto out;
     }
@@ -5082,7 +5082,7 @@ glusterd_import_friend_volume(dict_t *peer_data, int count,
         ret = snprintf(key, sizeof(key), "volume%d.update", count);
         ret = dict_get_int32n(peer_data, key, ret, &update);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -5199,7 +5199,7 @@ glusterd_import_friend_volumes_synctask(void *opaque)
     peer_data = arg->peer_data;
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5256,7 +5256,7 @@ glusterd_import_friend_volumes(dict_t *peer_data)
 
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5282,8 +5282,8 @@ glusterd_get_global_server_quorum_ratio(dict_t *opts, double *quorum)
     ret = dict_get_strn(opts, GLUSTERD_QUORUM_RATIO_KEY,
                         SLEN(GLUSTERD_QUORUM_RATIO_KEY), &quorum_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GLUSTERD_QUORUM_RATIO_KEY, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GLUSTERD_QUORUM_RATIO_KEY, NULL);
     } else {
         ret = gf_string2percent(quorum_str, quorum);
     }
@@ -5299,8 +5299,8 @@ glusterd_get_global_opt_version(dict_t *opts, uint32_t *version)
     ret = dict_get_strn(opts, GLUSTERD_GLOBAL_OPT_VERSION,
                         SLEN(GLUSTERD_GLOBAL_OPT_VERSION), &version_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                GLUSTERD_GLOBAL_OPT_VERSION, NULL);
     } else {
         ret = gf_string2uint(version_str, version);
     }
@@ -5345,7 +5345,7 @@ glusterd_import_global_opts(dict_t *friend_data)
                           SLEN("global-opt-count"), &count);
     if (ret) {
         // old version peer
-        gf_smsg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=global-opt-count", NULL);
         ret = 0;
         goto out;
@@ -5426,7 +5426,7 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
 
     ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -5698,16 +5698,16 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
         ret = dict_set_nstrn(dict, key, keylen, "Scrubber Daemon",
                              SLEN("Scrubber Daemon"));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.path", count);
     ret = dict_set_dynstrn(dict, key, keylen, gf_strdup(uuid_utoa(MY_UUID)));
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -5721,7 +5721,7 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
             ret = dict_get_int32n(vol_opts, "nfs.port", SLEN("nfs.port"),
                                   &port);
             if (ret) {
-                gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+                gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                         "Key=nfs.port", NULL);
                 goto out;
             }
@@ -5732,24 +5732,24 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
     keylen = snprintf(key, sizeof(key), "brick%d.port", count);
     ret = dict_set_int32n(dict, key, keylen, port);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.pid", count);
     ret = dict_set_int32n(dict, key, keylen, pid);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
     keylen = snprintf(key, sizeof(key), "brick%d.status", count);
     ret = dict_set_int32n(dict, key, keylen, running);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -6077,7 +6077,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
         ret = dict_set_strn(dict, GLUSTER_BRICK_GRACEFUL_CLEANUP,
                             SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), "enable");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set cluster.brick-graceful-cleanup key");
             goto err;
         }
@@ -7486,8 +7486,8 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     ret = snprintf(key, sizeof(key), "brick%d.device", count);
     ret = dict_get_strn(dict, key, ret, &device);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7502,8 +7502,8 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     ret = snprintf(key, sizeof(key), "brick%d.fs_name", count);
     ret = dict_get_strn(dict, key, ret, &fs_name);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7675,8 +7675,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_fsname);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7685,8 +7685,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
 
     ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_type);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7779,8 +7779,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.block_size", base_key);
     ret = dict_set_uint64(dict, key, block_size);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7789,8 +7789,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.free", base_key);
     ret = dict_set_uint64(dict, key, memfree);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7799,8 +7799,8 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
     snprintf(key, sizeof(key), "%s.total", base_key);
     ret = dict_set_uint64(dict, key, memtotal);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         goto out;
     }
 
@@ -7810,7 +7810,7 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
         snprintf(key, sizeof(key), "%s.total_inodes", base_key);
         ret = dict_set_uint64(dict, key, inodes_total);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -7821,7 +7821,7 @@ glusterd_add_brick_detail_to_dict(glusterd_volinfo_t *volinfo,
         snprintf(key, sizeof(key), "%s.free_inodes", base_key);
         ret = dict_set_uint64(dict, key, inodes_free);
         if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
             goto out;
         }
@@ -7936,8 +7936,8 @@ glusterd_add_brick_to_dict(glusterd_volinfo_t *volinfo,
 
 out:
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
         gf_msg_debug(this->name, 0, "Returning %d", ret);
     }
 
@@ -8409,8 +8409,8 @@ glusterd_sm_tr_log_transition_add_to_dict(dict_t *dict,
 
 out:
     if (key[0] != '\0' && ret != 0)
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                "Key=%s", key, NULL);
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED, "Key=%s",
+                key, NULL);
     gf_msg_debug("glusterd", 0, "returning %d", ret);
     return ret;
 }
@@ -10077,7 +10077,7 @@ glusterd_append_gsync_status(dict_t *dst, dict_t *src)
 
     ret = dict_get_strn(src, "gsync-status", SLEN("gsync-status"), &stop_msg);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=gsync-status", NULL);
         ret = 0;
         goto out;
@@ -10374,7 +10374,7 @@ glusterd_profile_volume_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
 
     ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &brick_count);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         ret = 0;  // no bricks in the rsp
         goto out;
@@ -10789,14 +10789,14 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
     ret = dict_set_int32n(ctx_dict, "hot_brick_count", SLEN("hot_brick_count"),
                           hot_brick_count);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=hot_brick_count", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(ctx_dict, "type", SLEN("type"), type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
         goto out;
     }
@@ -12251,7 +12251,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
     ret = dict_get_int32n(req_dict, "rebalance-command",
                           SLEN("rebalance-command"), &cmd);
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get the cmd");
         goto out;
     }
@@ -12287,7 +12287,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
     snprintf(key, sizeof(key), "time-left-%d", i);
     ret = dict_set_uint64(op_ctx, key, volinfo->rebal.time_left);
     if (ret)
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "failed to set time left");
 
 out:
@@ -12983,7 +12983,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
             ret = dict_set_dynstr_with_alloc(volinfo->dict, NFS_DISABLE_MAP_KEY,
                                              "on");
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                        "Failed to set option '" NFS_DISABLE_MAP_KEY
                        "' on volume "
                        "%s",
@@ -13015,7 +13015,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "features.quota-deem-statfs", "on");
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, errno,
+                    gf_msg(this->name, GF_LOG_ERROR, ret,
                            GD_MSG_DICT_SET_FAILED,
                            "Failed to set option "
                            "'features.quota-deem-statfs' "
@@ -13033,7 +13033,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
                 ret = dict_set_dynstr_with_alloc(
                     volinfo->dict, "transport.address-family", addr_family);
                 if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, errno,
+                    gf_msg(this->name, GF_LOG_ERROR, ret,
                            GD_MSG_DICT_SET_FAILED,
                            "failed to set transport."
                            "address-family on %s",
@@ -13048,7 +13048,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
         ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                          "storage.fips-mode-rchecksum", "on");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set option 'storage.fips-mode-rchecksum' "
                    "on volume %s",
                    volinfo->volname);
@@ -13062,7 +13062,7 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
         ret = dict_set_dynstr_with_alloc(volinfo->dict,
                                          "cluster.granular-entry-heal", "on");
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set option 'cluster.granular-entry-heal' "
                    "on volume %s",
                    volinfo->volname);
@@ -14952,7 +14952,7 @@ glusterd_add_peers_to_auth_list(char *volname)
 
     ret = dict_get_str_sizen(volinfo->dict, "auth.allow", &auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                "auth allow list is not set");
         goto out;
     }
@@ -14990,14 +14990,14 @@ glusterd_add_peers_to_auth_list(char *volname)
         ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
                             new_auth_allow_list);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
             goto out;
         }
         ret = dict_set_strn(volinfo->dict, "old.auth.allow",
                             SLEN("old.auth.allow"), auth_allow_list);
         if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set old auth.allow list");
             goto out;
         }
@@ -15033,7 +15033,7 @@ glusterd_replace_old_auth_allow_list(char *volname)
     ret = dict_get_str_sizen(volinfo->dict, "old.auth.allow",
                              &old_auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(this->name, GF_LOG_INFO, ret, GD_MSG_DICT_GET_FAILED,
                "old auth allow list is not set, no need to replace the list");
         ret = 0;
         goto out;
@@ -15043,7 +15043,7 @@ glusterd_replace_old_auth_allow_list(char *volname)
     ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
                         old_auth_allow_list);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Unable to replace auth.allow list");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -1490,14 +1490,14 @@ volgen_graph_set_xl_options(volgen_graph_t *graph, dict_t *dict)
 
     ret = dict_get_str_sizen(dict, "xlator", &xlator);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=xlator", NULL);
         goto out;
     }
 
     ret = dict_get_str_sizen(dict, "loglevel", &loglevel);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=loglevel", NULL);
         goto out;
     }
@@ -1603,14 +1603,14 @@ gfproxy_server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* We are a trusted client */
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret != 0) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
 
     ret = dict_set_int32_sizen(set_dict, "gfproxy-server", 1);
     if (ret != 0) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=gfproxy-server", NULL);
         goto out;
     }
@@ -2516,7 +2516,7 @@ brick_graph_add_pump(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     ret = dict_get_int32(volinfo->dict, "enable-pump", &pump);
     if (ret == -ENOENT) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=enable-pump", NULL);
         ret = pump = 0;
     }
@@ -2898,7 +2898,7 @@ server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (!ret) {
         ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
                    " translator name and loglevel for log level request");
             goto out;
@@ -4525,7 +4525,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         ret = dict_set_str_sizen(set_dict, "client.send-gids",
                                  ret ? "false" : "true");
         if (ret)
-            gf_msg(THIS->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
+            gf_msg(THIS->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                    "changing client"
                    " protocol option failed");
     }
@@ -4832,7 +4832,7 @@ prepare_shd_volume_options(glusterd_volinfo_t *volinfo, dict_t *mod_dict,
 
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
@@ -5153,7 +5153,7 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
         ret = dict_set_sizen_str_sizen(set_dict, "performance.stat-prefetch",
                                        "off");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=performance.stat-prefetch", NULL);
             goto out;
         }
@@ -5161,28 +5161,28 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
         ret = dict_set_sizen_str_sizen(set_dict,
                                        "performance.client-io-threads", "off");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=performance.client-io-threads", NULL);
             goto out;
         }
 
         ret = dict_set_str_sizen(set_dict, "client-transport-type", nfs_xprt);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
 
         ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
 
         ret = dict_set_sizen_str_sizen(set_dict, "nfs-volume-file", "yes");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=nfs-volume-file", NULL);
             goto out;
         }
@@ -5418,7 +5418,7 @@ build_quotad_graph(volgen_graph_t *graph, dict_t *mod_dict)
 
         ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5617,7 +5617,7 @@ glusterd_generate_client_per_brick_volfile(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto free_dict;
     }
@@ -5706,7 +5706,7 @@ generate_dummy_client_volfiles(glusterd_volinfo_t *volinfo)
     for (i = 0; types[i]; i++) {
         ret = dict_set_str(dict, "client-transport-type", types[i]);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
@@ -5714,7 +5714,7 @@ generate_dummy_client_volfiles(glusterd_volinfo_t *volinfo)
 
         ret = dict_set_uint32(dict, "trusted-client", GF_CLIENT_OTHER);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5782,7 +5782,7 @@ generate_client_volfiles(glusterd_volinfo_t *volinfo,
     for (i = 0; types[i]; i++) {
         ret = dict_set_str(dict, "client-transport-type", types[i]);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
@@ -5790,7 +5790,7 @@ generate_client_volfiles(glusterd_volinfo_t *volinfo,
 
         ret = dict_set_uint32(dict, "trusted-client", client_type);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5857,7 +5857,7 @@ glusterd_snapdsvc_generate_volfile(volgen_graph_t *graph,
     if (!ret) {
         ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
                    " translator name and loglevel for log level "
                    "request");
@@ -5946,7 +5946,7 @@ prepare_bitrot_scrub_volume_options(glusterd_volinfo_t *volinfo,
 
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
@@ -6408,7 +6408,7 @@ validate_shdopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
     }
     ret = dict_set_int32_sizen(val_dict, "graph-check", 1);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=graph-check", NULL);
         goto out;
     }
@@ -6473,7 +6473,7 @@ validate_nfsopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
 
     ret = dict_set_str_sizen(val_dict, "volume-name", volinfo->volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set volume name");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -1490,14 +1490,14 @@ volgen_graph_set_xl_options(volgen_graph_t *graph, dict_t *dict)
 
     ret = dict_get_str_sizen(dict, "xlator", &xlator);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=xlator", NULL);
         goto out;
     }
 
     ret = dict_get_str_sizen(dict, "loglevel", &loglevel);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=loglevel", NULL);
         goto out;
     }
@@ -1603,14 +1603,14 @@ gfproxy_server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* We are a trusted client */
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret != 0) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
 
     ret = dict_set_int32_sizen(set_dict, "gfproxy-server", 1);
     if (ret != 0) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=gfproxy-server", NULL);
         goto out;
     }
@@ -2217,7 +2217,7 @@ brick_graph_add_ro(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (dict_get_str_boolean(set_dict, "features.read-only", 0) &&
         (dict_get_str_boolean(set_dict, "features.worm", 0) ||
          dict_get_str_boolean(set_dict, "features.worm-file-level", 0))) {
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "read-only and worm cannot be set together");
         ret = -1;
         goto out;
@@ -2516,7 +2516,7 @@ brick_graph_add_pump(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     ret = dict_get_int32(volinfo->dict, "enable-pump", &pump);
     if (ret == -ENOENT) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=enable-pump", NULL);
         ret = pump = 0;
     }
@@ -2898,7 +2898,7 @@ server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (!ret) {
         ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
                    " translator name and loglevel for log level request");
             goto out;
@@ -3731,7 +3731,7 @@ volgen_graph_build_dht_cluster(volgen_graph_t *graph,
     /* NUFA and Switch section */
     if (dict_get_str_boolean(volinfo->dict, "cluster.nufa", 0) &&
         dict_get_str_boolean(volinfo->dict, "cluster.switch", 0)) {
-        gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "nufa and switch cannot be set together");
         ret = -1;
         goto out;
@@ -4525,7 +4525,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         ret = dict_set_str_sizen(set_dict, "client.send-gids",
                                  ret ? "false" : "true");
         if (ret)
-            gf_msg(THIS->name, GF_LOG_WARNING, errno, GD_MSG_DICT_SET_FAILED,
+            gf_msg(THIS->name, GF_LOG_WARNING, ret, GD_MSG_DICT_SET_FAILED,
                    "changing client"
                    " protocol option failed");
     }
@@ -4832,7 +4832,7 @@ prepare_shd_volume_options(glusterd_volinfo_t *volinfo, dict_t *mod_dict,
 
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
@@ -5153,7 +5153,7 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
         ret = dict_set_sizen_str_sizen(set_dict, "performance.stat-prefetch",
                                        "off");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=performance.stat-prefetch", NULL);
             goto out;
         }
@@ -5161,28 +5161,28 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
         ret = dict_set_sizen_str_sizen(set_dict,
                                        "performance.client-io-threads", "off");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=performance.client-io-threads", NULL);
             goto out;
         }
 
         ret = dict_set_str_sizen(set_dict, "client-transport-type", nfs_xprt);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
 
         ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
 
         ret = dict_set_sizen_str_sizen(set_dict, "nfs-volume-file", "yes");
         if (ret) {
-            gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=nfs-volume-file", NULL);
             goto out;
         }
@@ -5418,7 +5418,7 @@ build_quotad_graph(volgen_graph_t *graph, dict_t *mod_dict)
 
         ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5617,7 +5617,7 @@ glusterd_generate_client_per_brick_volfile(glusterd_volinfo_t *volinfo)
 
     ret = dict_set_uint32(dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto free_dict;
     }
@@ -5706,7 +5706,7 @@ generate_dummy_client_volfiles(glusterd_volinfo_t *volinfo)
     for (i = 0; types[i]; i++) {
         ret = dict_set_str(dict, "client-transport-type", types[i]);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
@@ -5714,7 +5714,7 @@ generate_dummy_client_volfiles(glusterd_volinfo_t *volinfo)
 
         ret = dict_set_uint32(dict, "trusted-client", GF_CLIENT_OTHER);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5782,7 +5782,7 @@ generate_client_volfiles(glusterd_volinfo_t *volinfo,
     for (i = 0; types[i]; i++) {
         ret = dict_set_str(dict, "client-transport-type", types[i]);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=client-transport-type", NULL);
             goto out;
         }
@@ -5790,7 +5790,7 @@ generate_client_volfiles(glusterd_volinfo_t *volinfo,
 
         ret = dict_set_uint32(dict, "trusted-client", client_type);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=trusted-client", NULL);
             goto out;
         }
@@ -5857,7 +5857,7 @@ glusterd_snapdsvc_generate_volfile(volgen_graph_t *graph,
     if (!ret) {
         ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
         if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+            gf_msg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
                    " translator name and loglevel for log level "
                    "request");
@@ -5946,7 +5946,7 @@ prepare_bitrot_scrub_volume_options(glusterd_volinfo_t *volinfo,
 
     ret = dict_set_uint32(set_dict, "trusted-client", GF_CLIENT_TRUSTED);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=trusted-client", NULL);
         goto out;
     }
@@ -6408,7 +6408,7 @@ validate_shdopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
     }
     ret = dict_set_int32_sizen(val_dict, "graph-check", 1);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=graph-check", NULL);
         goto out;
     }
@@ -6473,7 +6473,7 @@ validate_nfsopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
 
     ret = dict_set_str_sizen(val_dict, "volume-name", volinfo->volname);
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_msg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set volume name");
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -568,7 +568,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
     ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
                           (int32_t *)&heal_op);
     if (ret || (heal_op == GF_SHD_OP_INVALID)) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=heal-op", NULL);
         ret = -1;
         goto out;
@@ -608,7 +608,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
         key = "cluster.granular-entry-heal";
         ret = dict_set_int8(dict, "is-special-key", 1);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=is-special-key", NULL);
             goto out;
         }
@@ -616,21 +616,21 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
 
     ret = dict_set_strn(dict, "key1", SLEN("key1"), key);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
 
     ret = dict_set_strn(dict, "value1", SLEN("value1"), value);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=value1", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -728,7 +728,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), volinfo->brick_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -1689,7 +1689,7 @@ glusterd_op_stage_heal_volume(dict_t *dict, char **op_errstr)
 
     opt_dict = volinfo->dict;
     if (!opt_dict) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED, NULL);
+        gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, NULL);
         ret = 0;
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -568,7 +568,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
     ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
                           (int32_t *)&heal_op);
     if (ret || (heal_op == GF_SHD_OP_INVALID)) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=heal-op", NULL);
         ret = -1;
         goto out;
@@ -608,7 +608,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
         key = "cluster.granular-entry-heal";
         ret = dict_set_int8(dict, "is-special-key", 1);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=is-special-key", NULL);
             goto out;
         }
@@ -616,21 +616,21 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
 
     ret = dict_set_strn(dict, "key1", SLEN("key1"), key);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
 
     ret = dict_set_strn(dict, "value1", SLEN("value1"), value);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=value1", NULL);
         goto out;
     }
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -728,7 +728,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
 
     ret = dict_set_int32n(dict, "count", SLEN("count"), volinfo->brick_count);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -451,7 +451,7 @@ glusterd_rpcsvc_options_build(dict_t *options)
         backlog = GLUSTERFS_SOCKET_LISTEN_BACKLOG;
         ret = dict_set_uint32(options, "transport.listen-backlog", backlog);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
                     "Key=transport.listen-backlog", NULL);
             goto out;
         }
@@ -587,7 +587,7 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
 
     ret = dict_get_str(THIS->options, GEOREP "-log-group", &greplg_s);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
                 "Key=log-group", NULL);
         ret = 0;
     } else {

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -451,7 +451,7 @@ glusterd_rpcsvc_options_build(dict_t *options)
         backlog = GLUSTERFS_SOCKET_LISTEN_BACKLOG;
         ret = dict_set_uint32(options, "transport.listen-backlog", backlog);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=transport.listen-backlog", NULL);
             goto out;
         }
@@ -587,7 +587,7 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
 
     ret = dict_get_str(THIS->options, GEOREP "-log-group", &greplg_s);
     if (ret) {
-        gf_smsg("glusterd", GF_LOG_ERROR, ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=log-group", NULL);
         ret = 0;
     } else {


### PR DESCRIPTION
'errno' is not set by any dictionary functions, so 'errno'
that is displayed in the error message is whatever it was
set previously. This patch fixes that by replacing ret
with the errno.

Fixes: #2083

Change-Id: Ief807d1001b062e5a7620d94441d16ecb1d32dba
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

