### PR TITLE
cli: Increased spacing in cli for option table

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -10392,8 +10392,8 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    cli_out("%-40s%-40s", "Option", "Value");
-    cli_out("%-40s%-40s", "------", "-----");
+    cli_out("%-40s %-39s", "Option", "Value");
+    cli_out("%-40s %-39s", "------", "-----");
     for (i = 1; i <= count; i++) {
         ret = snprintf(dict_key, sizeof dict_key, "key%d", i);
         ret = dict_get_strn(dict, dict_key, ret, &key);
@@ -10410,7 +10410,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
                    dict_key);
             goto out;
         }
-        cli_out("%-40s%-40s", key, value);
+        cli_out("%-40s %-39s", key, value);
     }
 
 out:


### PR DESCRIPTION
Updates: #2313

>Issue:
>Some options have name larger than length 40,
>due to which the output of command `gluster vol get <volname> all`
>mixes up the option, value for long option names.

>Fix:
>Increased the spacing in cli for `gluster vol get <volname> all`
>output to 50.

>Fixes: #2313

>Change-Id: I841730ced074547a81171a4432d15ec9c35f39cd
>Signed-off-by: nik-redhat <nladha@redhat.com>

>* Added separator

>Change-Id: I210877c89bc468ed6a3090cd14fde7ecee1d33b6
>Signed-off-by: nik-redhat <nladha@redhat.com>

>* Removed separator and added space

>Change-Id: Ic0eb9c9bc39a354465aabd939f72bc65be738f6c
>Signed-off-by: nik-redhat <nladha@redhat.com>

Change-Id: Ieac402abc7add36b7f4a879bea7cd53628399913
Signed-off-by: nik-redhat <nladha@redhat.com>

