### PR TITLE
core: Avoid several dict OR key is NULL message in brick logs

### DIFF
--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -2134,7 +2134,7 @@ index_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     int ret = -1;
     char *flag = NULL;
 
-    ret = dict_get_str(xdata, "link-count", &flag);
+    ret = dict_get_str_sizen(xdata, "link-count", &flag);
     if ((ret == 0) && (strcmp(flag, GF_XATTROP_INDEX_COUNT) == 0)) {
         STACK_WIND(frame, index_fstat_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->fstat, fd, xdata);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2574,18 +2574,21 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     posix_locks_private_t *priv = this->private;
     pl_local_t *local = NULL;
     short lock_type = 0;
+    int ret = 0;
 
-    int ret = dict_get_uint32(xdata, GF_LOCK_MODE, &lk_flags);
-    if (ret == 0) {
-        if (priv->mandatory_mode == MLK_NONE)
-            gf_log(this->name, GF_LOG_DEBUG,
-                   "Lock flags received "
-                   "in a non-mandatory locking environment, "
-                   "continuing");
-        else
-            gf_log(this->name, GF_LOG_DEBUG,
-                   "Lock flags received, "
-                   "continuing");
+    if (xdata) {
+        ret = dict_get_uint32(xdata, GF_LOCK_MODE, &lk_flags);
+        if (ret == 0) {
+            if (priv->mandatory_mode == MLK_NONE)
+                gf_log(this->name, GF_LOG_DEBUG,
+                       "Lock flags received "
+                       "in a non-mandatory locking environment, "
+                       "continuing");
+            else
+                gf_log(this->name, GF_LOG_DEBUG,
+                       "Lock flags received, "
+                       "continuing");
+        }
     }
 
     if ((flock->l_start < 0) || ((flock->l_start + flock->l_len) < 0)) {

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2918,9 +2918,11 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         goto out;
     }
 
-    ret = dict_get_int8(xdata, "sync_backend_xattrs", &sync_backend_xattrs);
-    if (ret) {
-        gf_msg_debug(this->name, -ret, "Unable to get sync_backend_xattrs");
+    if (xdata) {
+        ret = dict_get_int8(xdata, "sync_backend_xattrs", &sync_backend_xattrs);
+        if (ret) {
+            gf_msg_debug(this->name, -ret, "Unable to get sync_backend_xattrs");
+        }
     }
 
     if (sync_backend_xattrs) {
@@ -5753,7 +5755,7 @@ posix_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     /* When READDIR_FILTER option is set to on, we can filter out
      * directory's entry from the entry->list.
      */
-    ret = dict_get_int32(dict, GF_READDIR_SKIP_DIRS, &skip_dirs);
+    ret = dict_get_int32_sizen(dict, GF_READDIR_SKIP_DIRS, &skip_dirs);
 
     LOCK(&fd->lock);
     {


### PR DESCRIPTION
Problem: dict_get_with_ref throw a message "dict or key is NULL"
         if dict or key is NULL.

Solution: Before access a key check if dictionary is valid.

> Fixes: #1909
> Change-Id: I50911679142b52f854baf20c187962a2a3698f2d
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> Cherry picked from commit de1b26d68e31b029a59e59a47b51a7e3e6fbfe22
> Reviewed on upstream link https://github.com/gluster/glusterfs/pull/1910

Fixes: #1909
Change-Id: I50911679142b52f854baf20c187962a2a3698f2d
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

