### PR TITLE
dht - fixing xattr inconsistency

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -50,6 +50,7 @@
 #include "xxhash.h"
 #include <ifaddrs.h>
 #include "glusterfs/libglusterfs-messages.h"
+#include "glusterfs/glusterfs-acl.h"
 #ifdef __FreeBSD__
 #include <pthread_np.h>
 #undef BIT_SET
@@ -74,6 +75,15 @@ char *vol_type_str[] = {
 
 typedef int32_t (*rw_op_t)(int32_t fd, char *buf, int32_t size);
 typedef int32_t (*rwv_op_t)(int32_t fd, const struct iovec *buf, int32_t size);
+
+char *xattrs_to_heal[] = {"user.",
+                          POSIX_ACL_ACCESS_XATTR,
+                          POSIX_ACL_DEFAULT_XATTR,
+                          QUOTA_LIMIT_KEY,
+                          QUOTA_LIMIT_OBJECTS_KEY,
+                          GF_SELINUX_XATTR_KEY,
+                          GF_XATTR_MDATA_KEY,
+                          NULL};
 
 void
 gf_xxh64_wrapper(const unsigned char *data, size_t const len,
@@ -5425,4 +5435,10 @@ gf_nanosleep(uint64_t nsec)
     } while (ret == -1 && errno == EINTR);
 
     return ret;
+}
+
+char **
+get_xattrs_to_heal()
+{
+    return xattrs_to_heal;
 }

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -180,6 +180,12 @@ enum _gf_xlator_ipc_targets {
 typedef enum _gf_special_pid gf_special_pid_t;
 typedef enum _gf_xlator_ipc_targets _gf_xlator_ipc_targets_t;
 
+/* Array to hold custom xattr keys */
+extern char *xattrs_to_heal[];
+
+char **
+get_xattrs_to_heal();
+
 /* The DHT file rename operation is not a straightforward rename.
  * It involves creating linkto and linkfiles, and can unlink or rename the
  * source file depending on the hashed and cached subvols for the source

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1183,3 +1183,4 @@ mgmt_is_multiplexed_daemon
 xlator_is_cleanup_starting
 gf_nanosleep
 graph_total_client_xlator
+get_xattrs_to_heal

--- a/tests/bugs/distribute/bug-1600379.t
+++ b/tests/bugs/distribute/bug-1600379.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+# Initialize
+#------------------------------------------------------------
+cleanup;
+
+# Start glusterd
+TEST glusterd;
+TEST pidof glusterd;
+TEST $CLI volume info;
+
+# Create a volume
+TEST $CLI volume create $V0 $H0:$B0/${V0}{1,2}
+
+# Verify volume creation
+EXPECT "$V0" volinfo_field $V0 'Volume Name';
+EXPECT 'Created' volinfo_field $V0 'Status';
+
+# Start volume and verify successful start
+TEST $CLI volume start $V0;
+EXPECT 'Started' volinfo_field $V0 'Status';
+TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 --entry-timeout=0 $M0;
+#------------------------------------------------------------
+
+# Test case - Remove xattr from killed brick on lookup
+#------------------------------------------------------------
+# Create a dir and set custom xattr
+TEST mkdir $M0/testdir
+TEST setfattr -n user.attr -v val $M0/testdir
+xattr_val=`getfattr -d $B0/${V0}2/testdir | awk '{print $1}'`;
+TEST ${xattr_val}='user.attr="val"';
+
+# Kill 2nd brick process
+TEST kill_brick $V0 $H0 $B0/${V0}2
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "1" online_brick_count
+
+# Remove custom xattr
+TEST setfattr -x user.attr $M0/testdir
+
+# Bring up the killed brick process
+TEST $CLI volume start $V0 force
+
+# Perform lookup
+sleep 5
+TEST ls $M0/testdir
+
+# Check brick xattrs
+xattr_val_2=`getfattr -d $B0/${V0}2/testdir`;
+TEST [ ${xattr_val_2} = ''] ;
+
+cleanup;

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -17,6 +17,7 @@
 #include <glusterfs/quota-common-utils.h>
 #include <glusterfs/upcall-utils.h>
 #include "glusterfs/compat-errno.h"  // for ENODATA on BSD
+#include <glusterfs/common-utils.h>
 
 #include <sys/time.h>
 #include <libgen.h>
@@ -42,15 +43,6 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_rmdir_unlock(call_frame_t *frame, xlator_t *this);
-
-char *xattrs_to_heal[] = {"user.",
-                          POSIX_ACL_ACCESS_XATTR,
-                          POSIX_ACL_DEFAULT_XATTR,
-                          QUOTA_LIMIT_KEY,
-                          QUOTA_LIMIT_OBJECTS_KEY,
-                          GF_SELINUX_XATTR_KEY,
-                          GF_XATTR_MDATA_KEY,
-                          NULL};
 
 static const char *dht_dbg_vxattrs[] = {DHT_DBG_HASHED_SUBVOL_PATTERN, NULL};
 
@@ -84,6 +76,8 @@ dht_set_fixed_dir_stat(struct iatt *stat)
 static gf_boolean_t
 dht_match_xattr(const char *key)
 {
+    char **xattrs_to_heal = get_xattrs_to_heal();
+
     return gf_get_index_by_elem(xattrs_to_heal, (char *)key) >= 0;
 }
 
@@ -5446,11 +5440,13 @@ dht_dir_common_set_remove_xattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     int call_cnt = 0;
     dht_local_t *local = NULL;
     char gfid_local[GF_UUID_BUF_SIZE] = {0};
+    char **xattrs_to_heal;
 
     conf = this->private;
     local = frame->local;
     call_cnt = conf->subvolume_cnt;
     local->flags = flags;
+    xattrs_to_heal = get_xattrs_to_heal();
 
     if (!gf_uuid_is_null(local->gfid)) {
         gf_uuid_unparse(local->gfid, gfid_local);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -52,10 +52,6 @@
 #define DHT_DBG_HASHED_SUBVOL_PATTERN "dht.file.hashed-subvol.*"
 #define DHT_DBG_HASHED_SUBVOL_KEY "dht.file.hashed-subvol."
 
-/* Array to hold custom xattr keys
- */
-extern char *xattrs_to_heal[];
-
 /* Rebalance nodeuuid flags */
 #define REBAL_NODEUUID_MINE 0x01
 

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -2265,6 +2265,7 @@ dht_dir_set_heal_xattr(xlator_t *this, dht_local_t *local, dict_t *dst,
     int luret = -1;
     int luflag = -1;
     int i = 0;
+    char **xattrs_to_heal;
 
     if (!src || !dst) {
         gf_smsg(this->name, GF_LOG_WARNING, EINVAL, DHT_MSG_DST_NULL_SET_FAILED,
@@ -2279,6 +2280,9 @@ dht_dir_set_heal_xattr(xlator_t *this, dht_local_t *local, dict_t *dst,
        and set it to dst dict, here index start from 1 because
        user xattr already checked in previous statement
     */
+
+    xattrs_to_heal = get_xattrs_to_heal();
+
     for (i = 1; xattrs_to_heal[i]; i++) {
         keyval = dict_get(src, xattrs_to_heal[i]);
         if (keyval) {

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -2154,6 +2154,15 @@ dht_dir_heal_xattrs(void *data)
         if (subvol == mds_subvol)
             continue;
         if (uret || uflag) {
+            /* Custom xattr heal is required - let posix handle it */
+            ret = dict_set_int8(xdata, "sync_backend_xattrs", _gf_true);
+            if (ret) {
+                gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_DICT_SET_FAILED,
+                        "path=%s", local->loc.path, "key=%s",
+                        "sync_backend_xattrs", NULL);
+                goto out;
+            }
+
             ret = syncop_setxattr(subvol, &local->loc, user_xattr, 0, xdata,
                                   NULL);
             if (ret) {
@@ -2162,6 +2171,8 @@ dht_dir_heal_xattrs(void *data)
                         DHT_MSG_DIR_XATTR_HEAL_FAILED,
                         "set-user-xattr-failed path=%s", local->loc.path,
                         "subvol=%s", subvol->name, "gfid=%s", gfid, NULL);
+            } else {
+                dict_del(xdata, "sync_backend_xattrs");
             }
         }
     }

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -3662,3 +3662,22 @@ out:
 
     return is_stale;
 }
+
+/* Delete user xattr from the file at the file-path specified by data and from
+ * dict */
+int
+posix_delete_user_xattr(dict_t *dict, char *k, data_t *v, void *data)
+{
+    int ret;
+    char *real_path = data;
+
+    ret = sys_lremovexattr(real_path, k);
+    if (ret) {
+        gf_msg("posix-helpers", GF_LOG_ERROR, P_MSG_XATTR_NOT_REMOVED, errno,
+               "removexattr failed. key %s path %s", k, real_path);
+    }
+
+    dict_del(dict, k);
+
+    return ret;
+}

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -54,6 +54,7 @@
 #include <glusterfs/events.h>
 #include "posix-gfid-path.h"
 #include <glusterfs/compat-uuid.h>
+#include <glusterfs/common-utils.h>
 
 extern char *marker_xattrs[];
 #define ALIGN_SIZE 4096
@@ -2715,6 +2716,7 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     int32_t ret = 0;
     ssize_t acl_size = 0;
     dict_t *xattr = NULL;
+    dict_t *subvol_xattrs = NULL;
     posix_xattr_filler_t filler = {
         0,
     };
@@ -2730,6 +2732,10 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     struct mdata_iatt mdata_iatt = {
         0,
     };
+    int8_t sync_backend_xattrs = _gf_false;
+    data_pair_t *custom_xattrs;
+    data_t *keyval = NULL;
+    char **xattrs_to_heal = get_xattrs_to_heal();
 
     DECLARE_OLD_FS_ID_VAR;
     SET_FS_ID(frame->root->uid, frame->root->gid);
@@ -2912,6 +2918,66 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         goto out;
     }
 
+    ret = dict_get_int8(xdata, "sync_backend_xattrs", &sync_backend_xattrs);
+    if (ret) {
+        gf_msg_debug(this->name, -ret, "Unable to get sync_backend_xattrs");
+    }
+
+    if (sync_backend_xattrs) {
+        /* List all custom xattrs */
+        subvol_xattrs = dict_new();
+        if (!subvol_xattrs)
+            goto out;
+
+        ret = dict_set_int32_sizen(xdata, "list-xattr", 1);
+        if (ret) {
+            gf_msg(this->name, GF_LOG_ERROR, 0, ENOMEM,
+                   "Unable to set list-xattr in dict ");
+            goto out;
+        }
+
+        subvol_xattrs = posix_xattr_fill(this, real_path, loc, NULL, -1, xdata,
+                                         NULL);
+
+        /* Remove all user xattrs from the file */
+        dict_foreach_fnmatch(subvol_xattrs, "user.*", posix_delete_user_xattr,
+                             real_path);
+
+        /* Remove all custom xattrs from the file */
+        for (i = 1; xattrs_to_heal[i]; i++) {
+            keyval = dict_get(subvol_xattrs, xattrs_to_heal[i]);
+            if (keyval) {
+                ret = sys_lremovexattr(real_path, xattrs_to_heal[i]);
+                if (ret) {
+                    gf_msg(this->name, GF_LOG_ERROR, P_MSG_XATTR_NOT_REMOVED,
+                           errno, "removexattr failed. key %s path %s",
+                           xattrs_to_heal[i], loc->path);
+                    goto out;
+                }
+
+                dict_del(subvol_xattrs, xattrs_to_heal[i]);
+                keyval = NULL;
+            }
+        }
+
+        /* Set custom xattrs based on info provided by DHT */
+        custom_xattrs = dict->members_list;
+
+        while (custom_xattrs != NULL) {
+            ret = sys_lsetxattr(real_path, custom_xattrs->key,
+                                custom_xattrs->value->data,
+                                custom_xattrs->value->len, flags);
+            if (ret) {
+                op_errno = errno;
+                gf_log(this->name, GF_LOG_ERROR, "setxattr failed - %s %d",
+                       custom_xattrs->key, ret);
+                goto out;
+            }
+
+            custom_xattrs = custom_xattrs->next;
+        }
+    }
+
     xattr = dict_new();
     if (!xattr)
         goto out;
@@ -3018,6 +3084,9 @@ out:
 
     if (xattr)
         dict_unref(xattr);
+
+    if (subvol_xattrs)
+        dict_unref(subvol_xattrs);
 
     return 0;
 }

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -671,4 +671,7 @@ posix_update_iatt_buf(struct iatt *buf, int fd, char *loc, dict_t *xdata);
 gf_boolean_t
 posix_is_layout_stale(dict_t *xdata, char *par_path, xlator_t *this);
 
+int
+posix_delete_user_xattr(dict_t *dict, char *k, data_t *v, void *data);
+
 #endif /* _POSIX_H */


### PR DESCRIPTION
The scenario of setting an xattr to a dir, killing one of the bricks,
removing the xattr, bringing back the brick results in xattr
inconsistency - The downed brick will still have the xattr, but the rest
won't.
This patch add a mechanism that will remove the extra xattrs during
lookup.

> fixes: #1324
> Change-Id: Ifec0b7aea6cd40daa8b0319b881191cf83e031d1
> Signed-off-by: Barak Sason Rofman <bsasonro@redhat.com>

fixes: #1324
Change-Id: Ifec0b7aea6cd40daa8b0319b881191cf83e031d1
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

