### PR TITLE
protocol/client: Fix lock memory leak (#2338)

### DIFF
--- a/tests/bugs/client/issue-2337-lock-mem-leak.c
+++ b/tests/bugs/client/issue-2337-lock-mem-leak.c
@@ -1,0 +1,52 @@
+#include <sys/file.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int
+main(int argc, char *argv[])
+{
+    int fd = -1;
+    char *filename = NULL;
+    struct flock lock = {
+        0,
+    };
+    int i = 0;
+    int ret = -1;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <filename> ", argv[0]);
+        goto out;
+    }
+
+    filename = argv[1];
+
+    fd = open(filename, O_RDWR | O_CREAT, 0);
+    if (fd < 0) {
+        fprintf(stderr, "open (%s) failed (%s)\n", filename, strerror(errno));
+        goto out;
+    }
+
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_len = 2;
+
+    while (i < 100) {
+        lock.l_start = i;
+        ret = fcntl(fd, F_SETLK, &lock);
+        if (ret < 0) {
+            fprintf(stderr, "fcntl setlk failed (%s)\n", strerror(errno));
+            goto out;
+        }
+
+        i++;
+    }
+
+    ret = 0;
+
+out:
+    return ret;
+}

--- a/tests/bugs/client/issue-2337-lock-mem-leak.t
+++ b/tests/bugs/client/issue-2337-lock-mem-leak.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#Test that lock fop is not leaking any memory for overlapping regions
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../fileio.rc
+
+cleanup;
+
+LOCK_TEST=$(dirname $0)/issue-2337-lock-mem-leak
+build_tester $(dirname $0)/issue-2337-lock-mem-leak.c -o ${LOCK_TEST}
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}1
+#Guard against flush-behind
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+
+TEST touch $M0/a
+TEST fd1=`fd_available`
+TEST fd_open $fd1 'w' $M0/a
+TEST flock -x $fd1
+statedump=$(generate_mount_statedump $V0 $M0)
+EXPECT_NOT "^nostatedump$" echo $statedump
+#Making sure no one changes this mem-tracker name
+TEST grep gf_client_mt_clnt_lock_t $statedump
+TEST fd_close $fd1
+
+statedump=$(generate_mount_statedump $V0 $M0)
+EXPECT_NOT "^nostatedump$" echo $statedump
+TEST ! grep gf_client_mt_clnt_lock_t $statedump
+
+TEST ${LOCK_TEST} $M0/a
+
+statedump=$(generate_mount_statedump $V0 $M0)
+EXPECT_NOT "^nostatedump$" echo $statedump
+TEST ! grep gf_client_mt_clnt_lock_t $statedump
+TEST cleanup_mount_statedump $V0
+TEST rm ${LOCK_TEST}
+cleanup

--- a/tests/volume.rc
+++ b/tests/volume.rc
@@ -423,6 +423,14 @@ function gf_check_file_opened_in_brick {
         fi
 }
 
+function gf_open_file_count_in_brick {
+        vol=$1
+        host=$2
+        brick=$3
+        realpath=$4
+        ls -l /proc/$(get_brick_pid $vol $host $brick)/fd | grep "${realpath}$" | wc -l
+}
+
 function gf_get_gfid_backend_file_path {
         brickpath=$1
         filepath_in_brick=$2

--- a/xlators/protocol/client/src/client-lk.c
+++ b/xlators/protocol/client/src/client-lk.c
@@ -249,6 +249,7 @@ __insert_and_merge(clnt_fd_ctx_t *fdctx, client_posix_lock_t *lock)
                 sum = add_locks(lock, conf);
 
                 sum->fd = lock->fd;
+                sum->owner = conf->owner;
 
                 __delete_client_lock(conf);
                 __destroy_client_lock(conf);
@@ -316,57 +317,77 @@ destroy_client_lock(client_posix_lock_t *lock)
     GF_FREE(lock);
 }
 
-int32_t
-delete_granted_locks_owner(fd_t *fd, gf_lkowner_t *owner)
+void
+destroy_client_locks_from_list(struct list_head *deleted)
 {
-    clnt_fd_ctx_t *fdctx = NULL;
     client_posix_lock_t *lock = NULL;
     client_posix_lock_t *tmp = NULL;
-    xlator_t *this = NULL;
-    clnt_conf_t *conf = NULL;
-
-    struct list_head delete_list;
-    int ret = 0;
+    xlator_t *this = THIS;
     int count = 0;
 
-    INIT_LIST_HEAD(&delete_list);
-    this = THIS;
-    conf = this->private;
-
-    pthread_spin_lock(&conf->fd_lock);
-
-    fdctx = this_fd_get_ctx(fd, this);
-    if (!fdctx) {
-        pthread_spin_unlock(&conf->fd_lock);
-
-        gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_FD_CTX_INVALID,
-                NULL);
-        ret = -1;
-        goto out;
-    }
-
-    list_for_each_entry_safe(lock, tmp, &fdctx->lock_list, list)
+    list_for_each_entry_safe(lock, tmp, deleted, list)
     {
-        if (is_same_lkowner(&lock->owner, owner)) {
-            list_del_init(&lock->list);
-            list_add_tail(&lock->list, &delete_list);
-            count++;
-        }
-    }
-
-    pthread_spin_unlock(&conf->fd_lock);
-
-    if (!list_empty(&delete_list)) {
-        list_for_each_entry_safe(lock, tmp, &delete_list, list)
-        {
-            list_del_init(&lock->list);
-            destroy_client_lock(lock);
-        }
+        list_del_init(&lock->list);
+        destroy_client_lock(lock);
+        count++;
     }
 
     /* FIXME: Need to actually print the locks instead of count */
     gf_msg_trace(this->name, 0, "Number of locks cleared=%d", count);
+}
 
+void
+__delete_granted_locks_owner_from_fdctx(clnt_fd_ctx_t *fdctx,
+                                        gf_lkowner_t *owner,
+                                        struct list_head *deleted)
+{
+    client_posix_lock_t *lock = NULL;
+    client_posix_lock_t *tmp = NULL;
+
+    gf_boolean_t is_null_lkowner = _gf_false;
+
+    if (is_lk_owner_null(owner)) {
+        is_null_lkowner = _gf_true;
+    }
+
+    list_for_each_entry_safe(lock, tmp, &fdctx->lock_list, list)
+    {
+        if (is_null_lkowner || is_same_lkowner(&lock->owner, owner)) {
+            list_del_init(&lock->list);
+            list_add_tail(&lock->list, deleted);
+        }
+    }
+}
+
+int32_t
+delete_granted_locks_owner(fd_t *fd, gf_lkowner_t *owner)
+{
+    clnt_fd_ctx_t *fdctx = NULL;
+    xlator_t *this = NULL;
+    clnt_conf_t *conf = NULL;
+    int ret = 0;
+    struct list_head deleted_locks;
+
+    this = THIS;
+    conf = this->private;
+    INIT_LIST_HEAD(&deleted_locks);
+
+    pthread_spin_lock(&conf->fd_lock);
+    {
+        fdctx = this_fd_get_ctx(fd, this);
+        if (!fdctx) {
+            pthread_spin_unlock(&conf->fd_lock);
+
+            gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_FD_CTX_INVALID,
+                    NULL);
+            ret = -1;
+            goto out;
+        }
+        __delete_granted_locks_owner_from_fdctx(fdctx, owner, &deleted_locks);
+    }
+    pthread_spin_unlock(&conf->fd_lock);
+
+    destroy_client_locks_from_list(&deleted_locks);
 out:
     return ret;
 }

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -306,8 +306,12 @@ int
 client_attempt_lock_recovery(xlator_t *this, clnt_fd_ctx_t *fdctx);
 int32_t
 delete_granted_locks_owner(fd_t *fd, gf_lkowner_t *owner);
-int32_t
-delete_granted_locks_fd(clnt_fd_ctx_t *fdctx);
+void
+__delete_granted_locks_owner_from_fdctx(clnt_fd_ctx_t *fdctx,
+                                        gf_lkowner_t *owner,
+                                        struct list_head *deleted);
+void
+destroy_client_locks_from_list(struct list_head *deleted);
 int32_t
 client_cmd_to_gf_cmd(int32_t cmd, int32_t *gf_cmd);
 void


### PR DESCRIPTION
Problem-1:
When an overlapping lock is issued the merged lock is not assigned the
owner. When flush is issued on the fd, this particular lock is not freed
leading to memory leak

Fix-1:
Assign the owner while merging the locks.

Problem-2:
On fd-destroy lock structs could be present in fdctx. For some reason
with flock -x command and closing of the bash fd, it leads to this code
path. Which leaks the lock structs.

Fix-2:
When fdctx is being destroyed in client, make sure to cleanup any lock
structs.

fixes: #2337
Change-Id: I298124213ce5a1cf2b1f1756d5e8a9745d9c0a1c
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

