### PR TITLE
Coverity: Resource leak fix (CID: 1356547)

### DIFF
--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -2114,6 +2114,7 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_NO_MEMORY, NULL);
         goto out;
     }
+    frame->local = local;
 
     /*
      * This is mainly for samba shares (or windows clients). As part of
@@ -2141,7 +2142,6 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     local->subvolume = subvolume;
     local->fd = fd_ref(fd);
-    frame->local = local;
 
     STACK_WIND(frame, gf_svc_readdirp_cbk, subvolume, subvolume->fops->readdirp,
                fd, size, off, xdata);


### PR DESCRIPTION
Issue:
In function gf_svc_readdirp() there is a chance that 'local' will be allocated
memory but not released in the failure path.

Fix:
In the failure path free the memory allocated to the 'local' variable.

Change-Id: I4474dc4d4be5432d169cb7d434728f211054997e
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1060

