### PR TITLE
coverity: resource leaks, bypass rand() security check

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -215,7 +215,6 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
     struct pmap_registry *pmap = NULL;
     struct pmap_ports *tmp_port = NULL;
     char *tmp_brick;
-    char *new_brickname;
     char *entry;
     size_t brickname_len;
     int ret = -1;
@@ -257,11 +256,10 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
                 entry = strstr(entry + brickname_len, brickname);
             }
         }
-        ret = gf_asprintf(&new_brickname, "%s %s", tmp_brick, brickname);
+        ret = gf_asprintf(&(tmp_port->brickname), "%s %s", tmp_brick,
+                          brickname);
         if (ret > 0) {
             ret = 0;
-            tmp_port->brickname = gf_strdup(new_brickname);
-            GF_FREE(new_brickname);
             GF_FREE(tmp_brick);
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -215,6 +215,7 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
     struct pmap_registry *pmap = NULL;
     struct pmap_ports *tmp_port = NULL;
     char *tmp_brick;
+    char *new_brickname;
     char *entry;
     size_t brickname_len;
     int ret = -1;
@@ -256,10 +257,11 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
                 entry = strstr(entry + brickname_len, brickname);
             }
         }
-        ret = gf_asprintf(&(tmp_port->brickname), "%s %s", tmp_brick,
-                          brickname);
+        ret = gf_asprintf(&new_brickname, "%s %s", tmp_brick, brickname);
         if (ret > 0) {
             ret = 0;
+            tmp_port->brickname = gf_strdup(new_brickname);
+            GF_FREE(new_brickname);
             GF_FREE(tmp_brick);
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -104,6 +104,7 @@ pmap_port_alloc(xlator_t *this)
     pmap = pmap_registry_get(this);
 
     while (true) {
+        /* coverity[DC.WEAK_CRYPTO] */
         p = (rand() % (pmap->max_port - pmap->base_port + 1)) + pmap->base_port;
         if (pmap_port_isfree(p)) {
             break;
@@ -260,6 +261,7 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
         if (ret > 0) {
             ret = 0;
             tmp_port->brickname = gf_strdup(new_brickname);
+            GF_FREE(new_brickname);
             GF_FREE(tmp_brick);
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -259,10 +259,9 @@ port_brick_bind(xlator_t *this, int port, char *brickname, void *xprt,
         }
         ret = gf_asprintf(&new_brickname, "%s %s", tmp_brick, brickname);
         if (ret > 0) {
-            ret = 0;
-            tmp_port->brickname = gf_strdup(new_brickname);
-            GF_FREE(new_brickname);
+            tmp_port->brickname = new_brickname;
             GF_FREE(tmp_brick);
+            ret = 0;
         }
     }
 


### PR DESCRIPTION
Fix:
Marked the security issue of using `rand()` as false-positive,
as we don't use `rand()` for any cryptographic things.

And, fixed the resource leak of a variable.

CID: 1452732, 1452733

Updates: #1060

Change-Id: Id4cb2eb1cf7ce6f814752a4fb23bdd41ec94592c
Signed-off-by: nik-redhat <nladha@redhat.com>

