### PR TITLE
Cid 1430111 : USE AFTER FREE

### DIFF
--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -3253,8 +3253,5 @@ gf_asprintf_append(char **string_ptr, const char *format, ...)
     rv = gf_vasprintf(string_ptr, format, arg);
     va_end(arg);
 
-    if (tmp)
-        GF_FREE(tmp);
-
     return rv;
 }

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -3247,8 +3247,6 @@ gf_asprintf_append(char **string_ptr, const char *format, ...)
 {
     va_list arg;
     int rv = 0;
-    char *tmp = *string_ptr;
-
     va_start(arg, format);
     rv = gf_vasprintf(string_ptr, format, arg);
     va_end(arg);

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -3247,9 +3247,14 @@ gf_asprintf_append(char **string_ptr, const char *format, ...)
 {
     va_list arg;
     int rv = 0;
+    char *tmp = *string_ptr;
+
     va_start(arg, format);
     rv = gf_vasprintf(string_ptr, format, arg);
     va_end(arg);
+
+    if (rv >= 0)
+        GF_FREE(tmp);
 
     return rv;
 }


### PR DESCRIPTION
CID: 1430111

Description:
gf_event is trying to reference events_str which is getting freed in
`gf_asprintf_append` by tmp pointer pointing to it. Since we are already freeing events_str after the
gf_event using GF_FREE it's not required to be freed in each gf_asprintf_append.

Updates: #1060

Change-Id: Iae4936b6ceeb9ed7989bcb17bbb6e1feac559b33
Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>