### PR TITLE
cluster/afr: Code coverage improvement for afr-self-heald.c

### DIFF
--- a/tests/line-coverage/afr-heal-info.t
+++ b/tests/line-coverage/afr-heal-info.t
@@ -32,6 +32,7 @@ TEST $CLI volume heal $V0 info summary --xml
 TEST $CLI volume heal $V0 info split-brain
 TEST $CLI volume heal $V0 info split-brain --xml
 
+TEST $CLI volume heal $V0 statistics
 TEST $CLI volume heal $V0 statistics heal-count
 
 # It may fail as the file is not in splitbrain


### PR DESCRIPTION
Problem 1:
The code to handle the volume heal split-brain was there in both
glfs-heal.c and afr-self-heald.c. The code path in the later file
was never hit since it will always be handled by self-heal.c.

Fix:
Removed the code to handle heal info split-brain request from
afr-self-heald.c file.

Problem 2:
The volume heal statistics was never called in any of the test cases.

Fix:
Calling volume heal statistics in afr-heal-info.t which will increase
the code coverage.

Change-Id: I242ef088bb2da9c8d9a200986514758cb0f08b37
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1000

