### PR TITLE
cluster/afr: Adding new option to handle gfid mismatches

### DIFF
--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -321,6 +321,8 @@ reconfigure(xlator_t *this, dict_t *options)
             afr_selfheal_childup(this, priv);
     }
 
+    GF_OPTION_RECONF("gfid-mismatch-heal", priv->gfid_mismatch_heal, options,
+                     bool, out);
     ret = 0;
 out:
     return ret;
@@ -571,6 +573,8 @@ init(xlator_t *this)
     GF_OPTION_INIT("use-anonymous-inode", priv->use_anon_inode, bool, out);
     if (priv->quorum_count != 0)
         priv->consistent_io = _gf_false;
+
+    GF_OPTION_INIT("gfid-mismatch-heal", priv->gfid_mismatch_heal, bool, out);
 
     priv->wait_count = 1;
 
@@ -1333,6 +1337,14 @@ struct volume_options options[] = {
      .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE,
      .tags = {"replicate"},
      .description = "Setting this option heals directory renames efficiently"},
+
+    {.key = {"gfid-mismatch-heal"},
+     .type = GF_OPTION_TYPE_BOOL,
+     .default_value = "no",
+     .op_version = {GD_OP_VERSION_10_0},
+     .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE,
+     .tags = {"replicate"},
+     .description = "Setting this option automatically heals gfid mismatches"},
 
     {.key = {NULL}},
 };

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -276,6 +276,7 @@ typedef struct _afr_private {
     gf_boolean_t consistent_io;
     gf_boolean_t data_self_heal; /* on/off */
     gf_boolean_t use_anon_inode;
+    gf_boolean_t gfid_mismatch_heal;
 
     /*For lock healing.*/
     struct list_head saved_locks;

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -22,6 +22,7 @@
 #define XATTROP_SUBDIR "xattrop"
 #define DIRTY_SUBDIR "dirty"
 #define ENTRY_CHANGES_SUBDIR "entry-changes"
+#define RENAME_CHANGES_SUBDIR "rename-changes"
 
 struct index_syncop_args {
     inode_t *parent;
@@ -2343,7 +2344,8 @@ index_priv_dump(xlator_t *this)
 
     snprintf(key_prefix, GF_DUMP_MAX_BUF_LEN, "%s.%s", this->type, this->name);
     gf_proc_dump_add_section("%s", key_prefix);
-    gf_proc_dump_write("xattrop-pending-count", "%"PRId64, priv->pending_count);
+    gf_proc_dump_write("xattrop-pending-count", "%" PRId64,
+                       priv->pending_count);
 
     return 0;
 }
@@ -2478,6 +2480,10 @@ init(xlator_t *this)
     }
 
     ret = index_dir_create(this, ENTRY_CHANGES_SUBDIR);
+    if (ret < 0)
+        goto out;
+
+    ret = index_dir_create(this, RENAME_CHANGES_SUBDIR);
     if (ret < 0)
         goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -1057,7 +1057,7 @@ struct volopt_map_entry glusterd_volopt_map[] = {
     {.key = "cluster.ensure-durability",
      .voltype = "cluster/replicate",
      .op_version = 3,
-    .type = NO_DOC,
+     .type = NO_DOC,
      .flags = VOLOPT_FLAG_CLIENT_OPT},
     {.key = "cluster.consistent-metadata",
      .voltype = "cluster/replicate",
@@ -3107,7 +3107,13 @@ struct volopt_map_entry glusterd_volopt_map[] = {
 
     {.key = "rebalance.ensure-durability",
      .voltype = "cluster/distribute",
-    .type = NO_DOC,
+     .type = NO_DOC,
      .op_version = GD_OP_VERSION_10_0,
+     .flags = VOLOPT_FLAG_CLIENT_OPT},
+
+    {.key = "cluster.gfid-mismatch-heal",
+     .voltype = "cluster/replicate",
+     .op_version = GD_OP_VERSION_10_0,
+     .value = "no",
      .flags = VOLOPT_FLAG_CLIENT_OPT},
     {.key = NULL}};


### PR DESCRIPTION
Introducing a new option called "gfid-mismatch-heal" which should
resolve gfid mismatches automatically when enabled.

NOTE:
This patch only introduces the new option, and creates a new directory
inside .glusterfs/indices/ which will store the metadata needed to do
the healing. Metadata storing and actual healing logic will be added
by the series of upcoming patches.

Change-Id: I1e1fd1cc23354d0309b786a405321acd7ef1806c
Updates: #502
Signed-off-by: karthik-us <ksubrahm@redhat.com>

