### PR TITLE
Coverity: Fix dereference before null check (CID: 1391415)

### DIFF
--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -733,8 +733,9 @@ gf_client_dump_inodes_to_dict(xlator_t *this, dict_t *dict)
                 clienttable->cliententries[count].next_free)
                 continue;
             client = clienttable->cliententries[count].client;
-            if (!strcmp(client->bound_xl->name, this->name)) {
-                if (client->bound_xl && client->bound_xl->itable) {
+            if (client->bound_xl &&
+                !strcmp(client->bound_xl->name, this->name)) {
+                if (client->bound_xl->itable) {
                     /* Presently every brick contains only
                      * one bound_xl for all connections.
                      * This will lead to duplicating of


### PR DESCRIPTION
Problem:
In function gf_client_dump_inodes_to_dict() there is a null check for
a variable which is already dereferenced in the previous line. This
means that there could be a chance that this variable is null. But it
is not being validate for null before dereferencing it in the first
place.

Fix:
Added null check before dereferencing the variable at the first place.

Change-Id: I988b0e93542782353a8059e33db1522b6a5e55f8
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1060

