### PR TITLE
features/shard: files larger than shard_block_size show the wrong size

### DIFF
--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -25,7 +25,9 @@ EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`
 TEST $CLI volume set $V0 performance.read-ahead on
 TEST $CLI volume set $V0 performance.parallel-readdir on
 
-sleep 5
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
 
 # Size of the file should be the aggregated size, not the shard-block-size
 EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`

--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -10,8 +10,6 @@ TEST pidof glusterd
 TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,3}
 TEST $CLI volume set $V0 features.shard on
 TEST $CLI volume set $V0 features.shard-block-size 4MB
-TEST $CLI volume set $V0 performance.read-ahead on
-TEST $CLI volume set $V0 performance.parallel-readdir on
 TEST $CLI volume start $V0
 
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
@@ -19,9 +17,17 @@ TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
 TEST $CLI volume set $V0 md-cache-timeout 10
 
 # Write data into a file such that its size crosses shard-block-size
-TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=8
+TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=10
 
 # Size of the file should be the aggregated size, not the shard-block-size
-EXPECT '8388608' stat -c %s $M0/foo
+EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`
+
+TEST $CLI volume set $V0 performance.read-ahead on
+TEST $CLI volume set $V0 performance.parallel-readdir on
+
+sleep 5
+
+# Size of the file should be the aggregated size, not the shard-block-size
+EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`
 
 cleanup

--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,3}
+TEST $CLI volume set $V0 features.shard on
+TEST $CLI volume set $V0 features.shard-block-size 4MB
+TEST $CLI volume set $V0 performance.read-ahead on
+TEST $CLI volume set $V0 performance.parallel-readdir on
+TEST $CLI volume start $V0
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+TEST $CLI volume set $V0 md-cache-timeout 10
+
+# Write data into a file such that its size crosses shard-block-size
+TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=8 oflag=direct
+
+# Size of the file should be the aggregated size, not the shard-block-size
+EXPECT '8388608' stat -c %s $M0/foo
+
+cleanup

--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -19,7 +19,7 @@ TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
 TEST $CLI volume set $V0 md-cache-timeout 10
 
 # Write data into a file such that its size crosses shard-block-size
-TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=8 oflag=direct
+TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=8
 
 # Size of the file should be the aggregated size, not the shard-block-size
 EXPECT '8388608' stat -c %s $M0/foo

--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -17,7 +17,7 @@ TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
 TEST $CLI volume set $V0 md-cache-timeout 10
 
 # Write data into a file such that its size crosses shard-block-size
-TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=10
+TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=10 oflag=direct
 
 # Size of the file should be the aggregated size, not the shard-block-size
 EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -4867,6 +4867,7 @@ shard_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     STACK_WIND(frame, shard_opendir_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->opendir, loc, fd, xdata);
 
+    dict_unref(xdata);
     return 0;
 
 err:

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -27,7 +27,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
-#include <glusterfs/byte-order.h>
 #include "readdir-ahead.h"
 #include "readdir-ahead-mem-types.h"
 #include <glusterfs/defaults.h>
@@ -649,7 +648,6 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
     struct rda_fd_ctx *ctx;
     off_t offset;
     struct rda_priv *priv = this->private;
-    int ret = 0;
 
     ctx = get_rda_fd_ctx(fd, this);
     if (!ctx)
@@ -698,16 +696,6 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
     GF_ATOMIC_INC(ctx->prefetching);
 
     UNLOCK(&ctx->lock);
-
-    /* if the file is sharded then server will return the below
-     * xattr as part of dict that is used to update the ia_size
-     * in d_stat
-     */
-    ret = dict_set_uint64(ctx->xattrs, GF_XATTR_SHARD_FILE_SIZE, 8 * 4);
-    if (ret) {
-        gf_msg_debug(this->name, -ret, "Unable to set list-xattr in dict ");
-        goto err;
-    }
 
     STACK_WIND(nframe, rda_fill_fd_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->readdirp, fd, priv->rda_req_size,

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -27,6 +27,7 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
+#include <glusterfs/byte-order.h>
 #include "readdir-ahead.h"
 #include "readdir-ahead-mem-types.h"
 #include <glusterfs/defaults.h>
@@ -648,6 +649,7 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
     struct rda_fd_ctx *ctx;
     off_t offset;
     struct rda_priv *priv = this->private;
+    int ret = 0;
 
     ctx = get_rda_fd_ctx(fd, this);
     if (!ctx)
@@ -696,6 +698,16 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
     GF_ATOMIC_INC(ctx->prefetching);
 
     UNLOCK(&ctx->lock);
+
+    /* if the file is sharded then server will return the below
+     * xattr as part of dict that is used to update the ia_size
+     * in d_stat
+     */
+    ret = dict_set_uint64(ctx->xattrs, GF_XATTR_SHARD_FILE_SIZE, 8 * 4);
+    if (ret) {
+        gf_msg_debug(this->name, -ret, "Unable to set list-xattr in dict ");
+        goto err;
+    }
 
     STACK_WIND(nframe, rda_fill_fd_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->readdirp, fd, priv->rda_req_size,


### PR DESCRIPTION
issue:
When the user executes 'ls' command, shard fetches the actual file-size
extended attribute from the file and displays the correct size to the user.
When parallel-readdir/readdir-ahead features are enabled, readdir of the
brick happens in the background which will not fetch actual file-size xattr
from the brick and caches it. When the user does 'ls' the entries are served
from this cache which doesn't have actual file size, so shard translator
thinks these files are created before sharding is enabled and shows the user
shard block size instead of the actual file size.

Solution:
Send xdata request to server to fetch the actual size of the sharded file
from the server from shard_opendir().

fixes: #1384
Change-Id: Id756b07b0ff1f746b0bf6d4081b6a1fd9e76adfb
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

