### PR TITLE
Coverity : Use after free

### DIFF
--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -3253,7 +3253,7 @@ gf_asprintf_append(char **string_ptr, const char *format, ...)
     rv = gf_vasprintf(string_ptr, format, arg);
     va_end(arg);
 
-    if (tmp)
+    if (rv >= 0)
         GF_FREE(tmp);
 
     return rv;


### PR DESCRIPTION
CID: 1430111

Description:
The previous condition `if(tmp)` was freeing  `tmp` always.
Hence,  replaced the condition with a new condition which checks if `rv >= 0`.

Updates: #1060

Change-Id: I0ebe18d1978b73b577ded259915b7305a58253ff
Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>

