### PR TITLE
Revert "fuse - remove unnecessary code block"

### DIFF
--- a/tests/basic/acl/acl-inherit.t
+++ b/tests/basic/acl/acl-inherit.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+. $(dirname $0)/../../include.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume start $V0
+
+TEST $GFS --volfile-id=$V0 --acl --volfile-server=$H0 $M0;
+
+cd $M0
+TEST mkdir test
+TEST setfacl -m d:m:rwx test
+TEST setfacl -m d:u::rwx test
+TEST setfacl -m d:g::rwx test
+TEST setfacl -m d:o::rwx test
+
+TEST mkdir test/new
+EXPECT "user::rwx" echo $(getfacl test/new | grep -E "^user")
+EXPECT "group::rwx" echo $(getfacl test/new | grep -E "^group")
+EXPECT "mask::rwx" echo $(getfacl test/new | grep -E "^mask")
+EXPECT "other::rwx" echo $(getfacl test/new | grep -E "^other")
+EXPECT "default:user::rwx" echo $(getfacl test/new | grep -E "^default:user")
+EXPECT "default:group::rwx" echo $(getfacl test/new | grep -E "^default:group")
+EXPECT "default:mask::rwx" echo $(getfacl test/new | grep -E "^default:mask")
+EXPECT "default:other::rwx" echo $(getfacl test/new | grep -E "^default:other")
+cd -
+
+cleanup

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -2235,6 +2235,7 @@ fuse_mknod(xlator_t *this, fuse_in_header_t *finh, void *msg,
     fuse_state_t *state = NULL;
 #if FUSE_KERNEL_MINOR_VERSION >= 12
     fuse_private_t *priv = NULL;
+    int32_t ret = -1;
 
     priv = this->private;
     if (priv->proto_minor < 12)
@@ -2306,6 +2307,7 @@ fuse_mkdir(xlator_t *this, fuse_in_header_t *finh, void *msg,
     char *name = (char *)(fmi + 1);
 #if FUSE_KERNEL_MINOR_VERSION >= 12
     fuse_private_t *priv = NULL;
+    int32_t ret = -1;
 #endif
 
     fuse_state_t *state;
@@ -2831,6 +2833,7 @@ fuse_create(xlator_t *this, fuse_in_header_t *finh, void *msg,
 #if FUSE_KERNEL_MINOR_VERSION >= 12
     struct fuse_create_in *fci = msg;
     fuse_private_t *priv = NULL;
+    int32_t ret = -1;
 #else
     struct fuse_open_in *fci = msg;
 #endif

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -330,6 +330,27 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
                 return;                                                        \
             }                                                                  \
             state->umask = fci->umask;                                         \
+                                                                               \
+            ret = dict_set_int16(state->xdata, "umask", fci->umask);           \
+            if (ret < 0) {                                                     \
+                gf_log("glusterfs-fuse", GF_LOG_WARNING,                       \
+                       "%s Failed adding umask"                                \
+                       " to request",                                          \
+                       op);                                                    \
+                send_fuse_err(this, finh, ENOMEM);                             \
+                free_fuse_state(state);                                        \
+                return;                                                        \
+            }                                                                  \
+            ret = dict_set_int16(state->xdata, "mode", fci->mode);             \
+            if (ret < 0) {                                                     \
+                gf_log("glusterfs-fuse", GF_LOG_WARNING,                       \
+                       "%s Failed adding mode "                                \
+                       "to request",                                           \
+                       op);                                                    \
+                send_fuse_err(this, finh, ENOMEM);                             \
+                free_fuse_state(state);                                        \
+                return;                                                        \
+            }                                                                  \
         }                                                                      \
     } while (0)
 


### PR DESCRIPTION
As per the discussion on #2353 it is decided to revert this patch to fix
the acl regression issue.
This reverts commit 07bb13291fbb92632d01d8c215b93e31ec9ae313.

fixes: #2353
Change-Id: Ie47479d9f894bac9c5d8a83b05c42e1ee98230dc
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

