### PR TITLE
cluster/dht: Don't access local after STACK_DESTROY

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -695,6 +695,7 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = -1;
     dht_conf_t *conf = 0;
     dht_layout_t *layout = NULL;
+    int32_t mds_heal_fresh_lookup = 0;
 
     GF_VALIDATE_OR_GOTO(this->name, frame, out);
     GF_VALIDATE_OR_GOTO(this->name, frame->local, out);
@@ -702,6 +703,7 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     conf = this->private;
     layout = local->selfheal.layout;
+    mds_heal_fresh_lookup = local->mds_heal_fresh_lookup;
 
     if (op_ret) {
         gf_msg_debug(this->name, op_ret,
@@ -722,7 +724,7 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  layout);
     }
 out:
-    if (local && local->mds_heal_fresh_lookup)
+    if (mds_heal_fresh_lookup)
         DHT_STACK_DESTROY(frame);
     return 0;
 }


### PR DESCRIPTION
There is a possibility that 'frame' could have been
destroyed in dht_selfheal_dir_setattr() which can
lead to local->mds_heal_fresh_lookup showing junk
non-zero number.  That will lead to double
STACK_DESTROY. Remembered the value of the variable
before the call to fix the access.

Fixes: #1214
Change-Id: I37d1657798bfb549bb3887e260484d58fff42c91
Signed-off-by: Pranith Kumar K <pkarampu@redhat.com>

