### PR TITLE
Fix broken geo replication history crawl after restarting it

### DIFF
--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -439,6 +439,10 @@ gf_history_b_search(int fd, unsigned long value, unsigned long from,
         goto out;
     if (cur_value == value) {
         return m_index;
+    } else if (cur_value == 0) {
+        // 0 is returned if the timestamp isn't found in the htime file
+        // In this case we need to search backward
+        return gf_history_b_search(fd, value, from, m_index - 1, len);
     } else if (value > cur_value) {
         ret = gf_history_get_timestamp(fd, m_index + 1, len, &cur_value);
         if (ret == -1)


### PR DESCRIPTION
I was also impacted by #2133. It was a nightmare to recreate each time the replication (4 days with some of our volumes)

After some long investigation and instrumentation in gf-history-changelog.c, I noticed that the htime file last index isn't up to date compared to the index in the xattr (trusted.glusterfs.htime) of the htime file.
I don't know if it's an expected behavior or a bug somewhere else.

To be able to do the history crawl, gsync needs to know start and end index to be able to apply all pending changelogs.
I found out the issue in the call to the binary search when checking the index for the end timestamp.
The max index can be sometimes out of the bound of the last value of the htime file, so it's returning 0 as the found timestamp.
This 0 value is detected as a correct value and so the binary search returns the max available index which is wrong.

So I added a check against 0 to be able to search backward until finding the right value.
I tested it intensively with all failing test scenarios I found from #2133 and so far, everything is going well. (eg: node failure, slave failure, restarting georep, etc)
