### PR TITLE
dict: Compilation should check string literal

### DIFF
--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -81,7 +81,8 @@
 #define GLUSTERD_MAX_SNAP_NAME 255
 #define GLUSTERFS_SOCKET_LISTEN_BACKLOG 1024
 #define GLUSTERD_BRICK_SERVERS "cluster.brick-vol-servers"
-#define SLEN(str) (sizeof(str) - 1)
+#define GLUSTER_STR_MUST_BE_LITERAL(__x) "" __x
+#define SLEN(str) (sizeof(GLUSTER_STR_MUST_BE_LITERAL(str)) - 1)
 
 #define ZR_MOUNTPOINT_OPT "mountpoint"
 #define ZR_ATTR_TIMEOUT_OPT "attribute-timeout"

--- a/libglusterfs/src/glusterfs/options.h
+++ b/libglusterfs/src/glusterfs/options.h
@@ -320,7 +320,7 @@ DECLARE_RECONF_OPT(uint32_t, time);
 
 #define GF_OPTION_RECONF(key, val, opt, type, err_label)                       \
     do {                                                                       \
-        if (xlator_option_reconf_##type(THIS, opt, key, SLEN(key), &(val)))    \
+        if (xlator_option_reconf_##type(THIS, opt, key, strlen(key), &(val)))  \
             goto err_label;                                                    \
     } while (0)
 

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1047,7 +1047,7 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
                 goto out;
             }
             strncpy(brickinfo->mount_dir, brick_mount_dir,
-                    SLEN(brickinfo->mount_dir));
+                    sizeof(brickinfo->mount_dir) - 1);
         }
 
         ret = glusterd_resolve_brick(brickinfo);

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -23,7 +23,6 @@
 #define TRASH_DIR "landfill"
 
 #define UUID0_STR "00000000-0000-0000-0000-000000000000"
-#define SLEN(str) (sizeof(str) - 1)
 
 #define LOC_HAS_ABSPATH(loc) (loc && (loc->path) && (loc->path[0] == '/'))
 #define LOC_IS_DIR(loc)                                                        \


### PR DESCRIPTION
Recently I made a mistake where a variable is passed instead of string
literal to _sizen variant but the compilation succeeded. This can lead
to serious bugs. Added guard rails to prevent this from happening in
future.

fixes: #2410
Change-Id: I8cf1408b4a0a497903162de32e2cfb008ad7853c
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>
