### PR TITLE
coverity: sanitize arguments to gf_attach

### DIFF
--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -163,7 +163,7 @@ usage(char *prog)
     return EXIT_FAILURE;
 }
 
-int
+static int
 sanitize_args(int argc, char **argv)
 {
     int ret = 0;


### PR DESCRIPTION
CID 1452749 :
> Untrusted value as argument (TAINTED_SCALAR)13. tainted_data:
>Passing tainted expression **argv to dict_set_str, which uses it as an offset.
>ret = dict_set_str(options, "transport.socket.connect-path", argv[optind]);

As far as I understood, untainting the arguments by checking it meets
the required expectations should make coverity not complain anymore. I
have therefore added checks to verify the file-type of the expected
arguments to gf_attach.

Updates: #1060
Change-Id: Ia8608d844ca3ede6d43f7ee5a793820b9a7bae52
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

