### PR TITLE
libglusterfs: add missing LOCK_DESTROY() calls

### DIFF
--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -184,6 +184,7 @@ __event_slot_dealloc(struct event_pool *event_pool, int idx)
     slot->fd = -1;
     slot->handled_error = 0;
     slot->in_handler = 0;
+    LOCK_DESTROY(&slot->lock);
     list_del_init(&slot->poller_death);
     if (fd != -1)
         event_pool->slots_used[table_idx]--;

--- a/libglusterfs/src/rbthash.c
+++ b/libglusterfs/src/rbthash.c
@@ -426,6 +426,7 @@ rbthash_table_destroy(rbthash_table_t *tbl)
     if (tbl->pool_alloced)
         mem_pool_destroy(tbl->entrypool);
 
+    LOCK_DESTROY(&tbl->tablelock);
     GF_FREE(tbl->buckets);
     GF_FREE(tbl);
 }


### PR DESCRIPTION
Add missing LOCK_DESTROY() calls in __event_slot_dealloc()
and rbthash_table_destroy().

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1960

