### PR TITLE
storage/posix: support timestamps with nanosecond precision

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1017,6 +1017,21 @@ if test "x${have_linkat}" = "xyes"; then
 fi
 AC_SUBST(HAVE_LINKAT)
 
+dnl prefer futimens for nanosecond resolution
+AC_CHECK_FUNC([futimens], [have_futimens=yes])
+if test "x${have_futimens}" = "xyes"; then
+   AC_DEFINE(HAVE_FUTIMENS, 1, [define if found futimens])
+else
+   AC_CHECK_FUNC([futimes], [have_futimes=yes])
+   if test "x${have_futimes}" = "xyes"; then
+      AC_DEFINE(HAVE_FUTIMES, 1, [define if found futimes])
+   else
+      AC_MSG_ERROR([This system doesn't support neither futimens() nor futimes()])
+   fi
+fi
+AC_SUBST(HAVE_FUTIMENS)
+AC_SUBST(HAVE_FUTIMES)
+
 dnl check for Monotonic clock
 AC_CHECK_LIB([rt], [clock_gettime], ,
              AC_MSG_WARN([System doesn't have monotonic clock using contrib]))

--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -149,8 +149,15 @@ sys_utimensat(int dirfd, const char *filename, const struct timespec times[2],
               int flags);
 #endif
 
+#if defined(HAVE_FUTIMENS)
+int
+sys_futimens(int fd, const struct timespec times[2]);
+#endif
+
+#if defined(HAVE_FUTIMES)
 int
 sys_futimes(int fd, const struct timeval times[2]);
+#endif
 
 int
 sys_creat(const char *pathname, mode_t mode);

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1046,6 +1046,7 @@ sys_fstat
 sys_fstatat
 sys_fsync
 sys_ftruncate
+sys_futimens
 sys_futimes
 sys_lchmod
 sys_lchown

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -340,11 +340,21 @@ sys_utimensat(int dirfd, const char *filename, const struct timespec times[2],
 }
 #endif
 
+#if defined(HAVE_FUTIMENS)
+int
+sys_futimens(int fd, const struct timespec times[2])
+{
+    return futimens(fd, times);
+}
+#endif
+
+#if defined(HAVE_FUTIMES)
 int
 sys_futimes(int fd, const struct timeval times[2])
 {
     return futimes(fd, times);
 }
+#endif
 
 int
 sys_creat(const char *pathname, mode_t mode)


### PR DESCRIPTION
If futimens() available, prefer it over futimes()
to support timestamps with nanosecond precision.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Fixes: #2429

