### PR TITLE
CID: 1351700 : Result not floating point

### DIFF
--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -1792,7 +1792,7 @@ dht_selfheal_layout_new_directory(call_frame_t *frame, loc_t *loc,
                      chunk);
     } else {
         weight_by_size = _gf_false;
-        chunk = ((unsigned long)0xffffffff) / bricks_to_use;
+        chunk = ((unsigned long)0xffffffff) / ((double)bricks_to_use);
     }
 
     start_subvol = dht_selfheal_layout_alloc_start(this, loc, layout);

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -1792,7 +1792,7 @@ dht_selfheal_layout_new_directory(call_frame_t *frame, loc_t *loc,
                      chunk);
     } else {
         weight_by_size = _gf_false;
-        chunk = ((unsigned long)0xffffffff) / ((double)bricks_to_use);
+        chunk = ((double)0xffffffff) / ((double)bricks_to_use);
     }
 
     start_subvol = dht_selfheal_layout_alloc_start(this, loc, layout);


### PR DESCRIPTION
Description:
The result of the division is truncated to an integer (a whole number), which is usually a loss of precision in a calculation.
Type-casted bricks_to_use to double to prevent the loss of precision.

Updates: #1060

Change-Id: I7e6aa29dbe27f2bb8e17231cc87c405798557694
Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>

