### PR TITLE
coverity: missing break in shard xlator

### DIFF
--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -885,6 +885,7 @@ shard_common_failure_unwind(glusterfs_fop_t fop, call_frame_t *frame,
             break;
         case GF_FOP_OPENDIR:
             SHARD_STACK_UNWIND(opendir, frame, op_ret, op_errno, 0, NULL);
+            break;
         default:
             gf_msg(THIS->name, GF_LOG_WARNING, 0, SHARD_MSG_INVALID_FOP,
                    "Invalid fop id = %d", fop);


### PR DESCRIPTION
CID: 1453117
Missing break in switch

This mistake happened through commit #2372.
Submitting this patch to correct the fault.

Change-Id: I6d1f77ea21a81ddef3734879cc4dd90565eecdfd
Updates: #1060
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

