### PR TITLE
geo-replication: fix Python 3.9 compatibility

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -890,7 +890,7 @@ class Mounter(object):
             t.start()
             tlim = rconf.starttime + gconf.get("connection-timeout")
             while True:
-                if not t.isAlive():
+                if not t.is_alive():
                     break
 
                 if time.time() >= tlim:


### PR DESCRIPTION
`Threading.Thread.isAlive()` was removed in Python 3.9 this cause sync daemon to fail.
`Threading.Thread.is_alive()` already exists in python 2 and 3 so backward compatibility should work as expected

Fixes: #2440

Links:
- https://bugs.python.org/issue37804
- https://docs.python.org/3.9/library/threading.html#threading.Thread.is_alive
- https://docs.python.org/3.0/library/threading.html#threading.Thread.is_alive
- https://docs.python.org/2.7/library/threading.html#threading.Thread.is_alive