### PR TITLE
xlators, cli: prefer timespec over timeval

### DIFF
--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -248,14 +248,8 @@ cli_cmd_unlock()
 static void
 seconds_from_now(unsigned secs, struct timespec *ts)
 {
-    struct timeval tv = {
-        0,
-    };
-
-    gettimeofday(&tv, NULL);
-
-    ts->tv_sec = tv.tv_sec + secs;
-    ts->tv_nsec = tv.tv_usec * 1000;
+    timespec_now_realtime(ts);
+    ts->tv_sec += secs;
 }
 
 int

--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -396,7 +396,7 @@ out:
 void
 svs_iatt_fill(uuid_t gfid, struct iatt *buf)
 {
-    struct timeval tv = {
+    struct timespec ts = {
         0,
     };
     xlator_t *this = NULL;
@@ -419,12 +419,9 @@ svs_iatt_fill(uuid_t gfid, struct iatt *buf)
 
     buf->ia_prot = ia_prot_from_st_mode(0755);
 
-    gettimeofday(&tv, 0);
-
-    buf->ia_mtime = buf->ia_atime = buf->ia_ctime = tv.tv_sec;
-    buf->ia_mtime_nsec = buf->ia_atime_nsec = buf->ia_ctime_nsec = (tv.tv_usec *
-                                                                    1000);
-
+    timespec_now_realtime(&ts);
+    buf->ia_mtime = buf->ia_atime = buf->ia_ctime = ts.tv_sec;
+    buf->ia_mtime_nsec = buf->ia_atime_nsec = buf->ia_ctime_nsec = ts.tv_nsec;
 out:
     return;
 }

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -185,7 +185,9 @@ static void
 default_meta_iatt_fill(struct iatt *iatt, inode_t *inode, ia_type_t type,
                        gf_boolean_t is_tunable)
 {
-    struct timeval tv = {};
+    struct timespec ts = {
+        0,
+    };
 
     iatt->ia_type = type;
     switch (type) {
@@ -209,11 +211,10 @@ default_meta_iatt_fill(struct iatt *iatt, inode_t *inode, ia_type_t type,
     meta_uuid_copy(iatt->ia_gfid, inode->gfid);
     iatt->ia_ino = gfid_to_ino(iatt->ia_gfid);
 
-    gettimeofday(&tv, 0);
-    iatt->ia_mtime = iatt->ia_ctime = iatt->ia_atime = tv.tv_sec;
+    timespec_now_realtime(&ts);
+    iatt->ia_mtime = iatt->ia_ctime = iatt->ia_atime = ts.tv_sec;
     iatt->ia_mtime_nsec = iatt->ia_ctime_nsec = iatt->ia_atime_nsec =
-        (tv.tv_usec * 1000);
-    return;
+        ts.tv_nsec;
 }
 
 void


### PR DESCRIPTION
Prefer timespec_now_realtime() over gettimeofday() to simplify and
avoid extra multiply by 1000.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

