### PR TITLE
glusterd, server: remove volfile checksum leftovers

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -205,7 +205,6 @@ typedef struct {
     /* need for proper handshake_t */
     int op_version; /* Starts with 1 for 3.3.0 */
     gf_boolean_t pending_quorum_action;
-    gf_boolean_t verify_volfile_checksum;
     gf_boolean_t trace;
     gf_boolean_t restart_done;
     dict_t *opts;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -589,16 +589,6 @@ server_build_config(xlator_t *this, server_conf_t *conf)
         conf->inode_lru_limit = 16384;
     }
 
-    conf->verify_volfile = 1;
-    data = dict_get(this->options, "verify-volfile-checksum");
-    if (data) {
-        ret = gf_string2boolean(data->data, &conf->verify_volfile);
-        if (ret != 0) {
-            gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PS_MSG_WRONG_VALUE,
-                    NULL);
-        }
-    }
-
     data = dict_get(this->options, "trace");
     if (data) {
         ret = gf_string2boolean(data->data, &conf->trace);

--- a/xlators/protocol/server/src/server-messages.h
+++ b/xlators/protocol/server/src/server-messages.h
@@ -153,8 +153,6 @@ GLFS_MSGID(
 #define PS_MSG_MAPPING_ERROR_STR "could not map to group list"
 #define PS_MSG_FD_CLEANUP_STR "fd cleanup"
 #define PS_MSG_FDENTRY_NULL_STR "no fdentry to clean"
-#define PS_MSG_WRONG_VALUE_STR                                                 \
-    "wrong value for 'verify-volfile-checksum', Neglecting option"
 #define PS_MSG_DIR_NOT_FOUND_STR "Directory doesnot exist"
 #define PS_MSG_CONF_DIR_INVALID_STR "invalid conf_dir"
 #define PS_MSG_SERVER_MSG_STR "server msg"

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -57,7 +57,6 @@ struct server_conf {
     rpcsvc_t *rpc;
     struct rpcsvc_config rpc_conf;
     int inode_lru_limit;
-    gf_boolean_t verify_volfile;
     gf_boolean_t trace;
     char *conf_dir;
     struct _volfile_ctx *volfile;


### PR DESCRIPTION
Remove volfile checksum leftovers which aren't actually
used since 4.1.6.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

