### PR TITLE
fuse: handle failure to get gids gracefully

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4835,7 +4835,7 @@ fuse_setlk_interrupt_handler(xlator_t *this, fuse_interrupt_record_t *fir)
         goto err;
     }
 
-    frame = get_call_frame_for_req(state);
+    frame = get_call_frame_for_req(state, GF_FOP_GETXATTR);
     if (!frame) {
         goto err;
     }

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -262,7 +262,7 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
             break;                                                             \
         }                                                                      \
                                                                                \
-        frame = get_call_frame_for_req(state);                                 \
+        frame = get_call_frame_for_req(state, op_num);                         \
         if (!frame) {                                                          \
             /* This is not completely clean, as some                           \
              * earlier allocations might remain unfreed                        \
@@ -486,7 +486,7 @@ GF_MUST_CHECK int32_t
 fuse_loc_fill(loc_t *loc, fuse_state_t *state, ino_t ino, ino_t par,
               const char *name);
 call_frame_t *
-get_call_frame_for_req(fuse_state_t *state);
+get_call_frame_for_req(fuse_state_t *state, int op_num);
 fuse_state_t *
 get_fuse_state(xlator_t *this, fuse_in_header_t *finh);
 void


### PR DESCRIPTION
If by any chance we fail to handle "/proc/$pid/status" file,
there was a crash which used to happen.

With this patch, that error is gracefully handled with a single group
added as root by default.

Fixes: #2467
Change-Id: I897a8f954deecabc48598dce03806154c7c1d189
Signed-off-by: Amar Tumballi <amar@kadalu.io>

