### PR TITLE
protocol/server: cleanup server configuration data

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -139,10 +139,6 @@ typedef struct {
     struct list_head list;
 } rpcsvc_listener_t;
 
-struct rpcsvc_config {
-    int max_block_size;
-};
-
 #define rpcsvc_auth_flavour(au) ((au).flavour)
 
 typedef struct drc_client drc_client_t;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -184,11 +184,6 @@ free_state(server_state_t *state)
         state->iobref = NULL;
     }
 
-    if (state->iobuf) {
-        iobuf_unref(state->iobuf);
-        state->iobuf = NULL;
-    }
-
     if (state->dict) {
         dict_unref(state->dict);
         state->dict = NULL;
@@ -608,17 +603,6 @@ server_build_config(xlator_t *this, server_conf_t *conf)
         }
     }
 
-    /* TODO: build_rpc_config (); */
-    ret = dict_get_int32(this->options, "limits.transaction-size",
-                         &conf->rpc_conf.max_block_size);
-    if (ret < 0) {
-        gf_msg_trace(this->name, 0,
-                     "defaulting limits.transaction-"
-                     "size to %d",
-                     DEFAULT_BLOCK_SIZE);
-        conf->rpc_conf.max_block_size = DEFAULT_BLOCK_SIZE;
-    }
-
     data = dict_get(this->options, "config-directory");
     if (data) {
         /* Check whether the specified directory exists,
@@ -735,9 +719,6 @@ server_print_params(char *str, int size, server_state_t *state)
     if (state->flags)
         filled += snprintf(str + filled, size - filled, "flags=%d,",
                            state->flags);
-    if (state->wbflags)
-        filled += snprintf(str + filled, size - filled, "wbflags=%d,",
-                           state->wbflags);
     if (state->size)
         filled += snprintf(str + filled, size - filled, "size=%zu,",
                            state->size);

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -26,7 +26,6 @@
 #include <glusterfs/defaults.h>
 #include "authenticate.h"
 
-#define DEFAULT_BLOCK_SIZE 4194304 /* 4MB */
 #define DEFAULT_VOLUME_FILE_PATH CONFDIR "/glusterfs.vol"
 #define GF_MAX_SOCKET_WINDOW_SIZE (1 * GF_UNIT_MB)
 #define GF_MIN_SOCKET_WINDOW_SIZE (0)
@@ -55,7 +54,6 @@ struct _child_status {
 };
 struct server_conf {
     rpcsvc_t *rpc;
-    struct rpcsvc_config rpc_conf;
     int inode_lru_limit;
     gf_boolean_t verify_volfile;
     gf_boolean_t trace;
@@ -64,7 +62,6 @@ struct server_conf {
     dict_t *auth_modules;
     pthread_mutex_t mutex;
     struct list_head xprt_list;
-    pthread_t barrier_th;
 
     gf_boolean_t server_manage_gids; /* resolve gids on brick */
     gid_cache_t gid_cache;
@@ -140,10 +137,8 @@ struct _server_state {
     fd_t *fd_out; /* destination fd in copy_file_range */
     dict_t *params;
     int32_t flags;
-    int wbflags;
     struct iovec payload_vector[MAX_IOVEC];
     int payload_count;
-    struct iobuf *iobuf;
     struct iobref *iobref;
 
     size_t size;
@@ -159,18 +154,15 @@ struct _server_state {
     off64_t off_out; /* destination offset in copy_file_range */
     mode_t mode;
     dev_t dev;
-    size_t nr_count;
     int cmd;
     int type;
     char *name;
-    int name_len;
 
     int mask;
     char is_revalidate;
     dict_t *dict;
     struct gf_flock flock;
     const char *volume;
-    dir_entry_t *entry;
     gf_seek_what_t what;
 
     dict_t *xdata;
@@ -180,8 +172,6 @@ struct _server_state {
 
     struct iovec rsp_vector[MAX_IOVEC];
     int rsp_count;
-    struct iobuf *rsp_iobuf;
-    struct iobref *rsp_iobref;
 
     /* subdir mount */
     client_t *client;


### PR DESCRIPTION
Drop the reference to non-existing 'limits.transaction-size'
option, cleanup 'struct server_conf' and related bits.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

