### PR TITLE
Coverity: Fix copy into fixed size buffer (CID: 1325542)

### DIFF
--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -1101,8 +1101,13 @@ __mnt3_fresh_lookup(mnt3_resolve_t *mres)
 {
     inode_unlink(mres->resolveloc.inode, mres->resolveloc.parent,
                  mres->resolveloc.name);
-    strncpy(mres->remainingdir, mres->resolveloc.path,
-            strlen(mres->resolveloc.path));
+    if (snprintf(mres->remainingdir, sizeof(mres->remainingdir), "%s",
+                 mres->resolveloc.path) >= sizeof(mres->remainingdir)) {
+        gf_msg(GF_MNT, GF_LOG_ERROR, EFAULT, NFS_MSG_RESOLVE_INODE_FAIL,
+               "Failed to copy resolve path: %s", mres->resolveloc.path);
+        nfs_loc_wipe(&mres->resolveloc);
+        return -EFAULT;
+    }
     nfs_loc_wipe(&mres->resolveloc);
     return __mnt3_resolve_subdir(mres);
 }


### PR DESCRIPTION
Problem:
In __mnt3_fresh_lookup() mres->resolveloc.path is being copied into
a fixed size string mres->remainingdir, with strncpy without checking
the size of the source string. This could lead to string overflow.

Fix:
Copy only till the destination string length and check whether the
soruce string overflows. If so log an error message and return.

Change-Id: I26dd0653d2636c667ad4e356d12d3d51956c77c3
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1060

