### PR TITLE
features/sharding: wrong dname results in dentry not found error

### DIFF
--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -963,8 +963,8 @@ shard_evicted_inode_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         __shard_inode_ctx_get(shard_inode, this, &ctx);
         if ((list_empty(&ctx->to_fsync_list)) && (list_empty(&ctx->ilist))) {
-            shard_make_block_bname(ctx->block_num, shard_inode->gfid,
-                                   block_bname, sizeof(block_bname));
+            shard_make_block_bname(ctx->block_num, ctx->base_gfid, block_bname,
+                                   sizeof(block_bname));
             inode_unlink(shard_inode, priv->dot_shard_inode, block_bname);
             /* The following unref corresponds to the ref held by
              * inode_link() at the time the shard was created or


### PR DESCRIPTION
Due to wrong dname passed to inode_unlink in
shard_evicted_inode_fsync_cbk() resulting in dentry not found
error.

This patch addresses the issue.

Fixes: #2470
Change-Id: I6c479980ae3fa7ba558327055a9e5e5c2d2a850f
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

