### PR TITLE
src/gsyncd.c: Null pointer passed to 1st parameter expecting 'nonnull'

### DIFF
--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -388,7 +388,11 @@ main(int argc, char **argv)
         goto out;
     }
 
-    b = basename(argv[0]);
+    if ( argc >= 1 )
+        b = basename(argv[0]);
+    else
+        goto out;
+
     for (i = invocables; i->name; i++) {
         if (strcmp(b, i->name) == 0)
             return i->invoker(argc, argv);


### PR DESCRIPTION
Clang suspects argv[0] to be null.

Added a check for argc to solve the same.
Updates: #1096
Change-Id: Ie0088a2b364396d2eade8c68fd39a7d409c71b8e
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

