### PR TITLE
tests: fix library location for ipc test

### DIFF
--- a/tests/features/ipc.t
+++ b/tests/features/ipc.t
@@ -26,7 +26,7 @@ EOPNOTSUPP=$( echo '#include <errno.h>\\EOPNOTSUPP\\' | tr '\\' '\n' | \
 # use libglusterfs's version, and dlopen() does not make any guarantee
 # on this. By preloading libglusterfs.so before launching python, we
 # ensure libglusterfs's UUID functions will be used.
-LD_PRELOAD=${prefix}/lib/libglusterfs.so
+LD_PRELOAD=${libdir}/libglusterfs.so
 export LD_PRELOAD
 
 # This is a pretty lame test.  Basically we just want to make sure that we


### PR DESCRIPTION
Since ${prefix}/lib is not always equal to ${libdir} (64-bit
build may be configured with '--libdir=/usr/lib64' for example),
prefer convenient ${libdir} for LD_PRELOAD'ing libglusterfs.so.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

