### PR TITLE
Taking new_client_lock outside the spinlock

### DIFF
--- a/xlators/protocol/client/src/client-lk.c
+++ b/xlators/protocol/client/src/client-lk.c
@@ -473,22 +473,21 @@ client_add_lock_for_recovery(fd_t *fd, struct gf_flock *flock,
     this = THIS;
     conf = this->private;
 
+    lock = new_client_lock(flock, owner, cmd, fd);
+    if (!lock) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
     pthread_spin_lock(&conf->fd_lock);
 
     fdctx = this_fd_get_ctx(fd, this);
     if (!fdctx) {
+        destroy_client_lock(lock);
         pthread_spin_unlock(&conf->fd_lock);
 
         gf_smsg(this->name, GF_LOG_WARNING, 0, PC_MSG_FD_GET_FAIL, NULL);
         ret = -EBADFD;
-        goto out;
-    }
-
-    lock = new_client_lock(flock, owner, cmd, fd);
-    if (!lock) {
-        pthread_spin_unlock(&conf->fd_lock);
-
-        ret = -ENOMEM;
         goto out;
     }
 

--- a/xlators/protocol/client/src/client-lk.c
+++ b/xlators/protocol/client/src/client-lk.c
@@ -483,8 +483,8 @@ client_add_lock_for_recovery(fd_t *fd, struct gf_flock *flock,
 
     fdctx = this_fd_get_ctx(fd, this);
     if (!fdctx) {
-        destroy_client_lock(lock);
         pthread_spin_unlock(&conf->fd_lock);
+        destroy_client_lock(lock);
 
         gf_smsg(this->name, GF_LOG_WARNING, 0, PC_MSG_FD_GET_FAIL, NULL);
         ret = -EBADFD;


### PR DESCRIPTION
This will avoid taking a spin lock if new_client_lock
does not succeed.

Change-Id: I35520d2fb4d33b4821de9efabf6557af050247f3
Fixes: #2446
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>

