### PR TITLE
extras/glusterfs-georep-upgrade.py: Remove try except block

### DIFF
--- a/extras/glusterfs-georep-upgrade.py
+++ b/extras/glusterfs-georep-upgrade.py
@@ -49,13 +49,7 @@ def modify_htime_file(brick_path):
                     path = os.path.join(changelog_path, date)
 
                 if changelog.startswith("CHANGELOG."):
-                    try:
-                        os.makedirs(path, mode = 0o600);
-                    except OSError as exc:
-                        if exc.errno == errno.EEXIST:
-                            pass
-                        else:
-                            raise
+                    os.makedirs(path, mode = 0o600, exist_ok = True)
 
                     #copy existing changelogs to new directory structure, delete old changelog files
                     shutil.copyfile(pth, os.path.join(path, changelog))


### PR DESCRIPTION
Use "exist_ok = True" option as a cleaner approach

Credits: @xhernandez
Change-Id: I7b114407646ee5cd9fee607a529445699a5eb4fd
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

