### PR TITLE
libglusterfs: drop unused THIS accessors

### DIFF
--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -233,18 +233,6 @@ __glusterfs_this_location()
     return this_location;
 }
 
-xlator_t *
-glusterfs_this_get()
-{
-    return *__glusterfs_this_location();
-}
-
-void
-glusterfs_this_set(xlator_t *this)
-{
-    thread_xlator = this;
-}
-
 /* SYNCOPCTX */
 
 void *

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -137,10 +137,6 @@
 
 xlator_t **
 __glusterfs_this_location(void);
-xlator_t *
-glusterfs_this_get(void);
-void
-glusterfs_this_set(xlator_t *);
 
 extern xlator_t global_xlator;
 extern struct volume_options global_xl_options[];

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -770,7 +770,6 @@ glusterfs_is_local_pathinfo
 glusterfs_leaf_position
 glusterfs_reachable_leaves
 __glusterfs_this_location
-glusterfs_this_set
 glusterfs_volfile_reconfigure
 glusterfs_xlator_link
 graph_reconf_validateopt


### PR DESCRIPTION
Drop unused glusterfs_this_get() and glusterfs_this_set().

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

