### PR TITLE
tests: remove extra binary produced by glfs-lease

### DIFF
--- a/tests/features/glfs-lease.t
+++ b/tests/features/glfs-lease.t
@@ -28,4 +28,5 @@ TEST $(dirname $0)/glfs-lease-recall $V0 $logdir/glfs-lease-recall.log $logdir/l
 TEST $CLI volume set $V0 leases off
 
 cleanup_tester $(dirname $0)/glfs-lease
+cleanup_tester $(dirname $0)/glfs-lease-recall
 cleanup;


### PR DESCRIPTION
Remove 'glfs-lease-recall' binary produced during the test.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

