### PR TITLE
libglusterfs: avoid mutex reinitialization

### DIFF
--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -50,11 +50,8 @@ __event_newtable(struct event_pool *event_pool, int table_idx)
     if (!table)
         return NULL;
 
-    for (i = 0; i < EVENT_EPOLL_SLOTS; i++) {
+    for (i = 0; i < EVENT_EPOLL_SLOTS; i++)
         table[i].fd = -1;
-        LOCK_INIT(&table[i].lock);
-        INIT_LIST_HEAD(&table[i].poller_death);
-    }
 
     event_pool->ereg[table_idx] = table;
     event_pool->slots_used[table_idx] = 0;


### PR DESCRIPTION
Found with 'valgrind --tool=drd':

Mutex reinitialization: mutex 0x53e3928, recursion count 0, owner 0.
   at 0x4850666: pthread_mutex_init_intercept (drd_pthread_intercepts.c:831)
   by 0x4850666: pthread_mutex_init (drd_pthread_intercepts.c:840)
   by 0x493696C: __event_slot_alloc (event-epoll.c:122)
   by 0x4936B49: event_slot_alloc (event-epoll.c:157)
   by 0x49372BF: event_register_epoll (event-epoll.c:391)
   by 0x48F4D3B: gf_event_register (event.c:63)
   by 0x16D8841A: socket_listen (socket.c:3748)
   by 0x49E013A: rpc_transport_listen (rpc-transport.c:424)
   by 0x49DBD01: rpcsvc_create_listener (rpcsvc.c:1991)
   by 0x49DC046: rpcsvc_create_listeners (rpcsvc.c:2075)
   by 0x168DE134: init (glusterd.c:1837)
   by 0x48B9A13: __xlator_init (xlator.c:612)
   by 0x48B9B52: xlator_init (xlator.c:637)
mutex 0x53e3928 was first observed at:
   at 0x4850666: pthread_mutex_init_intercept (drd_pthread_intercepts.c:831)
   by 0x4850666: pthread_mutex_init (drd_pthread_intercepts.c:840)
   by 0x49366AD: __event_newtable (event-epoll.c:55)
   by 0x4936815: __event_slot_alloc (event-epoll.c:92)
   by 0x4936B49: event_slot_alloc (event-epoll.c:157)
   by 0x49372BF: event_register_epoll (event-epoll.c:391)
   by 0x48F4D3B: gf_event_register (event.c:63)
   by 0x16D8841A: socket_listen (socket.c:3748)
   by 0x49E013A: rpc_transport_listen (rpc-transport.c:424)
   by 0x49DBD01: rpcsvc_create_listener (rpcsvc.c:1991)
   by 0x49DC046: rpcsvc_create_listeners (rpcsvc.c:2075)
   by 0x168DE134: init (glusterd.c:1837)
   by 0x48B9A13: __xlator_init (xlator.c:612)

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

