### PR TITLE
cluster/afr: Use appropriate msgid in afr_is_reopen_allowed_cbk()

### DIFF
--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -363,7 +363,7 @@ afr_is_reopen_allowed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[i].op_ret = op_ret;
     local->replies[i].op_errno = op_errno;
     if (op_ret != 0) {
-        gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
+        gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_DICT_GET_FAILED,
                "Failed getlk for %s", uuid_utoa(local->fd->inode->gfid));
     }
 


### PR DESCRIPTION
Problem:
In one of the gf_msg log in function afr_is_reopen_allowed_cbk()
it uses the msgid AFR_MSG_LK_HEAL_DOM when it fails to get whether
reopen is allowed or not on a FD. The msgid AFR_MSG_LK_HEAL_DOM is
introduced specifically to identify lock heal related messages.

Fix:
Since the fuction afr_is_reopen_allowed_cbk() depends on whether
the reopen can be allowed or not based on the values set in the
dict, use the msgid AFR_MSG_DICT_GET_FAILED if it failed to get
the status of reopen, which would be more appropriate.

Fixes: #2507
Change-Id: I249b917f47377677cf917471a171e27c2ea13dff
Signed-off-by: karthik-us <ksubrahm@redhat.com>

