### PR TITLE
afr: fix possible string buffer overflow

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -808,8 +808,9 @@ unlock:
             goto unwind;
         }
 
-        ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
-                                                  UUID0_STR, &tlen, ' ');
+        ret = afr_serialize_xattrs_with_delimiter(
+            frame, this, xattr_serz, local->cont.getxattr.xattr_len, UUID0_STR,
+            &tlen, ' ');
         if (ret) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1339,8 +1339,9 @@ afr_is_inode_refresh_reqd(inode_t *inode, xlator_t *this, int event_gen1,
 
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter);
+                                    char *buf, size_t size,
+                                    const char *default_str, int32_t *serz_len,
+                                    char delimiter);
 gf_boolean_t
 afr_is_symmetric_error(call_frame_t *frame, xlator_t *this);
 


### PR DESCRIPTION
In function 'afr_serialize_xattrs_with_delimiter',
    inlined from 'afr_getxattr_list_node_uuids_cbk'
    at afr-inode-read.c:811:15:
afr-common.c:7504:19: warning: 'strncat' specified bound 36
equals source length [-Wstringop-overflow=]
 7504 |             buf = strncat(buf, default_str, str_len);
      |                   ^
afr-common.c:7519:19: warning: 'strncat' specified bound depends
on the length of the source argument [-Wstringop-overflow=]
 7519 |             buf = strncat(buf, xattr, str_len);
      |                   ^
afr-inode-read.c: In function 'afr_getxattr_list_node_uuids_cbk':
afr-common.c:7518:23: note: length computed here
 7518 |             str_len = strlen(xattr);

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

