### PR TITLE
ganesha_ha: ganesha_grace RA fails in start() and/or fails in

### DIFF
--- a/extras/ganesha/ocf/ganesha_grace
+++ b/extras/ganesha/ocf/ganesha_grace
@@ -122,15 +122,18 @@ ganesha_grace_start()
 
 	# case 1
 	if [[ -z "${attr}" ]]; then
+		ocf_log debug "grace start: returning success case 1"
 		return ${OCF_SUCCESS}
 	fi
 
 	# case 2
-	if [[ "${attr}" = *"value=1" ]]; then
+	if [[ "${attr}" = *"host=\"${host}\" value=\"1\"" ]]; then
+		ocf_log debug "grace start: returning success case 2"
 		return ${OCF_SUCCESS}
 	fi
 
 	# case 3
+	ocf_log info "grace start returning: not running case 3 (${attr})"
 	return ${OCF_NOT_RUNNING}
 }
 
@@ -162,7 +165,7 @@ ganesha_grace_monitor()
 {
 	local host=$(ocf_local_nodename)
 
-	ocf_log debug "ganesha_grace monitor ${host}"
+	ocf_log debug "ganesha_grace_monitor ${host}"
 
 	attr=$(attrd_updater --query --node=${host} --name=${OCF_RESKEY_grace_active} 2> /dev/null)
         if [ $? -ne 0 ]; then
@@ -174,13 +177,16 @@ ganesha_grace_monitor()
 	# chance to create it. In which case we'll pretend
 	# everything is okay this time around
 	if [[ -z "${attr}" ]]; then
+		ocf_log debug "grace monitor: returning success case 1"
 		return ${OCF_SUCCESS}
 	fi
 
-	if [[ "${attr}" = *"value=1" ]]; then
+	if [[ "${attr}" = *"host=\"${host}\" value=\"1\"" ]]; then
+		ocf_log debug "grace monitor: returning success case 2"
 		return ${OCF_SUCCESS}
 	fi
 
+	ocf_log info "grace monitor: returning not running case 3 (${attr})"
 	return ${OCF_NOT_RUNNING}
 }
 


### PR DESCRIPTION
 monitor()

shell [[ ]] string compare fails to match returned attr to the
pattern and subsequently returns status of "not running", resulting
in dependencies such as the IPaddr (cluster_ip) RA not starting

Change-Id: I2c8d6f5c4cf0480672d52d8aa0d9226950441dc9
Fixes: #2522
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

