### PR TITLE
changelog: fix strncat usage warning

### DIFF
--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -1968,7 +1968,7 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
     }
 
     if (bname)
-        strncat(result, bname, strlen(bname) + 1);
+        snprintf(result + len, sizeof(result) - len, "%s", bname);
 
     *path = gf_strdup(result);
 


### PR DESCRIPTION
changelog-helpers.c: In function 'resolve_pargfid_to_path':
changelog-helpers.c:1971:9: warning: 'strncat' specified bound depends
on the length of the source argument [-Wstringop-overflow=]
 1971 |         strncat(result, bname, strlen(bname) + 1);
      |         ^
changelog-helpers.c:1971:32: note: length computed here
 1971 |         strncat(result, bname, strlen(bname) + 1);

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

