### PR TITLE
libglusterfs, xlators: prefer open_memstream() for strfd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1112,6 +1112,11 @@ if test "x${have_posix_fallocate}" = "xyes"; then
    AC_DEFINE(HAVE_POSIX_FALLOCATE, 1, [define if posix_fallocate exists])
 fi
 
+AC_CHECK_FUNC([open_memstream], [have_open_memstream=yes])
+if test "x${have_open_memstream}" = "xyes"; then
+   AC_DEFINE(HAVE_OPEN_MEMSTREAM, 1, [define if open_memstream exists])
+fi
+
 # On fedora-29, copy_file_range syscall and the libc API both are present.
 # Whereas, on some machines such as centos-7, RHEL-7, the API is not there.
 # Only the system call is present. So, this change is to determine whether

--- a/libglusterfs/src/glusterfs/strfd.h
+++ b/libglusterfs/src/glusterfs/strfd.h
@@ -11,15 +11,22 @@
 #ifndef _STRFD_H
 #define _STRFD_H
 
+/* This is a stack-allocated object used to collect
+   (mostly by concatenation) strings with all usual
+   C burden like strlen(), realloc() etc. hidden. */
+
 typedef struct {
-    void *data;
-    size_t alloc_size;
+    char *data;
     size_t size;
-    off_t pos;
+#ifdef HAVE_OPEN_MEMSTREAM
+    FILE *fp;
+#else
+    size_t alloc_size;
+#endif /* HAVE_OPEN_MEMSTREAM */
 } strfd_t;
 
-strfd_t *
-strfd_open();
+int
+strfd_open(strfd_t *strfd);
 
 int
 strprintf(strfd_t *strfd, const char *fmt, ...)
@@ -28,7 +35,7 @@ strprintf(strfd_t *strfd, const char *fmt, ...)
 int
 strvprintf(strfd_t *strfd, const char *fmt, va_list ap);
 
-int
+void
 strfd_close(strfd_t *strfd);
 
 #endif


### PR DESCRIPTION
If supported by the C library, prefer open_memstream()
for strfd. Tiny related cleanups here and there as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

