### PR TITLE
geo-replication: use is_alive for Python 3.9 compatibility (#2441)

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -890,7 +890,7 @@ class Mounter(object):
             t.start()
             tlim = rconf.starttime + gconf.get("connection-timeout")
             while True:
-                if not t.isAlive():
+                if not t.is_alive():
                     break
 
                 if time.time() >= tlim:


### PR DESCRIPTION
Threading.Thread.isAlive() was removed in Python 3.9 this cause sync
daemon to fail. Threading.Thread.is_alive() already exists in python 2
and 3 so backward compatibility should work as expected.

Fixes: #2440
Signed-off-by: Anton Korshikov <chado@chado.by>

