### PR TITLE
Bitrot and scrub process cmdline arg addition (#2402)

### DIFF
--- a/tests/bitrot/br-state-check.t
+++ b/tests/bitrot/br-state-check.t
@@ -5,6 +5,15 @@
 . $(dirname $0)/../nfs.rc
 
 cleanup;
+
+function gluster_client_list_bitd_status () {
+	gluster volume status $V0 client-list | sed -n '/bitd/'p | wc -l
+}
+
+function gluster_client_list_scrub_status () {
+	gluster volume status $V0 client-list | sed -n '/scrub/'p | wc -l
+}
+
 SCRIPT_TIMEOUT=350
 
 TEST glusterd
@@ -19,6 +28,10 @@ TEST $CLI volume bitrot $V0 enable
 
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" get_bitd_count
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" get_scrubd_count
+
+## Check status client-list to verify that bitd and scrubd figure in it
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" gluster_client_list_bitd_status
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" gluster_client_list_scrub_status
 
 ## perform a series of scrub related state change tests. As of now, there'
 ## no way to check if a given change has been correctly acknowledged by

--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
@@ -20,7 +20,7 @@ void
 glusterd_bitdsvc_build(glusterd_svc_t *svc)
 {
     svc->manager = glusterd_bitdsvc_manager;
-    svc->start = glusterd_bitdsvc_start;
+    svc->start = glusterd_genericsvc_start;
     svc->stop = glusterd_bitdsvc_stop;
 }
 
@@ -110,28 +110,6 @@ out:
 
     gf_msg_debug(THIS->name, 0, "Returning %d", ret);
 
-    return ret;
-}
-
-int
-glusterd_bitdsvc_start(glusterd_svc_t *svc, int flags)
-{
-    int ret = -1;
-    dict_t *cmdict = NULL;
-
-    cmdict = dict_new();
-    if (!cmdict)
-        goto error_return;
-
-    ret = dict_set_str(cmdict, "cmdarg0", "--global-timer-wheel");
-    if (ret)
-        goto dealloc_dict;
-
-    ret = glusterd_svc_start(svc, flags, cmdict);
-
-dealloc_dict:
-    dict_unref(cmdict);
-error_return:
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
@@ -25,9 +25,6 @@ int
 glusterd_bitdsvc_manager(glusterd_svc_t *svc, void *data, int flags);
 
 int
-glusterd_bitdsvc_start(glusterd_svc_t *svc, int flags);
-
-int
 glusterd_bitdsvc_stop(glusterd_svc_t *svc, int sig);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
@@ -22,7 +22,7 @@ void
 glusterd_scrubsvc_build(glusterd_svc_t *svc)
 {
     svc->manager = glusterd_scrubsvc_manager;
-    svc->start = glusterd_scrubsvc_start;
+    svc->start = glusterd_genericsvc_start;
     svc->stop = glusterd_scrubsvc_stop;
 }
 
@@ -107,30 +107,6 @@ out:
         gf_event(EVENT_SVC_MANAGER_FAILED, "svc_name=%s", svc->name);
     gf_msg_debug(THIS->name, 0, "Returning %d", ret);
 
-    return ret;
-}
-
-int
-glusterd_scrubsvc_start(glusterd_svc_t *svc, int flags)
-{
-    int ret = -1;
-    dict_t *cmdict = NULL;
-
-    cmdict = dict_new();
-    if (!cmdict) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_CREATE_FAIL, NULL);
-        goto error_return;
-    }
-
-    ret = dict_set_str(cmdict, "cmdarg0", "--global-timer-wheel");
-    if (ret)
-        goto dealloc_dict;
-
-    ret = glusterd_svc_start(svc, flags, cmdict);
-
-dealloc_dict:
-    dict_unref(cmdict);
-error_return:
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
@@ -30,9 +30,6 @@ int
 glusterd_scrubsvc_manager(glusterd_svc_t *svc, void *data, int flags);
 
 int
-glusterd_scrubsvc_start(glusterd_svc_t *svc, int flags);
-
-int
 glusterd_scrubsvc_stop(glusterd_svc_t *svc, int sig);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -534,3 +534,42 @@ out:
     }
     return ret;
 }
+
+/*
+ * A generic function replacing two functions,
+ * glusterd_bitdsvc_start and glusterd_scrubsvc_start
+ * wherein both do the same set of operations.
+ */
+
+int
+glusterd_genericsvc_start(glusterd_svc_t *svc, int flags)
+{
+    int i = 0;
+    int ret = -1;
+    dict_t *cmdline = NULL;
+    char key[16] = {0};
+    char *options[] = {svc->name, "--process-name", NULL};
+
+    cmdline = dict_new();
+    if (!cmdline) {
+        gf_smsg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_DICT_CREATE_FAIL, NULL);
+        return ret;
+    }
+
+    for (i = 0; options[i]; i++) {
+        ret = snprintf(key, sizeof(key), "arg%d", i);
+        ret = dict_set_strn(cmdline, key, ret, options[i]);
+        if (ret)
+            goto out;
+    }
+
+    ret = dict_set_str(cmdline, "cmdarg0", "--global-timer-wheel");
+    if (ret)
+        goto out;
+
+    ret = glusterd_svc_start(svc, flags, cmdline);
+
+out:
+    dict_unref(cmdline);
+    return ret;
+}

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
@@ -109,4 +109,7 @@ int
 glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
                           char *sockpath, int frame_timeout,
                           glusterd_muxsvc_conn_notify_t notify);
+
+int
+glusterd_genericsvc_start(glusterd_svc_t *svc, int flags);
 #endif


### PR DESCRIPTION
* Bitrot and scrub process cmdline arg addition

The bitd and scrubd services when viewed from the
perspective of the `gluster volume status <volname> client-list`
returned `unknown` as the `--process-name` cmdline
arg wasn't provided when starting up these services.

Replaced the functions glusterd_bitdsvc_start and
glusterd_scrubsvc_start with glusterd_genericsvc_start.

Simplified the return structure by removing a goto.

Fixes: #2398
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>
Change-Id: Ic89a7d4481bbf5b14e610f2395bb822b77b7ab9e

