### PR TITLE
rsync tries to sync glusterfs.lockinfo which is an internal xattr 

### DIFF
--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -651,6 +651,7 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("system.posix_acl_access", key, FNM_PERIOD) == 0) ||
           (fnmatch("glusterfs.gfid.newfile", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
+          (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0)))
         ret = -1;
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -135,8 +135,9 @@ posix_handle_georep_xattrs(call_frame_t *frame, const char *name, int *op_errno,
     int pid = 1;
     gf_boolean_t filter_xattr = _gf_true;
     static const char *georep_xattr[] = {
-        "*.glusterfs.*.stime", "*.glusterfs.*.xtime",
-        "*.glusterfs.*.entry_stime", "*.glusterfs.volume-mark.*", NULL};
+        "*.glusterfs.*.stime",       "*.glusterfs.*.xtime",
+        "*.glusterfs.lockinfo",      "*.glusterfs.*.entry_stime",
+        "*.glusterfs.volume-mark.*", NULL};
 
     if (!name) {
         /* No need to do anything here */


### PR DESCRIPTION
Inorder to fix the above stated issue, added glusterfs.lockinfo
among the set of xattrs that are to be ignored by rsync

Fixes: #2421
Change-Id: I1eb6903fa60791032dacaab2b5a2bed0962bf24f
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

