### PR TITLE
delay-gen: Fix duration overflow

### DIFF
--- a/xlators/debug/delay-gen/src/delay-gen.c
+++ b/xlators/debug/delay-gen/src/delay-gen.c
@@ -27,7 +27,7 @@ delay_gen(xlator_t *this, int fop)
         return 0;
 
     if ((rand() % DELAY_GRANULARITY) < dg->delay_ppm)
-        gf_nanosleep(dg->delay_duration * GF_US_IN_NS);
+        gf_nanosleep((uint64_t)dg->delay_duration * GF_US_IN_NS);
 
     return 0;
 }
@@ -530,7 +530,7 @@ init(xlator_t *this)
 
     GF_OPTION_INIT("delay-percentage", delay_percent, percent, out);
     GF_OPTION_INIT("enable", delay_enable_fops, str, out);
-    GF_OPTION_INIT("delay-duration", dg->delay_duration, int32, out);
+    GF_OPTION_INIT("delay-duration", dg->delay_duration, uint32, out);
 
     delay_gen_set_delay_ppm(dg, delay_percent);
 

--- a/xlators/debug/delay-gen/src/delay-gen.h
+++ b/xlators/debug/delay-gen/src/delay-gen.h
@@ -18,10 +18,9 @@
 #include <glusterfs/defaults.h>
 
 typedef struct {
-    int enable[GF_FOP_MAXVALUE];
-    int op_count;
-    int delay_ppm;
-    int delay_duration;
+    uint32_t delay_ppm;
+    uint32_t delay_duration;
+    bool enable[GF_FOP_MAXVALUE];
 } dg_t;
 
 #endif /* __DELAY_GEN_H__ */


### PR DESCRIPTION
The delay duration was defined as a 32-bit signed integer, but was
implicitly converted to a 64-bit unsigned value, which caused some
conversion issues.

Fixes: #2540
Change-Id: I282f0146e8a00ab7b1cb8329469c2c5b5c370ec6
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

