### PR TITLE
rpc: use the only pthread_mutexattr_t object

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -2256,8 +2256,7 @@ rpcsvc_program_register(rpcsvc_t *svc, rpcsvc_program_t *program,
     int ret = -1, i = 0;
     rpcsvc_program_t *newprog = NULL;
     char already_registered = 0;
-    pthread_mutexattr_t attr[EVENT_MAX_THREADS];
-    pthread_mutexattr_t thr_attr;
+    pthread_mutexattr_t attr;
 
     if (!svc) {
         goto out;
@@ -2298,20 +2297,19 @@ rpcsvc_program_register(rpcsvc_t *svc, rpcsvc_program_t *program,
     }
 
     INIT_LIST_HEAD(&newprog->program);
-    pthread_mutexattr_init(&thr_attr);
-    pthread_mutexattr_settype(&thr_attr, PTHREAD_MUTEX_ADAPTIVE_NP);
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
 
     for (i = 0; i < EVENT_MAX_THREADS; i++) {
-        pthread_mutexattr_init(&attr[i]);
-        pthread_mutexattr_settype(&attr[i], PTHREAD_MUTEX_ADAPTIVE_NP);
         INIT_LIST_HEAD(&newprog->request_queue[i].request_queue);
-        pthread_mutex_init(&newprog->request_queue[i].queue_lock, &attr[i]);
+        pthread_mutex_init(&newprog->request_queue[i].queue_lock, &attr);
         pthread_cond_init(&newprog->request_queue[i].queue_cond, NULL);
         newprog->request_queue[i].program = newprog;
     }
 
-    pthread_mutex_init(&newprog->thr_lock, &thr_attr);
+    pthread_mutex_init(&newprog->thr_lock, &attr);
     pthread_cond_init(&newprog->thr_cond, NULL);
+    pthread_mutexattr_destroy(&attr);
 
     newprog->alive = _gf_true;
 


### PR DESCRIPTION
Use the only pthread_mutexattr_t object to initialize
all related mutexes as PTHREAD_MUTEX_ADAPTIVE_NP,
add missing pthread_mutexattr_destroy() call as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

