### PR TITLE
xlators: fix all -Wold-style-declaration warnings

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2521,8 +2521,8 @@ dht_dfreaddirp_done(dht_dfoffset_ctx_t *offset_var, int cnt)
     return result;
 }
 
-int static gf_defrag_ctx_subvols_init(dht_dfoffset_ctx_t *offset_var,
-                                      xlator_t *this)
+static int
+gf_defrag_ctx_subvols_init(dht_dfoffset_ctx_t *offset_var, xlator_t *this)
 {
     int i;
     dht_conf_t *conf = NULL;
@@ -3084,12 +3084,12 @@ out:
     return NULL;
 }
 
-int static gf_defrag_get_entry(xlator_t *this, int i,
-                               struct dht_container **container, loc_t *loc,
-                               dht_conf_t *conf, gf_defrag_info_t *defrag,
-                               fd_t *fd, dict_t *migrate_data,
-                               struct dir_dfmeta *dir_dfmeta, dict_t *xattr_req,
-                               int *perrno)
+static int
+gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
+                    loc_t *loc, dht_conf_t *conf, gf_defrag_info_t *defrag,
+                    fd_t *fd, dict_t *migrate_data,
+                    struct dir_dfmeta *dir_dfmeta, dict_t *xattr_req,
+                    int *perrno)
 {
     int ret = 0;
     char is_linkfile = 0;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2067,7 +2067,8 @@ do_blocked_rw(pl_inode_t *pl_inode)
     Note: There is no IO blocking with mandatory lock enforced as it may be
     a stale data from an old client.
  */
-gf_boolean_t static within_range(posix_lock_t *existing, posix_lock_t *new)
+static gf_boolean_t
+within_range(posix_lock_t *existing, posix_lock_t *new)
 {
     if (existing->fl_start <= new->fl_start && existing->fl_end >= new->fl_end)
         return _gf_true;


### PR DESCRIPTION
dht-rebalance.c:2524:1: warning: ‘static’ is not at beginning
of declaration [-Wold-style-declaration]
 2524 | int static gf_defrag_ctx_subvols_init(dht_dfoffset_ctx_t *offset_var,

dht-rebalance.c:3087:1: warning: ‘static’ is not at beginning
of declaration [-Wold-style-declaration]
 3087 | int static gf_defrag_get_entry(xlator_t *this, int i,

posix.c:2070:1: warning: ‘static’ is not at beginning
of declaration [-Wold-style-declaration]
 2070 | gf_boolean_t static within_range(posix_lock_t *existing, posix_lock_t *new)

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

