### PR TITLE
glusterd: save lock backtrace only in DEBUG builds

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -524,8 +524,7 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
     glusterd_conf_t *priv = NULL;
     gf_boolean_t is_valid = _gf_true;
     uuid_t owner = {0};
-    xlator_t *this = NULL;
-    char *bt = NULL;
+    xlator_t *this = THIS;
     struct timespec delay = {0};
     char *key_dup = NULL;
     glusterfs_ctx_t *mgmt_lock_timer_ctx = NULL;
@@ -642,6 +641,9 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
         goto out;
     }
 
+#ifdef DEBUG
+    char *bt = NULL;
+
     /* Saving the backtrace into the pre-allocated buffer, ctx->btbuf*/
     if ((bt = gf_backtrace_save(NULL))) {
         snprintf(key, sizeof(key), "debug.last-success-bt-%s", key_dup);
@@ -653,6 +655,8 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
                    key_dup, uuid_utoa(uuid));
         ret = 0;
     }
+
+#endif
 
     gf_msg_debug(this->name, 0, "Lock for %s successfully held by %s", key_dup,
                  uuid_utoa(uuid));
@@ -674,8 +678,6 @@ gd_mgmt_v3_unlock_timer_cbk(void *data)
     glusterd_mgmt_v3_lock_timer *mgmt_lock_timer = NULL;
     char *key = NULL;
     int keylen;
-    char bt_key[PATH_MAX] = "";
-    int bt_key_len = 0;
     int32_t ret = -1;
     glusterfs_ctx_t *mgmt_lock_timer_ctx = NULL;
     xlator_t *mgmt_lock_timer_xl = NULL;
@@ -693,6 +695,10 @@ gd_mgmt_v3_unlock_timer_cbk(void *data)
     keylen = strlen(key);
     dict_deln(conf->mgmt_v3_lock, key, keylen);
 
+#ifdef DEBUG
+    char bt_key[PATH_MAX] = "";
+    int bt_key_len = 0;
+
     bt_key_len = snprintf(bt_key, PATH_MAX, "debug.last-success-bt-%s", key);
     if (bt_key_len != SLEN("debug.last-success-bt-") + keylen) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CREATE_KEY_FAIL,
@@ -702,6 +708,7 @@ gd_mgmt_v3_unlock_timer_cbk(void *data)
     }
 
     dict_deln(conf->mgmt_v3_lock, bt_key, bt_key_len);
+#endif
 
     ret = dict_get_bin(conf->mgmt_v3_lock_timer, key,
                        (void **)&mgmt_lock_timer);
@@ -721,7 +728,9 @@ out:
         timer = mgmt_lock_timer->timer;
         GF_FREE(timer->data);
         gf_timer_call_cancel(mgmt_lock_timer_ctx, mgmt_lock_timer->timer);
+#ifdef DEBUG
         dict_deln(conf->mgmt_v3_lock_timer, bt_key, bt_key_len);
+#endif
         mgmt_lock_timer->timer = NULL;
         gf_log(this->name, GF_LOG_INFO,
                "unlock timer is cancelled for volume_type"
@@ -821,6 +830,7 @@ glusterd_mgmt_v3_unlock(const char *name, uuid_t uuid, char *type)
 
     (void)snprintf(key_dup, sizeof(key_dup), "%s", key);
 
+#ifdef DEBUG
     /* Remove the backtrace key as well */
     ret = snprintf(key, sizeof(key), "debug.last-success-bt-%s", key_dup);
     if (ret != SLEN("debug.last-success-bt-") + keylen) {
@@ -831,6 +841,7 @@ glusterd_mgmt_v3_unlock(const char *name, uuid_t uuid, char *type)
         goto out;
     }
     dict_deln(priv->mgmt_v3_lock, key, ret);
+#endif
 
     gf_msg_debug(this->name, 0, "Lock for %s %s successfully released", type,
                  name);


### PR DESCRIPTION
Fix:
Save the backtrace for locking only in case of DEBUG builds.

Fixes: #705

Change-Id: Ie80183db73ea2129334989636358ee4e0790b144
Signed-off-by: nik-redhat <nladha@redhat.com>

