### PR TITLE
locks: Fix null gfid in lock contention notifications

### DIFF
--- a/tests/bugs/locks/issue-2551.t
+++ b/tests/bugs/locks/issue-2551.t
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+function check_time() {
+    local max="${1}"
+    local start="$(date +"%s")"
+
+    shift
+
+    if "${@}"; then
+        if [[ $(($(date +"%s") - ${start})) -lt ${max} ]]; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+cleanup
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 disperse 3 redundancy 1 $H0:$B0/brick{0..2}
+TEST $CLI volume set $V0 disperse.eager-lock on
+TEST $CLI volume set $V0 disperse.eager-lock-timeout 30
+TEST $CLI volume set $V0 features.locks-notify-contention on
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.open-behind off
+TEST $CLI volume set $V0 performance.quick-read off
+
+TEST $CLI volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick2
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0 $M0
+
+TEST mkdir $M0/dir
+TEST dd if=/dev/zero of=$M0/dir/test bs=4k count=1
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+TEST $CLI volume stop $V0
+TEST $CLI volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/brick2
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0 $M0
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0 $M1
+
+TEST dd if=/dev/zero of=$M0/dir/test bs=4k count=1 conv=notrunc
+TEST check_time 5 dd if=/dev/zero of=$M1/dir/test bs=4k count=1 conv=notrunc

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -466,9 +466,7 @@ pl_inode_get(xlator_t *this, inode_t *inode, pl_local_t *local)
         pl_inode->check_mlock_info = _gf_true;
         pl_inode->mlock_enforced = _gf_false;
 
-        /* -2 means never looked up. -1 means something went wrong and link
-         * tracking is disabled. */
-        pl_inode->links = -2;
+        pl_inode->remove_running = 0;
 
         ret = __inode_ctx_put(inode, this, (uint64_t)(long)(pl_inode));
         if (ret) {
@@ -1400,11 +1398,6 @@ pl_inode_remove_prepare(xlator_t *xl, call_frame_t *frame, loc_t *loc,
 
     pthread_mutex_lock(&pl_inode->mutex);
 
-    if (pl_inode->removed) {
-        error = ESTALE;
-        goto unlock;
-    }
-
     if (pl_inode_has_owners(xl, frame->root->client, pl_inode, &now, contend)) {
         error = -1;
         /* We skip the unlock here because the caller must create a stub when
@@ -1417,7 +1410,6 @@ pl_inode_remove_prepare(xlator_t *xl, call_frame_t *frame, loc_t *loc,
     pl_inode->is_locked = _gf_true;
     pl_inode->remove_running++;
 
-unlock:
     pthread_mutex_unlock(&pl_inode->mutex);
 
 done:
@@ -1487,19 +1479,17 @@ pl_inode_remove_cbk(xlator_t *xl, pl_inode_t *pl_inode, int32_t error)
 
     pthread_mutex_lock(&pl_inode->mutex);
 
-    if (error == 0) {
-        if (pl_inode->links >= 0) {
-            pl_inode->links--;
-        }
-        if (pl_inode->links == 0) {
-            pl_inode->removed = _gf_true;
-        }
-    }
-
     pl_inode->remove_running--;
 
     if ((pl_inode->remove_running == 0) && list_empty(&pl_inode->waiting)) {
         pl_inode->is_locked = _gf_false;
+
+        /* At this point it's possible that the inode has been deleted, but
+         * there could be open fd's still referencing it, so we can't prevent
+         * pending locks from being granted. If the file has really been
+         * deleted, whatever the client does once the lock is granted will
+         * fail with the appropriate error, so we don't need to worry about
+         * it here. */
 
         list_for_each_entry(dom, &pl_inode->dom_list, inode_list)
         {
@@ -1551,11 +1541,6 @@ pl_inode_remove_inodelk(pl_inode_t *pl_inode, pl_inode_lock_t *lock)
 {
     pl_dom_list_t *dom;
     pl_inode_lock_t *ilock;
-
-    /* If the inode has been deleted, we won't allow any lock. */
-    if (pl_inode->removed) {
-        return -ESTALE;
-    }
 
     /* We only synchronize with locks made for regular operations coming from
      * the user. Locks done for internal purposes are hard to control and could

--- a/xlators/features/locks/src/locks.h
+++ b/xlators/features/locks/src/locks.h
@@ -203,10 +203,8 @@ struct __pl_inode {
 
     gf_boolean_t track_fop_wind_count;
 
-    int32_t links;           /* Number of hard links the inode has. */
     uint32_t remove_running; /* Number of remove operations running. */
     gf_boolean_t is_locked;  /* Regular locks will be blocked. */
-    gf_boolean_t removed;    /* The inode has been deleted. */
 };
 typedef struct __pl_inode pl_inode_t;
 


### PR DESCRIPTION
This patch fixes 3 problems:

First problem:

After commit c0bd592e, the pl_inode_t object was also created in the
cbk of lookup requests. Lookup requests are a bit different than any
other request because the inode received may not be completely
initialized. In particular, inode->gfid may be null.

This caused that the gfid stored in the pl_inode_t object was null in
some cases. This gfid is used mostly for logs, but also to send lock
contention notifications. This meant that some notifications could be
sent with a null gfid, making impossible for the client xlator to
correctly identify the contending inode, so the lock was not released
immediately when eager-lock was also enabled.

Second problem:

The feature introduced by c0bd592e needed to track the number of
hardlinks of each inode to detect when it was deleted. However it
was done using the 'get-link-count' special xattr on lookup, while
posix only implements it for unlink and rename.

Also, the number of hardlinks was not incremented for mkdir, mknod,
rename, ..., so it didn't work correctly for directories.

Third problem:

When the last hardlink of an open file is deleted, all locks will be
denied with ESTALE error, but that's not correct. Access to the open
fd must succeed.

The first problem is fixed by avoiding creating pl_inode_t objects
during lookup. Second and third problems are fixed by completely
ignoring if the file has been deleted or not. Even if we grant a
lock on a non-existing file, the next operation done by the client
inside the lock will return the correct error, which should be enough.

Fixes: #2551
Change-Id: Ic73e82f6b725b838c1600b6a128ea36a75f13253
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>