### PR TITLE
features/shard: files larger than shard_block_size show the wrong size

### DIFF
--- a/tests/bugs/shard/issue-1384.t
+++ b/tests/bugs/shard/issue-1384.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,3}
+TEST $CLI volume set $V0 features.shard on
+TEST $CLI volume set $V0 features.shard-block-size 4MB
+TEST $CLI volume start $V0
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+TEST $CLI volume set $V0 md-cache-timeout 10
+
+# Write data into a file such that its size crosses shard-block-size
+TEST dd if=/dev/zero of=$M0/foo bs=1048576 count=10 oflag=direct
+
+# Size of the file should be the aggregated size, not the shard-block-size
+EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`
+
+TEST $CLI volume set $V0 performance.read-ahead on
+TEST $CLI volume set $V0 performance.parallel-readdir on
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+# Size of the file should be the aggregated size, not the shard-block-size
+EXPECT "10485760" echo `ls -la $M0 | grep foo | awk '{print $5}'`
+
+cleanup

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -878,6 +878,7 @@ shard_common_failure_unwind(glusterfs_fop_t fop, call_frame_t *frame,
             break;
         case GF_FOP_OPENDIR:
             SHARD_STACK_UNWIND(opendir, frame, op_ret, op_errno, 0, NULL);
+            break;
         default:
             gf_msg(THIS->name, GF_LOG_WARNING, 0, SHARD_MSG_INVALID_FOP,
                    "Invalid fop id = %d", fop);

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -4783,7 +4783,7 @@ shard_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 }
 
-int
+static int
 shard_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
               dict_t *xdata)
 {

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -4766,7 +4766,7 @@ shard_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 shard_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -876,6 +876,8 @@ shard_common_failure_unwind(glusterfs_fop_t fop, call_frame_t *frame,
         case GF_FOP_SEEK:
             SHARD_STACK_UNWIND(seek, frame, op_ret, op_errno, 0, NULL);
             break;
+        case GF_FOP_OPENDIR:
+            SHARD_STACK_UNWIND(opendir, frame, op_ret, op_errno, 0, NULL);
         default:
             gf_msg(THIS->name, GF_LOG_WARNING, 0, SHARD_MSG_INVALID_FOP,
                    "Invalid fop id = %d", fop);
@@ -4764,11 +4766,56 @@ shard_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
+shard_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+{
+    SHARD_STACK_UNWIND(open, frame, op_ret, op_errno, fd, xdata);
+    return 0;
+}
+
+int
 shard_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
            fd_t *fd, dict_t *xdata)
 {
     STACK_WIND(frame, shard_open_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->open, loc, flags, fd, xdata);
+    return 0;
+}
+
+int
+shard_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
+              dict_t *xdata)
+{
+    int ret;
+
+    xdata = xdata ? dict_ref(xdata) : dict_new();
+    if (!xdata) {
+        ret = -1;
+        goto err;
+    }
+
+    /* if the file is sharded then server will return the below
+     * xattr as part of dict that is used to update the ia_size
+     * in d_stat. This is helpful incase readdir-ahead is enabled
+     */
+    ret = dict_set_uint64(xdata, GF_XATTR_SHARD_FILE_SIZE, 8 * 4);
+    if (ret) {
+        gf_msg_debug(this->name, -ret,
+                     "Unable to set GF_XATTR_SHARD_FILE_SIZE in the dict ");
+        goto err;
+    }
+
+    STACK_WIND(frame, shard_opendir_cbk, FIRST_CHILD(this),
+               FIRST_CHILD(this)->fops->opendir, loc, fd, xdata);
+
+    dict_unref(xdata);
+    return 0;
+
+err:
+    if (xdata)
+        dict_unref(xdata);
+
+    shard_common_failure_unwind(GF_FOP_OPENDIR, frame, -1, ENOMEM);
     return 0;
 }
 
@@ -7276,6 +7323,7 @@ shard_releasedir(xlator_t *this, fd_t *fd)
 struct xlator_fops fops = {
     .lookup = shard_lookup,
     .open = shard_open,
+    .opendir = shard_opendir,
     .flush = shard_flush,
     .fsync = shard_fsync,
     .stat = shard_stat,


### PR DESCRIPTION
issue:
When the user executes 'ls' command, shard fetches the actual file-size
extended attribute from the file and displays the correct size to the user.
When parallel-readdir/readdir-ahead features are enabled, readdir of the
brick happens in the background which will not fetch actual file-size xattr
from the brick and caches it. When the user does 'ls' the entries are served
from this cache which doesn't have actual file size, so shard translator
thinks these files are created before sharding is enabled and shows the user
shard block size instead of the actual file size.

Solution:
Send xdata request to server to fetch the actual size of the sharded file
from the server.

fixes: #1384
Change-Id: Id756b07b0ff1f746b0bf6d4081b6a1fd9e76adfb
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>

