### PR TITLE
rpc: drop unused condition variable

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -2308,7 +2308,6 @@ rpcsvc_program_register(rpcsvc_t *svc, rpcsvc_program_t *program,
     }
 
     pthread_mutex_init(&newprog->thr_lock, &attr);
-    pthread_cond_init(&newprog->thr_cond, NULL);
     pthread_mutexattr_destroy(&attr);
 
     newprog->alive = _gf_true;

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -439,7 +439,6 @@ struct rpcsvc_program {
     struct list_head program;
     rpcsvc_request_queue_t request_queue[EVENT_MAX_THREADS];
     pthread_mutex_t thr_lock;
-    pthread_cond_t thr_cond;
     int threadcount;
     int thr_queue;
     pthread_key_t req_queue_key;


### PR DESCRIPTION
Drop unused 'struct rpcsvc_program' condition variable.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

