### PR TITLE
mount: no mount over /tmp

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -434,6 +434,11 @@ check_recursive_mount ()
         exit 2;
     fi
 
+    if [ $1 = "/tmp" ]; then
+        warn "Cannot mount over /tmp";
+        exit 2;
+    fi
+
     # GFID check first
     # remove trailing / from mount point
     mnt_dir=${1%/};


### PR DESCRIPTION
Accessing /tmp appears in mount process, should not mount
glusterfs over /tmp.
Otherwise, the thread will hang. And result in other problems
because the inaccessable /tmp.

Fixes:#2565

Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>

