### PR TITLE
libglusterfs: drop iobuf RDMA leftovers

### DIFF
--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -20,8 +20,6 @@
 
 #define GF_VARIABLE_IOBUF_COUNT 32
 
-#define GF_RDMA_DEVICE_COUNT 8
-
 /* Lets try to define the new anonymous mapping
  * flag, in case the system is still using the
  * now deprecated MAP_ANON flag.
@@ -123,11 +121,6 @@ struct iobuf_pool {
     uint64_t request_misses; /* mostly the requests for higher
                                value of iobufs */
     int arena_cnt;
-    int rdma_device_count;
-    struct list_head *mr_list[GF_RDMA_DEVICE_COUNT];
-    void *device[GF_RDMA_DEVICE_COUNT];
-    int (*rdma_registration)(void **, void *);
-    int (*rdma_deregistration)(struct list_head **, struct iobuf_arena *);
 };
 
 struct iobuf_pool *

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -124,9 +124,6 @@ __iobuf_arena_destroy(struct iobuf_pool *iobuf_pool,
 {
     GF_VALIDATE_OR_GOTO("iobuf", iobuf_arena, out);
 
-    if (iobuf_pool->rdma_deregistration)
-        iobuf_pool->rdma_deregistration(iobuf_pool->mr_list, iobuf_arena);
-
     __iobuf_arena_destroy_iobufs(iobuf_arena);
 
     if (iobuf_arena->mem_base && iobuf_arena->mem_base != MAP_FAILED)
@@ -170,10 +167,6 @@ __iobuf_arena_alloc(struct iobuf_pool *iobuf_pool, size_t page_size,
     if (iobuf_arena->mem_base == MAP_FAILED) {
         gf_smsg(THIS->name, GF_LOG_WARNING, 0, LG_MSG_MAPPING_FAILED, NULL);
         goto err;
-    }
-
-    if (iobuf_pool->rdma_registration) {
-        iobuf_pool->rdma_registration(iobuf_pool->device, iobuf_arena);
     }
 
     list_add_tail(&iobuf_arena->all_list, &iobuf_pool->all_arenas);
@@ -338,14 +331,6 @@ iobuf_pool_new(void)
     }
 
     iobuf_pool->default_page_size = 128 * GF_UNIT_KB;
-
-    iobuf_pool->rdma_registration = NULL;
-    iobuf_pool->rdma_deregistration = NULL;
-
-    for (i = 0; i < GF_RDMA_DEVICE_COUNT; i++) {
-        iobuf_pool->device[i] = NULL;
-        iobuf_pool->mr_list[i] = NULL;
-    }
 
     /* No locking required here
      * as no one else can use this pool yet


### PR DESCRIPTION
Drop unused RDMA leftovers from 'struct iobuf_pool'.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

