### PR TITLE
protocol/client: Do not reopen fd post handshake if posix lock is held

### DIFF
--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -644,7 +644,7 @@ client_post_handshake(call_frame_t *frame, xlator_t *this)
         list_for_each_entry_safe(fdctx, tmp, &conf->saved_fds, sfd_pos)
         {
             if (fdctx->remote_fd != -1 ||
-                (!list_empty(&fdctx->lock_list) && conf->strict_locks))
+                (!fdctx_lock_lists_empty(fdctx) && conf->strict_locks))
                 continue;
 
             fdctx->reopen_done = client_child_up_reopen_done;

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -15,6 +15,15 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/common-utils.h>
 
+gf_boolean_t
+fdctx_lock_lists_empty(clnt_fd_ctx_t *fdctx)
+{
+    if (list_empty(&fdctx->lock_list) && fd_lk_ctx_empty(fdctx->lk_ctx))
+        return _gf_true;
+
+    return _gf_false;
+}
+
 int
 client_fd_lk_list_empty(fd_lk_ctx_t *lk_ctx, gf_boolean_t try_lock)
 {
@@ -435,7 +444,7 @@ client_get_remote_fd(xlator_t *this, fd_t *fd, int flags, int64_t *remote_fd,
                 *remote_fd = fdctx->remote_fd;
             }
 
-            locks_involved = !list_empty(&fdctx->lock_list);
+            locks_involved = !fdctx_lock_lists_empty(fdctx);
         }
     }
     pthread_spin_unlock(&conf->fd_lock);

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -796,7 +796,7 @@ client_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         pthread_spin_lock(&conf->fd_lock);
         {
             fdctx = this_fd_get_ctx(fd, this);
-            if (fdctx && !list_empty(&fdctx->lock_list)) {
+            if (fdctx && !fdctx_lock_lists_empty(fdctx)) {
                 ret = -1;
                 op_errno = EBADFD;
             }

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -397,4 +397,7 @@ client_add_lock_for_recovery(fd_t *fd, struct gf_flock *flock,
 int
 client_is_setlk(int32_t cmd);
 
+gf_boolean_t
+fdctx_lock_lists_empty(clnt_fd_ctx_t *fdctx);
+
 #endif /* !_CLIENT_H */


### PR DESCRIPTION
Problem:
With client.strict-locks enabled, in some cases where the posix lock is
taken after a brick gets disconnected, the fd is getting reopened when
the brick gets reconnected to the client as part of client_post_handshake.
In such cases the saved fdctx's lock_list may not have the latest
information.

Fix:
Check the lock information in the fdctx->lk_ctx as well post handshake
which will have the latest information on the locks.
Also check for this field in other places as well to prevent writes
happening with anonymous fd even without re-opening the fd on the
restarted brick.

Fixes: #2581
Change-Id: I7a0799e242ce188c6597dec0a65b4dae7dcd815b
Signed-off-by: karthik-us <ksubrahm@redhat.com>

