### PR TITLE
features/locks: Remove common.c duplicate code

### DIFF
--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -853,8 +853,6 @@ __insert_and_merge(pl_inode_t *pl_inode, posix_lock_t *lock)
                 __destroy_lock(conf);
 
                 __destroy_lock(lock);
-                INIT_LIST_HEAD(&sum->list);
-                posix_lock_to_flock(sum, &sum->user_flock);
                 __insert_and_merge(pl_inode, sum);
 
                 return;


### PR DESCRIPTION
The add_locks function has already called __insert_and_merge once,
so the repeated calls are deleted

Fixes: #2502
Signed-off-by: Jifeng Zhou <z583340363@gmail.com>

