### PR TITLE
libglusterfs, rpc: cleanup iovec macros

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -499,7 +499,7 @@ union gf_sock_union {
 #define GF_UNLINK_PATH GF_HIDDEN_PATH "/unlink"
 #define GF_LANDFILL_PATH GF_HIDDEN_PATH "/landfill"
 
-#define IOV_MIN(n) min(IOV_MAX, n)
+#define MAX_IOVEC 16
 
 static inline gf_boolean_t
 gf_irrelevant_entry(struct dirent *entry)

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -20,10 +20,6 @@
 
 #include <rpc/rpc_msg.h>
 
-#ifndef MAX_IOVEC
-#define MAX_IOVEC 16
-#endif
-
 #ifndef AI_ADDRCONFIG
 #define AI_ADDRCONFIG 0
 #endif /* AI_ADDRCONFIG */

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -24,10 +24,6 @@
 #include <glusterfs/compat.h>
 #include <glusterfs/client_t.h>
 
-#ifndef MAX_IOVEC
-#define MAX_IOVEC 16
-#endif
-
 /* TODO: we should store prognums at a centralized location to avoid conflict
          or use a robust random number generator to avoid conflicts
 */

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -66,6 +66,8 @@
 #define POLL_MASK_OUTPUT (POLLOUT)
 #define POLL_MASK_ERROR (POLLERR | POLLHUP | POLLNVAL)
 
+#define IOV_MIN(n) min(IOV_MAX, n)
+
 typedef int
 SSL_unary_func(SSL *);
 typedef int

--- a/rpc/rpc-transport/socket/src/socket.h
+++ b/rpc/rpc-transport/socket/src/socket.h
@@ -24,10 +24,6 @@
 
 #include "rpc-transport.h"
 
-#ifndef MAX_IOVEC
-#define MAX_IOVEC 16
-#endif /* MAX_IOVEC */
-
 #define GF_DEFAULT_SOCKET_LISTEN_PORT GF_DEFAULT_BASE_PORT
 
 #define RPC_MAX_FRAGMENT_SIZE 0x7fffffff

--- a/xlators/features/compress/src/cdc.h
+++ b/xlators/features/compress/src/cdc.h
@@ -17,10 +17,6 @@
 
 #include <glusterfs/xlator.h>
 
-#ifndef MAX_IOVEC
-#define MAX_IOVEC 16
-#endif
-
 typedef struct cdc_priv {
     int window_size;
     int mem_level;


### PR DESCRIPTION
Define MAX_IOVEC once, move IOV_MIN closer to its actual use.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

