### PR TITLE
libglusterfs: remove dead monitoring code

### DIFF
--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -42,38 +42,6 @@ dump_mem_acct_details(xlator_t *xl, int fd)
 }
 
 static void
-dump_global_memory_accounting(int fd)
-{
-#if MEMORY_ACCOUNTING_STATS
-    int i = 0;
-    uint64_t count = 0;
-
-    uint64_t tcalloc = GF_ATOMIC_GET(gf_memory_stat_counts.total_calloc);
-    uint64_t tmalloc = GF_ATOMIC_GET(gf_memory_stat_counts.total_malloc);
-    uint64_t tfree = GF_ATOMIC_GET(gf_memory_stat_counts.total_free);
-
-    dprintf(fd, "memory.total.calloc %lu\n", tcalloc);
-    dprintf(fd, "memory.total.malloc %lu\n", tmalloc);
-    dprintf(fd, "memory.total.realloc %lu\n",
-            GF_ATOMIC_GET(gf_memory_stat_counts.total_realloc));
-    dprintf(fd, "memory.total.free %lu\n", tfree);
-    dprintf(fd, "memory.total.in-use %lu\n", ((tcalloc + tmalloc) - tfree));
-
-    for (i = 0; i < GF_BLK_MAX_VALUE; i++) {
-        count = GF_ATOMIC_GET(gf_memory_stat_counts.blk_size[i]);
-        dprintf(fd, "memory.total.blk_size.%s %lu\n",
-                gf_mem_stats_blk[i].blk_size_str, count);
-    }
-
-    dprintf(fd, "#----\n");
-#endif
-
-    /* This is not a metric to be watched in admin guide,
-       but keeping it here till we resolve all leak-issues
-       would be great */
-}
-
-static void
 dump_latency_and_count(xlator_t *xl, int fd)
 {
     int32_t index = 0;
@@ -179,10 +147,6 @@ dump_global_metrics(glusterfs_ctx_t *ctx, int fd)
     dprintf(fd, "### BrickName: %s\n", ctx->cmd_args.brick_name);
     dprintf(fd, "### MountName: %s\n", ctx->cmd_args.mount_point);
     dprintf(fd, "### VolumeName: %s\n", ctx->cmd_args.volume_name);
-
-    /* Dump memory accounting */
-    dump_global_memory_accounting(fd);
-    dprintf(fd, "# -----\n");
 
     dump_call_stack_details(ctx, fd);
     dump_dict_details(ctx, fd);


### PR DESCRIPTION
Drop dump_global_memory_accounting() since
MEMORY_ACCOUNTING_STATS was dropped as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

