### PR TITLE
posix: Make posix entry creation atomic

### DIFF
--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -135,6 +135,7 @@
 #define VIRTUAL_GFID_XATTR_KEY "glusterfs.gfid"
 #define GF_XATTR_MDATA_KEY "trusted.glusterfs.mdata"
 #define UUID_CANONICAL_FORM_LEN 36
+#define UUID_CANONICAL_FORM_LEN_RENAME 43
 
 #define GET_ANCESTRY_PATH_KEY "glusterfs.ancestry.path"
 #define GET_ANCESTRY_DENTRY_KEY "glusterfs.ancestry.dentry"

--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -111,6 +111,9 @@ int
 sys_rename(const char *oldpath, const char *newpath);
 
 int
+sys_renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
+
+int
 sys_link(const char *oldpath, const char *newpath);
 
 int

--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -96,7 +96,7 @@ int
 sys_unlink(const char *pathname);
 
 int
-sys_unlinkat(int dfd, const char *pathname);
+sys_unlinkat(int dfd, const char *pathname, int flags);
 
 int
 sys_rmdir(const char *pathname);

--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -111,7 +111,8 @@ int
 sys_rename(const char *oldpath, const char *newpath);
 
 int
-sys_renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
+sys_renameat(int olddirfd, const char *oldpath, int newdirfd,
+             const char *newpath);
 
 int
 sys_link(const char *oldpath, const char *newpath);

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1073,6 +1073,7 @@ sys_readdir
 sys_readlink
 sys_readv
 sys_rename
+sys_renameat
 sys_rmdir
 sys_stat
 sys_statvfs

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -254,11 +254,11 @@ sys_rename(const char *oldpath, const char *newpath)
 }
 
 int
-sys_renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath)
+sys_renameat(int olddirfd, const char *oldpath, int newdirfd,
+             const char *newpath)
 {
     return FS_RET_CHECK0(renameat(olddirfd, oldpath, newdirfd, newpath), errno);
 }
-
 
 int
 sys_link(const char *oldpath, const char *newpath)

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -218,12 +218,12 @@ sys_unlink(const char *pathname)
 }
 
 int
-sys_unlinkat(int dfd, const char *pathname)
+sys_unlinkat(int dfd, const char *pathname, int flags)
 {
 #ifdef GF_SOLARIS_HOST_OS
-    return FS_RET_CHECK0(solaris_unlinkat(dfd, pathname, 0), errno);
+    return FS_RET_CHECK0(solaris_unlinkat(dfd, pathname, flags), errno);
 #endif
-    return FS_RET_CHECK0(unlinkat(dfd, pathname, 0), errno);
+    return FS_RET_CHECK0(unlinkat(dfd, pathname, flags), errno);
 }
 
 int

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -254,6 +254,13 @@ sys_rename(const char *oldpath, const char *newpath)
 }
 
 int
+sys_renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath)
+{
+    return FS_RET_CHECK0(renameat(olddirfd, oldpath, newdirfd, newpath), errno);
+}
+
+
+int
 sys_link(const char *oldpath, const char *newpath)
 {
 #ifdef HAVE_LINKAT

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -497,6 +497,14 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     gf_loglevel_t level = GF_LOG_NONE;
     mode_t mode_bit = 0;
     posix_inode_ctx_t *ctx = NULL;
+    char *uuid_str = NULL;
+    char gfid_tmp_path[PATH_MAX] = {
+        0,
+    };
+    char orig_real_path[PATH_MAX] = {
+        0,
+    };
+    gf_boolean_t atomic_creation = _gf_false;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -534,6 +542,14 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     if (preparent.ia_prot.sgid) {
         gid = preparent.ia_gid;
+    }
+    strcpy(orig_real_path, real_path);
+    if (frame->root->pid != GF_SERVER_PID_TRASH) {
+        uuid_str = uuid_utoa(uuid_req);
+        (void)snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/%s",
+                       priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+        real_path = gfid_tmp_path;
+        atomic_creation = _gf_true;
     }
 
     /* Check if the 'gfid' already exists, because this mknod may be an
@@ -693,6 +709,13 @@ post_op:
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
     op_ret = 0;
+    if (atomic_creation) {
+        op_ret = sys_rename(real_path, orig_real_path);
+        if (op_ret)
+            gf_log(this->name, GF_LOG_ERROR,
+                   "rename is failing old_path %s new_path %s", real_path,
+                   orig_real_path);
+    }
 
 out:
     SET_TO_OLD_FS_ID();
@@ -746,6 +769,16 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     data_t *arg_data = NULL;
     char pgfid[GF_UUID_BUF_SIZE] = {0};
     mode_t mode_bit = 0;
+    char was_present = 0;
+    int index = 0;
+    char *uuid_str = NULL;
+    char gfid_tmp_path[PATH_MAX] = {
+        0,
+    };
+    char orig_real_path[PATH_MAX] = {
+        0,
+    };
+    gf_boolean_t atomic_creation = _gf_false;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -785,13 +818,16 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                              uuid_req, out);
     DISK_SPACE_CHECK_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out);
 
-    MAKE_ENTRY_HANDLE(real_path, par_path, this, loc, NULL);
+    MAKE_ENTRY_HANDLE(real_path, par_path, this, loc, &stbuf);
     if (!real_path || !par_path) {
         op_ret = -1;
         op_errno = ESTALE;
         goto out;
     }
 
+    strcpy(orig_real_path, real_path);
+    if (stbuf.ia_ino)
+        was_present = 1;
     gid = frame->root->gid;
 
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
@@ -985,7 +1021,18 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         dict_del_sizen(xdata, GF_PREOP_PARENT_KEY);
     }
 
-    op_ret = sys_mkdir(real_path, mode);
+    if (!was_present && (frame->root->pid != GF_SERVER_PID_TRASH)) {
+        index = uuid_req[0];
+        uuid_str = uuid_utoa(uuid_req);
+        (void)snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/%s",
+                       priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+        op_ret = sys_mkdirat(priv->arrdfd[index], uuid_str, mode);
+        real_path = gfid_tmp_path;
+        atomic_creation = _gf_true;
+    } else {
+        op_ret = sys_mkdir(real_path, mode);
+    }
+
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKDIR_FAILED,
@@ -1049,6 +1096,13 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
     op_ret = 0;
+    if (atomic_creation) {
+        op_ret = sys_rename(real_path, orig_real_path);
+        if (op_ret)
+            gf_log(this->name, GF_LOG_ERROR,
+                   "rename is failing old_path %s new_path %s", real_path,
+                   orig_real_path);
+    }
 
 out:
     SET_TO_OLD_FS_ID();
@@ -1714,6 +1768,13 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     uuid_t uuid_req = {
         0,
     };
+    char gfid_tmp_path[PATH_MAX] = {
+        0,
+    };
+    char orig_real_path[PATH_MAX] = {
+        0,
+    };
+    char *uuid_str = NULL;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -1736,7 +1797,7 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
         op_errno = ESTALE;
         goto out;
     }
-
+    strcpy(orig_real_path, real_path);
     SET_FS_ID(frame->root->uid, gid);
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
@@ -1751,6 +1812,11 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     if (preparent.ia_prot.sgid) {
         gid = preparent.ia_gid;
     }
+
+    uuid_str = uuid_utoa(uuid_req);
+    (void)snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/%s",
+                   priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+    real_path = gfid_tmp_path;
 
     op_ret = sys_symlink(linkname, real_path);
 
@@ -1829,7 +1895,12 @@ ignore:
 
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
-    op_ret = 0;
+    op_ret = sys_rename(real_path, orig_real_path);
+    if (op_ret) {
+        gf_log(this->name, GF_LOG_ERROR,
+               "rename is failing old_path %s new_path %s", real_path,
+               orig_real_path);
+    }
 
 out:
     SET_TO_OLD_FS_ID();
@@ -1889,6 +1960,19 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     gf_boolean_t get_link_count = _gf_false;
     posix_inode_ctx_t *ctx_old = NULL;
     posix_inode_ctx_t *ctx_new = NULL;
+    char *oldpath = NULL;
+    char *newpath = NULL;
+    char tmpgfidpath[PATH_MAX] = {
+        0,
+    };
+    char newgfidpath[PATH_MAX] = {
+        0,
+    };
+    char dummygfid[PATH_MAX] = {
+        0,
+    };
+    int index = 0;
+    gf_boolean_t atomic_creation = _gf_false;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -1986,8 +2070,33 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         }
     }
 
-    if (IA_ISDIR(oldloc->inode->ia_type))
-        posix_handle_unset(this, oldloc->inode->gfid, NULL);
+    if (IA_ISDIR(oldloc->inode->ia_type) &&
+        frame->root->pid != GF_SERVER_PID_TRASH) {
+        MAKE_HANDLE_ABSPATH(oldpath, this, oldloc->inode->gfid);
+        MAKE_HANDLE_RELPATH(newpath, this, newloc->pargfid, newloc->name);
+        snprintf(tmpgfidpath, (PATH_MAX - 1), "%s_rename", oldpath);
+        snprintf(newgfidpath, (PATH_MAX - 1), "%s", oldpath);
+        index = oldloc->inode->gfid[0];
+        snprintf(dummygfid, (PATH_MAX - 1), "%s_rename",
+                 uuid_utoa(oldloc->inode->gfid));
+        op_ret = sys_symlink(newpath, tmpgfidpath);
+        if (op_ret) {
+            op_errno = errno;
+            gf_log(this->name, GF_LOG_ERROR,
+                   "Symlink creation is failed for path %s to %s error is %s",
+                   newpath, tmpgfidpath, strerror(errno));
+            goto out;
+        }
+        op_ret = mkfifoat(priv->arrdfd[index], dummygfid, 0666);
+        if (op_ret) {
+            op_errno = errno;
+            gf_log(this->name, GF_LOG_ERROR,
+                   "Creation of dummy rename gfid path %s is failed",
+                   dummygfid);
+            goto out;
+        }
+        atomic_creation = _gf_true;
+    }
 
     pthread_mutex_lock(&ctx_old->pgfid_lock);
     {
@@ -2078,15 +2187,32 @@ unlock:
         goto out;
     }
 
-    if (was_dir)
+    if (was_dir) {
         posix_handle_unset(this, victim, NULL);
+        posix_handle_unset(this, oldloc->inode->gfid, NULL);
+    }
 
     if (was_present && !was_dir && nlink == 1)
         posix_handle_unset(this, victim, NULL);
 
-    if (IA_ISDIR(oldloc->inode->ia_type)) {
-        posix_handle_soft(this, real_newpath, newloc, oldloc->inode->gfid,
-                          NULL);
+    if (IA_ISDIR(oldloc->inode->ia_type) && atomic_creation) {
+        posix_handle_unset(this, oldloc->inode->gfid, NULL);
+        op_ret = sys_rename(tmpgfidpath, newgfidpath);
+        if (op_ret) {
+            gf_log(this->name, GF_LOG_ERROR,
+                   "rename tmp_gfid %s to expected gfid %s", tmpgfidpath,
+                   newgfidpath);
+            op_errno = errno;
+            goto out;
+        }
+
+        op_ret = unlinkat(priv->arrdfd[index], dummygfid, 0);
+        if (op_ret && errno != EEXIST) {
+            gf_log(this->name, GF_LOG_ERROR, "unlink of gfid %s is failed",
+                   dummygfid);
+            op_errno = errno;
+            goto out;
+        }
     }
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
@@ -2347,6 +2473,14 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     uuid_t uuid_req = {
         0,
     };
+    int index = 0;
+    char *uuid_str = NULL;
+    char gfid_tmp_path[PATH_MAX] = {
+        0,
+    };
+    char orig_real_path[PATH_MAX] = {
+        0,
+    };
 
     dict_t *xdata_rsp = dict_ref(xdata);
 
@@ -2374,6 +2508,9 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         op_errno = ESTALE;
         goto out;
     }
+    strcpy(orig_real_path, real_path);
+    if (!stbuf.ia_ino)
+        was_present = 0;
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false, _gf_true);
@@ -2394,10 +2531,7 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         _flags = flags | O_CREAT;
     }
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
-                         _gf_false);
-    if ((op_ret == -1) && (errno == ENOENT)) {
-        was_present = 0;
+    if (!was_present) {
         if (posix_is_layout_stale(xdata, par_path, this)) {
             op_ret = -1;
             op_errno = EIO;
@@ -2424,7 +2558,16 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     mode_bit = (priv->create_mask & mode) | priv->force_create_mode;
     mode = posix_override_umask(mode, mode_bit);
-    _fd = sys_open(real_path, _flags, mode);
+    if (was_present) {
+        _fd = sys_open(real_path, _flags, mode);
+    } else {
+        index = uuid_req[0];
+        uuid_str = uuid_utoa(uuid_req);
+        (void)snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/%s",
+                       priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+        _fd = sys_openat(priv->arrdfd[index], uuid_str, _flags, mode);
+        real_path = gfid_tmp_path;
+    }
 
     if (_fd == -1) {
         op_errno = errno;
@@ -2521,7 +2664,13 @@ fill_stat:
                "failed to set the fd context path=%s fd=%p", real_path, fd);
 
     op_ret = 0;
-
+    if (!was_present) {
+        op_ret = sys_rename(real_path, orig_real_path);
+        if (op_ret)
+            gf_log(this->name, GF_LOG_ERROR,
+                   "rename is failing old_path %s new_path %s", real_path,
+                   orig_real_path);
+    }
 out:
     SET_TO_OLD_FS_ID();
 

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -838,8 +838,6 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     gid = frame->root->gid;
     strcpy(orig_real_path, real_path);
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
-
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
                          _gf_false);
 
@@ -2179,7 +2177,6 @@ unlock:
         posix_handle_unset(this, victim, NULL);
 
     if (IA_ISDIR(oldloc->inode->ia_type) && atomic_creation) {
-        posix_handle_unset(this, oldloc->inode->gfid, NULL);
         if ((op_ret = rename_two_path(this, tmpgfidpath, newgfidpath))) {
             op_errno = errno;
             goto out;

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -472,7 +472,8 @@ rename_two_path(xlator_t *this, const char *old, const char *new)
 {
     if (sys_rename(old, new)) {
         gf_log(this->name, GF_LOG_ERROR,
-               "rename is failing old_path %s new_path %s", old, new);
+               "rename is failing old_path %s new_path %s error is %s", old,
+               new, strerror(errno));
         return -1;
     }
 
@@ -509,7 +510,6 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     gf_loglevel_t level = GF_LOG_NONE;
     mode_t mode_bit = 0;
     posix_inode_ctx_t *ctx = NULL;
-    char *uuid_str = NULL;
     char gfid_tmp_path[PATH_MAX] = {
         0,
     };
@@ -558,9 +558,9 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     strcpy(orig_real_path, real_path);
     if (frame->root->pid != GF_SERVER_PID_TRASH) {
-        uuid_str = uuid_utoa(uuid_req);
         snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/tt/%s",
-                 priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+                 priv->base_path, GF_HIDDEN_PATH, uuid_req[0],
+                 uuid_utoa(uuid_req));
         real_path = gfid_tmp_path;
         atomic_creation = _gf_true;
     }
@@ -1779,7 +1779,6 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     char orig_real_path[PATH_MAX] = {
         0,
     };
-    char *uuid_str = NULL;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -1819,9 +1818,8 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
         gid = preparent.ia_gid;
     }
 
-    uuid_str = uuid_utoa(uuid_req);
     snprintf(gfid_tmp_path, sizeof(gfid_tmp_path), "%s/%s/%02x/tt/%s",
-             priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_str);
+             priv->base_path, GF_HIDDEN_PATH, uuid_req[0], uuid_utoa(uuid_req));
     real_path = gfid_tmp_path;
 
     op_ret = sys_symlink(linkname, real_path);

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -867,7 +867,7 @@ posix_handle_unset_gfid(xlator_t *this, uuid_t gfid)
     dfd = priv->arrdfd[index];
 
     snprintf(newstr, sizeof(newstr), "%02x/%s", gfid[1], uuid_utoa(gfid));
-    ret = sys_unlinkat(dfd, newstr);
+    ret = sys_unlinkat(dfd, newstr, 0);
     if (ret && (errno != ENOENT)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE,
                "unlink %s failed", newstr);

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -780,14 +780,17 @@ posix_handle_hard(xlator_t *this, const char *oldpath, uuid_t gfid,
         }
     }
 
-    if (newbuf.st_ino != oldbuf->st_ino || newbuf.st_dev != oldbuf->st_dev) {
-        gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLE_CREATE,
-               "mismatching ino/dev between file %s (%lld/%lld) "
-               "and handle %s (%lld/%lld)",
-               oldpath, (long long)oldbuf->st_ino, (long long)oldbuf->st_dev,
-               uuid_utoa(gfid), (long long)newbuf.st_ino,
-               (long long)newbuf.st_dev);
-        ret = -1;
+    if (oldbuf) {
+        if (newbuf.st_ino != oldbuf->st_ino ||
+            newbuf.st_dev != oldbuf->st_dev) {
+            gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLE_CREATE,
+                   "mismatching ino/dev between file %s (%lld/%lld) "
+                   "and handle %s (%lld/%lld)",
+                   oldpath, (long long)oldbuf->st_ino,
+                   (long long)oldbuf->st_dev, uuid_utoa(gfid),
+                   (long long)newbuf.st_ino, (long long)newbuf.st_dev);
+            ret = -1;
+        }
     }
 
     return ret;

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -786,9 +786,9 @@ posix_handle_hard(xlator_t *this, const char *oldpath, uuid_t gfid,
             gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLE_CREATE,
                    "mismatching ino/dev between file %s (%lld/%lld) "
                    "and handle %s (%lld/%lld)",
-                   oldpath, (long long)oldbuf->st_ino,
-                   (long long)oldbuf->st_dev, uuid_utoa(gfid),
-                   (long long)newbuf.st_ino, (long long)newbuf.st_dev);
+                   oldpath, (long long)oldbuf->st_ino, (long long)oldbuf->st_dev,
+                   uuid_utoa(gfid), (long long)newbuf.st_ino,
+                   (long long)newbuf.st_dev);
             ret = -1;
         }
     }

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -786,9 +786,9 @@ posix_handle_hard(xlator_t *this, const char *oldpath, uuid_t gfid,
             gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLE_CREATE,
                    "mismatching ino/dev between file %s (%lld/%lld) "
                    "and handle %s (%lld/%lld)",
-                   oldpath, (long long)oldbuf->st_ino, (long long)oldbuf->st_dev,
-                   uuid_utoa(gfid), (long long)newbuf.st_ino,
-                   (long long)newbuf.st_dev);
+                   oldpath, (long long)oldbuf->st_ino,
+                   (long long)oldbuf->st_dev, uuid_utoa(gfid),
+                   (long long)newbuf.st_ino, (long long)newbuf.st_dev);
             ret = -1;
         }
     }

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -223,4 +223,8 @@ posix_disk_space_check(struct posix_private *priv);
 
 dict_t *
 _fill_writev_xdata(fd_t *fd, dict_t *xdata, xlator_t *this, int is_append);
+
+int
+posix_handle_relpath(xlator_t *this, uuid_t gfid, const char *basename,
+                     char *buf, size_t buflen);
 #endif /* !_POSIX_HANDLE_H */

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -223,8 +223,4 @@ posix_disk_space_check(struct posix_private *priv);
 
 dict_t *
 _fill_writev_xdata(fd_t *fd, dict_t *xdata, xlator_t *this, int is_append);
-
-int
-posix_handle_relpath(xlator_t *this, uuid_t gfid, const char *basename,
-                     char *buf, size_t buflen);
 #endif /* !_POSIX_HANDLE_H */

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -736,7 +736,8 @@ posix_gfid_heal_inode_is_valid(xlator_t *this, inode_t *inode, uuid_t gfid,
             } else {
                 gf_msg_debug(this->name, 0,
                              "Can not create handle path for path %s "
-                             " because inode is NULL", real_path);
+                             " because inode is NULL",
+                             real_path);
                 goto out;
             }
         }
@@ -745,7 +746,6 @@ posix_gfid_heal_inode_is_valid(xlator_t *this, inode_t *inode, uuid_t gfid,
 out:
     return ret;
 }
-
 
 /* The inode here is expected to update posix_mdata stored on disk.
  * Don't use it as a general purpose inode and don't expect it to
@@ -786,7 +786,8 @@ again:
                 gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_LSTAT_FAILED,
                        "lstat failed on %s", real_path);
             } else {
-                ret = posix_gfid_heal_inode_is_valid(this, inode, gfid, loc, real_path);
+                ret = posix_gfid_heal_inode_is_valid(this, inode, gfid, loc,
+                                                     real_path);
                 if (!ret)
                     goto again;
             }

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1346,7 +1346,7 @@ posix_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     VALIDATE_OR_GOTO(fd, out);
 
     SET_FS_ID(frame->root->uid, frame->root->gid);
-    MAKE_INODE_HANDLE(real_path, this, loc, NULL);
+    MAKE_INODE_HANDLE_DIR(real_path, this, loc, NULL);
     if (!real_path) {
         op_errno = ESTALE;
         goto out;

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -149,4 +149,7 @@ posix_handle_init(xlator_t *this);
 int
 posix_handle_trash_init(xlator_t *this);
 
+int
+posix_handle_relpath(xlator_t *this, uuid_t gfid, const char *basename,
+                     char *buf, size_t buflen);
 #endif /* !_POSIX_INODE_HANDLE_H */

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -94,6 +94,41 @@
         }                                                                      \
     } while (0)
 
+#define MAKE_INODE_HANDLE_DIR(rpath, this, loc, iatt_p)                        \
+    do {                                                                       \
+        if (!this->private) {                                                  \
+            op_ret = -1;                                                       \
+            gf_msg("make_inode_handle", GF_LOG_ERROR, 0,                       \
+                   P_MSG_INODE_HANDLE_CREATE,                                  \
+                   "private is NULL, fini is already called");                 \
+            break;                                                             \
+        }                                                                      \
+        if (gf_uuid_is_null(loc->gfid)) {                                      \
+            op_ret = -1;                                                       \
+            gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INODE_HANDLE_CREATE,     \
+                   "null gfid for path %s", (loc)->path);                      \
+            break;                                                             \
+        }                                                                      \
+        errno = 0;                                                             \
+        op_ret = posix_istat(this, loc->inode, loc->gfid, NULL, iatt_p, loc);  \
+>>>>>>> posix: Resolved various reviewer comment
+        if (errno != ELOOP) {                                                  \
+            MAKE_HANDLE_PATH(rpath, this, (loc)->gfid, NULL);                  \
+            if (!rpath) {                                                      \
+                op_ret = -1;                                                   \
+                gf_msg(this->name, GF_LOG_ERROR, errno,                        \
+                       P_MSG_INODE_HANDLE_CREATE,                              \
+                       "Failed to create inode handle "                        \
+                       "for path %s",                                          \
+                       (loc)->path);                                           \
+            }                                                                  \
+            break;                                                             \
+        } /* __ret == -1 && errno == ELOOP */                                  \
+        else {                                                                 \
+            op_ret = -1;                                                       \
+        }                                                                      \
+    } while (0)
+
 #define POSIX_ANCESTRY_PATH (1 << 0)
 #define POSIX_ANCESTRY_DENTRY (1 << 1)
 

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -110,8 +110,8 @@
             break;                                                             \
         }                                                                      \
         errno = 0;                                                             \
-        op_ret = posix_istat(this, loc->inode, loc->gfid, NULL, iatt_p, loc);  \
->>>>>>> posix: Resolved various reviewer comment
+        op_ret = posix_istat(this, loc->inode, loc->gfid, NULL, iatt_p,        \
+                             _gf_true);                                        \
         if (errno != ELOOP) {                                                  \
             MAKE_HANDLE_PATH(rpath, this, (loc)->gfid, NULL);                  \
             if (!rpath) {                                                      \

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -385,8 +385,8 @@ posix_fhandle_pair(call_frame_t *frame, xlator_t *this, int fd, char *key,
 void
 posix_janitor_timer_start(xlator_t *this);
 int
-posix_gfid_heal(xlator_t *this, const char *path, loc_t *loc,
-                dict_t *xattr_req);
+posix_gfid_get_set(xlator_t *this, const char *path, loc_t *loc,
+                   dict_t *xattr_req);
 int
 posix_entry_create_xattr_set(xlator_t *this, loc_t *loc, const char *path,
                              dict_t *dict);


### PR DESCRIPTION
    Problem: During the testing of readdir(p) on the github issue (#2197)
    We have found in posix_lookup posix_gfid_heal is the function
    that takes maximum time while trying to validate path link with gfid.

    Solution: To avoid gfid_heal during lookup codepath make all entry
              creation(create/symlink/mkdir/rename/mknod) to atomic so
              that lookup does not need to validate gfid link.
              If a real path is exist it means gfid link is valid.
    To make entry creation fop to atomic we are following below approach
        1) During brick start populate/set a xattr(graceful_cleanup) on brick root
        2) Populate a new_real_path based on gfid under first hash
        3) Change the real_path to new_real_path
        4) All operations are execute on new_real_path
        5) Rename the new_real_path to original_real_path
        6) If a process is crashed between any steps at the time of start
           a brick process need to cleanup stale real_path or populate correct
           gfid link (in case of rename dir only)

Fixes: #2326
Change-Id: Ic65bb5a7a178faac08f97f40057b6e5c7510000a
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

