### PR TITLE
lock: Avoid to call pthread_mutex_lock by grant_blocked_locks()

### DIFF
--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -192,8 +192,7 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
             __destroy_lock(plock);
         }
     }
-    pthread_mutex_unlock(&pl_inode->mutex);
-    grant_blocked_locks(this, pl_inode);
+    grant_blocked_locks(this, pl_inode, _gf_true);
     ret = 0;
 out:
     *blkd = bcount;

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -70,7 +70,7 @@ int
 pl_lock_preempt(pl_inode_t *pl_inode, posix_lock_t *reqlock);
 
 void
-grant_blocked_locks(xlator_t *this, pl_inode_t *inode);
+grant_blocked_locks(xlator_t *this, pl_inode_t *inode, gf_boolean_t lock_flag);
 
 void
 posix_lock_to_flock(posix_lock_t *lock, struct gf_flock *flock);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -1185,7 +1185,7 @@ delete_locks_of_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd)
         __destroy_lock(l);
     }
 
-    grant_blocked_locks(this, pl_inode);
+    grant_blocked_locks(this, pl_inode, _gf_false);
 
     do_blocked_rw(pl_inode);
 }
@@ -1862,9 +1862,7 @@ pl_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         __delete_locks_of_owner(pl_inode, frame->root->client,
                                 &frame->root->lk_owner);
     }
-    pthread_mutex_unlock(&pl_inode->mutex);
-
-    grant_blocked_locks(this, pl_inode);
+    grant_blocked_locks(this, pl_inode, _gf_true);
 
     do_blocked_rw(pl_inode);
 


### PR DESCRIPTION
The function grant_blocked_locks() needs to call pthread_mutex_lock
only while the lock has not been taken by parent function.

Fixes: #1333
Change-Id: I08d2d974c5786e0d7786c8ce6ad26f73c0e6aa76
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

