### PR TITLE
coverity: Use after free

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -985,7 +985,7 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
     // Build comparison logic here.
     pthread_mutex_lock(&conf->import_volumes);
     {
-        ret = glusterd_compare_friend_data(ev_ctx->vols, ev_ctx->peer_ver,
+        ret = glusterd_compare_friend_data(&(ev_ctx->vols), ev_ctx->peer_ver,
                                            &status, event->peername);
         if (ret) {
             pthread_mutex_unlock(&conf->import_volumes);
@@ -1058,15 +1058,18 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
 
     new_event->ctx = new_ev_ctx;
 
-    ret = dict_get_strn(ev_ctx->vols, "hostname_in_cluster",
-                        SLEN("hostname_in_cluster"), &hostname);
-    if (ret || !hostname) {
-        gf_msg_debug(this->name, 0, "Unable to fetch local hostname from peer");
-    } else if (snprintf(local_node_hostname, sizeof(local_node_hostname), "%s",
-                        hostname) >= sizeof(local_node_hostname)) {
-        gf_msg_debug(this->name, 0, "local_node_hostname truncated");
-        ret = -1;
-        goto out;
+    if (ev_ctx->vols) {
+        ret = dict_get_strn(ev_ctx->vols, "hostname_in_cluster",
+                            SLEN("hostname_in_cluster"), &hostname);
+        if (ret || !hostname) {
+            gf_msg_debug(this->name, 0,
+                         "Unable to fetch local hostname from peer");
+        } else if (snprintf(local_node_hostname, sizeof(local_node_hostname),
+                            "%s", hostname) >= sizeof(local_node_hostname)) {
+            gf_msg_debug(this->name, 0, "local_node_hostname truncated");
+            ret = -1;
+            goto out;
+        }
     }
 
     glusterd_friend_sm_inject_event(new_event);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5401,7 +5401,7 @@ out:
 }
 
 int32_t
-glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
+glusterd_compare_friend_data(dict_t **peer_data, dict_t *cmp, int32_t *status,
                              char *hostname)
 {
     int32_t ret = -1;
@@ -5412,12 +5412,12 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
     glusterd_conf_t *priv = NULL;
     glusterd_friend_synctask_args_t *arg = NULL;
 
-    GF_ASSERT(peer_data);
+    GF_ASSERT(*peer_data);
     GF_ASSERT(status);
 
     priv = this->private;
     GF_ASSERT(priv);
-    ret = glusterd_import_global_opts(peer_data);
+    ret = glusterd_import_global_opts(*peer_data);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GLOBAL_OPT_IMPORT_FAIL,
                "Importing global "
@@ -5425,7 +5425,7 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
         goto out;
     }
 
-    ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
+    ret = dict_get_int32n(*peer_data, "count", SLEN("count"), &count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
@@ -5440,10 +5440,10 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
                "Out Of Memory");
         goto out;
     }
-    arg->peer_data = dict_ref(peer_data);
+    arg->peer_data = dict_ref(*peer_data);
     arg->peer_ver_data = dict_ref(cmp);
     while (i <= count) {
-        ret = glusterd_compare_friend_volume(peer_data, arg, i, status,
+        ret = glusterd_compare_friend_volume(*peer_data, arg, i, status,
                                              hostname);
         if (ret)
             goto out;
@@ -5472,6 +5472,8 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
 out:
     if ((ret || !update) && arg) {
         dict_unref(arg->peer_data);
+        *peer_data = NULL;
+
         dict_unref(arg->peer_ver_data);
         GF_FREE(arg);
     }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -241,7 +241,7 @@ glusterd_add_volumes_to_export_dict(dict_t *peer_data, char **buf,
                                     u_int *length);
 
 int32_t
-glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
+glusterd_compare_friend_data(dict_t **peer_data, dict_t *cmp, int32_t *status,
                              char *hostname);
 
 int


### PR DESCRIPTION
Issue:
The pointer `ev_ctx->vols` will get freed in the function
`glusterd_compare_friend_data()` if the status is RJT.

Fix:
Added a NULL check for the pointer, before using it.

CID: 1458103
Updates: #1060

Change-Id: I9f4f19ad8a4eff59bc2074235572a7c9ed0a4444
Signed-off-by: nik-redhat <nladha@redhat.com>

