### PR TITLE
firewall: Updated the range of open ports by firewall

### DIFF
--- a/extras/firewalld/glusterfs.xml
+++ b/extras/firewalld/glusterfs.xml
@@ -10,5 +10,5 @@
 <port protocol="tcp" port="38467"/>    <!--Gluster NFS service -->
 <port protocol="tcp" port="38468"/>    <!--Gluster NFS service -->
 <port protocol="tcp" port="38469"/>    <!--Gluster NFS service -->
-<port protocol="tcp" port="49152-49664"/>  <!--512 ports for bricks -->
+<port protocol="tcp" port="49152-60999"/>  <!--Ports needed for bricks -->
 </service>


### PR DESCRIPTION
Issue:
The ports for the brick process are now randomized and don't do a
sequential probing from 49152 to the max-port. Hence, if the port number
outside the allowed range of the firewall is allowed to the brick, there
can be connectivity issues.

Fix:
Updated the range to allow all the ports(up to the max-port) for gluster
bricks, in the firewall service file.

Note:
I am aware this is not the best security practice, but to have a failure-proof
scenario this needs to be done. The user can always modify the max
range of ports manually after installing gluster if they want to.

Fixes: #2515

Change-Id: Ib48c6bfba0ecbf995c07e4690eb9a0a718433718
Signed-off-by: nik-redhat <nladha@redhat.com>

