### PR TITLE
libglusterfs: generic buffer infrastructure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,7 @@ AC_CONFIG_FILES([Makefile
                 heal/Makefile
                 heal/src/Makefile
                 glusterfs.spec
+                tests/basic/gf-buf.t
                 tools/glusterfind/src/tool.conf
                 tools/glusterfind/glusterfind
                 tools/glusterfind/Makefile
@@ -999,6 +1000,20 @@ if test x$STATIC_ASSERT = "xyes"; then
    AC_DEFINE(HAVE_STATIC_ASSERT, 1, [Define if C11 _Static_assert is supported.])
 fi
 
+dnl Since gcc warns on unknown attribute, force -Werror=attributes.
+saved_CFLAGS=$CFLAGS
+CFLAGS="-Werror=attributes"
+AC_MSG_CHECKING([whether $CC supports __attribute__((__cleanup__))])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [[struct s { int x; }; void f(struct s *s) {}]],
+   [[struct s v __attribute__((__cleanup__(f)));]])],
+[CLEANUP=yes], [CLEANUP=no])
+AC_MSG_RESULT([$CLEANUP])
+CFLAGS="$saved_CFLAGS"
+if test x$CLEANUP != "xyes"; then
+   AC_MSG_ERROR([__attribute__((__cleanup__)) is not supported, exiting.])
+fi
+
 if test "x${have_backtrace}" != "xyes"; then
 AC_TRY_COMPILE([#include <math.h>], [double x=0.0; x=ceil(0.0);],
    [],
@@ -1722,7 +1737,7 @@ esac
 CONTRIBDIR='$(top_srcdir)/contrib'
 AC_SUBST(CONTRIBDIR)
 
-GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS)'
+GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE'
 GF_CPPINCLUDES='-include $(top_builddir)/config.h -include $(top_builddir)/site.h -I$(top_srcdir)/libglusterfs/src -I$(top_builddir)/libglusterfs/src'
 if test "x${USE_CONTRIB_URCU}" = "xyes"; then
     GF_CPPINCLUDES="${GF_CPPINCLUDES} -I\$(CONTRIBDIR)/userspace-rcu"
@@ -1731,10 +1746,16 @@ GF_CPPFLAGS="$GF_CPPFLAGS $GF_CPPDEFINES $GF_CPPINCLUDES"
 AC_SUBST([GF_CPPFLAGS])
 
 AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
+if  test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS"; then
+    AC_DEFINE(GF_LINUX_HOST_OS, 1, [Configured on Linux OS.])
+fi
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
+if  test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS"; then
+    AC_DEFINE(GF_DARWIN_HOST_OS, 1, [Configured on Darwin OS.])
+fi
 AM_CONDITIONAL([GF_BSD_HOST_OS], test "${GF_HOST_OS}" = "GF_BSD_HOST_OS")
 if  test "${GF_HOST_OS}" = "GF_BSD_HOST_OS"; then
-    AC_DEFINE(GF_BSD_HOST_OS, 1, [This is a BSD compatible OS.])
+    AC_DEFINE(GF_BSD_HOST_OS, 1, [Configured on a BSD-compatible OS.])
 fi
 
 AC_SUBST(GLUSTERD_WORKDIR)

--- a/doc/developer-guide/gf-buf.md
+++ b/doc/developer-guide/gf-buf.md
@@ -1,0 +1,139 @@
+Generic buffer infrastructure
+=============================
+
+Generic buffer is the simple concept to implement basic operations on
+the memory area of the known size. Basically the buffer is just a pair
+of raw C pointer and size; if the last byte of the pointed area is '\0',
+this area can be treated as a C string.
+
+Generic buffers are intended to be a function- or block-scoped. Going
+down to the storage management, the basic idea is to maintain an
+internal memory allocated with `alloca()` for small areas or with
+`malloc()` for the larger ones. For the latter, an allocated buffer
+should be freed with the function specified by using GCC (and now
+Clang as well) specific `__attribute__((__cleanup__(...)))` variable
+declaration.
+
+API is very simple and mostly covers initialization, copying, clearing,
+concatenation and basic formatted output. Macros with name ending in
+`_string()` operates on strings (i. e. areas where the last byte is
+set to '\0'), and `_data()` counterparts assumes raw memory areas.
+
+### Internal area allocation
+
+All allocation sizes are rounded up to the next greater multiple
+of `GF_BUF_ROUNDUP`. If the result exceeds `GF_BUF_STACK_THRESHOLD`,
+allocation request is served with `GF_MALLOC()`, and allocated area
+will be freed by `gf_buf_cleanup()` when the variable goes out of
+scope. Otherwise it's served with `alloca()`, so freeing is performed
+automatically when the call stack is destroyed.
+
+### Declaration
+
+`gf_buf_decl_null(&buf)` declares null buffer. This buffer should be
+initialized before doing anything useful.
+
+`gf_buf_decl_string(&buf)` declares the buffer which is equivalent to
+empty (zero-length) string "". Nothing is allocated, neither on stack
+or on heap (i. e. buffer internally references a constant C string).
+
+`gf_buf_decl_init_string(&buf, "text")` declares the buffer which is
+equivalent to string "text". Again, the buffer internally references
+a constant C string. Note that `gf_buffer_decl_string(&buf)` is just
+a useful shortcut for `gf_buffer_decl_init_string(&buf, "")`.
+
+`gf_buf_decl_init_string(&buf, ptr)` with non-constant `ptr` declares
+the buffer which internally references a C string pointed by `ptr`,
+i. e. nothing is allocated or copied. So if the data pointed by `ptr`
+is changed during the lifetime of `buf`, the behavior is undefined. If
+`ptr` is NULL or not initialized, the behavior is undefined as well.
+
+`gf_buf_decl_init_data(&buf, data, size)` is very similar to the above
+but declares the buffer holding the reference to `size`-bytes memory
+area pointed by `data`.
+
+### Basic operations
+
+`gf_buf_reset(&buf)` unconditionally (regardless of an actual type and
+contents) resets an internal state of `buf` to null buffer, i. e. as
+if it is just declared with `gf_buf_decl_null(&buf)`.
+
+`gf_buf_clear_string(&buf)` clears the buffer by setting its data to
+empty (zero-length) string "". In contrast with `gf_buf_decl_string()`,
+if `buf` references a constant C string, an internal area for the
+zero-length string is dynamically allocated. An underlying buffer
+type is forced to be a string.
+
+`gf_buf_clear_data(&buf)` is very similar to the above but sets the
+buffer's data size to 0, so the buffer should be considered as empty.
+An underlying buffer type is forced to be a raw buffer.
+
+`gf_buf_assign_string(&buf, "text")` or `gf_buf_assign(&buf, ptr)`
+copies the provided C string into a buffer, allocating or enlarging
+an internal area if necessary. Underlying buffer type is forced to
+be a string.
+
+`gf_buf_assign_data(&buf, data, size)` is very similar to the above but
+copies the provided memory area of specified. size. Underlying buffer
+type is forced to be a raw buffer.
+
+`gf_buf_copy(&to, &from)` copies one buffer to another, allocating or
+enlarging destination's buffer internal area if necessary. Underlying
+buffer type is copied as well.
+
+`gf_buf_equal(&buf0, &buf1)` compares two buffers as memory areas.
+Equal buffers have byte-to-byte contents of the same length. Note
+that the size of an internally allocated area may be different for
+equal buffers.
+
+`gf_buf_data(&buf)` returns raw pointer to an internally allocated
+area. This pointer should be considered as read-only and not intented
+to alter the buffer contents.
+
+`gf_buf_data_size(&buf)` returns size of data currently stored in the
+buffer. If an underlying buffer type is a string, terminating null byte
+is included.
+
+`gf_buf_copyout(&buf)` copies the buffer contents with `gf_memdup()`
+and returns the pointer to newly allocated area. For the null buffer,
+NULL pointer is returned.
+
+`gf_buf_compact(&buf)` shrinks the buffer so internally allocated area
+becomes of exactly the same size as actually used. Note that the
+buffers are never compacted implicitly.
+
+### Concatenation and formatted output
+
+`gf_buf_concat(&dst, &src)` concatenates the contents of two buffers
+into the first one, enlarging its internal area if necessary. Both
+buffers may be strings or raw buffers, and concatenation result is
+defined as follows:
+
+  - If both `dst` and `src` are strings, null byte at the end of `dst`
+    is overwritten with the first byte from `src`, and the result is
+    forced to be a string. This is a (hopefully) safe analog of
+    `strcat()` from standard C library.
+
+  - If both `dst` and `src` are raw buffers, the memory areas are
+    adjacently concatenated, and the result is forced to be a raw
+    buffer.
+
+  - If `dst` is a string but `src` is not, null byte at the end of
+    `dst` is overwritten by the first byte of adjacently concatenated
+    area from `src`, and the result is forced to be a raw buffer.
+
+  - If `dst` is a raw buffer but `src` is a string, data from `src` is
+    adjacently concatenated with `dst` including '\0' byte, and the
+    result is forced to be a string.
+
+`gf_buf_concat_string(&buf, str)` is very similar to the above but
+concatenates the contents of the buffer with C string (so the result
+is always forced to be a string as well).
+
+`gf_buf_sprintf(&buf, fmt, args...)` ensures that an internally
+allocated area is large enough to hold the result of
+`sprintf(fmt, args...)` and performs the formatted output into
+the buffer.
+
+`gf_buf_snprintf(&buf, size, fmt, args...)` is similar but writes
+at most `size` bytes, including terminating '\0', into the buffer.

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -72,7 +72,7 @@ libglusterfs_la_HEADERS = glusterfs/common-utils.h glusterfs/defaults.h \
 	glusterfs/quota-common-utils.h glusterfs/rot-buffs.h \
 	glusterfs/compat-uuid.h glusterfs/upcall-utils.h glusterfs/throttle-tbf.h \
 	glusterfs/events.h glusterfs/atomic.h glusterfs/monitoring.h \
-	glusterfs/async.h glusterfs/glusterfs-fops.h
+	glusterfs/async.h glusterfs/glusterfs-fops.h glusterfs/gf-buf.h
 
 libglusterfs_ladir = $(includedir)/glusterfs
 

--- a/libglusterfs/src/glusterfs/gf-buf.h
+++ b/libglusterfs/src/glusterfs/gf-buf.h
@@ -1,0 +1,283 @@
+#ifndef _GF_BUF_H_
+#define _GF_BUF_H_
+
+#include "glusterfs/common-utils.h"
+
+#ifndef GF_BUF_STACK_THRESHOLD
+#define GF_BUF_STACK_THRESHOLD 64
+#endif
+
+#ifndef GF_BUF_ROUNDUP
+#define GF_BUF_ROUNDUP 16
+#endif
+
+#ifndef GF_ALLOCA_ALIGN
+#define GF_ALLOCA_ALIGN 16
+#endif
+
+typedef struct gf_buf {
+    unsigned long heap : 1;
+    unsigned long allocated : __BITS_PER_LONG - 1;
+    unsigned long string : 1;
+    unsigned long used : __BITS_PER_LONG - 1;
+    char *data;
+} gf_buf_t;
+
+#define gf_buf_decl_null(var)                                                  \
+    gf_buf_t var                                                               \
+        __attribute__((__cleanup__(gf_buf_cleanup))) = {0, 0, 0, 0, NULL}
+
+#define gf_buf_decl_string(var)                                                \
+    gf_buf_t var __attribute__((__cleanup__(gf_buf_cleanup))) = {0, 0, 1, 1, ""}
+
+#define gf_buf_decl_init_data(var, ptr, size)                                  \
+    gf_buf_t var __attribute__((__cleanup__(gf_buf_cleanup))) = {              \
+        0, 0, 0, (size), (ptr)}
+
+#define gf_buf_decl_init_string(var, str)                                      \
+    gf_buf_t var __attribute__((__cleanup__(gf_buf_cleanup))) = {              \
+        0, 0, 1, strlen(str) + 1, (str)}
+
+static inline void *
+__gf_buf_malloc(size_t size)
+{
+    return GF_MALLOC((size), gf_common_mt_char);
+}
+
+static inline void
+__gf_buf_free(void *ptr)
+{
+    GF_FREE(ptr);
+}
+
+static inline void
+gf_buf_cleanup(struct gf_buf *buf)
+{
+    if (buf->heap)
+        __gf_buf_free(buf->data);
+}
+
+static inline size_t
+__gf_buf_roundup(size_t size)
+{
+    return (size + (GF_BUF_ROUNDUP - 1)) & (-GF_BUF_ROUNDUP);
+}
+
+#define __gf_alloca(size)                                                      \
+    __builtin_alloca_with_align((size), GF_ALLOCA_ALIGN * CHAR_BIT)
+
+#define __gf_buf_assign(buf, ptr, size)                                        \
+    do {                                                                       \
+        size_t __sz = __gf_buf_roundup(size);                                  \
+        if (__sz > GF_BUF_STACK_THRESHOLD) {                                   \
+            (buf)->data = memcpy(__gf_buf_malloc(__sz), (ptr), (size));        \
+            (buf)->heap = 1;                                                   \
+        } else {                                                               \
+            (buf)->data = memcpy(__gf_alloca(__sz), (ptr), (size));            \
+            (buf)->heap = 0;                                                   \
+        }                                                                      \
+        (buf)->allocated = __sz;                                               \
+    } while (0)
+
+#define gf_buf_assign_string(buf, str)                                         \
+    do {                                                                       \
+        size_t __nr = strlen(str) + 1;                                         \
+        if ((buf)->allocated >= __nr)                                          \
+            memcpy((buf)->data, (str), __nr);                                  \
+        else {                                                                 \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            __gf_buf_assign((buf), (str), __nr);                               \
+        }                                                                      \
+        (buf)->used = __nr;                                                    \
+        (buf)->string = 1;                                                     \
+    } while (0)
+
+#define gf_buf_assign_data(buf, ptr, size)                                     \
+    do {                                                                       \
+        if ((buf)->allocated >= (size))                                        \
+            memcpy((buf)->data, (ptr), (size));                                \
+        else {                                                                 \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            __gf_buf_assign((buf), (ptr), (size));                             \
+        }                                                                      \
+        (buf)->used = size;                                                    \
+        (buf)->string = 0;                                                     \
+    } while (0)
+
+#define gf_buf_reset(buf)                                                      \
+    do {                                                                       \
+        if ((buf)->heap)                                                       \
+            __gf_free((buf)->data);                                            \
+        (buf)->data = NULL;                                                    \
+        (buf)->allocated = 0;                                                  \
+        (buf)->used = 0;                                                       \
+        (buf)->string = 0;                                                     \
+        (buf)->heap = 0;                                                       \
+    } while (0)
+
+#define __gf_buf_alloc_minimal(buf)                                            \
+    do {                                                                       \
+        (buf)->data = __gf_alloca(GF_BUF_ROUNDUP);                             \
+        (buf)->allocated = GF_BUF_ROUNDUP;                                     \
+        (buf)->heap = 0;                                                       \
+    } while (0)
+
+#define gf_buf_clear_string(buf)                                               \
+    do {                                                                       \
+        if ((buf)->allocated == 0)                                             \
+            __gf_buf_alloc_minimal(buf);                                       \
+        (buf)->data[0] = '\0';                                                 \
+        (buf)->used = 1;                                                       \
+        (buf)->string = 1;                                                     \
+    } while (0)
+
+#define gf_buf_clear_data(buf)                                                 \
+    do {                                                                       \
+        if ((buf)->allocated == 0)                                             \
+            __gf_buf_alloc_minimal(buf);                                       \
+        memset((buf)->data, 0, (buf)->allocated);                              \
+        (buf)->used = 0;                                                       \
+        (buf)->string = 0;                                                     \
+    } while (0)
+
+#define gf_buf_copy(dst, src)                                                  \
+    do {                                                                       \
+        if ((dst)->allocated >= (src)->used)                                   \
+            memcpy((dst)->data, (src)->data, (src)->used);                     \
+        else {                                                                 \
+            if ((dst)->heap)                                                   \
+                __gf_buf_free((dst)->data);                                    \
+            __gf_buf_assign((dst), (src)->data, (src)->used);                  \
+        }                                                                      \
+        (dst)->used = (src)->used;                                             \
+        (dst)->string = (src)->string;                                         \
+    } while (0)
+
+#define gf_buf_equal(buf0, buf1)                                               \
+    ((buf0)->used == ((buf1)->used) &&                                         \
+     !memcmp((buf0)->data, (buf1)->data, (buf0)->used))
+
+#define gf_buf_concat(dst, src)                                                \
+    do {                                                                       \
+        char *__tmp = NULL;                                                    \
+        size_t __of = (dst)->string ? 1 : 0;                                   \
+        size_t __sz = (dst)->used + (src)->used - __of, __nr = __sz;           \
+        if ((dst)->allocated >= __sz)                                          \
+            memcpy((dst)->data + (dst)->used - __of, (src)->data,              \
+                   (src)->used);                                               \
+        else {                                                                 \
+            __nr = __gf_buf_roundup(__sz);                                     \
+            if (__nr > GF_BUF_STACK_THRESHOLD)                                 \
+                __tmp = __gf_buf_malloc(__nr);                                 \
+            else                                                               \
+                __tmp = __gf_alloca(__nr);                                     \
+            memcpy(__tmp, (dst)->data, (dst)->used - __of);                    \
+            memcpy(__tmp + (dst)->used - __of, (src)->data, (src)->used);      \
+            if ((dst)->heap)                                                   \
+                __gf_buf_free((dst)->data);                                    \
+            (dst)->data = __tmp;                                               \
+            (dst)->heap = !!(__nr > GF_BUF_STACK_THRESHOLD);                   \
+            (dst)->allocated = __nr;                                           \
+        }                                                                      \
+        (dst)->used = __sz;                                                    \
+        (dst)->string = (src)->string;                                         \
+    } while (0)
+
+#define gf_buf_concat_string(buf, str)                                         \
+    do {                                                                       \
+        char *__tmp = NULL;                                                    \
+        size_t __of = (buf)->string ? 1 : 0, __ln = strlen(str) + 1;           \
+        size_t __sz = (buf)->used + strlen(str) + ((buf)->string ? 0 : 1),     \
+               __nr = __sz;                                                    \
+        if ((buf)->allocated >= __sz)                                          \
+            memcpy((buf)->data + (buf)->used - __of, (str), __ln);             \
+        else {                                                                 \
+            __nr = __gf_buf_roundup(__sz);                                     \
+            if (__nr > GF_BUF_STACK_THRESHOLD)                                 \
+                __tmp = __gf_buf_malloc(__nr);                                 \
+            else                                                               \
+                __tmp = __gf_alloca(__nr);                                     \
+            memcpy(__tmp, (buf)->data, (buf)->used - __of);                    \
+            memcpy(__tmp + (buf)->used - __of, (str), __ln);                   \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            (buf)->data = __tmp;                                               \
+            (buf)->heap = !!(__nr > GF_BUF_STACK_THRESHOLD);                   \
+            (buf)->allocated = __nr;                                           \
+        }                                                                      \
+        (buf)->used = __sz;                                                    \
+        (buf)->string = 1;                                                     \
+    } while (0)
+
+#define gf_buf_sprintf(buf, ...)                                               \
+    do {                                                                       \
+        size_t __sz = snprintf(NULL, 0, __VA_ARGS__) + 1;                      \
+        if ((buf)->allocated < __sz) {                                         \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            __sz = __gf_buf_roundup(__sz);                                     \
+            if (__sz > GF_BUF_STACK_THRESHOLD) {                               \
+                (buf)->data = __gf_buf_malloc(__sz);                           \
+                (buf)->heap = 1;                                               \
+            } else {                                                           \
+                (buf)->data = __gf_alloca(__sz);                               \
+                (buf)->heap = 0;                                               \
+            }                                                                  \
+            (buf)->allocated = __sz;                                           \
+        }                                                                      \
+        (buf)->used = sprintf((buf)->data, __VA_ARGS__) + 1;                   \
+        (buf)->string = 1;                                                     \
+    } while (0)
+
+#define gf_buf_snprintf(buf, size, ...)                                        \
+    do {                                                                       \
+        size_t __sz = snprintf(NULL, 0, __VA_ARGS__) + 1, __nr;                \
+        if (__sz > (size))                                                     \
+            __sz = (size);                                                     \
+        if ((buf)->allocated < __sz) {                                         \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            __sz = __gf_buf_roundup(__sz);                                     \
+            if (__sz > GF_BUF_STACK_THRESHOLD) {                               \
+                (buf)->data = __gf_buf_malloc(__sz);                           \
+                (buf)->heap = 1;                                               \
+            } else {                                                           \
+                (buf)->data = __gf_alloca(__sz);                               \
+                (buf)->heap = 0;                                               \
+            }                                                                  \
+            (buf)->allocated = __sz;                                           \
+        }                                                                      \
+        __nr = snprintf((buf)->data, (size), __VA_ARGS__) + 1;                 \
+        (buf)->used = (__nr > (size) ? (size) : __nr);                         \
+        (buf)->string = 1;                                                     \
+    } while (0)
+
+#define gf_buf_compact(buf)                                                    \
+    do {                                                                       \
+        size_t __sz = ((buf)->used ? __gf_buf_roundup((buf)->used)             \
+                                   : GF_BUF_ROUNDUP);                          \
+        if ((buf)->allocated > __sz) {                                         \
+            char *__tmp = NULL;                                                \
+            if (__sz > GF_BUF_STACK_THRESHOLD)                                 \
+                __tmp = __gf_buf_malloc(__sz);                                 \
+            else                                                               \
+                __tmp = __gf_alloca(__sz);                                     \
+            memcpy(__tmp, (buf)->data, (buf)->used);                           \
+            if ((buf)->heap)                                                   \
+                __gf_buf_free((buf)->data);                                    \
+            (buf)->data = __tmp;                                               \
+            (buf)->heap = !!(__sz > GF_BUF_STACK_THRESHOLD);                   \
+            (buf)->allocated = __sz;                                           \
+        }                                                                      \
+    } while (0)
+
+#define gf_buf_data(buf) ((buf)->used ? (buf)->data : NULL)
+
+#define gf_buf_data_size(buf) ((buf)->used)
+
+#define gf_buf_copyout(buf)                                                    \
+    ((buf)->used ? gf_memdup((buf)->data, ((buf)->used)) : NULL)
+
+#endif /* _GF_BUF_H_ */

--- a/tests/basic/gf-buf.c
+++ b/tests/basic/gf-buf.c
@@ -1,0 +1,715 @@
+#include <stdio.h>
+#include <assert.h>
+#include <glusterfs/gf-buf.h>
+
+size_t
+gf_required_string_size(char *str)
+{
+    return __gf_buf_roundup(strlen(str) + 1);
+}
+
+size_t
+gf_used_string_size(char *str)
+{
+    return strlen(str) + 1;
+}
+
+unsigned
+gf_heap_allocated(char *str)
+{
+    return gf_required_string_size(str) > GF_BUF_STACK_THRESHOLD;
+}
+
+#define gf_buf_assert_string(buf, _heap, _allocated, _used, _str)              \
+    do {                                                                       \
+        assert((buf)->heap == _heap);                                          \
+        assert((buf)->allocated == _allocated);                                \
+        assert((buf)->string == 1);                                            \
+        assert((buf)->used == _used);                                          \
+        assert(!strcmp((buf)->data, _str));                                    \
+    } while (0)
+
+#define gf_buf_assert_simple(buf, str)                                         \
+    gf_buf_assert_string((buf), gf_heap_allocated(str),                        \
+                         gf_required_string_size(str),                         \
+                         gf_used_string_size(str), (str))
+
+#define gf_buf_assert_data(buf, _heap, _allocated, _used, _data, _size)        \
+    do {                                                                       \
+        assert((buf)->heap == (_heap));                                        \
+        assert((buf)->allocated == (_allocated));                              \
+        assert((buf)->string == 0);                                            \
+        assert((buf)->used == (_used));                                        \
+        if ((_size))                                                           \
+            assert(!memcmp((buf)->data, (_data), (_size)));                    \
+    } while (0)
+
+void
+gf_buf_test_string_basic(void)
+{
+    char big[PATH_MAX];
+
+    gf_buf_decl_string(buf0);
+    gf_buf_decl_init_string(buf1, "test");
+    gf_buf_decl_init_string(buf2, "longlonglonglonglonglonglonglong");
+
+    gf_buf_assert_string(&buf0, 0, 0, 1, "");
+    gf_buf_assert_string(&buf1, 0, 0, 5, "test");
+    gf_buf_assert_string(&buf2, 0, 0, 33, "longlonglonglonglonglonglonglong");
+
+    gf_buf_assign_string(&buf0, "abcdef");
+    gf_buf_assert_simple(&buf0, "abcdef");
+
+    gf_buf_assign_string(&buf1, "0123456789");
+    gf_buf_assert_simple(&buf1, "0123456789");
+
+    memset(big, 'a', PATH_MAX - 1);
+    big[PATH_MAX - 1] = '\0';
+    gf_buf_assign_string(&buf2, big);
+    gf_buf_assert_simple(&buf2, big);
+
+    gf_buf_clear_string(&buf0);
+    gf_buf_assert_string(&buf0, gf_heap_allocated("abcdef"),
+                         gf_required_string_size("abcdef"),
+                         gf_used_string_size(""), "");
+
+    gf_buf_clear_string(&buf1);
+    gf_buf_assert_string(&buf1, gf_heap_allocated("0123456789"),
+                         gf_required_string_size("0123456789"),
+                         gf_used_string_size(""), "");
+
+    gf_buf_clear_string(&buf2);
+    gf_buf_assert_string(&buf2, gf_heap_allocated(big),
+                         gf_required_string_size(big), gf_used_string_size(""),
+                         "");
+}
+
+void
+gf_buf_test_string_compact(void)
+{
+    gf_buf_decl_string(buf0);
+    gf_buf_assert_string(&buf0, 0, 0, 1, "");
+    gf_buf_compact(&buf0);
+    gf_buf_assert_string(&buf0, 0, 0, 1, "");
+
+    gf_buf_assign_string(&buf0, "test");
+    gf_buf_assert_simple(&buf0, "test");
+
+    gf_buf_assign_string(&buf0, "longlonglonglonglonglonglonglong");
+    gf_buf_assert_simple(&buf0, "longlonglonglonglonglonglonglong");
+
+    gf_buf_assign_string(&buf0, "0123456789");
+    gf_buf_assert_string(
+        &buf0, gf_heap_allocated("longlonglonglonglonglonglonglong"),
+        gf_required_string_size("longlonglonglonglonglonglonglong"),
+        gf_used_string_size("0123456789"), "0123456789");
+
+    gf_buf_compact(&buf0);
+    gf_buf_assert_simple(&buf0, "0123456789");
+
+    gf_buf_assign_string(&buf0, "abcd");
+    gf_buf_assert_string(&buf0, gf_heap_allocated("0123456789"),
+                         gf_required_string_size("0123456789"),
+                         gf_used_string_size("abcd"), "abcd");
+
+    gf_buf_compact(&buf0);
+    gf_buf_assert_simple(&buf0, "abcd");
+}
+
+void
+gf_buf_test_string_copy(void)
+{
+    gf_buf_decl_string(buf0);
+    gf_buf_decl_init_string(buf1, "test");
+    gf_buf_decl_init_string(buf2, "longlonglonglonglonglonglonglong");
+
+    gf_buf_copy(&buf0, &buf1);
+    gf_buf_assert_simple(&buf0, "test");
+
+    gf_buf_copy(&buf1, &buf2);
+    gf_buf_assert_simple(&buf1, "longlonglonglonglonglonglonglong");
+
+    gf_buf_copy(&buf2, &buf0);
+    gf_buf_assert_simple(&buf2, "test");
+
+    gf_buf_copy(&buf1, &buf2);
+    gf_buf_assert_string(
+        &buf1, gf_heap_allocated("longlonglonglonglonglonglonglong"),
+        gf_required_string_size("longlonglonglonglonglonglonglong"),
+        gf_used_string_size("test"), "test");
+}
+
+void
+gf_buf_test_string_equal(void)
+{
+    gf_buf_decl_init_string(buf0, "test");
+    gf_buf_decl_init_string(buf1, "test");
+    gf_buf_decl_init_string(buf2, "abcd");
+    gf_buf_decl_init_string(buf3, "testtest");
+    gf_buf_decl_init_string(buf4, "longlonglonglonglonglonglonglong");
+
+    assert(gf_buf_equal(&buf0, &buf1));
+    assert(!gf_buf_equal(&buf0, &buf2));
+    assert(!gf_buf_equal(&buf0, &buf3));
+    assert(!gf_buf_equal(&buf0, &buf4));
+
+    gf_buf_copy(&buf2, &buf0);
+    assert(gf_buf_equal(&buf0, &buf2));
+
+    gf_buf_copy(&buf0, &buf4);
+    assert(gf_buf_equal(&buf0, &buf4));
+
+    gf_buf_copy(&buf1, &buf4);
+    assert(gf_buf_equal(&buf1, &buf4));
+
+    gf_buf_copy(&buf2, &buf4);
+    assert(gf_buf_equal(&buf2, &buf4));
+
+    gf_buf_copy(&buf3, &buf4);
+    assert(gf_buf_equal(&buf3, &buf4));
+
+    assert(gf_buf_equal(&buf4, &buf4));
+}
+
+void
+gf_buf_test_string_concat(void)
+{
+    char big0[PATH_MAX], big1[PATH_MAX], big2[PATH_MAX], out[PATH_MAX * 3];
+
+    gf_buf_decl_string(buf0);
+    gf_buf_decl_string(buf1);
+    gf_buf_decl_init_string(buf2, "test");
+
+    gf_buf_concat(&buf0, &buf1);
+    gf_buf_assert_simple(&buf0, "");
+
+    gf_buf_concat(&buf0, &buf2);
+    gf_buf_assert_simple(&buf0, "test");
+
+    gf_buf_assign_string(&buf0, "x");
+    gf_buf_assert_string(&buf0, gf_heap_allocated("test"),
+                         gf_required_string_size("test"),
+                         gf_used_string_size("x"), "x");
+
+    gf_buf_concat_string(&buf0, "yz");
+    gf_buf_assert_string(&buf0, gf_heap_allocated("test"),
+                         gf_required_string_size("test"),
+                         gf_used_string_size("xyz"), "xyz");
+
+    gf_buf_concat_string(&buf0, "0123456789");
+    gf_buf_assert_simple(&buf0, "xyz0123456789");
+
+    gf_buf_assign_string(&buf0, "abcd");
+    gf_buf_assign_string(&buf1, "1234");
+    gf_buf_assign_string(&buf2, "xyzt");
+    gf_buf_concat(&buf0, &buf1);
+    gf_buf_concat(&buf0, &buf2);
+    gf_buf_assert_string(&buf0, gf_heap_allocated("xyz0123456789"),
+                         gf_required_string_size("xyz0123456789"),
+                         gf_used_string_size("abcd1234xyzt"), "abcd1234xyzt");
+
+    memset(big0, 'a', PATH_MAX - 1);
+    big0[PATH_MAX - 1] = '\0';
+    memset(big1, 'b', PATH_MAX - 1);
+    big1[PATH_MAX - 1] = '\0';
+    memset(big2, 'c', PATH_MAX - 1);
+    big2[PATH_MAX - 1] = '\0';
+    out[0] = '\0';
+
+    gf_buf_assign_string(&buf0, big0);
+    gf_buf_assert_simple(&buf0, big0);
+
+    gf_buf_assign_string(&buf1, big1);
+    gf_buf_assert_simple(&buf1, big1);
+
+    gf_buf_assign_string(&buf2, big2);
+    gf_buf_assert_simple(&buf2, big2);
+
+    strcat(out, big0);
+    strcat(out, big1);
+    strcat(out, big2);
+
+    gf_buf_concat(&buf0, &buf1);
+    gf_buf_concat(&buf0, &buf2);
+    gf_buf_assert_simple(&buf0, out);
+}
+
+void
+gf_buf_test_sprintf(void)
+{
+    char *p = "oops";
+    int x = 123, y = 0xaaaabbbb;
+
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_string(buf1);
+    gf_buf_decl_init_string(buf2, "test");
+    gf_buf_decl_init_string(buf3, "abcd0123");
+
+    gf_buf_sprintf(&buf0, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf0, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_sprintf(&buf1, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf1, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_sprintf(&buf2, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf2, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_assign_string(&buf3, "longlonglonglonglonglonglonglonglong");
+    gf_buf_sprintf(&buf3, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_string(
+        &buf3, gf_heap_allocated("longlonglonglonglonglonglonglonglong"),
+        gf_required_string_size("longlonglonglonglonglonglonglonglong"),
+        gf_used_string_size("x = 123 y = 0xaaaabbbb p = oops"),
+        "x = 123 y = 0xaaaabbbb p = oops");
+
+    assert(gf_buf_equal(&buf0, &buf1));
+    assert(gf_buf_equal(&buf1, &buf2));
+    assert(gf_buf_equal(&buf2, &buf3));
+
+    gf_buf_reset(&buf0);
+    gf_buf_reset(&buf1);
+    gf_buf_reset(&buf2);
+    gf_buf_reset(&buf3);
+
+    gf_buf_sprintf(&buf0, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf0, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_sprintf(&buf1, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf1, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_sprintf(&buf2, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf2, "x = 123 y = 0xaaaabbbb p = oops");
+
+    gf_buf_sprintf(&buf3, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf3, "x = 123 y = 0xaaaabbbb p = oops");
+
+    assert(gf_buf_equal(&buf0, &buf1));
+    assert(gf_buf_equal(&buf1, &buf2));
+    assert(gf_buf_equal(&buf2, &buf3));
+}
+
+void
+gf_buf_test_snprintf(void)
+{
+    char *p = "oops";
+    int x = 123, y = 0xaaaabbbb;
+
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_string(buf1);
+    gf_buf_decl_init_string(buf2, "longlonglonglonglonglonglonglonglong");
+
+    gf_buf_snprintf(&buf0, 8, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf0, "x = 123");
+
+    gf_buf_snprintf(&buf1, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf1, "x = 123 y = 0xaaaabbbb");
+
+    gf_buf_snprintf(&buf2, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf2, "x = 123 y = 0xaaaabbbb");
+
+    assert(gf_buf_equal(&buf1, &buf2));
+
+    gf_buf_reset(&buf0);
+    gf_buf_reset(&buf1);
+    gf_buf_reset(&buf2);
+
+    gf_buf_snprintf(&buf0, 8, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf0, "x = 123");
+
+    gf_buf_snprintf(&buf1, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf1, "x = 123 y = 0xaaaabbbb");
+
+    gf_buf_snprintf(&buf2, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_assert_simple(&buf2, "x = 123 y = 0xaaaabbbb");
+
+    assert(gf_buf_equal(&buf1, &buf2));
+}
+
+void
+gf_buf_test_string_null(void)
+{
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_null(buf1);
+    gf_buf_decl_null(buf2);
+    gf_buf_decl_string(buf3);
+    gf_buf_decl_init_string(buf4, "test");
+
+    gf_buf_assign_string(&buf0, "abcd");
+    gf_buf_copy(&buf1, &buf3);
+    gf_buf_copy(&buf2, &buf4);
+
+    gf_buf_assert_simple(&buf0, "abcd");
+    gf_buf_assert_simple(&buf1, "");
+    gf_buf_assert_simple(&buf2, "test");
+
+    assert(gf_buf_equal(&buf1, &buf3));
+    assert(gf_buf_equal(&buf2, &buf4));
+}
+
+void
+gf_buf_test_string_copyout(void)
+{
+    char *p, *q, *r;
+
+    gf_buf_decl_init_string(buf0, "abcd");
+    gf_buf_decl_string(buf1);
+    gf_buf_decl_null(buf2);
+
+    p = gf_buf_copyout(&buf0);
+    assert(!strcmp(p, "abcd"));
+    GF_FREE(p);
+
+    q = gf_buf_copyout(&buf1);
+    assert(!strcmp(q, ""));
+    GF_FREE(q);
+
+    r = gf_buf_copyout(&buf2);
+    assert(r == NULL);
+}
+
+void
+gf_buf_test_data_basic(void)
+{
+    int i;
+    char data0[] = {0xa0, 0xa1, 0xa2, 0xa3};
+    char data1[] = {0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+                    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf};
+    char data2[32], data3[64], zero[64];
+
+    memset(zero, 0, sizeof(zero));
+
+    for (i = 0; i < sizeof(data2); i++)
+        data2[i] = 0xc0 + i;
+
+    for (i = 0; i < sizeof(data3); i++)
+        data3[i] = 0xd0 + i;
+
+    gf_buf_decl_init_data(buf0, data0, sizeof(data0));
+    gf_buf_decl_init_data(buf1, data1, sizeof(data1));
+
+    gf_buf_assert_data(&buf0, 0, 0, sizeof(data0), data0, sizeof(data0));
+    gf_buf_assert_data(&buf1, 0, 0, sizeof(data1), data1, sizeof(data1));
+
+    gf_buf_assign_data(&buf0, data2, sizeof(data2));
+    gf_buf_assign_data(&buf1, data3, sizeof(data3));
+
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(data2)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data2)), sizeof(data2), data2, sizeof(data2));
+    gf_buf_assert_data(
+        &buf1, __gf_buf_roundup(sizeof(data3)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data3)), sizeof(data3), data3, sizeof(data3));
+
+    gf_buf_clear_data(&buf0);
+    gf_buf_assert_data(&buf0,
+                       __gf_buf_roundup(sizeof(data2)) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(sizeof(data2)), 0, zero, sizeof(data2));
+
+    gf_buf_clear_data(&buf1);
+    gf_buf_assert_data(&buf1,
+                       __gf_buf_roundup(sizeof(data3)) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(sizeof(data3)), 0, zero, sizeof(data3));
+}
+
+void
+gf_buf_test_data_compact(void)
+{
+    char small[8], medium[32], large[256], huge[32768];
+
+    memset(small, 'a', sizeof(small));
+    memset(medium, 'b', sizeof(medium));
+    memset(large, 'c', sizeof(large));
+    memset(huge, 'd', sizeof(huge));
+
+    gf_buf_decl_null(buf0);
+
+    gf_buf_assign_data(&buf0, huge, sizeof(huge));
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(huge)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(huge)), sizeof(huge), huge, sizeof(huge));
+
+    /* Compact huge -> large */
+    gf_buf_assign_data(&buf0, large, sizeof(large));
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(huge)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(huge)), sizeof(large), large, sizeof(large));
+    gf_buf_compact(&buf0);
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(large)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(large)), sizeof(large), large, sizeof(large));
+
+    /* Compact large -> medium */
+    gf_buf_assign_data(&buf0, medium, sizeof(medium));
+    gf_buf_assert_data(&buf0,
+                       __gf_buf_roundup(sizeof(large)) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(sizeof(large)), sizeof(medium), medium,
+                       sizeof(medium));
+    gf_buf_compact(&buf0);
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(medium)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(medium)), sizeof(medium), medium,
+        sizeof(medium));
+
+    /* Compact medium -> small */
+    gf_buf_assign_data(&buf0, small, sizeof(small));
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(medium)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(medium)), sizeof(small), small, sizeof(small));
+    gf_buf_compact(&buf0);
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(small)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(small)), sizeof(small), small, sizeof(small));
+}
+
+void
+gf_buf_test_data_copy(void)
+{
+    char data1[8], data2[64];
+
+    memset(data1, 'a', sizeof(data1));
+    memset(data2, 'b', sizeof(data2));
+
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_init_data(buf1, data1, sizeof(data1));
+    gf_buf_decl_init_data(buf2, data2, sizeof(data2));
+
+    gf_buf_copy(&buf0, &buf1);
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(data1)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data1)), sizeof(data1), data1, sizeof(data1));
+
+    gf_buf_copy(&buf1, &buf2);
+    gf_buf_assert_data(
+        &buf1, __gf_buf_roundup(sizeof(data2)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data2)), sizeof(data2), data2, sizeof(data2));
+
+    gf_buf_copy(&buf2, &buf0);
+    gf_buf_assert_data(
+        &buf2, __gf_buf_roundup(sizeof(data1)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data1)), sizeof(data1), data1, sizeof(data1));
+
+    gf_buf_copy(&buf1, &buf2);
+    gf_buf_assert_data(
+        &buf1, __gf_buf_roundup(sizeof(data2)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data2)), sizeof(data1), data1, sizeof(data1));
+}
+
+void
+gf_buf_test_data_equal(void)
+{
+    char data0[4], data1[4], data2[4], data3[8], data4[64];
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data1, 0xa, sizeof(data1));
+    memset(data2, 0xb, sizeof(data2));
+    memset(data3, 0xc, sizeof(data3));
+    memset(data4, 0xd, sizeof(data4));
+
+    gf_buf_decl_init_data(buf0, data0, sizeof(data0));
+    gf_buf_decl_init_data(buf1, data1, sizeof(data1));
+    gf_buf_decl_init_data(buf2, data2, sizeof(data2));
+    gf_buf_decl_init_data(buf3, data3, sizeof(data3));
+    gf_buf_decl_init_data(buf4, data4, sizeof(data4));
+
+    assert(gf_buf_equal(&buf0, &buf1));
+    assert(!gf_buf_equal(&buf0, &buf2));
+    assert(!gf_buf_equal(&buf0, &buf3));
+    assert(!gf_buf_equal(&buf0, &buf4));
+
+    gf_buf_copy(&buf2, &buf0);
+    assert(gf_buf_equal(&buf0, &buf2));
+
+    gf_buf_copy(&buf0, &buf4);
+    assert(gf_buf_equal(&buf0, &buf4));
+
+    gf_buf_copy(&buf1, &buf4);
+    assert(gf_buf_equal(&buf1, &buf4));
+
+    gf_buf_copy(&buf2, &buf4);
+    assert(gf_buf_equal(&buf2, &buf4));
+
+    gf_buf_copy(&buf3, &buf4);
+    assert(gf_buf_equal(&buf3, &buf4));
+
+    assert(gf_buf_equal(&buf4, &buf4));
+}
+
+void
+gf_buf_test_data_concat()
+{
+    size_t size;
+    char ignored[8];
+    char data0[8], data1[32], data2[256], data3[32768],
+        total[8 + 32 + 256 + 32768];
+
+    memset(ignored, 0x0, sizeof(ignored));
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data1, 0xb, sizeof(data1));
+    memset(data2, 0xc, sizeof(data2));
+    memset(data3, 0xd, sizeof(data3));
+
+    gf_buf_decl_init_data(buf0, data0, sizeof(data0));
+    gf_buf_decl_init_data(buf1, data1, sizeof(data1));
+    gf_buf_decl_init_data(buf2, data2, sizeof(data2));
+    gf_buf_decl_init_data(buf3, data3, sizeof(data3));
+
+    memcpy(total, data0, sizeof(data0));
+    memcpy(total + sizeof(data0), data1, sizeof(data1));
+    gf_buf_concat(&buf0, &buf1);
+    size = sizeof(data0) + sizeof(data1);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), size, total, size);
+
+    memcpy(total + sizeof(data0) + sizeof(data1), data2, sizeof(data2));
+    gf_buf_concat(&buf0, &buf2);
+    size = sizeof(data0) + sizeof(data1) + sizeof(data2);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), size, total, size);
+
+    memcpy(total + sizeof(data0) + sizeof(data1) + sizeof(data2), data3,
+           sizeof(data3));
+    gf_buf_concat(&buf0, &buf3);
+    size = sizeof(data0) + sizeof(data1) + sizeof(data2) + sizeof(data3);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), size, total, size);
+
+    gf_buf_clear_data(&buf0);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), 0, ignored, 0);
+    gf_buf_clear_data(&buf1);
+    gf_buf_assert_data(&buf1, GF_BUF_ROUNDUP > GF_BUF_STACK_THRESHOLD,
+                       GF_BUF_ROUNDUP, 0, ignored, 0);
+
+    gf_buf_concat(&buf0, &buf1);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), 0, ignored, 0);
+
+    gf_buf_compact(&buf0);
+    gf_buf_assert_data(&buf0, GF_BUF_ROUNDUP > GF_BUF_STACK_THRESHOLD,
+                       GF_BUF_ROUNDUP, 0, ignored, 0);
+}
+
+void
+gf_buf_test_data_null()
+{
+    char data0[4], data3[16], data4[64];
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data3, 0xb, sizeof(data3));
+    memset(data4, 0xc, sizeof(data4));
+
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_null(buf1);
+    gf_buf_decl_null(buf2);
+    gf_buf_decl_init_data(buf3, data3, sizeof(data3));
+    gf_buf_decl_init_data(buf4, data4, sizeof(data4));
+
+    gf_buf_assign_data(&buf0, data0, sizeof(data0));
+    gf_buf_copy(&buf1, &buf3);
+    gf_buf_copy(&buf2, &buf4);
+
+    gf_buf_assert_data(
+        &buf0, __gf_buf_roundup(sizeof(data0)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data0)), sizeof(data0), data0, sizeof(data0));
+    gf_buf_assert_data(
+        &buf1, __gf_buf_roundup(sizeof(data3)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data3)), sizeof(data3), data3, sizeof(data3));
+    gf_buf_assert_data(
+        &buf2, __gf_buf_roundup(sizeof(data4)) > GF_BUF_STACK_THRESHOLD,
+        __gf_buf_roundup(sizeof(data4)), sizeof(data4), data4, sizeof(data4));
+
+    assert(gf_buf_equal(&buf1, &buf3));
+    assert(gf_buf_equal(&buf2, &buf4));
+}
+
+void
+gf_buf_test_data_copyout()
+{
+    char data0[16], data1[64], *d0, *d1, *null;
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data1, 0xb, sizeof(data1));
+
+    gf_buf_decl_init_data(buf0, data0, sizeof(data0));
+    gf_buf_decl_init_data(buf1, data1, sizeof(data1));
+    gf_buf_decl_null(buf2);
+
+    d0 = gf_buf_copyout(&buf0);
+    assert(!memcmp(d0, data0, sizeof(data0)));
+    GF_FREE(d0);
+
+    d1 = gf_buf_copyout(&buf1);
+    assert(!memcmp(d1, data1, sizeof(data1)));
+    GF_FREE(d1);
+
+    null = gf_buf_copyout(&buf2);
+    assert(null == NULL);
+}
+
+void
+gf_buf_test_misc(void)
+{
+    size_t size;
+    char data[16];
+
+    memset(data, '!', sizeof(data));
+
+    gf_buf_decl_null(buf0);
+    gf_buf_decl_null(buf1);
+
+    gf_buf_assign_data(&buf0, data, sizeof(data));
+    gf_buf_assign_string(&buf1, "test");
+
+    /* data + string -> string */
+    gf_buf_concat(&buf0, &buf1);
+    gf_buf_assert_simple(&buf0, "!!!!!!!!!!!!!!!!test");
+
+    gf_buf_reset(&buf0);
+    gf_buf_reset(&buf1);
+
+    gf_buf_assign_string(&buf0, "test");
+    gf_buf_assign_data(&buf1, data, sizeof(data));
+
+    /* string + data -> data */
+    gf_buf_concat(&buf0, &buf1);
+    size = strlen("test") + sizeof(data);
+    gf_buf_assert_data(&buf0, __gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD,
+                       __gf_buf_roundup(size), size, "test!!!!!!!!!!!!!!!!",
+                       size);
+
+    gf_buf_reset(&buf0);
+    gf_buf_reset(&buf1);
+
+    gf_buf_assign_data(&buf0, data, sizeof(data));
+    gf_buf_concat_string(&buf0, "test");
+
+    /* data + C string -> C string */
+    gf_buf_assert_simple(&buf0, "!!!!!!!!!!!!!!!!test");
+}
+
+int
+main(int argc, char *argv[])
+{
+    gf_buf_test_string_basic();
+    gf_buf_test_string_compact();
+    gf_buf_test_string_copy();
+    gf_buf_test_string_equal();
+    gf_buf_test_string_concat();
+    gf_buf_test_string_null();
+    gf_buf_test_string_copyout();
+
+    gf_buf_test_sprintf();
+    gf_buf_test_snprintf();
+
+    gf_buf_test_data_basic();
+    gf_buf_test_data_compact();
+    gf_buf_test_data_copy();
+    gf_buf_test_data_equal();
+    gf_buf_test_data_concat();
+    gf_buf_test_data_null();
+    gf_buf_test_data_copyout();
+
+    gf_buf_test_misc();
+    return 0;
+}

--- a/tests/basic/gf-buf.t.in
+++ b/tests/basic/gf-buf.t.in
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+
+TEST build_tester $(dirname $0)/gf-buf.c \
+     -DGF_BUF_STACK_THRESHOLD=16 -DGF_BUF_ROUNDUP=8 \
+     -include @abs_top_builddir@/config.h \
+     @CFLAGS@ @GF_CFLAGS@ -lglusterfs
+TEST $(dirname $0)/gf-buf
+rm -f $(dirname $0)/gf-buf


### PR DESCRIPTION
Generic buffer is the simple concept to implement basic operations
on the memory area of the known size. Basically the buffer is just
a pair of raw C pointer and size; if the last byte of the pointed
area is '\0', this area can be treated as a C string.

Generic buffers are intended to be a function- or block-scoped, and
provides simple API mostly covers initialization, copying, clearing,
concatenation and basic formatted output.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

