### PR TITLE
libglusterfs: generic buffer infrastructure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,11 +21,13 @@ CLEANFILES = glusterfs-api.pc libgfchangelog.pc contrib/umountd/Makefile
 
 clean-local:
 	find . -name '*.o' -o -name '*.lo' -o -name '.Po' | xargs rm -f
+	rm -fv tests/basic/gf-buf
 
 gitclean: distclean
 	find . -name Makefile.in -exec rm -f {} \;
 	find . -name mount.glusterfs -exec rm -f {} \;
 	find . -name .deps -o -name .libs | xargs rm -rf
+	rm -fv tests/basic/gf-buf.t
 	rm -fr autom4te.cache
 	rm -f missing aclocal.m4 config.h.in config.guess config.sub ltmain.sh install-sh configure depcomp
 

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,7 @@ AC_CONFIG_FILES([Makefile
                 heal/Makefile
                 heal/src/Makefile
                 glusterfs.spec
+                tests/basic/gf-buf.t
                 tools/glusterfind/src/tool.conf
                 tools/glusterfind/glusterfind
                 tools/glusterfind/Makefile
@@ -999,6 +1000,32 @@ if test x$STATIC_ASSERT = "xyes"; then
    AC_DEFINE(HAVE_STATIC_ASSERT, 1, [Define if C11 _Static_assert is supported.])
 fi
 
+dnl Check for __attribute__((__cleanup__(f))). Since gcc
+dnl warns on unknown attribute, force -Werror=attributes.
+saved_CFLAGS=$CFLAGS
+CFLAGS="-Werror=attributes"
+AC_MSG_CHECKING([whether $CC supports __attribute__((__cleanup__))])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [[struct s { int x; }; void f(struct s *s) {}]],
+   [[struct s v __attribute__((__cleanup__(f)));]])],
+[CLEANUP=yes], [CLEANUP=no])
+AC_MSG_RESULT([$CLEANUP])
+CFLAGS="$saved_CFLAGS"
+if test x$CLEANUP != "xyes"; then
+   AC_MSG_ERROR([__attribute__((__cleanup__)) is not supported, exiting.])
+fi
+
+dnl Check for __builtin_alloca_with_align.
+AC_MSG_CHECKING([whether $CC supports __builtin_alloca_with_align])
+AC_TRY_LINK([], [void *p = __builtin_alloca_with_align(64, 64);],
+            [HAVE_BUILTIN_ALLOCA_WITH_ALIGN=yes],
+            [HAVE_BUILTIN_ALLOCA_WITH_ALIGN=no])
+AC_MSG_RESULT([$HAVE_BUILTIN_ALLOCA_WITH_ALIGN])
+if test x$HAVE_BUILTIN_ALLOCA_WITH_ALIGN = "xyes"; then
+   AC_DEFINE(HAVE_BUILTIN_ALLOCA_WITH_ALIGN, 1,
+      [Define if the compiler supports __builtin_alloca_with_align() function.])
+fi
+
 if test "x${have_backtrace}" != "xyes"; then
 AC_TRY_COMPILE([#include <math.h>], [double x=0.0; x=ceil(0.0);],
    [],
@@ -1722,7 +1749,7 @@ esac
 CONTRIBDIR='$(top_srcdir)/contrib'
 AC_SUBST(CONTRIBDIR)
 
-GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS)'
+GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE'
 GF_CPPINCLUDES='-include $(top_builddir)/config.h -include $(top_builddir)/site.h -I$(top_srcdir)/libglusterfs/src -I$(top_builddir)/libglusterfs/src'
 if test "x${USE_CONTRIB_URCU}" = "xyes"; then
     GF_CPPINCLUDES="${GF_CPPINCLUDES} -I\$(CONTRIBDIR)/userspace-rcu"
@@ -1731,10 +1758,16 @@ GF_CPPFLAGS="$GF_CPPFLAGS $GF_CPPDEFINES $GF_CPPINCLUDES"
 AC_SUBST([GF_CPPFLAGS])
 
 AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
+if  test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS"; then
+    AC_DEFINE(GF_LINUX_HOST_OS, 1, [Configured on Linux OS.])
+fi
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
+if  test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS"; then
+    AC_DEFINE(GF_DARWIN_HOST_OS, 1, [Configured on Darwin OS.])
+fi
 AM_CONDITIONAL([GF_BSD_HOST_OS], test "${GF_HOST_OS}" = "GF_BSD_HOST_OS")
 if  test "${GF_HOST_OS}" = "GF_BSD_HOST_OS"; then
-    AC_DEFINE(GF_BSD_HOST_OS, 1, [This is a BSD compatible OS.])
+    AC_DEFINE(GF_BSD_HOST_OS, 1, [Configured on a BSD-compatible OS.])
 fi
 
 AC_SUBST(GLUSTERD_WORKDIR)

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -72,7 +72,7 @@ libglusterfs_la_HEADERS = glusterfs/common-utils.h glusterfs/defaults.h \
 	glusterfs/quota-common-utils.h glusterfs/rot-buffs.h \
 	glusterfs/compat-uuid.h glusterfs/upcall-utils.h glusterfs/throttle-tbf.h \
 	glusterfs/events.h glusterfs/atomic.h glusterfs/monitoring.h \
-	glusterfs/async.h glusterfs/glusterfs-fops.h
+	glusterfs/async.h glusterfs/glusterfs-fops.h glusterfs/gf-buf.h
 
 libglusterfs_ladir = $(includedir)/glusterfs
 

--- a/libglusterfs/src/glusterfs/gf-buf.h
+++ b/libglusterfs/src/glusterfs/gf-buf.h
@@ -1,0 +1,456 @@
+#ifndef _GF_BUF_H_
+#define _GF_BUF_H_
+
+#include "glusterfs/common-utils.h"
+
+#ifndef GF_BUF_STACK_THRESHOLD
+#define GF_BUF_STACK_THRESHOLD 64
+#endif
+
+#ifndef GF_BUF_ROUNDUP
+#define GF_BUF_ROUNDUP 16
+#endif
+
+#ifndef GF_ALLOCA_ALIGN
+#define GF_ALLOCA_ALIGN 16
+#endif
+
+typedef struct gf_buf {
+    unsigned long heap : 1;
+    unsigned long allocated : __BITS_PER_LONG - 1;
+    unsigned long string : 1;
+    unsigned long used : __BITS_PER_LONG - 1;
+    char *data;
+} gf_buf_t;
+
+static inline void *
+__gf_buf_malloc(size_t size)
+{
+    return GF_MALLOC((size), gf_common_mt_char);
+}
+
+static inline void
+__gf_buf_free(void *ptr)
+{
+    GF_FREE(ptr);
+}
+
+static inline void
+__gf_buf_cleanup(struct gf_buf *buf)
+{
+    if (buf->heap)
+        __gf_buf_free(buf->data);
+}
+
+static inline size_t
+__gf_buf_roundup(size_t size)
+{
+    return (size + (GF_BUF_ROUNDUP - 1)) & (-GF_BUF_ROUNDUP);
+}
+
+#ifdef HAVE_BUILTIN_ALLOCA_WITH_ALIGN
+
+#define __gf_buf_alloca(size)                                                  \
+    __builtin_alloca_with_align((size), GF_ALLOCA_ALIGN * CHAR_BIT)
+
+#else /* not HAVE_BUILTIN_ALLOCA_WITH_ALIGN */
+
+#define __gf_buf_alloca(size) __builtin_alloca(size)
+
+#endif /* HAVE_BUILTIN_ALLOCA_WITH_ALIGN */
+
+#define gf_buf_decl_null(var, size)                                            \
+    gf_buf_t var __attribute__((__cleanup__(__gf_buf_cleanup))) = {            \
+        !!(__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD),                   \
+        __gf_buf_roundup(size), 0, 0,                                          \
+        (__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD)                      \
+            ? ({                                                               \
+                  char *__tmp = __gf_buf_malloc(__gf_buf_roundup(size));       \
+                  if (__tmp)                                                   \
+                      memset(__tmp, 0, (size));                                \
+                  __tmp;                                                       \
+              })                                                               \
+            : ({                                                               \
+                  char *__tmp = __gf_buf_alloca(__gf_buf_roundup(size));       \
+                  memset(__tmp, 0, (size));                                    \
+                  __tmp;                                                       \
+              })}
+
+#define gf_buf_decl_string(var, size)                                          \
+    gf_buf_t var __attribute__((__cleanup__(__gf_buf_cleanup))) = {            \
+        !!(__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD),                   \
+        __gf_buf_roundup(size), 1, 1,                                          \
+        (__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD)                      \
+            ? ({                                                               \
+                  char *__tmp = __gf_buf_malloc(__gf_buf_roundup(size));       \
+                  if (__tmp)                                                   \
+                      *__tmp = '\0';                                           \
+                  __tmp;                                                       \
+              })                                                               \
+            : ({                                                               \
+                  char *__tmp = __gf_buf_alloca(__gf_buf_roundup(size));       \
+                  *__tmp = '\0';                                               \
+                  __tmp;                                                       \
+              })}
+
+#define gf_buf_decl_string_init(var, size, string)                             \
+    gf_buf_t var __attribute__((__cleanup__(__gf_buf_cleanup))) = {            \
+        !!(__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD),                   \
+        __gf_buf_roundup(size), 1, strlen(string) + 1,                         \
+        (__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD)                      \
+            ? ({                                                               \
+                  char *__tmp = __gf_buf_malloc(__gf_buf_roundup(size));       \
+                  if (__tmp)                                                   \
+                      memcpy(__tmp, (string), strlen(string) + 1);             \
+                  __tmp;                                                       \
+              })                                                               \
+            : ({                                                               \
+                  char *__tmp = __gf_buf_alloca(__gf_buf_roundup(size));       \
+                  memcpy(__tmp, (string), strlen(string) + 1);                 \
+                  __tmp;                                                       \
+              })}
+
+#define gf_buf_decl_data_init(var, size, data, datasize)                       \
+    gf_buf_t var __attribute__((__cleanup__(__gf_buf_cleanup))) = {            \
+        !!(__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD),                   \
+        __gf_buf_roundup(size), 0, (datasize),                                 \
+        (__gf_buf_roundup(size) > GF_BUF_STACK_THRESHOLD)                      \
+            ? ({                                                               \
+                  char *__tmp = __gf_buf_malloc(__gf_buf_roundup(size));       \
+                  if (__tmp)                                                   \
+                      memcpy(__tmp, (data), (datasize));                       \
+                  __tmp;                                                       \
+              })                                                               \
+            : ({                                                               \
+                  char *__tmp = __gf_buf_alloca(__gf_buf_roundup(size));       \
+                  memcpy(__tmp, (data), (datasize));                           \
+                  __tmp;                                                       \
+              })}
+
+static inline int
+gf_buf_error(gf_buf_t *buf)
+{
+    return buf->data == NULL;
+}
+
+static inline char *
+gf_buf_data(gf_buf_t *buf)
+{
+    return buf->used ? buf->data : NULL;
+}
+
+static inline size_t
+gf_buf_data_size(gf_buf_t *buf)
+{
+    return buf->used;
+}
+
+static inline char *
+gf_buf_copyout(gf_buf_t *buf)
+{
+    return buf->used ? gf_memdup(buf->data, buf->used) : NULL;
+}
+
+static inline void
+gf_buf_reset(gf_buf_t *buf)
+{
+    if (buf->heap)
+        __gf_buf_free(buf->data);
+    buf->data = NULL;
+    buf->allocated = 0;
+    buf->used = 0;
+    buf->string = 0;
+    buf->heap = 0;
+}
+
+static inline int
+__gf_buf_alloc_minimal(gf_buf_t *buf)
+{
+    buf->data = __gf_buf_malloc(GF_BUF_ROUNDUP);
+    if (buf->data) {
+        buf->allocated = GF_BUF_ROUNDUP;
+        buf->heap = 1;
+        return 0;
+    }
+    return 1;
+}
+
+static inline void
+gf_buf_clear_string(gf_buf_t *buf)
+{
+    if (buf->allocated == 0)
+        if (__gf_buf_alloc_minimal(buf))
+            return;
+    buf->data[0] = '\0';
+    buf->used = 1;
+    buf->string = 1;
+}
+
+static inline void
+gf_buf_clear_data(gf_buf_t *buf)
+{
+    if (buf->allocated == 0)
+        if (__gf_buf_alloc_minimal(buf))
+            return;
+    memset(buf->data, 0, buf->allocated);
+    buf->used = 0;
+    buf->string = 0;
+}
+
+static inline int
+__gf_buf_assign(gf_buf_t *buf, char *ptr, size_t size)
+{
+    size_t __sz = __gf_buf_roundup(size);
+
+    if (__sz > buf->allocated) {
+        buf->data = __gf_buf_malloc(__sz);
+        if (buf->data) {
+            memcpy(buf->data, ptr, size);
+            buf->allocated = __sz;
+            buf->heap = 1;
+            return 0;
+        } else
+            buf->allocated = 0;
+    }
+    return 1;
+}
+
+static inline void
+gf_buf_assign_string(gf_buf_t *buf, char *str)
+{
+    size_t __sz = strlen(str) + 1;
+
+    if (buf->allocated >= __sz)
+        memcpy(buf->data, str, __sz);
+    else {
+        if (buf->heap)
+            __gf_buf_free(buf->data);
+        if (__gf_buf_assign(buf, str, __sz))
+            return;
+    }
+    buf->used = __sz;
+    buf->string = 1;
+}
+
+static inline void
+gf_buf_assign_data(gf_buf_t *buf, char *ptr, size_t size)
+{
+    if (buf->allocated >= size)
+        memcpy(buf->data, ptr, size);
+    else {
+        if (buf->heap)
+            __gf_buf_free(buf->data);
+        if (__gf_buf_assign(buf, ptr, size))
+            return;
+    }
+    buf->used = size;
+    buf->string = 0;
+}
+
+static inline void
+gf_buf_copy(gf_buf_t *dst, gf_buf_t *src)
+{
+    if (dst->allocated >= src->used)
+        memcpy(dst->data, src->data, src->used);
+    else {
+        if (dst->heap)
+            __gf_buf_free(dst->data);
+        if (__gf_buf_assign(dst, src->data, src->used))
+            return;
+    }
+    dst->used = src->used;
+    dst->string = src->string;
+}
+
+static inline int
+gf_buf_equal(gf_buf_t *buf0, gf_buf_t *buf1)
+{
+    return buf0->used == buf1->used &&
+           !memcmp(buf0->data, buf1->data, buf0->used);
+}
+
+static inline int
+gf_buf_join(gf_buf_t *dst, gf_buf_t *src)
+{
+    size_t *__sz;
+
+    if (dst->string || src->string)
+        return 1;
+    __sz = dst->used + src->used;
+
+    if (dst->allocated >= __sz)
+        memcpy(dst->data + dst->used, src->data, src->used);
+    else {
+        size_t __nr = __gf_buf_roundup(__sz);
+        char *__tmp = __gf_buf_malloc(__nr);
+
+        if (__tmp) {
+            memcpy(__tmp, dst->data, dst->used);
+            memcpy(__tmp + dst->used, src->data, src->used);
+            if (dst->heap)
+                __gf_buf_free(dst->data);
+            dst->data = __tmp;
+            dst->heap = 1;
+            dst->allocated = __nr;
+        } else
+            return 1;
+    }
+
+    dst->used = __sz;
+    return 0;
+}
+
+static inline int
+gf_buf_concat(gf_buf_t *dst, gf_buf_t *src)
+{
+    size_t *__sz;
+
+    if (!dst->string || !src->string)
+        return 1;
+    __sz = dst->used + src->used - 1;
+
+    if (dst->allocated >= __sz)
+        memcpy(dst->data + dst->used - 1, src->data, src->used);
+    else {
+        size_t __nr = __gf_buf_roundup(__sz);
+        char *__tmp = __gf_buf_malloc(__nr);
+
+        if (__tmp) {
+            memcpy(__tmp, dst->data, dst->used - 1);
+            memcpy(__tmp + dst->used - 1, src->data, src->used);
+            if (dst->heap)
+                __gf_buf_free(dst->data);
+            dst->data = __tmp;
+            dst->heap = 1;
+            dst->allocated = __nr;
+        } else
+            return 1;
+    }
+
+    dst->used = __sz;
+    return 0;
+}
+
+static inline int
+gf_buf_concat_string(gf_buf_t *dst, char *str)
+{
+    size_t *__sz, __ln;
+
+    if (!dst->string || !str)
+        return 1;
+
+    __ln = strlen(str);
+    __sz = dst->used + __ln;
+
+    if (dst->allocated >= __sz)
+        memcpy(dst->data + dst->used - 1, str, __ln + 1);
+    else {
+        size_t __nr = __gf_buf_roundup(__sz);
+        char *__tmp = __gf_buf_malloc(__nr);
+
+        if (__tmp) {
+            memcpy(__tmp, dst->data, dst->used - 1);
+            memcpy(__tmp + dst->used - 1, str, __ln + 1);
+            if (dst->heap)
+                __gf_buf_free(dst->data);
+            dst->data = __tmp;
+            dst->heap = 1;
+            dst->allocated = __nr;
+        } else
+            return 1;
+    }
+
+    dst->used = __sz;
+    return 0;
+}
+
+static inline int
+gf_buf_sprintf(gf_buf_t *buf, const char *fmt, ...)
+{
+    va_list ap;
+    size_t __sz;
+
+    va_start(ap, fmt);
+    __sz = vsnprintf(NULL, 0, fmt, ap) + 1;
+    va_end(ap);
+
+    if (buf->allocated < __sz) {
+        char *__tmp;
+
+        __sz = __gf_buf_roundup(__sz);
+        __tmp = __gf_buf_malloc(__sz);
+        if (__tmp) {
+            if (buf->heap)
+                __gf_buf_free(buf->data);
+            buf->heap = 1;
+            buf->data = __tmp;
+            buf->allocated = __sz;
+        } else
+            return 1;
+    }
+
+    va_start(ap, fmt);
+    buf->used = vsprintf(buf->data, fmt, ap) + 1;
+    va_end(ap);
+
+    buf->string = 1;
+    return 0;
+}
+
+static inline int
+gf_buf_snprintf(gf_buf_t *buf, size_t size, const char *fmt, ...)
+{
+    va_list ap;
+    size_t __sz, __nr;
+
+    va_start(ap, fmt);
+    __sz = snprintf(NULL, 0, fmt, ap) + 1;
+    va_end(ap);
+
+    if (__sz > size)
+        __sz = size;
+    if (buf->allocated < __sz) {
+        char *__tmp;
+
+        __sz = __gf_buf_roundup(__sz);
+        __tmp = __gf_buf_malloc(__sz);
+        if (__tmp) {
+            if (buf->heap)
+                __gf_buf_free(buf->data);
+            buf->heap = 1;
+            buf->data = __tmp;
+            buf->allocated = __sz;
+        } else
+            return 1;
+    }
+
+    va_start(ap, fmt);
+    __nr = vsnprintf(buf->data, size, fmt, ap) + 1;
+    va_end(ap);
+
+    buf->used = (__nr > size ? size : __nr);
+    buf->string = 1;
+    return 0;
+}
+
+static inline int
+gf_buf_compact(gf_buf_t *buf)
+{
+    size_t __sz = (buf->used ?
+                   __gf_buf_roundup(buf->used) :
+                   GF_BUF_ROUNDUP);
+
+    if (buf->allocated > __sz) {
+        char *__tmp = __gf_buf_malloc(__sz);
+        if (__tmp) {
+            memcpy(__tmp, buf->data, buf->used);
+            if (buf->heap)
+                __gf_buf_free(buf->data);
+            buf->data = __tmp;
+            buf->heap = 1;
+            buf->allocated = __sz;
+        }
+    }
+}
+
+#endif /* _GF_BUF_H_ */

--- a/tests/basic/gf-buf.c
+++ b/tests/basic/gf-buf.c
@@ -1,0 +1,353 @@
+#include <stdio.h>
+#include <assert.h>
+#include <glusterfs/gf-buf.h>
+
+#define __gf_max(x, y) ((x) > (y) ? (x) : (y))
+
+#define __gf_buf_assert_string(__buf, __data, __allocated, __used)             \
+    do {                                                                       \
+        assert(!strcmp((__buf)->data, (__data)));                              \
+        assert((__buf)->string == 1);                                          \
+        assert((__buf)->allocated == __gf_max(GF_BUF_ROUNDUP, (__allocated))); \
+        assert((__buf)->used == __used);                                       \
+    } while (0)
+
+#define __gf_buf_assert_data(__buf, __data, __size, __allocated, __used)       \
+    do {                                                                       \
+        assert(!memcmp((__buf)->data, (__data), (__size)));                    \
+        assert((__buf)->string == 0);                                          \
+        assert((__buf)->allocated == __gf_max(GF_BUF_ROUNDUP, (__allocated))); \
+        assert((__buf)->used == __used);                                       \
+    } while (0)
+
+void
+gf_buf_test_assign_string(void)
+{
+    char data[] = {0xa, 0xb, 0xc, 0xd};
+    char *long0 = "abcdabcdabcdabcdabcdabcdabcdabcd",
+         *long1 =
+             "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd";
+
+    gf_buf_decl_null(buf0, 16);
+    gf_buf_decl_string(buf1, 32);
+    gf_buf_decl_string_init(buf2, 32, "test");
+    gf_buf_decl_string_init(buf3, 64, "longlonglonglonglonglonglonglong");
+    gf_buf_decl_data_init(buf4, 32, data, sizeof(data));
+
+    gf_buf_assign_string(&buf0, "abcdabcd");
+    __gf_buf_assert_string(&buf0, "abcdabcd", 16, strlen("abcdabcd") + 1);
+
+    gf_buf_assign_string(&buf1, "x");
+    __gf_buf_assert_string(&buf1, "x", 32, strlen("x") + 1);
+
+    gf_buf_assign_string(&buf2, long1);
+    __gf_buf_assert_string(&buf2, long1, __gf_buf_roundup(strlen(long1) + 1),
+                           strlen(long1) + 1);
+
+    gf_buf_assign_string(&buf3, long0);
+    __gf_buf_assert_string(&buf3, long0, 64, strlen(long0) + 1);
+
+    gf_buf_assign_string(&buf4, long1);
+    __gf_buf_assert_string(&buf4, long1, __gf_buf_roundup(strlen(long1) + 1),
+                           strlen(long1) + 1);
+}
+
+void
+gf_buf_test_assign_data(void)
+{
+    char data0[8], data1[16], data2[128], data3[1024], data4[4096];
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data1, 0xb, sizeof(data0));
+    memset(data2, 0xc, sizeof(data0));
+    memset(data3, 0xd, sizeof(data0));
+    memset(data4, 0xe, sizeof(data0));
+
+    gf_buf_decl_null(buf0, 16);
+    gf_buf_decl_string(buf1, 32);
+    gf_buf_decl_string_init(buf2, 32, "test");
+    gf_buf_decl_string_init(buf3, 64, "longlonglonglonglonglonglonglong");
+    gf_buf_decl_data_init(buf4, 32, data0, sizeof(data0));
+
+    gf_buf_assign_data(&buf0, data0, sizeof(data0));
+    __gf_buf_assert_data(&buf0, data0, sizeof(data0), 16, sizeof(data0));
+
+    gf_buf_assign_data(&buf1, data1, sizeof(data1));
+    __gf_buf_assert_data(&buf1, data1, sizeof(data1), 32, sizeof(data1));
+
+    gf_buf_assign_data(&buf2, data2, sizeof(data2));
+    __gf_buf_assert_data(&buf2, data2, sizeof(data2), sizeof(data2),
+                         sizeof(data2));
+
+    gf_buf_assign_data(&buf3, data3, sizeof(data3));
+    __gf_buf_assert_data(&buf3, data3, sizeof(data3), sizeof(data3),
+                         sizeof(data3));
+
+    gf_buf_assign_data(&buf4, data4, sizeof(data4));
+    __gf_buf_assert_data(&buf4, data4, sizeof(data4), sizeof(data4),
+                         sizeof(data4));
+}
+
+void
+gf_buf_test_copy(void)
+{
+    char *long0 = "abcdabcdabcdabcdabcdabcdabcdabcd",
+         *long1 =
+             "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd";
+    char data5[8], data6[16], data7[128], data8[1024];
+
+    memset(data5, 0xa, sizeof(data5));
+    memset(data6, 0xb, sizeof(data6));
+    memset(data7, 0xc, sizeof(data7));
+    memset(data8, 0xd, sizeof(data8));
+
+    gf_buf_decl_null(buf0, 8);
+    gf_buf_decl_string(buf1, 32);
+    gf_buf_decl_string_init(buf2, 16, "abcdabcd");
+    gf_buf_decl_string_init(buf3, 64, long0);
+    gf_buf_decl_string_init(buf4, 128, long1);
+
+    gf_buf_decl_data_init(buf5, 32, data5, sizeof(data5));
+    gf_buf_decl_data_init(buf6, 32, data6, sizeof(data6));
+    gf_buf_decl_data_init(buf7, 256, data7, sizeof(data7));
+    gf_buf_decl_data_init(buf8, 1024, data8, sizeof(data8));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf1);
+    assert(gf_buf_equal(&buf0, &buf1));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf2);
+    assert(gf_buf_equal(&buf0, &buf2));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf3);
+    assert(gf_buf_equal(&buf0, &buf3));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf4);
+    assert(gf_buf_equal(&buf0, &buf4));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf5);
+    assert(gf_buf_equal(&buf0, &buf5));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf6);
+    assert(gf_buf_equal(&buf0, &buf6));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf7);
+    assert(gf_buf_equal(&buf0, &buf7));
+
+    gf_buf_reset(&buf0);
+    gf_buf_copy(&buf0, &buf8);
+    assert(gf_buf_equal(&buf0, &buf8));
+
+    gf_buf_copy(&buf1, &buf5);
+    assert(gf_buf_equal(&buf1, &buf5));
+    gf_buf_copy(&buf2, &buf6);
+    assert(gf_buf_equal(&buf2, &buf6));
+
+    gf_buf_copy(&buf7, &buf3);
+    assert(gf_buf_equal(&buf7, &buf3));
+    gf_buf_copy(&buf8, &buf4);
+    assert(gf_buf_equal(&buf8, &buf4));
+}
+
+void
+gf_buf_test_join(void)
+{
+    char data0[8], data1[16], data2[128], data3[256], data4[512];
+    char result0[8 + 16], result1[128 + 256 + 512];
+
+    memset(data0, 0xa, sizeof(data0));
+    memset(data1, 0xb, sizeof(data1));
+    memset(data2, 0xc, sizeof(data2));
+    memset(data3, 0xd, sizeof(data3));
+    memset(data4, 0xe, sizeof(data4));
+
+    memset(result0, 0xa, sizeof(data0));
+    memset(result0 + sizeof(data0), 0xb, sizeof(data1));
+
+    memset(result1, 0xc, sizeof(data2));
+    memset(result1 + sizeof(data2), 0xd, sizeof(data3));
+    memset(result1 + sizeof(data2) + sizeof(data3), 0xe, sizeof(data4));
+
+    gf_buf_decl_data_init(buf0, 32, data0, sizeof(data0));
+    gf_buf_decl_data_init(buf1, 32, data1, sizeof(data1));
+    gf_buf_decl_data_init(buf2, 256, data2, sizeof(data2));
+    gf_buf_decl_data_init(buf3, 512, data3, sizeof(data3));
+    gf_buf_decl_data_init(buf4, 1024, data4, sizeof(data4));
+
+    assert(gf_buf_join(&buf0, &buf1) == 0);
+    __gf_buf_assert_data(&buf0, result0, sizeof(result0), 32, sizeof(result0));
+
+    assert(gf_buf_join(&buf2, &buf3) == 0);
+    assert(gf_buf_join(&buf2, &buf4) == 0);
+    __gf_buf_assert_data(&buf2, result1, sizeof(result1), sizeof(result1),
+                         sizeof(result1));
+}
+
+void
+gf_buf_test_concat(void)
+{
+    gf_buf_decl_string(buf0, 16);
+    gf_buf_decl_string_init(buf1, 8, "x");
+    gf_buf_decl_string_init(buf2, 32, "01234567");
+    gf_buf_decl_string_init(buf3, 64, "abcdabcdabcdabcdabcdabcdabcdabcd");
+
+    gf_buf_decl_string(buf4, 32);
+    gf_buf_decl_string_init(buf5, 8, "abcd");
+    gf_buf_decl_string_init(buf6, 16, "01234567");
+    gf_buf_decl_string_init(buf7, 32, "aaaabbbbccccdddd");
+
+    assert(gf_buf_concat(&buf0, &buf1) == 0);
+    __gf_buf_assert_string(&buf0, "x", 16, 2);
+
+    assert(gf_buf_concat(&buf2, &buf3) == 0);
+    __gf_buf_assert_string(
+        &buf2, "01234567abcdabcdabcdabcdabcdabcdabcdabcd",
+        __gf_buf_roundup(strlen("01234567abcdabcdabcdabcdabcdabcdabcdabcd") +
+                         1),
+        strlen("01234567abcdabcdabcdabcdabcdabcdabcdabcd") + 1);
+
+    assert(gf_buf_concat_string(&buf4, "abcd") == 0);
+    __gf_buf_assert_string(&buf4, "abcd", 32, strlen("abcd") + 1);
+
+    assert(gf_buf_concat_string(&buf5, "xyzt") == 0);
+    __gf_buf_assert_string(&buf5, "abcdxyzt",
+                           __gf_buf_roundup(strlen("abcdxyzt") + 1),
+                           strlen("abcdxyzt") + 1);
+
+    assert(gf_buf_concat_string(&buf6, "8") == 0);
+    __gf_buf_assert_string(&buf6, "012345678", 16,
+                           strlen("012345678") + 1);
+
+    assert(gf_buf_concat_string(&buf7, "abcdabcdabcdabcdabcdabcdabcdabcd") ==
+           0);
+    __gf_buf_assert_string(
+        &buf7, "aaaabbbbccccddddabcdabcdabcdabcdabcdabcdabcdabcd",
+        __gf_buf_roundup(
+            strlen("aaaabbbbccccddddabcdabcdabcdabcdabcdabcdabcdabcd") + 1),
+        strlen("aaaabbbbccccddddabcdabcdabcdabcdabcdabcdabcdabcd") + 1);
+}
+
+void
+gf_buf_test_sprintf(void)
+{
+    char *p = "oops";
+    int x = 123, y = 0xaaaabbbb;
+    char *output = "x = 123 y = 0xaaaabbbb p = oops";
+
+    gf_buf_decl_string(buf0, 8);
+    gf_buf_decl_string(buf1, 16);
+    gf_buf_decl_string_init(buf2, 16, "test");
+    gf_buf_decl_string_init(buf3, 32, "abcd0123");
+
+    gf_buf_sprintf(&buf0, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf0, output, __gf_buf_roundup(strlen(output) + 1),
+                           strlen(output) + 1);
+
+    gf_buf_sprintf(&buf1, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf1, output, __gf_buf_roundup(strlen(output) + 1),
+                           strlen(output) + 1);
+
+    gf_buf_sprintf(&buf2, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf2, output, __gf_buf_roundup(strlen(output) + 1),
+                           strlen(output) + 1);
+
+    gf_buf_reset(&buf3);
+    gf_buf_sprintf(&buf3, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf2, output, __gf_buf_roundup(strlen(output) + 1),
+                           strlen(output) + 1);
+
+    assert(gf_buf_equal(&buf0, &buf1));
+    assert(gf_buf_equal(&buf1, &buf2));
+    assert(gf_buf_equal(&buf2, &buf3));
+}
+
+void
+gf_buf_test_snprintf(void)
+{
+    char *p = "oops";
+    int x = 123, y = 0xaaaabbbb;
+    char *output = "x = 123 y = 0xaaaabbbb p = oops";
+
+    gf_buf_decl_string(buf0, 8);
+    gf_buf_decl_string_init(buf1, 16, "oops");
+    gf_buf_decl_string_init(buf2, 64, "longlonglonglonglonglonglonglonglong");
+
+    gf_buf_snprintf(&buf0, 8, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf0, "x = 123", 8, strlen("x = 123") + 1);
+
+    gf_buf_snprintf(&buf1, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(
+        &buf1, "x = 123 y = 0xaaaabbbb",
+        __gf_buf_roundup(strlen("x = 123 y = 0xaaaabbbb") + 1),
+        strlen("x = 123 y = 0xaaaabbbb") + 1);
+
+    gf_buf_snprintf(&buf2, 23, "x = %d y = 0x%x p = %s", x, y, p);
+    __gf_buf_assert_string(&buf2, "x = 123 y = 0xaaaabbbb", 64,
+                           strlen("x = 123 y = 0xaaaabbbb") + 1);
+
+    assert(gf_buf_equal(&buf1, &buf2));
+
+    gf_buf_snprintf(&buf1, 19, "x = %d y = 0x%x p = %s", x, y, p);
+    gf_buf_snprintf(&buf2, 19, "x = %d y = 0x%x p = %s", x, y, p);
+    assert(gf_buf_equal(&buf1, &buf2));
+}
+
+char *
+__make_string(int c, size_t size)
+{
+    char *ptr = __gf_buf_malloc(size + 1);
+    memset(ptr, c, size);
+    ptr[size] = '\0';
+    return ptr;
+}
+
+void
+gf_buf_test_misc(void)
+{
+    int i, nr = 0;
+    char *ptr;
+
+    gf_buf_decl_string(buf0, 512);
+    gf_buf_decl_string(buf1, 32);
+    gf_buf_decl_string(buf2, 512);
+
+    for (i = 0; i < 16; i++) {
+	ptr = __make_string('a' + i, (i + 1) * 2);
+	gf_buf_assign_string(&buf1, ptr);
+	gf_buf_concat(&buf0, &buf1);
+	gf_buf_concat_string(&buf2, ptr);
+	nr += (i + 1) * 2;
+	__gf_buf_free(ptr);
+    }
+
+    assert(gf_buf_data_size(&buf0) == nr + 1);
+    assert(gf_buf_data_size(&buf2) == nr + 1);
+    assert(gf_buf_equal(&buf0, &buf2));
+
+    gf_buf_assign_string(&buf0, "abcd");
+    gf_buf_assign_string(&buf2, "0123456789");
+
+    gf_buf_compact(&buf0);
+    gf_buf_compact(&buf2);
+}
+
+int
+main(int argc, char *argv[])
+{
+    gf_buf_test_assign_string();
+    gf_buf_test_assign_data();
+    gf_buf_test_copy();
+    gf_buf_test_join();
+    gf_buf_test_concat();
+    gf_buf_test_sprintf();
+    gf_buf_test_snprintf();
+    gf_buf_test_misc();
+
+    return 0;
+}

--- a/tests/basic/gf-buf.t.in
+++ b/tests/basic/gf-buf.t.in
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+
+TEST build_tester $(dirname $0)/gf-buf.c \
+     -DGF_BUF_STACK_THRESHOLD=16 -DGF_BUF_ROUNDUP=8 \
+     -include @abs_top_builddir@/config.h \
+     @CFLAGS@ @GF_CFLAGS@ -lglusterfs
+TEST $(dirname $0)/gf-buf
+rm -f $(dirname $0)/gf-buf


### PR DESCRIPTION
Generic buffer is the simple concept to implement basic operations
on the memory area of the known size. Basically the buffer is just
a pair of raw C pointer and size; if the last byte of the pointed
area is '\0', this area can be treated as a C string.

Generic buffers are intended to be a function- or block-scoped, and
provides simple API mostly covers initialization, copying, clearing,
concatenation and basic formatted output.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

