### PR TITLE
line-coverage: Improve glusterd line coverage

### DIFF
--- a/tests/line-coverage/glusterd-coverage.t
+++ b/tests/line-coverage/glusterd-coverage.t
@@ -19,7 +19,7 @@ TEST ! $CLI_1 volume set ${V0}_1 ganesha.enable enable
 
 # Coverage for bitrot feature
 TEST ! $CLI_1 volume bitrot ${V0}_1 disable
-TEST $CLI_1 volume stop ${V0}_1 
+TEST $CLI_1 volume stop ${V0}_1
 TEST ! $CLI_1 volume bitrot ${V0}_1 enable
 
 TEST $CLI_1 volume start ${V0}_1
@@ -50,10 +50,29 @@ pid=$(ps aux | grep 'glusterd.pid' | grep -v 'grep' | awk '{print $2}')
 TEST generate_statedump $pid
 
 # Replace-brick negative scenarios
-TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_{1} ${V0}_2 $H1:$B1/${V0}_2_{4} commit force
+# Invalid syntax
+TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_1 ${V0}_2 $H1:$B1/${V0}_2_4 commit force
+# On a volume which is not started
+TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_1 $H1:$B1/${V0}_2_4 commit force
 TEST $CLI_1 volume start ${V0}_2
-TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_{1} ${V0}_2 $H1:$B1/${V0}_2_{4} commit force
-TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_{1} ${V0}_2 $H2:$B1/${V0}_2_{4} commit force
-TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_{1} ${V0}_2 $H1:$B1/${V0}_2_{1} commit force
+# On a distribute only volume
+TEST ! $CLI_1 volume replace-brick ${V0}_2 $H1:$B1/${V0}_2_1 $H1:$B1/${V0}_2_4 commit force
+
+# Create a replica volume for testing other negative scenarios
+TEST $CLI_1 volume create ${V0}_3 replica 3 $H1:$B1/${V0}_3_{1,2,3};
+TEST $CLI_1 volume start ${V0}_3
+
+# Invalid source brick path
+TEST ! $CLI_1 volume replace-brick ${V0}_3 $H1:$B1/${V0}_3_0 $H1:$B1/${V0}_3_4 commit force
+# Source brick path with wrong hostname
+TEST ! $CLI_1 volume replace-brick ${V0}_3 $H2:$B1/${V0}_3_1 $H2:$B1/${V0}_3_4 commit force
+# Replacing with same brick
+TEST ! $CLI_1 volume replace-brick ${V0}_3 $H1:$B1/${V0}_3_1 $H1:$B1/${V0}_3_1 commit force
+# Replacing with another existing brick
+TEST ! $CLI_1 volume replace-brick ${V0}_3 $H1:$B1/${V0}_3_1 $H1:$B1/${V0}_2_1 commit force
+
+# Reset-brick negative scenario
+# Reset-brick with different brick path
+TEST ! $CLI_1 volume reset-brick ${V0}_3 $H1:$B1/${V0}_3_2 $H1:$B1/${V0}_3_4 commit force
 
 cleanup;


### PR DESCRIPTION
Problem:
The current glusterd-coverage.t case has a syntax error for
replace-brick test cases, which will prevent it from covering
other failure code paths which are intended by the tests.

Fix:
1. This patch fixes the syntax error so that it will hit different
failure paths in multiple glusterd files.
2. Added a negative test to improve the reste-brick coverage.

Change-Id: I077b7a3738949e0d86c4e826fa3dd302ea326b6c
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1052

