### PR TITLE
build, libglusterfs: autodetect path to tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,6 +270,27 @@ if test "x$RPCGEN" = "xno"; then
    AC_MSG_ERROR([`rpcgen` not found, glusterfs needs `rpcgen` exiting..])
 fi
 
+AC_CHECK_PROG([MOUNT], [mount], ["$(which mount)"], [no])
+if test "x$MOUNT" != "xno"; then
+   AC_DEFINE_UNQUOTED(_PATH_MOUNT, ["$MOUNT"], [Path to mount.])
+else
+   AC_MSG_ERROR(['mount' not found, exiting.])
+fi
+
+AC_CHECK_PROG([UMOUNT], [umount], ["$(which umount)"], [no])
+if test "x$UMOUNT" != "xno"; then
+   AC_DEFINE_UNQUOTED(_PATH_UMOUNT, ["$UMOUNT"], [Path to umount.])
+else
+   AC_MSG_ERROR(['umount' not found, exiting.])
+fi
+
+AC_CHECK_PROG([SETFATTR], [setfattr], ["$(which setfattr)"], [no])
+if test "x$SETFATTR" != "xno"; then
+   AC_DEFINE_UNQUOTED(_PATH_SETFATTR, ["$SETFATTR"], [Path to setfattr.])
+else
+   AC_MSG_ERROR(['setfattr' not found, exiting.])
+fi
+
 # Initialize CFLAGS before usage
 AC_ARG_ENABLE([debug],
               AC_HELP_STRING([--enable-debug],

--- a/contrib/fuse-lib/mount-gluster-compat.h
+++ b/contrib/fuse-lib/mount-gluster-compat.h
@@ -85,12 +85,6 @@ typedef long long mount_flag_t;
 #endif
 #endif
 
-#ifdef GF_LINUX_HOST_OS
-#define _PATH_MOUNT "/bin/mount"
-#else /* FreeBSD, NetBSD, MacOS X */
-#define _PATH_MOUNT "/sbin/mount"
-#endif
-
 #ifdef FUSE_UTIL
 #define MALLOC(size) malloc (size)
 #define FREE(ptr) free (ptr)

--- a/libglusterfs/src/glusterfs/compat.h
+++ b/libglusterfs/src/glusterfs/compat.h
@@ -34,9 +34,6 @@
 #include <endian.h>
 #endif
 
-#ifndef _PATH_UMOUNT
-#define _PATH_UMOUNT "/bin/umount"
-#endif
 #define GF_XATTR_NAME_MAX XATTR_NAME_MAX
 #endif /* GF_LINUX_HOST_OS */
 
@@ -198,10 +195,6 @@ enum {
 #define FALLOC_FL_INSERT_RANGE 0x20   /* Expands the size */
 #define FALLOC_FL_COLLAPSE_RANGE 0x08 /* Reduces the size */
 
-#ifndef _PATH_UMOUNT
-#define _PATH_UMOUNT "/sbin/umount"
-#endif
-
 void
 gf_extattr_list_reshape(char *list, ssize_t size);
 
@@ -280,9 +273,6 @@ gf_extattr_list_reshape(char *list, ssize_t size);
 #define FTW_CONTINUE 0
 #endif
 
-#ifndef _PATH_UMOUNT
-#define _PATH_UMOUNT "/sbin/umount"
-#endif
 #endif /* GF_DARWIN_HOST_OS */
 
 #ifdef GF_SOLARIS_HOST_OS
@@ -362,9 +352,6 @@ enum {
 
 #ifndef _PATH_MOUNTED
 #define _PATH_MOUNTED "/etc/mtab"
-#endif
-#ifndef _PATH_UMOUNT
-#define _PATH_UMOUNT "/sbin/umount"
 #endif
 
 #ifndef O_ASYNC

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -27,15 +27,6 @@
 #include <sys/wait.h>
 #include <dlfcn.h>
 
-#ifndef _PATH_SETFATTR
-#ifdef GF_LINUX_HOST_OS
-#define _PATH_SETFATTR "setfattr"
-#endif
-#ifdef __NetBSD__
-#define _PATH_SETFATTR "/usr/pkg/bin/setfattr"
-#endif
-#endif
-
 /* Any negative pid to make it special client */
 #define QUOTA_CRAWL_PID "-100"
 


### PR DESCRIPTION
build, libglusterfs: autodetect path to tools
    
Drop OS-specific hardcoded values and autodetect
paths to 'mount', 'umount' and 'setfattr' tools.
    
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
