### PR TITLE
cluster/afr: Avoid unnecessary new-entry-marking

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -375,4 +375,7 @@ afr_selfheal_entry_delete(xlator_t *this, inode_t *dir, const char *name,
                           inode_t *inode, int child, struct afr_reply *replies);
 int
 afr_anon_inode_create(xlator_t *this, int child, inode_t **linked_inode);
+void
+afr_selfheal_fill_cell(afr_private_t *priv, dict_t *src_xdata, int *cell,
+                       int sink, int idx);
 #endif /* !_AFR_SELFHEAL_H */


### PR DESCRIPTION
Problem:
afr is doing an xattrop to do new-entry-pending heals marking for files
that are created as part of heal. For this:
- Lookup on sink brick is done to check if the gfid exists or not
- If it is not present then sequentially new entry marking is done on
  each of the source bricks before creating the file.
In most cases by the time afr detects that it needs to do new entry
marking, it would have already done a named lookup which would lead to
possession of the xattrs to make the decision without the lookup. If all
source bricks contain file with pending marking on the sink brick, there
is no need for new entry marking. This would save 3 sequential network
calls LOOKUP, 2 XATTROPs(In replica-3 or arbiter setup).

Fix:
If named lookup xattrs already have pending markers to the new entry
brick, then skip new entry marking.

fixes: #2626
Change-Id: Ife949fe6fe4e08408332bafd8f13baedcec1827a
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

