### PR TITLE
cluster/afr: Use tie-breaker-inodelk for metadata heal

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -455,8 +455,8 @@ afr_selfheal_metadata(call_frame_t *frame, xlator_t *this, inode_t *inode)
 
     locked_replies = alloca0(sizeof(*locked_replies) * priv->child_count);
 
-    ret = afr_selfheal_inodelk(frame, this, inode, this->name, LLONG_MAX - 1, 0,
-                               data_lock);
+    ret = afr_selfheal_tie_breaker_inodelk(frame, this, inode, this->name,
+                                           LLONG_MAX - 1, 0, data_lock);
     {
         if (ret < priv->child_count) {
             ret = -ENOTCONN;


### PR DESCRIPTION
Problem:
Metadata heal uses normal inodelk. If 2 metadata heals are triggered on
the same file, one progresses after the other leading to extra delay and
an unnecessary lookup only to find there is nothing to heal.

Fix:
Use tie-breaker inodelk so that only 1 heal takes the responsibility to
complete heal.

fixes: #2632
Change-Id: I9537cc2de19ae37c77b91a1a7f4bfb4cc8bcd3e3
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

