### PR TITLE
protocol/server: Honor don't care in resolution

### DIFF
--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -408,9 +408,14 @@ resolve_inode_simple(call_frame_t *frame)
     inode = inode_find(state->itable, resolve->gfid);
 
     if (!inode) {
-        resolve->op_ret = -1;
-        resolve->op_errno = ESTALE;
-        ret = 1;
+        if (resolve->type == RESOLVE_DONTCARE) {
+            gf_uuid_copy(state->loc_now->gfid, resolve->gfid);
+            ret = 0;
+        } else {
+            resolve->op_ret = -1;
+            resolve->op_errno = ESTALE;
+            ret = 1;
+        }
         goto out;
     }
 


### PR DESCRIPTION
When a lookup on a gfid comes, if the inode corresponding to gfid is not
present in the inode table, then both resolution and actual lookup fops
will do lookups which is redundant. I found that entry lookup prevents
this by honoring RESOLVE_DONTCARE part in resolution where as the same
check is not present in resolving inode. We need to add that to reduce
the number of lookups in case of some operations like Self-heal.

fixes: #2634
Change-Id: I00599e79c0ec0a2628de211aa614717c09fcc06f
Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>

