### PR TITLE
coverity: Uninitialized scalar variable

### DIFF
--- a/libglusterfs/src/gf-io-common.c
+++ b/libglusterfs/src/gf-io-common.c
@@ -506,10 +506,10 @@ gf_io_thread_pool_start(gf_io_thread_pool_t *pool,
     /* Sync phase 0: Creation of all threads. */
 
     res = gf_io_thread_create(cfg, ids, &created, gf_io_thread_main, &sync);
+    pending = cfg->num_threads - created + 1;
     if (caa_unlikely(res < 0)) {
         goto done_sync;
     }
-    pending = cfg->num_threads - created + 1;
 
     res = gf_io_sync_wait(&sync, pending, res);
     if (caa_unlikely(res < 0)) {


### PR DESCRIPTION
Probem:
In gf_io_thread_pool_start() if it fails to create threads there is
a chance that the variable 'pending' will have some garbage value
since it is not initialized.
CID: #1458456

Fix:
Set value to the variable 'pending' if gf_io_thread_create() fails,
before jumping to done_sync.

Change-Id: Ib326dd7493bd4e27eb0be5b836f20ee0828c3e73
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1060

