### PR TITLE
glusterd: generate UUID once at startup

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -803,9 +803,6 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
     } while (0)
 
 int
-glusterd_uuid_init();
-
-int
 glusterd_uuid_generate_save();
 
 #define MY_UUID (__glusterd_uuid())
@@ -815,8 +812,7 @@ __glusterd_uuid()
 {
     glusterd_conf_t *priv = THIS->private;
 
-    if (gf_uuid_is_null(priv->uuid))
-        glusterd_uuid_init();
+    GF_UUID_ASSERT(priv->uuid);
     return &priv->uuid[0];
 }
 


### PR DESCRIPTION
Call 'glusterd_uuid_init()' only once at startup and avoid
extra null UUID check in '__glusterd_uuid()' a.k.a. MY_UUID.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

