### PR TITLE
afr: check for valid iatt

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -911,7 +911,7 @@ afr_shd_anon_inode_cleaner(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     }
 
     /*Inode is deleted from subvol*/
-    if (count == 1 || (iatt->ia_type != IA_IFDIR && multiple_links)) {
+    if (count == 1 || (iatt && iatt->ia_type != IA_IFDIR && multiple_links)) {
         gf_msg(healer->this->name, GF_LOG_WARNING, 0,
                AFR_MSG_EXPUNGING_FILE_OR_DIR, "expunging %s %s/%s on %s", type,
                priv->anon_inode_name, entry->d_name, subvol->name);


### PR DESCRIPTION
Problem:
If the entry being processed by afr_shd_anon_inode_cleaner() is no
longer present, gfid lookup fails with ENOENT on all bricks and iatt
will never be assigned, causing a crash due to null dereference.

Fix:
Add a null-check for iatt.

Fixes: #2659
Change-Id: I6abfc8063677861ce9388ca4efdf491ec956dc74
Signed-off-by: Ravishankar N <ravishankar@redhat.com>

