### PR TITLE
glusterd: cleanup defrag info

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -127,7 +127,7 @@ __glusterd_defrag_notify(struct rpc_clnt *rpc, void *mydata,
 
             LOCK(&defrag->lock);
             {
-                defrag->connected = 1;
+                defrag->connected = _gf_true;
             }
             UNLOCK(&defrag->lock);
 
@@ -143,7 +143,7 @@ __glusterd_defrag_notify(struct rpc_clnt *rpc, void *mydata,
                     UNLOCK(&defrag->lock);
                     return 0;
                 }
-                defrag->connected = 0;
+                defrag->connected = _gf_false;
             }
             UNLOCK(&defrag->lock);
 
@@ -236,8 +236,6 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
         goto out;
 
     defrag = volinfo->rebal.defrag;
-
-    defrag->cmd = cmd;
 
     volinfo->rebal.defrag_cmd = cmd;
     volinfo->rebal.op = op;
@@ -367,7 +365,6 @@ glusterd_rebalance_defrag_init(glusterd_volinfo_t *volinfo, defrag_cbk_fn_t cbk)
         goto out;
     defrag = volinfo->rebal.defrag;
 
-    defrag->cmd = volinfo->rebal.defrag_cmd;
     LOCK_INIT(&defrag->lock);
     if (cbk)
         defrag->cbk_fn = cbk;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -328,20 +328,11 @@ typedef int (*defrag_cbk_fn_t)(glusterd_volinfo_t *volinfo,
                                gf_defrag_status_t status);
 
 struct glusterd_defrag_info_ {
-    uint64_t total_files;
-    uint64_t total_data;
-    uint64_t num_files_lookedup;
-    uint64_t total_failures;
     int refcnt;
     gf_lock_t lock;
-    int cmd;
-    uint32_t connected;
-    pthread_t th;
+    gf_boolean_t connected;
     struct rpc_clnt *rpc;
-    struct gf_defrag_brickinfo_ *bricks; /* volinfo->brick_count */
     defrag_cbk_fn_t cbk_fn;
-    gf_defrag_status_t defrag_status;
-    char mount[1024];
 };
 
 typedef struct glusterd_defrag_info_ glusterd_defrag_info_t;


### PR DESCRIPTION
Remove unused members of 'struct glusterd_defrag_info_'
and prefer 'gf_boolean_t' where appropriate.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

