### PR TITLE
common-utils: Fix name resolution on IPv6-only hosts/networks

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -471,7 +471,7 @@ out:
 }
 
 int32_t
-gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
+gf_resolve_ip6(const char *hostname, uint16_t port, void **dnscache,
                struct addrinfo **addr_info)
 {
     int32_t ret = 0;
@@ -507,7 +507,7 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
                      hostname);
 
         memset(&hints, 0, sizeof(hints));
-        hints.ai_family = family;
+        hints.ai_family = AF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;
 
         ret = gf_asprintf(&port_str, "%d", port);
@@ -517,7 +517,7 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
         if ((ret = getaddrinfo(hostname, port_str, &hints, &cache->first)) !=
             0) {
             gf_smsg("resolver", GF_LOG_ERROR, 0, LG_MSG_GETADDRINFO_FAILED,
-                    "family=%d", family, "ret=%s", gai_strerror(ret), NULL);
+                    "ret=%s", gai_strerror(ret), NULL);
 
             GF_FREE(*dnscache);
             *dnscache = NULL;

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3325,7 +3325,7 @@ gf_process_reserved_ports(unsigned char *ports, uint32_t ceiling)
 out:
     GF_FREE(ports_info);
 
-#else /* FIXME: Non Linux Host */
+#else  /* FIXME: Non Linux Host */
     ret = 0;
 #endif /* GF_LINUX_HOST_OS */
 
@@ -5185,7 +5185,7 @@ close_fds_except_custom(int *fdv, size_t count, void *prm,
             closer(i, prm);
     }
     sys_closedir(d);
-#else /* !GF_LINUX_HOST_OS */
+#else  /* !GF_LINUX_HOST_OS */
     struct rlimit rl;
     int ret = -1;
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -272,7 +272,7 @@ void
 gf_global_variable_init(void);
 
 int32_t
-gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
+gf_resolve_ip6(const char *hostname, uint16_t port, void **dnscache,
                struct addrinfo **addr_info);
 
 void

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -252,17 +252,9 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
         }
     }
 
-    /* Need to update transport-address family if address-family is not provided
-       to command-line arguments
-    */
-    if (inet_pton(AF_INET6, remote_host, &serveraddr)) {
-        sockaddr->sa_family = AF_INET6;
-    }
-
     /* TODO: gf_resolve is a blocking call. kick in some
        non blocking dns techniques */
-    ret = gf_resolve_ip6(remote_host, remote_port, sockaddr->sa_family,
-                         &this->dnscache, &addr_info);
+    ret = gf_resolve_ip6(remote_host, remote_port, &this->dnscache, &addr_info);
     if (ret == -1) {
         gf_log(this->name, GF_LOG_ERROR, "DNS resolution failed on host %s",
                remote_host);

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -218,7 +218,6 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     uint16_t remote_port = GF_DEFAULT_SOCKET_LISTEN_PORT;
     struct addrinfo *addr_info = NULL;
     int32_t ret = 0;
-    struct in6_addr serveraddr;
 
     remote_host_data = dict_get_sizen(options, "remote-host");
     if (remote_host_data == NULL) {


### PR DESCRIPTION
af_inet_client_get_remote_sockaddr is broken for IPv6 only
hosts/networks and hostnames.

It manually sets family to AF_INET6 if it detects the given hostname is 
actually an IPv6 address, but that leaves family set to AF_INET for 
other cases. Which means that for IPv6 host, the gf_resolve_ip6 call
 to getaddrinfo will fail - there will be no AF_INET addrs for a v6 only host.

Fix this by just getting rid of the attempt to set AF_INET6 for v6
addresses, and removing family specification.

Just use AF_UNSPEC in the getaddrinfo call to let getaddrinfo and
underlying address selections mechanisms do their thing.

Should work where the hostname is a v6 address too.

Fixes client mounting on v6-only.

