### PR TITLE
libglusterfs, rpc, xlators: use common thread naming scheme

### DIFF
--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -802,7 +802,7 @@ event_dispatch_epoll(struct event_pool *event_pool)
             ev_data->event_index = i + 1;
 
             ret = gf_thread_create(&t_id, NULL, event_dispatch_epoll_worker,
-                                   ev_data, "epoll%03hx", i & 0x3ff);
+                                   ev_data, "epoll%d", i);
             if (!ret) {
                 event_pool->pollers[i] = t_id;
 
@@ -905,7 +905,7 @@ event_reconfigure_threads_epoll(struct event_pool *event_pool, int value)
 
                     ret = gf_thread_create(&t_id, NULL,
                                            event_dispatch_epoll_worker, ev_data,
-                                           "epoll%03hx", i & 0x3ff);
+                                           "epoll%d", i);
                     if (ret) {
                         gf_smsg("epoll", GF_LOG_WARNING, 0,
                                 LG_MSG_START_EPOLL_THREAD_FAILED, "index=%d", i,

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -845,7 +845,7 @@ rpcsvc_handle_rpc_call(rpcsvc_t *svc, rpc_transport_t *trans,
             if (spawn_request_handler) {
                 ret = gf_thread_create(&queue->thread, NULL,
                                        rpcsvc_request_handler, queue,
-                                       "rpcrqhnd");
+                                       "rpcrqhnd%d", (int)num);
                 if (!ret) {
                     gf_log(GF_RPCSVC, GF_LOG_INFO,
                            "spawned a request handler thread for queue %d",

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4149,7 +4149,7 @@ gf_defrag_parallel_migration_init(xlator_t *this, gf_defrag_info_t *defrag,
     /*Spawn Threads Here*/
     while (index < thread_spawn_count) {
         ret = gf_thread_create(&(tid[index]), NULL, gf_defrag_task,
-                               (void *)defrag, "dhtmig%d", (index + 1) & 0x3ff);
+                               (void *)defrag, "dhtmig%d", index);
         if (ret != 0) {
             gf_msg("DHT", GF_LOG_ERROR, ret, 0, "Thread[%d] creation failed. ",
                    index);

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -1307,7 +1307,7 @@ br_scrubber_scale_up(xlator_t *this, struct br_scrubber *fsscrub,
 
         INIT_LIST_HEAD(&scrub->list);
         ret = gf_thread_create(&scrub->scrubthread, NULL, br_scrubber_proc,
-                               fsscrub, "brsproc");
+                               fsscrub, "brsproc%d", i);
         if (ret)
             break;
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1759,7 +1759,7 @@ br_init_signer(xlator_t *this, br_private_t *priv)
 
     for (i = 0; i < priv->signer_th_count; i++) {
         ret = gf_thread_create(&priv->obj_queue->workers[i], NULL,
-                               br_process_object, this, "brpobj");
+                               br_process_object, this, "brpobj%d", i);
         if (ret != 0) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret,
                     BRB_MSG_THREAD_CREATION_FAILED, NULL);

--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -611,7 +611,7 @@ gf_history_consume(void *data)
 
             ret = gf_thread_create(&th_id[iter], NULL,
                                    gf_changelog_consume_wrap, curr,
-                                   "clogc%03hx", (iter + 1) & 0x3ff);
+                                   "clogc%d", iter);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, ret,
                        CHANGELOG_LIB_MSG_THREAD_CREATION_FAILED,

--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -109,8 +109,7 @@ changelog_init_rpc_threads(xlator_t *this, changelog_priv_t *priv, rbuf_t *rbuf,
     /* spawn dispatcher threads */
     for (; j < nr_dispatchers; j++) {
         ret = gf_thread_create(&priv->ev_dispatcher[j], NULL,
-                               changelog_ev_dispatch, conn, "clogd%03hx",
-                               j & 0x3ff);
+                               changelog_ev_dispatch, conn, "clogd%d", j);
         if (ret != 0) {
             changelog_cleanup_dispatchers(this, priv, j);
             break;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3679,7 +3679,7 @@ glusterd_add_volumes_to_export_dict(dict_t *peer_data, char **buf,
             }
             th_ret = gf_thread_create_detached(
                 &th_id, glusterd_add_bulk_volumes_create_thread, arg,
-                "bulkvoldict");
+                "bulkvoldict%d", i);
             if (th_ret) {
                 gf_log(this->name, GF_LOG_ERROR,
                        "glusterd_add_bulk_volume %s"

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6537,7 +6537,8 @@ notify(xlator_t *this, int32_t event, void *data, ...)
                                           gf_fuse_mt_pthread_t);
                 for (i = 0; i < private->reader_thread_count; i++) {
                     ret = gf_thread_create(&private->fuse_thread[i], NULL,
-                                           fuse_thread_proc, this, "fuseproc");
+                                           fuse_thread_proc, this,
+                                           "fuseproc%d", i);
                     if (ret != 0) {
                         gf_log(this->name, GF_LOG_DEBUG,
                                "pthread_create() failed (%s)", strerror(errno));

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -833,7 +833,7 @@ __iot_workers_scale(iot_conf_t *conf)
         diff--;
 
         ret = gf_thread_create(&thread, &conf->w_attr, iot_worker, conf,
-                               "iotwr%03hx", conf->curr_count & 0x3ff);
+                               "iotwr%d", conf->curr_count);
         if (ret == 0) {
             pthread_detach(thread);
             conf->curr_count++;


### PR DESCRIPTION
Follow the common 'name%d' thread naming scheme where
more than one thread is created for the specific task.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

