### PR TITLE
mem-pool: Fix unaligned access causing fatal SIGBUS on sparc 

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -62,9 +62,9 @@ struct mem_acct {
 };
 
 struct mem_header {
-    uint32_t type;
-    size_t size;
     struct mem_acct *mem_acct;
+    size_t size;
+    uint32_t type;
     gf_mem_magic_t magic;
 #ifdef DEBUG
     struct list_head acct_list;

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -68,7 +68,8 @@ struct mem_header {
 #ifdef DEBUG
     struct list_head acct_list;
 #endif
-    int padding[8];
+    /* ensures alignment */
+    void *data[];
 };
 
 #define GF_MEM_HEADER_SIZE (sizeof(struct mem_header))

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -32,7 +32,8 @@
 #include <cmocka.h>
 #endif
 
-#define GF_MEM_TRAILER_SIZE 8
+typedef uint32_t gf_mem_magic_t;
+#define GF_MEM_TRAILER_SIZE sizeof(gf_mem_magic_t)
 #define GF_MEM_HEADER_MAGIC 0xCAFEBABE
 #define GF_MEM_TRAILER_MAGIC 0xBAADF00D
 #define GF_MEM_INVALID_MAGIC 0xDEADC0DE
@@ -64,7 +65,7 @@ struct mem_header {
     uint32_t type;
     size_t size;
     struct mem_acct *mem_acct;
-    uint32_t magic;
+    gf_mem_magic_t magic;
 #ifdef DEBUG
     struct list_head acct_list;
 #endif
@@ -76,7 +77,7 @@ struct mem_header {
 
 #ifdef DEBUG
 struct mem_invalid {
-    uint32_t magic;
+    gf_mem_magic_t magic;
     void *mem_acct;
     uint32_t type;
     size_t size;

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -122,8 +122,8 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
         }
     }
 
-    header->type = type;
     header->mem_acct = mem_acct;
+    header->type = type;
     header->magic = GF_MEM_HEADER_MAGIC;
 
     return gf_mem_header_prepare(header, size);

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -35,19 +35,55 @@ gf_mem_acct_enable_set(void *data)
     return;
 }
 
+/* Calculate the total allocation size required, taking alignment
+ * requirements into consideration.
+ */
+static size_t
+__gf_total_alloc_size(size_t req_size)
+{
+    return req_size + GF_MEM_HEADER_SIZE + GF_MEM_TRAILER_SIZE;
+}
+
+/* Byte by byte read/write of the trailer, because the trailer may not be
+ * placed on a naturally aligned address - some platforms require memory
+ * accesses to be aligned with the word size.
+ */
+static void
+__gf_mem_trailer_write(uint8_t *trailer)
+{
+    int i = 0;
+    for (i = GF_MEM_TRAILER_SIZE - 1; i > 0; i--) {
+        *trailer++ = (uint8_t)(GF_MEM_TRAILER_MAGIC >> (i * 8));
+    }
+    *trailer = (uint8_t)GF_MEM_TRAILER_MAGIC;
+}
+
+static gf_mem_magic_t
+__gf_mem_trailer_read(uint8_t *trailer)
+{
+    gf_mem_magic_t magic = 0;
+
+    int i;
+    for (i = GF_MEM_TRAILER_SIZE - 1; i > 0; i--) {
+        magic |= (gf_mem_magic_t)(*trailer++ << (i * 8));
+    }
+    magic |= (gf_mem_magic_t)*trailer;
+
+    return magic;
+}
+
 static void *
 gf_mem_header_prepare(struct mem_header *header, size_t size)
 {
-    void *ptr;
-
     header->size = size;
 
-    ptr = header + 1;
-
     /* data follows in this gap of 'size' bytes */
-    *(uint32_t *)(ptr + size) = GF_MEM_TRAILER_MAGIC;
+    uint8_t *end = ((uint8_t *)header) + __gf_total_alloc_size(header->size);
+    uint8_t *trailer = end - GF_MEM_TRAILER_SIZE;
 
-    return ptr;
+    __gf_mem_trailer_write(trailer);
+
+    return header->data;
 }
 
 static void *
@@ -146,7 +182,7 @@ __gf_calloc(size_t nmemb, size_t size, uint32_t type, const char *typestr)
     xl = THIS;
 
     req_size = nmemb * size;
-    tot_size = req_size + GF_MEM_HEADER_SIZE + GF_MEM_TRAILER_SIZE;
+    tot_size = __gf_total_alloc_size(req_size);
 
     ptr = calloc(1, tot_size);
 
@@ -170,7 +206,7 @@ __gf_malloc(size_t size, uint32_t type, const char *typestr)
 
     xl = THIS;
 
-    tot_size = size + GF_MEM_HEADER_SIZE + GF_MEM_TRAILER_SIZE;
+    tot_size = __gf_total_alloc_size(size);
 
     ptr = malloc(tot_size);
     if (!ptr) {
@@ -195,7 +231,7 @@ __gf_realloc(void *ptr, size_t size)
     header = (struct mem_header *)(ptr - GF_MEM_HEADER_SIZE);
     GF_ASSERT(header->magic == GF_MEM_HEADER_MAGIC);
 
-    tot_size = size + GF_MEM_HEADER_SIZE + GF_MEM_TRAILER_SIZE;
+    tot_size = __gf_total_alloc_size(size);
     header = realloc(header, tot_size);
     if (!header) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
@@ -262,7 +298,7 @@ __gf_mem_invalidate(void *ptr)
     };
 
     /* calculate the last byte of the allocated area */
-    end = ptr + GF_MEM_HEADER_SIZE + inval.size + GF_MEM_TRAILER_SIZE;
+    end = ptr + __gf_total_alloc_size(inval.size);
 
     /* overwrite the old mem_header */
     memcpy(ptr, &inval, sizeof(inval));
@@ -331,8 +367,11 @@ __gf_free(void *free_ptr)
     }
 
     // This points to a memory overrun
-    GF_ASSERT(GF_MEM_TRAILER_MAGIC ==
-              *(uint32_t *)((char *)free_ptr + header->size));
+    {
+        void *end = ((char *)ptr) + __gf_total_alloc_size(header->size);
+        uint8_t *trailer = end - GF_MEM_TRAILER_SIZE;
+        GF_ASSERT(GF_MEM_TRAILER_MAGIC == __gf_mem_trailer_read(trailer));
+    }
 
     LOCK(&mem_acct->rec[header->type].lock);
     {

--- a/libglusterfs/src/unittest/mem_pool_unittest.c
+++ b/libglusterfs/src/unittest/mem_pool_unittest.c
@@ -35,7 +35,7 @@ typedef struct __attribute__((packed)) {
     size_t size;
     xlator_t *xl;
     uint32_t header_magic;
-    uint8_t pad[8];
+    void *data[];
 } mem_header_t;
 
 /*

--- a/libglusterfs/src/unittest/mem_pool_unittest.c
+++ b/libglusterfs/src/unittest/mem_pool_unittest.c
@@ -30,11 +30,11 @@
 /*
  * memory header for gf_mem_set_acct_info
  */
-typedef struct __attribute__((packed)) {
+typedef struct {
     uint32_t type;
     size_t size;
     xlator_t *xl;
-    uint32_t header_magic;
+    gf_mem_magic_t header_magic;
     void *data[];
 } mem_header_t;
 
@@ -44,6 +44,12 @@ typedef struct __attribute__((packed)) {
 int
 gf_mem_set_acct_info(xlator_t *xl, char **alloc_ptr, size_t size, uint32_t type,
                      const char *typestr);
+size_t
+__gf_total_alloc_size(size_t req_size);
+void
+__gf_mem_trailer_write(uint8_t *trailer);
+gf_mem_magic_t
+__gf_mem_trailer_read(uint8_t *trailer);
 
 /*
  * Helper functions
@@ -102,8 +108,8 @@ helper_check_memory_headers(char *mem, xlator_t *xl, size_t size, uint32_t type)
     assert_int_equal(p->size, size);
     assert_true(p->xl == xl);
     assert_int_equal(p->header_magic, GF_MEM_HEADER_MAGIC);
-    assert_true(*(uint32_t *)(mem + sizeof(mem_header_t) + size) ==
-                GF_MEM_TRAILER_MAGIC);
+    assert_true(__gf_mem_trailer_read((uint8_t *)mem + sizeof(mem_header_t) +
+                                      size) == GF_MEM_TRAILER_MAGIC);
 }
 
 /*


### PR DESCRIPTION
The mem-pool code writes a trailer marker at the end of memory allocations
to sanity check for memory write over-runs.  The code does not align the
marker on its required boundary though. This causes unaligned accesses.

Unaligned access may be just slower on some platforms, but on others it can
cause faults and abnormal exits.  E.g., this was causing a SIGBUS on
Linux/SPARC64.

Fix by rounding up the header+data size to the needed alignment for the
trailer.

Another solution might be just to remove the trailer code, and rely on other
malloc debugging tools.  E.g., LD_PRELOADable malloc debug libraries, GCC
ASAN and so on, valgrind, etc.