### PR TITLE
glusterd: Modify the default ping-timeout value of glusterd

### DIFF
--- a/extras/glusterd.vol.in
+++ b/extras/glusterd.vol.in
@@ -6,7 +6,7 @@ volume management
     option transport.socket.keepalive-interval 2
     option transport.socket.read-fail-log off
     option transport.socket.listen-port 24007
-    option ping-timeout 0
+    option ping-timeout 42
     option event-threads 1
 #   option lock-timer 180
 #   option transport.address-family inet6


### PR DESCRIPTION
Fix the problem that glusterd blocking time is too long in some scenarios

Fixes: #2677
Signed-off-by: Jifeng Zhou <z583340363@gmail.com>

