### PR TITLE
libglusterfs, xlators: cache hostname in global context

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4818,20 +4818,13 @@ glusterfs_is_local_pathinfo(char *pathinfo, gf_boolean_t *is_local)
 {
     int ret = 0;
     char pathinfohost[1024] = {0};
-    char localhost[1024] = {0};
 
     *is_local = _gf_false;
     ret = get_pathinfo_host(pathinfo, pathinfohost, sizeof(pathinfohost));
-    if (ret)
-        goto out;
-
-    ret = gethostname(localhost, sizeof(localhost));
-    if (ret)
-        goto out;
-
-    if (!strcmp(localhost, pathinfohost))
-        *is_local = _gf_true;
-out:
+    if (ret == 0) {
+        if (!strcmp(gf_gethostname(), pathinfohost))
+            *is_local = _gf_true;
+    }
     return ret;
 }
 
@@ -5484,4 +5477,10 @@ char **
 get_xattrs_to_heal()
 {
     return xattrs_to_heal;
+}
+
+char *
+gf_gethostname(void)
+{
+    return global_ctx->hostname;
 }

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -196,6 +196,9 @@ extern char *xattrs_to_heal[];
 char **
 get_xattrs_to_heal();
 
+char *
+gf_gethostname(void);
+
 /* The DHT file rename operation is not a straightforward rename.
  * It involves creating linkto and linkfiles, and can unlink or rename the
  * source file depending on the hashed and cached subvols for the source

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -756,6 +756,7 @@ struct _glusterfs_ctx {
 
     gf_boolean_t cleanup_starting;
     gf_boolean_t destroy_ctx;
+    char *hostname;
     char volume_id[GF_UUID_BUF_SIZE]; /* Used only in protocol/client */
 };
 typedef struct _glusterfs_ctx glusterfs_ctx_t;
@@ -850,4 +851,5 @@ int
 glusterfs_read_secure_access_file(void);
 int
 glusterfs_graph_fini(glusterfs_graph_t *graph);
+
 #endif /* _GLUSTERFS_H */

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -479,21 +479,10 @@ glusterfs_graph_unknown_options(glusterfs_graph_t *graph)
 static void
 fill_uuid(char *uuid, int size, struct timeval tv)
 {
-    char hostname[50] = {
-        0,
-    };
     char now_str[GF_TIMESTR_SIZE];
 
-    if (gethostname(hostname, sizeof(hostname) - 1) != 0) {
-        gf_msg("graph", GF_LOG_ERROR, errno, LG_MSG_GETHOSTNAME_FAILED,
-               "gethostname failed");
-        hostname[sizeof(hostname) - 1] = '\0';
-    }
-
     gf_time_fmt_tv(now_str, sizeof now_str, &tv, gf_timefmt_dirent);
-    snprintf(uuid, size, "%s-%d-%s", hostname, getpid(), now_str);
-
-    return;
+    snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(), now_str);
 }
 
 static int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -604,6 +604,7 @@ gf_fop_string
 __gf_free
 gf_free_mig_locks
 gf_getgrouplist
+gf_gethostname
 gf_get_hostname_from_ip
 gf_get_index_by_elem
 gf_global_mem_acct_enable_set

--- a/xlators/cluster/dht/src/nufa.c
+++ b/xlators/cluster/dht/src/nufa.c
@@ -554,7 +554,6 @@ nufa_init(xlator_t *this)
     data_t *data = NULL;
     char *local_volname = NULL;
     int ret = -1;
-    char my_hostname[256];
     gf_boolean_t addr_match = _gf_false;
     nufa_args_t args = {
         0,
@@ -570,14 +569,7 @@ nufa_init(xlator_t *this)
 
     } else {
         addr_match = _gf_true;
-        local_volname = "localhost";
-        ret = gethostname(my_hostname, 256);
-        if (ret == 0)
-            local_volname = my_hostname;
-
-        else
-            gf_msg(this->name, GF_LOG_WARNING, errno,
-                   DHT_MSG_GET_HOSTNAME_FAILED, "could not find hostname");
+        local_volname = gf_gethostname();
     }
 
     args.this = this;

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -5048,16 +5048,8 @@ glusterd_get_gsync_status(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     };
     glusterd_volinfo_t *volinfo = NULL;
     int ret = 0;
-    char my_hostname[256] = {
-        0,
-    };
+    char *my_hostname = gf_gethostname();
     xlator_t *this = THIS;
-
-    ret = gethostname(my_hostname, 256);
-    if (ret) {
-        /* stick to N/A */
-        (void)strcpy(my_hostname, "N/A");
-    }
 
     ret = dict_get_str(dict, "primary", &volname);
     if (ret < 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5131,10 +5131,6 @@ glusterd_print_gsync_status_by_vol(FILE *fp, glusterd_volinfo_t *volinfo)
 {
     int ret = -1;
     dict_t *gsync_rsp_dict = NULL;
-    char my_hostname[256] = {
-        0,
-    };
-
     xlator_t *this = THIS;
 
     GF_VALIDATE_OR_GOTO(this->name, volinfo, out);
@@ -5146,13 +5142,8 @@ glusterd_print_gsync_status_by_vol(FILE *fp, glusterd_volinfo_t *volinfo)
         goto out;
     }
 
-    ret = gethostname(my_hostname, sizeof(my_hostname));
-    if (ret) {
-        /* stick to N/A */
-        (void)strcpy(my_hostname, "N/A");
-    }
-
-    ret = glusterd_get_gsync_status_mst(volinfo, gsync_rsp_dict, my_hostname);
+    ret = glusterd_get_gsync_status_mst(volinfo, gsync_rsp_dict,
+                                        gf_gethostname());
     /* Ignoring ret as above function always returns ret = 0 */
 
     ret = glusterd_print_gsync_status(fp, gsync_rsp_dict);

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -915,9 +915,6 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     clnt_conf_t *conf = this->private;
     dict_t *options = this->options;
     char counter_str[32] = {0};
-    char hostname[256] = {
-        0,
-    };
 
     if (conf->fops) {
         ret = dict_set_int32_sizen(options, "fops-version",
@@ -949,16 +946,9 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     snprintf(counter_str, sizeof(counter_str), "-%" PRIu64, conf->setvol_count);
     conf->setvol_count++;
 
-    if (gethostname(hostname, 256) == -1) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, PC_MSG_GETHOSTNAME_FAILED,
-                NULL);
-
-        goto fail;
-    }
-
     ret = gf_asprintf(&process_uuid_xl, GLUSTER_PROCESS_UUID_FMT,
                       this->ctx->process_uuid, this->graph->id, getpid(),
-                      hostname, this->name, counter_str);
+                      gf_gethostname(), this->name, counter_str);
     if (-1 == ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_PROCESS_UUID_SET_FAIL,
                 NULL);

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -720,17 +720,8 @@ posix_init(xlator_t *this)
         _private->arrdfd[i] = -1;
 
     ret = dict_get_str(this->options, "hostname", &_private->hostname);
-    if (ret) {
-        _private->hostname = GF_CALLOC(256, sizeof(char), gf_common_mt_char);
-        if (!_private->hostname) {
-            goto out;
-        }
-        ret = gethostname(_private->hostname, 256);
-        if (ret < 0) {
-            gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HOSTNAME_MISSING,
-                   "could not find hostname ");
-        }
-    }
+    if (ret)
+        _private->hostname = gf_gethostname();
 
     /* Check for Extended attribute support, if not present, log it */
     size = sys_lgetxattr(dir_data->data, "user.x", &value, sizeof(value));
@@ -1254,8 +1245,6 @@ out:
 
             GF_FREE(_private->base_path);
 
-            GF_FREE(_private->hostname);
-
             GF_FREE(_private->trash_path);
 
             GF_FREE(_private);
@@ -1356,7 +1345,6 @@ posix_fini(xlator_t *this)
     pthread_cond_destroy(&priv->fsync_cond);
     pthread_mutex_destroy(&priv->janitor_mutex);
     pthread_cond_destroy(&priv->janitor_cond);
-    GF_FREE(priv->hostname);
     GF_FREE(priv->trash_path);
     GF_FREE(priv);
     this->private = NULL;


### PR DESCRIPTION
Call gethostname() at the very beginning of global context
initialization and then use the hostname where appropriate.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

