### PR TITLE
glusterd: reset mgmt_v3_lock_timeout after it be used

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -577,8 +577,6 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
     }
 
     mgmt_lock_timer->xl = THIS;
-    /*changing to default timeout value*/
-    priv->mgmt_v3_lock_timeout = GF_LOCK_TIMER;
 
     ret = -1;
     mgmt_lock_timer_xl = mgmt_lock_timer->xl;
@@ -596,6 +594,9 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
     key_dup = gf_strdup(key);
     delay.tv_sec = priv->mgmt_v3_lock_timeout;
     delay.tv_nsec = 0;
+
+    /*changing to default timeout value*/
+    priv->mgmt_v3_lock_timeout = GF_LOCK_TIMER;
 
     mgmt_lock_timer->timer = gf_timer_call_after(
         mgmt_lock_timer_ctx, delay, gd_mgmt_v3_unlock_timer_cbk, key_dup);


### PR DESCRIPTION
Problem:
in mgmt v3, lock will be released after 3 minutes by default.
for those commands which will take more time, it can recieve
a timeout parameter instead of the default 3 minutes.
but commit  91cbcd1 broke this method, reset timeout before it be used.
so that lock release timeout is always 3 minutes.

Solution:
reset mgmt_v3_lock_timeout to default after it be used.

fixes: 91cbcd1 glusterd-locks: misc. changes
Signed-off-by: Ren Lei <ren.lei4@zte.com.cn>


