### PR TITLE
build: cleanup automake usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1740,12 +1740,10 @@ fi
 GF_CPPFLAGS="$GF_CPPFLAGS $GF_CPPDEFINES $GF_CPPINCLUDES"
 AC_SUBST([GF_CPPFLAGS])
 
+dnl Note GF_BSD_HOST_OS and GF_SOLARIS_HOST_OS are not used
+dnl through Makefile.am and so not defined as conditionals.
 AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
-AM_CONDITIONAL([GF_BSD_HOST_OS], test "${GF_HOST_OS}" = "GF_BSD_HOST_OS")
-if  test "${GF_HOST_OS}" = "GF_BSD_HOST_OS"; then
-    AC_DEFINE(GF_BSD_HOST_OS, 1, [This is a BSD compatible OS.])
-fi
 
 AC_SUBST(GLUSTERD_WORKDIR)
 AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d ${GLUSTERD_WORKDIR} && test -d ${sysconfdir}/glusterd )

--- a/xlators/features/changelog/src/Makefile.am
+++ b/xlators/features/changelog/src/Makefile.am
@@ -21,7 +21,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/rpc-transport/socket/src \
 	-I$(top_srcdir)/xlators/features/changelog/lib/src/ \
-	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS) \
+	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \
 	-DDATADIR=\"$(localstatedir)\"
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)

--- a/xlators/features/compress/src/Makefile.am
+++ b/xlators/features/compress/src/Makefile.am
@@ -11,8 +11,7 @@ cdc_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la $(ZLIB_LIBS)
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \
-	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS) \
-	$(LIBZ_CFLAGS)
+	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE $(LIBZ_CFLAGS)
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)
 


### PR DESCRIPTION
Define only GF_LINUX_HOST_OS and GF_DARWIN_HOST_OS as automake
conditions since others aren't used through Makefile.am files,
drop duplicated '-D$(GF_HOST_OS)' from them where found.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

