### PR TITLE
dht: dht_local_wipe is crashed while running rename operation

### DIFF
--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -123,7 +123,9 @@ dht_rename_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
     subvol_cnt = dht_subvol_cnt(this, prev);
-    local->ret_cache[subvol_cnt] = op_ret;
+
+    if (subvol_cnt >= 0)
+        local->ret_cache[subvol_cnt] = op_ret;
 
     if (op_ret == -1) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);


### PR DESCRIPTION
dht_local_wipe is crashed while dht is winding a rename_dir
operation if some of the subvol has killed.The dht_local_wipe
is crashed during cleanup of ret_cache due to ret_cache corrupted
by dht_rename_dir function at the time of updating the status.

Solution: Check the subvol_cnt (index) it should be positive to
          avoid a buffer corruption.

Change-Id: I84775e2a436c3f08e068d2c8925d3369a2872c0b
Fixes: #2693
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

