### PR TITLE
build, xlators: cleanup configure and automake usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,8 +632,16 @@ AC_SUBST(USE_POSIX_ACLS)
 
 # libglusterfs/checksum
 AC_CHECK_HEADERS([openssl/md5.h])
-AC_CHECK_LIB([z], [adler32], [ZLIB_LIBS="-lz"], AC_MSG_ERROR([zlib is required to build glusterfs]))
-AC_SUBST(ZLIB_LIBS)
+
+# Zlib is used by libglusterfs checksum and cdc xlator.
+PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0], [have_zlib=yes], [have_zlib=no])
+if test x$have_zlib = xyes; then
+   AC_DEFINE(HAVE_ZLIB, 1, [Define if zlib is found.])
+   AC_SUBST([ZLIB_CFLAGS])
+   AC_SUBST([ZLIB_LIBS])
+else
+   AC_MSG_ERROR([zlib is required to build glusterfs])
+fi
 
 AC_CHECK_HEADERS([linux/falloc.h])
 
@@ -872,22 +880,6 @@ AC_SUBST(EVENTS_ENABLED)
 AC_SUBST(EVENTS_SUBDIR)
 AM_CONDITIONAL([BUILD_EVENTS], [test "x${BUILD_EVENTS}" = "xyes"])
 # end Events section
-
-# CDC xlator - check if libz is present if so enable HAVE_LIB_Z
-BUILD_CDC=yes
-PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0],,
-                  [AC_CHECK_LIB([z], [deflate], [ZLIB_LIBS="-lz"],
-                                [BUILD_CDC=no])])
-echo -n "features requiring zlib enabled: "
-if test "x$BUILD_CDC" = "xyes" ; then
-  echo "yes"
-  AC_DEFINE(HAVE_LIB_Z, 1, [define if zlib is present])
-else
-  echo "no"
-fi
-AC_SUBST(ZLIB_CFLAGS)
-AC_SUBST(ZLIB_LIBS)
-# end CDC xlator secion
 
 #start firewalld section
 BUILD_FIREWALLD="no"
@@ -1740,12 +1732,10 @@ fi
 GF_CPPFLAGS="$GF_CPPFLAGS $GF_CPPDEFINES $GF_CPPINCLUDES"
 AC_SUBST([GF_CPPFLAGS])
 
+dnl Note GF_BSD_HOST_OS and GF_SOLARIS_HOST_OS are not used
+dnl through Makefile.am and so not defined as conditionals.
 AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
-AM_CONDITIONAL([GF_BSD_HOST_OS], test "${GF_HOST_OS}" = "GF_BSD_HOST_OS")
-if  test "${GF_HOST_OS}" = "GF_BSD_HOST_OS"; then
-    AC_DEFINE(GF_BSD_HOST_OS, 1, [This is a BSD compatible OS.])
-fi
 
 AC_SUBST(GLUSTERD_WORKDIR)
 AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d ${GLUSTERD_WORKDIR} && test -d ${sysconfdir}/glusterd )

--- a/xlators/features/changelog/src/Makefile.am
+++ b/xlators/features/changelog/src/Makefile.am
@@ -21,7 +21,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/rpc-transport/socket/src \
 	-I$(top_srcdir)/xlators/features/changelog/lib/src/ \
-	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS) \
+	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \
 	-DDATADIR=\"$(localstatedir)\"
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)

--- a/xlators/features/compress/src/Makefile.am
+++ b/xlators/features/compress/src/Makefile.am
@@ -11,8 +11,7 @@ cdc_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la $(ZLIB_LIBS)
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \
-	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS) \
-	$(LIBZ_CFLAGS)
+	-fPIC -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE $(ZLIB_CFLAGS)
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)
 

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -11,15 +11,11 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/syscall.h>
+#include <zlib.h>
 
 #include "cdc.h"
 #include "cdc-mem-types.h"
 
-#ifdef HAVE_LIB_Z
-#include "zlib.h"
-#endif
-
-#ifdef HAVE_LIB_Z
 /* gzip header looks something like this
  * (RFC 1950)
  *
@@ -523,5 +519,3 @@ inflate_cleanup_out:
 passthrough_out:
     return ret;
 }
-
-#endif

--- a/xlators/features/compress/src/cdc.c
+++ b/xlators/features/compress/src/cdc.c
@@ -84,15 +84,8 @@ int32_t
 cdc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
           off_t offset, uint32_t flags, dict_t *xdata)
 {
-    fop_readv_cbk_t cbk = NULL;
-
-#ifdef HAVE_LIB_Z
-    cbk = cdc_readv_cbk;
-#else
-    cbk = default_readv_cbk;
-#endif
-    STACK_WIND(frame, cbk, FIRST_CHILD(this), FIRST_CHILD(this)->fops->readv,
-               fd, size, offset, flags, xdata);
+    STACK_WIND(frame, cdc_readv_cbk, FIRST_CHILD(this),
+               FIRST_CHILD(this)->fops->readv, fd, size, offset, flags, xdata);
     return 0;
 }
 
@@ -234,12 +227,12 @@ init(xlator_t *this)
     /* Set Gzip (De)Compression Level */
     GF_OPTION_INIT("compression-level", priv->cdc_level, int32, err);
     if (((priv->cdc_level < 1) || (priv->cdc_level > 9)) &&
-        (priv->cdc_level != GF_CDC_DEF_COMPRESSION)) {
+        (priv->cdc_level != Z_DEFAULT_COMPRESSION)) {
         gf_log(this->name, GF_LOG_WARNING,
                "Invalid gzip (de)compression level (%d),"
                " using default",
                priv->cdc_level);
-        priv->cdc_level = GF_CDC_DEF_COMPRESSION;
+        priv->cdc_level = Z_DEFAULT_COMPRESSION;
     }
 
     /* Set Gzip Memory Level */

--- a/xlators/features/compress/src/cdc.h
+++ b/xlators/features/compress/src/cdc.h
@@ -11,11 +11,8 @@
 #ifndef __CDC_H
 #define __CDC_H
 
-#ifdef HAVE_LIB_Z
-#include "zlib.h"
-#endif
-
 #include <glusterfs/xlator.h>
+#include <zlib.h>
 
 typedef struct cdc_priv {
     int window_size;
@@ -42,9 +39,8 @@ typedef struct cdc_info {
     struct iobref *iobref;
 
     /* zlib bits */
-#ifdef HAVE_LIB_Z
     z_stream stream;
-#endif
+
     unsigned long crc;
 } cdc_info_t;
 
@@ -55,12 +51,6 @@ typedef struct cdc_info {
 /* Gzip defaults */
 #define GF_CDC_DEF_WINDOWSIZE -15 /* default value */
 #define GF_CDC_MAX_WINDOWSIZE -8  /* max value     */
-
-#ifdef HAVE_LIB_Z
-#define GF_CDC_DEF_COMPRESSION Z_DEFAULT_COMPRESSION
-#else
-#define GF_CDC_DEF_COMPRESSION -1
-#endif
 
 #define GF_CDC_DEF_MEMLEVEL 8
 #define GF_CDC_DEF_BUFFERSIZE 262144  // 256K - default compression buffer size

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -1910,7 +1910,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
                     "that tags every fop with a namespace hash for later "
                     "throttling, stats collection, logging, etc."},
 
-#ifdef HAVE_LIB_Z
     /* Compressor-decompressor xlator options
      * defaults used from xlator/features/compress/src/cdc.h
      */
@@ -1942,7 +1941,6 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .option = "debug",
      .type = NO_DOC,
      .op_version = 3},
-#endif
 
     /* Quota xlator options */
     {


### PR DESCRIPTION
Define only GF_LINUX_HOST_OS and GF_DARWIN_HOST_OS as automake
conditions since others aren't used through Makefile.am files,
drop duplicated '-D$(GF_HOST_OS)' from changelog and cdc xlator
makefiles, detect zlib only once and tweak cdc xlator to use
zlib unconditionally.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

