### PR TITLE
build, libglusterfs: add --with-malloc=[tcmalloc,jemalloc,system] options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -337,22 +337,58 @@ if test "x$enable_ubsan" = "xyes"; then
         GF_LDFLAGS="${GF_LDFLAGS} -lubsan"
 fi
 
-# Initialize CFLAGS before usage
-BUILD_TCMALLOC=no
-USE_MEMPOOL=yes
-AC_ARG_WITH([tcmalloc],
-        [AC_HELP_STRING([--without-tcmalloc], [Use gluster based mempool])],
-        [with_tcmalloc="no"], [with_tcmalloc="yes"])
-if test "x$with_tcmalloc" = "xyes"; then
-    AC_CHECK_LIB([tcmalloc], [malloc], [],
-                 [AC_MSG_ERROR([tcmalloc library needs to be present])])
-    BUILD_TCMALLOC=yes
-    GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
-    GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+dnl Initialize pkg-config magic.
+PKG_PROG_PKG_CONFIG
+
+dnl Select malloc implementation. TCMalloc is preferred since it is
+dnl known to have the best performance on a wide range of benchmarks.
+
+MALLOC_IMPL=tcmalloc
+
+AC_ARG_WITH([malloc],
+            AC_HELP_STRING([--with-malloc=@<:@tcmalloc,jemalloc,system@:>@],
+                             [Use tcmalloc, jemalloc or system default malloc.]))
+case x$with_malloc in
+  x|xtcmalloc)
+    PKG_CHECK_MODULES([TCMALLOC], [libtcmalloc], [use_tcmalloc=yes], [use_tcmalloc=no])
+    if test x$use_tcmalloc = xyes; then
+        AC_DEFINE(USE_TCMALLOC, 1, [Define to 1 if tcmalloc is used.])
+        GF_LDFLAGS="${GF_LDFLAGS} ${TCMALLOC_LIBS}"
+        MALLOC_IMPL=tcmalloc
+    else
+        AC_MSG_ERROR([unable to detect tcmalloc, make sure it's installed.])
+    fi
+    ;;
+  xjemalloc)
+    PKG_CHECK_MODULES([JEMALLOC], [jemalloc], [use_jemalloc=yes], [use_jemalloc=no])
+    if test x$use_jemalloc = xyes; then
+        AC_DEFINE(USE_JEMALLOC, 1, [Define to 1 if jemalloc is used.])
+        GF_LDFLAGS="${GF_LDFLAGS} ${JEMALLOC_LIBS}"
+        MALLOC_IMPL=jemalloc
+    else
+        AC_MSG_ERROR([unable to detect jemalloc, make sure it's installed.])
+    fi
+    ;;
+  xsystem)
+    MALLOC_IMPL=system
+    ;;
+  *)
+    AC_MSG_ERROR([Please specify --with-malloc=@<:@tcmalloc,jemalloc,system@:>@])
+    ;;
+esac
+
+dnl With TCMalloc, memory pools are disabled by default.
+if test x$MALLOC_IMPL = xtcmalloc; then
     AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
     USE_MEMPOOL=no
+else
+    USE_MEMPOOL=yes
 fi
 
+dnl Custom memory management function may be confused with compiler builtins.
+if test x$MALLOC_IMPL != xsystem; then
+    GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
+fi
 
 dnl When possible, prefer libtirpc over glibc rpc.
 dnl
@@ -1820,7 +1856,7 @@ echo "Use TIRPC            : $with_libtirpc"
 echo "With Python          : ${PYTHON_VERSION}"
 echo "Cloudsync            : $BUILD_CLOUDSYNC"
 echo "Metadata dispersal   : $BUILD_METADISP"
-echo "Link with TCMALLOC   : $BUILD_TCMALLOC"
+echo "Memory management    : $MALLOC_IMPL"
 echo "Enable Brick Mux     : $USE_BRICKMUX"
 echo "Building with LTO    : $LTO_BUILD"
 echo
@@ -1831,4 +1867,11 @@ if test "x$SANITIZER" != "xnone"; then
         echo "'export ${SANITIZER^^}_OPTIONS=log_path=/path/to/xxx.log' to collect"
         echo "sanitizer output. Further details and more options can be"
         echo "found at https://github.com/google/sanitizers."
+fi
+
+dnl Warn if malloc implementation other than TCMalloc is selected.
+if test x$MALLOC_IMPL != xtcmalloc; then
+    echo "Warning: consider using TCMalloc as the default memory allocator since"
+    echo "it is known to have the best performance on a wide range of benchmarks."
+    echo "For the details on TCMalloc, see https://github.com/google/tcmalloc."
 fi

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -68,10 +68,17 @@
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without libtirpc
 %{?_without_libtirpc:%global _without_libtirpc --without-libtirpc}
 
-# libtcmalloc
-# if you wish to compile an rpm without tcmalloc (i.e. use gluster mempool)
-# rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without tcmalloc
-%{?_without_tcmalloc:%global _without_libtcmalloc --without-tcmalloc}
+# tcmalloc is now the default
+%global _with_tcmalloc 1
+%{?_with_tcmalloc:%global _with_tcmalloc --with-malloc=tcmalloc}
+
+# if you wish to compile an rpm with jemalloc...
+# rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --with jemalloc
+%{?_with_jemalloc:%global _with_jemalloc --with-malloc=jemalloc}
+
+# ...or fallback to system default malloc...
+# rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --with system-malloc
+%{?_with_system_malloc:%global _with_system_malloc --with-malloc=system}
 
 # Do not use libtirpc on EL6, it does not have xdr_uint64_t() and xdr_uint32_t
 # Do not use libtirpc on EL7, it does not have xdr_sizeof()
@@ -256,6 +263,9 @@ BuildRequires:    systemd
 %if ( 0%{?_with_tcmalloc:1} )
 Requires:         gperftools-libs%{?_isa}
 %endif
+%if ( 0%{?_with_jemalloc:1} )
+Requires:         jemalloc%{?_isa}
+%endif
 
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 Requires:         libgfrpc0%{?_isa} = %{version}-%{release}
@@ -277,6 +287,9 @@ BuildRequires:    libaio-devel libacl-devel
 BuildRequires:    python%{_pythonver}-devel
 %if ( 0%{?_with_tcmalloc:1} )
 BuildRequires:    gperftools-devel
+%endif
+%if ( 0%{?_with_jemalloc:1} )
+BuildRequires:    jemalloc-devel
 %endif
 %if ( 0%{?rhel} && 0%{?rhel} < 8 )
 BuildRequires:    python-ctypes
@@ -871,7 +884,9 @@ done
         %{?_with_ipv6default} \
         %{?_without_linux_io_uring} \
         %{?_without_libtirpc} \
-        %{?_without_tcmalloc}
+        %{?_with_tcmalloc} \
+        %{?_with_jemalloc} \
+        %{?_with_system_malloc}
 
 # fix hardening and remove rpath in shlibs
 %if ( 0%{?fedora} && 0%{?fedora} > 17 ) || ( 0%{?rhel} && 0%{?rhel} > 6 )

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -21,6 +21,12 @@
 #include <string.h>
 #include <stdarg.h>
 
+#if defined(USE_TCMALLOC)
+#include <gperftools/tcmalloc.h>
+#elif defined(USE_JEMALLOC)
+#include <jemalloc/jemalloc.h>
+#endif /* custom malloc */
+
 /*
  * Need this for unit tests since inline functions
  * access memory allocation and need to use the


### PR DESCRIPTION
build, libglusterfs: add --with-malloc option
    
Extend '--enable-tcmalloc' quirks to more generic
'--with-malloc=[tcmalloc,jemalloc,system]' option
to select Google's tcmalloc which is now the default,
FreeBSD's originated jemalloc or system malloc,
respectively. Also update glusterfs.spec.in so
tcmalloc is selected by default but '--with jemalloc'
and '--with system-malloc' is provided as well.
    
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
