### PR TITLE
00-geo-rep/georep-upgrade.t: replace find command with file path

### DIFF
--- a/tests/00-geo-rep/georep-upgrade.t
+++ b/tests/00-geo-rep/georep-upgrade.t
@@ -47,11 +47,7 @@ EXPECT '1' echo $(ls /bricks/brick1/.glusterfs/changelogs/htime/HTIME.$epoch2 | 
 ###############################################################################################
 #Upgrade
 ###############################################################################################
-### This needed to be fixed as this very vague finding a file with name in '/'
-### multiple file with same name can exist
-### for temp fix picking only 1st result
-TEST upgrade_script=$(find / -type f -name glusterfs-georep-upgrade.py -print | head -n 1)
-TEST python3 $upgrade_script $brick
+TEST python3 extras/glusterfs-georep-upgrade.py $brick
 
 ###############################################################################################
 #After upgrade


### PR DESCRIPTION
$find / -type f -name glusterfs-georep-upgrade.py is replaced
with exact path of the file.

This handles anomaly of multiple files with same name, and
also eliminates extra time spent with the find command.

This is backport of https://github.com/gluster/glusterfs/pull/2692

Fixes: #2691
Change-Id: Id4c9061312c2996076fda1ede20af2cfb2849a24
Signed-off-by: Shwetha K Acharya sacharya@redhat.com