### PR TITLE
glusterd: auth.allow value is corrupted after add-brick operation

### DIFF
--- a/tests/bugs/glusterd/bug-1720566.t
+++ b/tests/bugs/glusterd/bug-1720566.t
@@ -17,6 +17,7 @@ $CLI_1 volume create $V0 $H1:$B1/$V0  $H2:$B2/$V0
 EXPECT 'Created' cluster_volinfo_field 1 $V0 'Status';
 $CLI_1 volume create $V1 $H1:$B1/$V1  $H2:$B2/$V1
 EXPECT 'Created' cluster_volinfo_field 1 $V1 'Status';
+$CLI_1 volume set $V0 auth.allow 1.2.3.4
 
 $CLI_1 volume start $V0
 EXPECT 'Started' cluster_volinfo_field 1 $V0 'Status';

--- a/tests/bugs/glusterd/bug-1720566.t
+++ b/tests/bugs/glusterd/bug-1720566.t
@@ -4,6 +4,13 @@
 . $(dirname $0)/../../cluster.rc
 . $(dirname $0)/../../volume.rc
 
+function volinfo_field()
+{
+    local vol=$1;
+    local field=$2;
+
+    $CLI_1 volume info $vol | grep "^$field: " | sed 's/.*: //';
+}
 
 cleanup;
 V0="TestLongVolnamec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9abcd"
@@ -40,7 +47,7 @@ TEST touch $M1/dir{1..4}/files{1..4};
 
 TEST $CLI_1 volume add-brick $V0 $H1:$B1/${V0}_1 $H2:$B2/${V0}_1
 TEST $CLI_1 volume add-brick $V1 $H1:$B1/${V1}_1 $H2:$B2/${V1}_1
-
+EXPECT '1.2.3.4' volinfo_field $V0 'auth.allow'
 
 TEST $CLI_1 volume rebalance $V0 start
 TEST $CLI_1 volume rebalance $V1  start

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15002,19 +15002,19 @@ glusterd_add_peers_to_auth_list(char *volname)
          * keep the copy of auth_allow_list as old_auth_allow_list in
          * volinfo->dict.
          */
+        ret = dict_set_dynstr_with_alloc(volinfo->dict, "old.auth.allow",
+                                         auth_allow_list);
+        if (ret) {
+            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                   "Unable to set old.auth.allow list");
+            goto out;
+        }
         dict_del_sizen(volinfo->dict, "auth.allow");
-        ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
-                            new_auth_allow_list);
+        ret = dict_set_dynstr_with_alloc(volinfo->dict, "auth.allow",
+                                         new_auth_allow_list);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
-            goto out;
-        }
-        ret = dict_set_strn(volinfo->dict, "old.auth.allow",
-                            SLEN("old.auth.allow"), auth_allow_list);
-        if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
-                   "Unable to set old auth.allow list");
             goto out;
         }
         ret = glusterd_create_volfiles_and_notify_services(volinfo);
@@ -15056,8 +15056,8 @@ glusterd_replace_old_auth_allow_list(char *volname)
     }
 
     dict_del_sizen(volinfo->dict, "auth.allow");
-    ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
-                        old_auth_allow_list);
+    ret = dict_set_dynstr_with_alloc(volinfo->dict, "auth.allow",
+                                     old_auth_allow_list);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to replace auth.allow list");

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15014,9 +15014,8 @@ glusterd_add_peers_to_auth_list(char *volname)
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
             goto out;
-        } else {
-            new_auth_allow_list = NULL;
         }
+        new_auth_allow_list = NULL;
         ret = glusterd_create_volfiles_and_notify_services(volinfo);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_VOLFILE_CREATE_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15009,13 +15009,13 @@ glusterd_add_peers_to_auth_list(char *volname)
                    "Unable to set old.auth.allow list");
             goto out;
         }
-        dict_del_sizen(volinfo->dict, "auth.allow");
-        ret = dict_set_dynstr_with_alloc(volinfo->dict, "auth.allow",
-                                         new_auth_allow_list);
+        ret = dict_set_dynstr(volinfo->dict, "auth.allow", new_auth_allow_list);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
             goto out;
+        } else {
+            new_auth_allow_list = NULL;
         }
         ret = glusterd_create_volfiles_and_notify_services(volinfo);
         if (ret) {
@@ -15055,7 +15055,6 @@ glusterd_replace_old_auth_allow_list(char *volname)
         goto out;
     }
 
-    dict_del_sizen(volinfo->dict, "auth.allow");
     ret = dict_set_dynstr_with_alloc(volinfo->dict, "auth.allow",
                                      old_auth_allow_list);
     if (ret) {


### PR DESCRIPTION
glusterd_add_peers_to_auth_list function added peer names in auth.allow
list along with a user configured auth.allow and saved user configured
auth.allow as a old.auth.allow. After add brick ran successfully it
call glusterd_replace_old_auth_allow_list to swap the key and regenerate
a volume graph.The list is corrupted because during dict_del (auth.allow)
(and old.auth.allow) buffer is clean up and same buffer is used to
save a new key.

Solution: Save auth.allow and old.auth.allow as a key after calling the
    function dict_set_dynstr_with_alloc, the fuction allocate a new buffer
    to save a key value in dictionary.

Fixes: #2625
Change-Id: I359bf906d3521f1644db6b16948c62198a58ac93
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

