### PR TITLE
glusterd_add_peers_to_auth_list function added peer names in auth.allow

### DIFF
--- a/tests/bugs/glusterd/bug-1720566.t
+++ b/tests/bugs/glusterd/bug-1720566.t
@@ -4,6 +4,13 @@
 . $(dirname $0)/../../cluster.rc
 . $(dirname $0)/../../volume.rc
 
+function volinfo_field()
+{
+    local vol=$1;
+    local field=$2;
+
+    $CLI_1 volume info $vol | grep "^$field: " | sed 's/.*: //';
+}
 
 cleanup;
 V0="TestLongVolnamec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9037fec363b7b536700ff06eedeae0dd9abcd"
@@ -17,6 +24,7 @@ $CLI_1 volume create $V0 $H1:$B1/$V0  $H2:$B2/$V0
 EXPECT 'Created' cluster_volinfo_field 1 $V0 'Status';
 $CLI_1 volume create $V1 $H1:$B1/$V1  $H2:$B2/$V1
 EXPECT 'Created' cluster_volinfo_field 1 $V1 'Status';
+$CLI_1 volume set $V0 auth.allow 1.2.3.4
 
 $CLI_1 volume start $V0
 EXPECT 'Started' cluster_volinfo_field 1 $V0 'Status';
@@ -40,7 +48,7 @@ TEST touch $M1/dir{1..4}/files{1..4};
 TEST $CLI_1 volume add-brick $V0 $H1:$B1/${V0}_1 $H2:$B2/${V0}_1
 TEST $CLI_1 volume add-brick $V1 $H1:$B1/${V1}_1 $H2:$B2/${V1}_1
 
-
+EXPECT '1.2.3.4' volinfo_field $V0 'auth.allow'
 TEST $CLI_1 volume rebalance $V0 start
 TEST $CLI_1 volume rebalance $V1  start
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -15101,21 +15101,20 @@ glusterd_add_peers_to_auth_list(char *volname)
          * keep the copy of auth_allow_list as old_auth_allow_list in
          * volinfo->dict.
          */
-        dict_del_sizen(volinfo->dict, "auth.allow");
-        ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
-                            new_auth_allow_list);
+        ret = dict_set_dynstr_with_alloc(volinfo->dict, "old.auth.allow",
+                                         auth_allow_list);
+        if (ret) {
+            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
+                   "Unable to set old.auth.allow list");
+            goto out;
+        }
+        ret = dict_set_dynstr(volinfo->dict, "auth.allow", new_auth_allow_list);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
                    "Unable to set new auth.allow list");
             goto out;
         }
-        ret = dict_set_strn(volinfo->dict, "old.auth.allow",
-                            SLEN("old.auth.allow"), auth_allow_list);
-        if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
-                   "Unable to set old auth.allow list");
-            goto out;
-        }
+        new_auth_allow_list = NULL;
         ret = glusterd_create_volfiles_and_notify_services(volinfo);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_VOLFILE_CREATE_FAIL,
@@ -15157,9 +15156,8 @@ glusterd_replace_old_auth_allow_list(char *volname)
         goto out;
     }
 
-    dict_del_sizen(volinfo->dict, "auth.allow");
-    ret = dict_set_strn(volinfo->dict, "auth.allow", SLEN("auth.allow"),
-                        old_auth_allow_list);
+    ret = dict_set_dynstr_with_alloc(volinfo->dict, "auth.allow",
+                                     old_auth_allow_list);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_DICT_SET_FAILED,
                "Unable to replace auth.allow list");


### PR DESCRIPTION
list along with a user configured auth.allow and saved user configured
auth.allow as a old.auth.allow. After add brick ran successfully it
call glusterd_replace_old_auth_allow_list to swap the key and regenerate
a volume graph.The list is corrupted because during dict_del (auth.allow)
(and old.auth.allow) buffer is clean up and same buffer is used to
save a new key.

Solution: Save auth.allow and old.auth.allow as a key after calling the
function dict_set_dynstr_with_alloc, the fuction allocate a new buffer
to save a key value in dictionary.

> Fixes: #2625
> Change-Id: I359bf906d3521f1644db6b16948c62198a58ac93
> Signed-off-by: Mohit Agrawal moagrawa@redhat.com
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/2703)

Fixes: #2625
Change-Id: Iee7c37d3b4349764c928e70f61ab713d2f3d1940
Signed-off-by: Mohit Agrawal moagrawa@redhat.com

