### PR TITLE
rpc, glusterd: drop tier leftover macro

### DIFF
--- a/rpc/rpc-lib/src/protocol-common.h
+++ b/rpc/rpc-lib/src/protocol-common.h
@@ -368,11 +368,7 @@ typedef enum gf_getspec_flags_type gf_getspec_flags_type;
 #define GD_MGMT_HNDSK_PROGRAM 1239873 /* Completely random */
 #define GD_MGMT_HNDSK_VERSION 1
 
-#define GD_VOLUME_NAME_MAX                                                     \
-    ((NAME_MAX + 1) - 5) /* Maximum size of volume name */
-#define GD_VOLUME_NAME_MAX_TIER                                                \
-    (GD_VOLUME_NAME_MAX + 5) /* +5 needed for '-hot'                           \
-                                and '-cold' suffixes*/
+#define GD_VOLUME_NAME_MAX (NAME_MAX + 1) /* Maximum size of volume name */
 
 #define GLUSTER_PROCESS_UUID_FMT                                               \
     "CTX_ID:%s-GRAPH_ID:%d-PID:%d-HOST:%s-PC_NAME:%s-RECON_NO:%s"

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -509,15 +509,9 @@ struct glusterd_volinfo_ {
        the volume which is snapped. In
        case of a non-snap volume, this
        field will be initialized as N/A */
-    char volname[NAME_MAX + 1];
-    /* NAME_MAX + 1 will be equal to
-     * GD_VOLUME_NAME_MAX + 5.(also to
-     * GD_VOLUME_NAME_MAX_TIER). An extra 5
-     * bytes are added to GD_VOLUME_NAME_MAX
-     * because, as part of the tiering
-     * volfile generation code, we are
-     * temporarily appending either "-hot"
-     * or "-cold" */
+
+    char volname[GD_VOLUME_NAME_MAX];
+
     gf_atomic_t volpeerupdate;
     /* Flag to check about volume has received updates
        from peer


### PR DESCRIPTION
Since tiering feature is mostly dropped, GD_VOLUME_NAME_MAX_TIER quirk
is no longer needed and may be replaced with plain GD_VOLUME_NAME_MAX.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

