### PR TITLE
libglusterfs, cli, rpc, xlators: consistently use time_t

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -1195,7 +1195,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
                               "remove-objects",
                               NULL};
     char *w = NULL;
-    uint32_t time = 0;
+    time_t time = 0;
     double percent = 0;
     char *end_ptr = NULL;
     int64_t limit = 0;

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -1428,9 +1428,9 @@ gf_cli_print_rebalance_status(dict_t *dict, enum gf_task_types task_type)
     uint32_t min = 0;
     uint32_t sec = 0;
     gf_boolean_t fix_layout = _gf_false;
-    uint64_t max_time = 0;
-    uint64_t max_elapsed = 0;
-    uint64_t time_left = 0;
+    time_t max_time = 0;
+    time_t max_elapsed = 0;
+    time_t time_left = 0;
     gf_boolean_t show_estimates = _gf_false;
 
     ret = dict_get_int32_sizen(dict, "count", &count);
@@ -1555,7 +1555,7 @@ gf_cli_print_rebalance_status(dict_t *dict, enum gf_task_types task_type)
             gf_log("cli", GF_LOG_TRACE, "failed to get run-time");
 
         snprintf(key, sizeof(key), "time-left-%d", i);
-        ret = dict_get_uint64(dict, key, &time_left);
+        ret = dict_get_time(dict, key, &time_left);
         if (ret)
             gf_log("cli", GF_LOG_TRACE, "failed to get time left");
 

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -1046,7 +1046,7 @@ gf_volume_name_validate(const char *volume_name)
 }
 
 int
-gf_string2time(const char *str, uint32_t *n)
+gf_string2time(const char *str, time_t *n)
 {
     unsigned long value = 0;
     char *tail = NULL;

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -965,7 +965,7 @@ gf_strn2boolean(const char *str, const int len, gf_boolean_t *b);
 int
 gf_string2percent(const char *str, double *n);
 int
-gf_string2time(const char *str, uint32_t *n);
+gf_string2time(const char *str, time_t *n);
 
 int
 gf_lockfd(int fd);

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -319,6 +319,19 @@ dict_get_uint64(dict_t *this, char *key, uint64_t *val);
 GF_MUST_CHECK int
 dict_set_uint64(dict_t *this, char *key, uint64_t val);
 
+/* POSIX-compliant systems requires the 'time_t' to be a signed integer. */
+#if __WORDSIZE == 64
+#define dict_get_time(dict, key, val) dict_get_int64((dict), (key), (val))
+#define dict_set_time(dict, key, val) dict_set_int64((dict), (key), (val))
+#elif __WORDSIZE == 32
+#define dict_get_time(dict, key, val)                   \
+    dict_get_int32((dict), (key), ((int32_t *)(val)))
+#define dict_set_time(dict, key, val)                   \
+    dict_set_int32((dict), (key), ((int32_t)(val)))
+#else
+#error "unknown word size"
+#endif /* WORDSIZE check */
+
 GF_MUST_CHECK int
 dict_check_flag(dict_t *this, char *key, int flag);
 GF_MUST_CHECK int

--- a/libglusterfs/src/glusterfs/options.h
+++ b/libglusterfs/src/glusterfs/options.h
@@ -198,7 +198,7 @@ DECLARE_INIT_OPT(gf_boolean_t, bool);
 DECLARE_INIT_OPT(xlator_t *, xlator);
 DECLARE_INIT_OPT(char *, path);
 DECLARE_INIT_OPT(double, double);
-DECLARE_INIT_OPT(uint32_t, time);
+DECLARE_INIT_OPT(time_t, time);
 
 #define DEFINE_INIT_OPT(type_t, type, conv)                                    \
     int xlator_option_init_##type(xlator_t *this, dict_t *options, char *key,  \
@@ -279,7 +279,7 @@ DECLARE_RECONF_OPT(gf_boolean_t, bool);
 DECLARE_RECONF_OPT(xlator_t *, xlator);
 DECLARE_RECONF_OPT(char *, path);
 DECLARE_RECONF_OPT(double, double);
-DECLARE_RECONF_OPT(uint32_t, time);
+DECLARE_RECONF_OPT(time_t, time);
 
 #define DEFINE_RECONF_OPT(type_t, type, conv)                                  \
     int xlator_option_reconf_##type(xlator_t *this, dict_t *options,           \

--- a/libglusterfs/src/options.c
+++ b/libglusterfs/src/options.c
@@ -452,7 +452,7 @@ xlator_option_validate_time(xlator_t *xl, const char *key, const char *value,
 {
     int ret = -1;
     char errstr[256];
-    uint32_t input_time = 0;
+    time_t input_time = 0;
 
     /* Check if the value is valid time */
     if (gf_string2time(value, &input_time) != 0) {
@@ -476,8 +476,7 @@ xlator_option_validate_time(xlator_t *xl, const char *key, const char *value,
 
     if ((input_time < opt->min) || (input_time > opt->max)) {
         snprintf(errstr, 256,
-                 "'%" PRIu32
-                 "' in 'option %s %s' is "
+                 "'%ld' in 'option %s %s' is "
                  "out of range [%.0f - %.0f]",
                  input_time, key, value, opt->min, opt->max);
         gf_smsg(xl->name, GF_LOG_ERROR, 0, LG_MSG_OUT_OF_RANGE, "error=%s",
@@ -1231,7 +1230,7 @@ DEFINE_INIT_OPT(gf_boolean_t, bool, gf_string2boolean);
 DEFINE_INIT_OPT(xlator_t *, xlator, xl_by_name);
 DEFINE_INIT_OPT(char *, path, pass);
 DEFINE_INIT_OPT(double, double, gf_string2double);
-DEFINE_INIT_OPT(uint32_t, time, gf_string2time);
+DEFINE_INIT_OPT(time_t, time, gf_string2time);
 
 DEFINE_RECONF_OPT(char *, str, pass);
 DEFINE_RECONF_OPT(uint64_t, uint64, gf_string2uint64);
@@ -1246,4 +1245,4 @@ DEFINE_RECONF_OPT(gf_boolean_t, bool, gf_string2boolean);
 DEFINE_RECONF_OPT(xlator_t *, xlator, xl_by_name);
 DEFINE_RECONF_OPT(char *, path, pass);
 DEFINE_RECONF_OPT(double, double, gf_string2double);
-DEFINE_RECONF_OPT(uint32_t, time, gf_string2time);
+DEFINE_RECONF_OPT(time_t, time, gf_string2time);

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -150,7 +150,7 @@ rpc_clnt_ping_timer_expired(void *rpc_ptr)
 
     if (disconnect) {
         gf_log(trans->name, GF_LOG_CRITICAL,
-               "server %s has not responded in the last %d "
+               "server %s has not responded in the last %ld "
                "seconds, disconnecting.",
                trans->peerinfo.identifier, conn->ping_timeout);
 

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -169,7 +169,9 @@ call_bail(void *data)
 
         gf_log(conn->name, GF_LOG_ERROR,
                "bailing out frame type(%s), op(%s(%d)), xid = 0x%x, "
-               "unique = %" PRIu64 ", sent = %s, timeout = %d for %s",
+               "unique = %" PRIu64
+               ", sent = %s, timeout = %ld "
+               "for %s",
                trav->rpcreq->prog->progname,
                (trav->rpcreq->prog->procnames)
                    ? trav->rpcreq->prog->procnames[trav->rpcreq->procnum]
@@ -1004,9 +1006,9 @@ rpc_clnt_connection_init(struct rpc_clnt *clnt, glusterfs_ctx_t *ctx,
         goto out;
     }
 
-    ret = dict_get_int32(options, "frame-timeout", &conn->frame_timeout);
+    ret = dict_get_time(options, "frame-timeout", &conn->frame_timeout);
     if (ret >= 0) {
-        gf_log(name, GF_LOG_INFO, "setting frame-timeout to %d",
+        gf_log(name, GF_LOG_INFO, "setting frame-timeout to %ld",
                conn->frame_timeout);
     } else {
         gf_log(name, GF_LOG_DEBUG, "defaulting frame-timeout to 30mins");
@@ -1014,9 +1016,9 @@ rpc_clnt_connection_init(struct rpc_clnt *clnt, glusterfs_ctx_t *ctx,
     }
     conn->rpc_clnt = clnt;
 
-    ret = dict_get_int32(options, "ping-timeout", &conn->ping_timeout);
+    ret = dict_get_time(options, "ping-timeout", &conn->ping_timeout);
     if (ret >= 0) {
-        gf_log(name, GF_LOG_DEBUG, "setting ping-timeout to %d",
+        gf_log(name, GF_LOG_DEBUG, "setting ping-timeout to %ld",
                conn->ping_timeout);
     } else {
         /*TODO: Once the epoll thread model is fixed,
@@ -1944,7 +1946,7 @@ rpc_clnt_reconfig(struct rpc_clnt *rpc, struct rpc_clnt_config *config)
     if (config->ping_timeout) {
         if (config->ping_timeout != rpc->conn.ping_timeout)
             gf_log(rpc->conn.name, GF_LOG_INFO,
-                   "changing ping timeout to %d (from %d)",
+                   "changing ping timeout to %ld (from %ld)",
                    config->ping_timeout, rpc->conn.ping_timeout);
 
         pthread_mutex_lock(&rpc->conn.lock);
@@ -1957,7 +1959,7 @@ rpc_clnt_reconfig(struct rpc_clnt *rpc, struct rpc_clnt_config *config)
     if (config->rpc_timeout) {
         if (config->rpc_timeout != rpc->conn.config.rpc_timeout)
             gf_log(rpc->conn.name, GF_LOG_INFO,
-                   "changing timeout to %d (from %d)", config->rpc_timeout,
+                   "changing timeout to %ld (from %ld)", config->rpc_timeout,
                    rpc->conn.config.rpc_timeout);
         rpc->conn.config.rpc_timeout = config->rpc_timeout;
     }

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -117,10 +117,10 @@ typedef struct rpc_auth_data {
 } rpc_auth_data_t;
 
 struct rpc_clnt_config {
-    int rpc_timeout;
+    time_t rpc_timeout;
     int remote_port;
     char *remote_host;
-    int ping_timeout;
+    time_t ping_timeout;
 };
 
 #define rpc_auth_flavour(au) ((au).flavour)
@@ -142,8 +142,8 @@ struct rpc_clnt_connection {
     uint64_t cleanup_gen;
     char *name;
     int32_t ping_started;
-    int32_t frame_timeout;
-    int32_t ping_timeout;
+    time_t frame_timeout;
+    time_t ping_timeout;
     gf_boolean_t disconnected;
     char connected;
 };

--- a/tests/bugs/distribute/bug-862967.t
+++ b/tests/bugs/distribute/bug-862967.t
@@ -29,7 +29,7 @@ TEST $CLI volume set $V0 stat-prefetch off
 TEST $CLI volume start $V0
 
 ## Mount FUSE
-TEST glusterfs --attribute-timeout=0 --entry-timeout=0 --gid-timeout=-1 -s $H0 --volfile-id $V0 $M0;
+TEST glusterfs --attribute-timeout=0 --entry-timeout=0 --gid-timeout=0 -s $H0 --volfile-id $V0 $M0;
 
 # change dir permissions
 mkdir $M0/dir;

--- a/tests/bugs/distribute/bug-915554.t
+++ b/tests/bugs/distribute/bug-915554.t
@@ -24,7 +24,7 @@ BRICK_COUNT=3
 TEST $CLI volume create $V0 $H0:$B0/${V0}0 $H0:$B0/${V0}1 $H0:$B0/${V0}2
 TEST $CLI volume start $V0
 
-TEST glusterfs --attribute-timeout=0 --entry-timeout=0 --gid-timeout=-1 -s $H0 --volfile-id $V0 $M0;
+TEST glusterfs --attribute-timeout=0 --entry-timeout=0 --gid-timeout=0 -s $H0 --volfile-id $V0 $M0;
 
 i=1
 # Write some data to a file and extend such that the file is sparse to a sector

--- a/xlators/cluster/afr/src/afr-self-heald.h
+++ b/xlators/cluster/afr/src/afr-self-heald.h
@@ -51,7 +51,7 @@ typedef struct {
 
     eh_t *split_brain;
     eh_t **statistics;
-    int timeout;
+    time_t timeout;
     uint32_t max_threads;
     uint32_t wait_qlength;
     uint32_t halo_max_latency_msec;

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -162,7 +162,7 @@ reconfigure(xlator_t *this, dict_t *options)
     afr_private_t *priv = NULL;
     xlator_t *read_subvol = NULL;
     int read_subvol_index = -1;
-    int timeout_old = 0;
+    time_t timeout_old = 0;
     int ret = -1;
     int index = -1;
     char *qtype = NULL;
@@ -286,7 +286,7 @@ reconfigure(xlator_t *this, dict_t *options)
                      out);
 
     timeout_old = priv->shd.timeout;
-    GF_OPTION_RECONF("heal-timeout", priv->shd.timeout, options, int32, out);
+    GF_OPTION_RECONF("heal-timeout", priv->shd.timeout, options, time, out);
 
     GF_OPTION_RECONF("consistent-metadata", priv->consistent_metadata, options,
                      bool, out);
@@ -558,7 +558,7 @@ init(xlator_t *this)
     GF_OPTION_INIT("self-heal-daemon", priv->shd.enabled, bool, out);
 
     GF_OPTION_INIT("iam-self-heal-daemon", priv->shd.iamshd, bool, out);
-    GF_OPTION_INIT("heal-timeout", priv->shd.timeout, int32, out);
+    GF_OPTION_INIT("heal-timeout", priv->shd.timeout, time, out);
 
     GF_OPTION_INIT("consistent-metadata", priv->consistent_metadata, bool, out);
     GF_OPTION_INIT("consistent-io", priv->consistent_io, bool, out);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4569,9 +4569,9 @@ gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status)
     uint64_t failures = 0;
     uint64_t skipped = 0;
     char *status = "";
-    double elapsed = 0;
-    uint64_t time_to_complete = 0;
-    uint64_t time_left = 0;
+    time_t elapsed = 0;
+    time_t time_to_complete = 0;
+    time_t time_left = 0;
     gf_defrag_info_t *defrag = conf->defrag;
 
     if (!defrag)
@@ -4598,8 +4598,8 @@ gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status)
             time_left = time_to_complete - elapsed;
 
         gf_log(THIS->name, GF_LOG_INFO,
-               "TIME: Estimated total time to complete (size)= %" PRIu64
-               " seconds, seconds left = %" PRIu64 "",
+               "TIME: Estimated total time to complete (size)= %ld"
+               " seconds, seconds left = %ld",
                time_to_complete, time_left);
     }
 
@@ -4622,7 +4622,7 @@ gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status)
     if (ret)
         gf_log(THIS->name, GF_LOG_WARNING, "failed to set status");
 
-    ret = dict_set_double(dict, "run-time", elapsed);
+    ret = dict_set_time(dict, "run-time", elapsed);
     if (ret)
         gf_log(THIS->name, GF_LOG_WARNING, "failed to set run-time");
 
@@ -4634,7 +4634,7 @@ gf_defrag_status_get(dht_conf_t *conf, dict_t *dict, gf_boolean_t log_status)
     if (ret)
         gf_log(THIS->name, GF_LOG_WARNING, "failed to set skipped file count");
 
-    ret = dict_set_uint64(dict, "time-left", time_left);
+    ret = dict_set_time(dict, "time-left", time_left);
     if (ret)
         gf_log(THIS->name, GF_LOG_WARNING, "failed to set time-left");
 
@@ -4661,7 +4661,7 @@ log:
         }
 
         gf_msg("DHT", GF_LOG_INFO, 0, DHT_MSG_REBALANCE_STATUS,
-               "Rebalance is %s. Time taken is %.2f secs "
+               "Rebalance is %s. Time taken is %ld secs "
                "Files migrated: %" PRIu64 ", size: %" PRIu64
                ", lookups: %" PRIu64 ", failures: %" PRIu64
                ", skipped: "

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -601,7 +601,7 @@ struct subvol_healer {
 struct _ec_self_heald {
     gf_boolean_t iamshd;
     gf_boolean_t enabled;
-    int timeout;
+    time_t timeout;
     uint32_t max_threads;
     uint32_t wait_qlength;
     struct subvol_healer *index_healers;
@@ -671,8 +671,8 @@ struct _ec {
     uint32_t background_heals;
     uint32_t heal_wait_qlen;
     uint32_t self_heal_window_size; /* max size of read/writes */
-    uint32_t eager_lock_timeout;
-    uint32_t other_eager_lock_timeout;
+    time_t eager_lock_timeout;
+    time_t other_eager_lock_timeout;
     struct list_head pending_fops;
     struct list_head heal_waiting;
     struct list_head healing;

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -262,16 +262,16 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("other-eager-lock", ec->other_eager_lock, options, bool,
                      failed);
     GF_OPTION_RECONF("eager-lock-timeout", ec->eager_lock_timeout, options,
-                     uint32, failed);
+                     time, failed);
     GF_OPTION_RECONF("other-eager-lock-timeout", ec->other_eager_lock_timeout,
-                     options, uint32, failed);
+                     options, time, failed);
     GF_OPTION_RECONF("background-heals", background_heals, options, uint32,
                      failed);
     GF_OPTION_RECONF("heal-wait-qlength", heal_wait_qlen, options, uint32,
                      failed);
     GF_OPTION_RECONF("self-heal-window-size", ec->self_heal_window_size,
                      options, uint32, failed);
-    GF_OPTION_RECONF("heal-timeout", ec->shd.timeout, options, int32, failed);
+    GF_OPTION_RECONF("heal-timeout", ec->shd.timeout, options, time, failed);
     ec_configure_background_heal_opts(ec, background_heals, heal_wait_qlen);
     GF_OPTION_RECONF("shd-max-threads", ec->shd.max_threads, options, uint32,
                      failed);
@@ -848,10 +848,9 @@ init(xlator_t *this)
     GF_OPTION_INIT("iam-self-heal-daemon", ec->shd.iamshd, bool, failed);
     GF_OPTION_INIT("eager-lock", ec->eager_lock, bool, failed);
     GF_OPTION_INIT("other-eager-lock", ec->other_eager_lock, bool, failed);
-    GF_OPTION_INIT("eager-lock-timeout", ec->eager_lock_timeout, uint32,
-                   failed);
+    GF_OPTION_INIT("eager-lock-timeout", ec->eager_lock_timeout, time, failed);
     GF_OPTION_INIT("other-eager-lock-timeout", ec->other_eager_lock_timeout,
-                   uint32, failed);
+                   time, failed);
     GF_OPTION_INIT("background-heals", ec->background_heals, uint32, failed);
     GF_OPTION_INIT("heal-wait-qlength", ec->heal_wait_qlen, uint32, failed);
     GF_OPTION_INIT("self-heal-window-size", ec->self_heal_window_size, uint32,
@@ -862,7 +861,7 @@ init(xlator_t *this)
     if (ec_assign_read_policy(ec, read_policy))
         goto failed;
 
-    GF_OPTION_INIT("heal-timeout", ec->shd.timeout, int32, failed);
+    GF_OPTION_INIT("heal-timeout", ec->shd.timeout, time, failed);
     GF_OPTION_INIT("shd-max-threads", ec->shd.max_threads, uint32, failed);
     GF_OPTION_INIT("shd-wait-qlength", ec->shd.wait_qlength, uint32, failed);
     GF_OPTION_INIT("optimistic-change-log", ec->optimistic_changelog, bool,

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3717,7 +3717,7 @@ reconfigure(xlator_t *this, dict_t *options)
     int log_format = -1;
     int logger = -1;
     uint32_t log_buf_size = 0;
-    uint32_t log_flush_timeout = 0;
+    time_t log_flush_timeout = 0;
     int32_t old_dump_interval;
     int32_t threads;
 
@@ -3879,7 +3879,7 @@ init(xlator_t *this)
     int log_level = -1;
     int ret = -1;
     uint32_t log_buf_size = 0;
-    uint32_t log_flush_timeout = 0;
+    time_t log_flush_timeout = 0;
     int32_t threads;
 
     if (!this)

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -528,9 +528,7 @@ reconfigure(xlator_t *this, dict_t *options)
     barrier_priv_t *priv = NULL;
     int ret = -1;
     gf_boolean_t barrier_enabled = _gf_false;
-    uint32_t timeout = {
-        0,
-    };
+    time_t timeout = 0;
     struct list_head queue = {
         0,
     };
@@ -589,9 +587,7 @@ init(xlator_t *this)
 {
     int ret = -1;
     barrier_priv_t *priv = NULL;
-    uint32_t timeout = {
-        0,
-    };
+    time_t timeout = 0;
 
     if (!this->children || this->children->next) {
         gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1849,12 +1849,12 @@ static int32_t
 br_signer_handle_options(xlator_t *this, br_private_t *priv, dict_t *options)
 {
     if (options) {
-        GF_OPTION_RECONF("expiry-time", priv->expiry_time, options, uint32,
+        GF_OPTION_RECONF("expiry-time", priv->expiry_time, options, time,
                          error_return);
         GF_OPTION_RECONF("signer-threads", priv->signer_th_count, options,
                          uint32, error_return);
     } else {
-        GF_OPTION_INIT("expiry-time", priv->expiry_time, uint32, error_return);
+        GF_OPTION_INIT("expiry-time", priv->expiry_time, time, error_return);
         GF_OPTION_INIT("signer-threads", priv->signer_th_count, uint32,
                        error_return);
     }
@@ -1871,7 +1871,7 @@ br_signer_init(xlator_t *this, br_private_t *priv)
     int32_t ret = 0;
     int numbricks = 0;
 
-    GF_OPTION_INIT("expiry-time", priv->expiry_time, uint32, error_return);
+    GF_OPTION_INIT("expiry-time", priv->expiry_time, time, error_return);
     GF_OPTION_INIT("brick-count", numbricks, int32, error_return);
     GF_OPTION_INIT("signer-threads", priv->signer_th_count, uint32,
                    error_return);

--- a/xlators/features/bit-rot/src/bitd/bit-rot.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.h
@@ -201,7 +201,7 @@ struct br_private {
                                       signing and the workers which sign
                                       the objects */
 
-    uint32_t expiry_time; /* objects "wait" time */
+    time_t expiry_time; /* objects "wait" time */
 
     uint32_t signer_th_count; /* Number of signing process threads */
 

--- a/xlators/features/changelog/src/changelog-helpers.h
+++ b/xlators/features/changelog/src/changelog-helpers.h
@@ -220,10 +220,10 @@ struct changelog_priv {
     int wfd;
 
     /* rollover time */
-    int32_t rollover_time;
+    time_t rollover_time;
 
     /* fsync() interval */
-    int32_t fsync_interval;
+    time_t fsync_interval;
 
     /* changelog type maps */
     const char *maps[CHANGELOG_MAX_TYPE];

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -1924,7 +1924,7 @@ changelog_assign_encoding(changelog_priv_t *priv, char *enc)
 }
 
 static void
-changelog_assign_barrier_timeout(changelog_priv_t *priv, uint32_t timeout)
+changelog_assign_barrier_timeout(changelog_priv_t *priv, time_t timeout)
 {
     LOCK(&priv->lock);
     {
@@ -2456,7 +2456,7 @@ reconfigure(xlator_t *this, dict_t *options)
     char csnap_dir[PATH_MAX] = {
         0,
     };
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     priv = this->private;
     if (!priv)
@@ -2537,8 +2537,8 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("encoding", tmp, options, str, out);
     changelog_assign_encoding(priv, tmp);
 
-    GF_OPTION_RECONF("rollover-time", priv->rollover_time, options, int32, out);
-    GF_OPTION_RECONF("fsync-interval", priv->fsync_interval, options, int32,
+    GF_OPTION_RECONF("rollover-time", priv->rollover_time, options, time, out);
+    GF_OPTION_RECONF("fsync-interval", priv->fsync_interval, options, time,
                      out);
     GF_OPTION_RECONF("changelog-barrier-timeout", timeout, options, time, out);
     changelog_assign_barrier_timeout(priv, timeout);
@@ -2601,7 +2601,7 @@ changelog_init_options(xlator_t *this, changelog_priv_t *priv)
 {
     int ret = 0;
     char *tmp = NULL;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
     char htime_dir[PATH_MAX] = {
         0,
     };
@@ -2655,9 +2655,9 @@ changelog_init_options(xlator_t *this, changelog_priv_t *priv)
     changelog_assign_encoding(priv, tmp);
     changelog_encode_change(priv);
 
-    GF_OPTION_INIT("rollover-time", priv->rollover_time, int32, dealloc_2);
+    GF_OPTION_INIT("rollover-time", priv->rollover_time, time, dealloc_2);
 
-    GF_OPTION_INIT("fsync-interval", priv->fsync_interval, int32, dealloc_2);
+    GF_OPTION_INIT("fsync-interval", priv->fsync_interval, time, dealloc_2);
 
     GF_OPTION_INIT("changelog-barrier-timeout", timeout, time, dealloc_2);
     changelog_assign_barrier_timeout(priv, timeout);

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -73,11 +73,11 @@ out:
  * timeout value(in seconds) set as an option to this xlator.
  * -1 error case
  */
-static int32_t
+static time_t
 get_recall_lease_timeout(xlator_t *this)
 {
     leases_private_t *priv = NULL;
-    int32_t timeout = -1;
+    time_t timeout = (time_t)-1;
 
     GF_VALIDATE_OR_GOTO("leases", this, out);
 

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -972,7 +972,7 @@ reconfigure(xlator_t *this, dict_t *options)
     */
 
     GF_OPTION_RECONF("lease-lock-recall-timeout", priv->recall_lease_timeout,
-                     options, int32, out);
+                     options, time, out);
 
     ret = 0;
 out:
@@ -994,7 +994,7 @@ init(xlator_t *this)
 
     GF_OPTION_INIT("leases", priv->leases_enabled, bool, out);
     GF_OPTION_INIT("lease-lock-recall-timeout", priv->recall_lease_timeout,
-                   int32, out);
+                   time, out);
     pthread_mutex_init(&priv->mutex, NULL);
     INIT_LIST_HEAD(&priv->client_list);
     INIT_LIST_HEAD(&priv->recall_list);

--- a/xlators/features/leases/src/leases.h
+++ b/xlators/features/leases/src/leases.h
@@ -159,7 +159,7 @@ struct _leases_private {
     pthread_t recall_thr;
     pthread_mutex_t mutex;
     pthread_cond_t cond;
-    int32_t recall_lease_timeout;
+    time_t recall_lease_timeout;
     gf_boolean_t inited_recall_thr;
     gf_boolean_t fini;
     gf_boolean_t leases_enabled;

--- a/xlators/features/quiesce/src/quiesce.h
+++ b/xlators/features/quiesce/src/quiesce.h
@@ -32,7 +32,7 @@ typedef struct {
     int queue_size;
     pthread_t thr;
     struct mem_pool *local_pool;
-    uint32_t timeout;
+    time_t timeout;
     char *failover_hosts;
     struct list_head failover_list;
 } quiesce_priv_t;

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -641,7 +641,7 @@ unwind:
 }
 
 static inline gf_boolean_t
-quota_timeout(time_t t, uint32_t timeout)
+quota_timeout(time_t t, time_t timeout)
 {
     return (gf_time() - t) >= timeout;
 }
@@ -5157,9 +5157,9 @@ quota_priv_dump(xlator_t *this)
     if (ret)
         goto out;
     else {
-        gf_proc_dump_write("soft-timeout", "%u", priv->soft_timeout);
-        gf_proc_dump_write("hard-timeout", "%u", priv->hard_timeout);
-        gf_proc_dump_write("alert-time", "%u", priv->log_timeout);
+        gf_proc_dump_write("soft-timeout", "%ld", priv->soft_timeout);
+        gf_proc_dump_write("hard-timeout", "%ld", priv->hard_timeout);
+        gf_proc_dump_write("alert-time", "%ld", priv->log_timeout);
         gf_proc_dump_write("quota-on", "%d", priv->is_quota_on);
         gf_proc_dump_write("statfs", "%d", priv->consider_statfs);
         gf_proc_dump_write("volume-uuid", "%s", priv->volume_uuid);

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -199,10 +199,9 @@ struct quota_local {
 typedef struct quota_local quota_local_t;
 
 struct quota_priv {
-    /* FIXME: consider time_t for timeouts. */
-    uint32_t soft_timeout;
-    uint32_t hard_timeout;
-    uint32_t log_timeout;
+    time_t soft_timeout;
+    time_t hard_timeout;
+    time_t log_timeout;
     double default_soft_lim;
     gf_boolean_t is_quota_on;
     gf_boolean_t consider_statfs;

--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -47,7 +47,7 @@ is_upcall_enabled(xlator_t *this)
 /*
  * Get the cache_invalidation_timeout
  */
-static int32_t
+static time_t
 get_cache_invalidation_timeout(xlator_t *this)
 {
     upcall_private_t *priv = NULL;

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -2226,7 +2226,7 @@ reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("cache-invalidation", priv->cache_invalidation_enabled,
                      options, bool, out);
     GF_OPTION_RECONF("cache-invalidation-timeout",
-                     priv->cache_invalidation_timeout, options, int32, out);
+                     priv->cache_invalidation_timeout, options, time, out);
 
     ret = 0;
 
@@ -2263,7 +2263,7 @@ init(xlator_t *this)
     GF_OPTION_INIT("cache-invalidation", priv->cache_invalidation_enabled, bool,
                    out);
     GF_OPTION_INIT("cache-invalidation-timeout",
-                   priv->cache_invalidation_timeout, int32, out);
+                   priv->cache_invalidation_timeout, time, out);
 
     LOCK_INIT(&priv->inode_ctx_lk);
     INIT_LIST_HEAD(&priv->inode_ctx_list);

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -49,7 +49,7 @@
 
 struct _upcall_private {
     gf_boolean_t cache_invalidation_enabled;
-    int32_t cache_invalidation_timeout;
+    time_t cache_invalidation_timeout;
     struct list_head inode_ctx_list;
     gf_lock_t inode_ctx_lk;
     gf_boolean_t reaper_init_done;

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -17,7 +17,7 @@
 #include "glusterd-messages.h"
 
 int
-glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, int frame_timeout,
+glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, time_t frame_timeout,
                    glusterd_conn_notify_t notify)
 {
     int ret = -1;

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.h
@@ -23,12 +23,12 @@ struct glusterd_conn_ {
     /* Existing daemons tend to specialize their respective
      * notify implementations, so ... */
     glusterd_conn_notify_t notify;
-    int frame_timeout;
+    time_t frame_timeout;
     char sockpath[PATH_MAX];
 };
 
 int
-glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, int frame_timeout,
+glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, time_t frame_timeout,
                    glusterd_conn_notify_t notify);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5768,7 +5768,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
         fprintf(fp, "Volume%d.rebalance.files: %" PRIu64 "\n", count,
                 volinfo->rebal.rebalance_files);
         fprintf(fp, "Volume%d.rebalance.data: %s\n", count, rebal_data);
-        fprintf(fp, "Volume%d.time_left: %" PRIu64 "\n", count,
+        fprintf(fp, "Volume%d.time_left: %ld\n", count,
                 volinfo->rebal.time_left);
 
         GF_FREE(rebal_data);

--- a/xlators/mgmt/glusterd/src/glusterd-statedump.c
+++ b/xlators/mgmt/glusterd/src/glusterd-statedump.c
@@ -199,7 +199,7 @@ glusterd_dump_priv(xlator_t *this)
         gf_proc_dump_write(key, "%d", priv->op_version);
 
         gf_proc_dump_build_key(key, "glusterd", "ping-timeout");
-        gf_proc_dump_write(key, "%d", priv->ping_timeout);
+        gf_proc_dump_write(key, "%ld", priv->ping_timeout);
 #ifdef BUILD_GNFS
         gf_proc_dump_build_key(key, "glusterd", "nfs.online");
         gf_proc_dump_write(key, "%d", priv->nfs_svc.online);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -461,7 +461,7 @@ glusterd_muxsvc_common_rpc_notify(glusterd_svc_proc_t *mux_proc,
 
 int
 glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
-                          char *sockpath, int frame_timeout,
+                          char *sockpath, time_t frame_timeout,
                           glusterd_muxsvc_conn_notify_t notify)
 {
     int ret = -1;

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
@@ -107,7 +107,7 @@ glusterd_proc_get_pid(glusterd_proc_t *proc);
 
 int
 glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
-                          char *sockpath, int frame_timeout,
+                          char *sockpath, time_t frame_timeout,
                           glusterd_muxsvc_conn_notify_t notify);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -9801,7 +9801,7 @@ glusterd_defrag_volume_status_update(glusterd_volinfo_t *volinfo,
     double run_time = 0;
     uint64_t promoted = 0;
     uint64_t demoted = 0;
-    uint64_t time_left = 0;
+    time_t time_left = 0;
 
     ret = dict_get_uint64(rsp_dict, "files", &files);
     if (ret)
@@ -9840,7 +9840,7 @@ glusterd_defrag_volume_status_update(glusterd_volinfo_t *volinfo,
     if (ret)
         gf_msg_trace(this->name, 0, "failed to get run-time");
 
-    ret2 = dict_get_uint64(rsp_dict, "time-left", &time_left);
+    ret2 = dict_get_time(rsp_dict, "time-left", &time_left);
     if (ret2)
         gf_msg_trace(this->name, 0, "failed to get time left");
 
@@ -12292,7 +12292,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
     glusterd_rebalance_rsp(op_ctx, &volinfo->rebal, i);
 
     snprintf(key, sizeof(key), "time-left-%d", i);
-    ret = dict_set_uint64(op_ctx, key, volinfo->rebal.time_left);
+    ret = dict_set_time(op_ctx, key, volinfo->rebal.time_left);
     if (ret)
         gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "failed to set time left");

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1939,10 +1939,10 @@ init(xlator_t *this)
     }
 
     conf->mgmt_v3_lock_timeout = GF_LOCK_TIMER;
-    if (dict_get_uint32(this->options, "lock-timer",
-                        &conf->mgmt_v3_lock_timeout) == 0) {
+    if (dict_get_time(this->options, "lock-timer",
+                      &conf->mgmt_v3_lock_timeout) == 0) {
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_SET_FAILED,
-               "lock-timer override: %d", conf->mgmt_v3_lock_timeout);
+               "lock-timer override: %ld", conf->mgmt_v3_lock_timeout);
     }
 
     /* Set option to run bricks on valgrind if enabled in glusterd.vol */
@@ -1967,7 +1967,7 @@ init(xlator_t *this)
     }
 
     /* Store ping-timeout in conf */
-    ret = dict_get_int32(this->options, "ping-timeout", &conf->ping_timeout);
+    ret = dict_get_time(this->options, "ping-timeout", &conf->ping_timeout);
     /* Not failing here since ping-timeout can be optional as well */
 
     glusterd_mgmt_v3_lock_init();

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -218,10 +218,10 @@ typedef struct {
     char *snap_bricks_directory;
     gf_store_handle_t *missed_snaps_list_shandle;
     struct cds_list_head missed_snaps_list;
-    int ping_timeout;
+    time_t ping_timeout;
     uint32_t generation;
     int32_t workers;
-    uint32_t mgmt_v3_lock_timeout;
+    time_t mgmt_v3_lock_timeout;
     gf_atomic_t blockers;
     pthread_mutex_t attach_lock; /* Lock can be per process or a common one */
     pthread_mutex_t volume_lock; /* We release the big_lock from lot of places
@@ -378,7 +378,7 @@ struct glusterd_bitrot_scrub_ {
     char *scrub_freq;
     uint64_t scrubbed_files;
     uint64_t unsigned_files;
-    uint64_t last_scrub_time;
+    time_t last_scrub_time;
     uint64_t scrub_duration;
     uint64_t error_count;
 };
@@ -396,7 +396,7 @@ struct glusterd_rebalance_ {
     gf_defrag_status_t defrag_status;
     uuid_t rebalance_id;
     double rebalance_time;
-    uint64_t time_left;
+    time_t time_left;
     dict_t *dict; /* Dict to store misc information
                    * like list of bricks being removed */
     glusterd_op_t op;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6839,7 +6839,7 @@ init(xlator_t *this_xl)
         priv->fopen_keep_cache = fopen_keep_cache;
     }
 
-    GF_OPTION_INIT("gid-timeout", priv->gid_cache_timeout, int32, cleanup_exit);
+    GF_OPTION_INIT("gid-timeout", priv->gid_cache_timeout, time, cleanup_exit);
 
     GF_OPTION_INIT("fuse-mountopts", priv->fuse_mountopts, str, cleanup_exit);
 

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -104,7 +104,7 @@ struct fuse_private {
     gf_boolean_t selinux;
     gf_boolean_t read_only;
     int32_t fopen_keep_cache;
-    int32_t gid_cache_timeout;
+    time_t gid_cache_timeout;
     gf_boolean_t enable_ino32;
     /* This is the mount option for disabling the root-squash for the
        mount irrespective of whether the root-squash option for the

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1673,7 +1673,7 @@ reconfigure(xlator_t *this, dict_t *options)
         GF_OPTION_RECONF("pass-through", this->pass_through, options, bool,
                          unlock);
 
-        GF_OPTION_RECONF("cache-timeout", table->cache_timeout, options, int32,
+        GF_OPTION_RECONF("cache-timeout", table->cache_timeout, options, time,
                          unlock);
 
         data = dict_get(options, "priority");
@@ -1765,7 +1765,7 @@ init(xlator_t *this)
 
     GF_OPTION_INIT("cache-size", table->cache_size, size_uint64, out);
 
-    GF_OPTION_INIT("cache-timeout", table->cache_timeout, int32, out);
+    GF_OPTION_INIT("cache-timeout", table->cache_timeout, time, out);
 
     GF_OPTION_INIT("min-file-size", table->min_file_size, size_uint64, out);
 
@@ -2056,7 +2056,7 @@ ioc_priv_dump(xlator_t *this)
         gf_proc_dump_write("cache_size", "%" PRIu64, priv->cache_size);
         gf_proc_dump_write("cache_used", "%" PRIu64, priv->cache_used);
         gf_proc_dump_write("inode_count", "%u", priv->inode_count);
-        gf_proc_dump_write("cache_timeout", "%u", priv->cache_timeout);
+        gf_proc_dump_write("cache_timeout", "%ld", priv->cache_timeout);
         gf_proc_dump_write("min-file-size", "%" PRIu64, priv->min_file_size);
         gf_proc_dump_write("max-file-size", "%" PRIu64, priv->max_file_size);
     }

--- a/xlators/performance/io-cache/src/io-cache.h
+++ b/xlators/performance/io-cache/src/io-cache.h
@@ -158,7 +158,7 @@ struct ioc_table {
     pthread_mutex_t table_lock;
     xlator_t *xl;
     uint32_t inode_count;
-    int32_t cache_timeout;
+    time_t cache_timeout;
     int32_t max_pri;
     struct mem_pool *mem_pool;
 };

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -942,7 +942,7 @@ iot_priv_dump(xlator_t *this)
     gf_proc_dump_write("maximum_threads_count", "%d", conf->max_count);
     gf_proc_dump_write("current_threads_count", "%d", conf->curr_count);
     gf_proc_dump_write("sleep_count", "%d", conf->sleep_count);
-    gf_proc_dump_write("idle_time", "%d", conf->idle_time);
+    gf_proc_dump_write("idle_time", "%ld", conf->idle_time);
     gf_proc_dump_write("stack_size", "%zd", conf->stack_size);
     gf_proc_dump_write("max_high_priority_threads", "%d",
                        conf->ac_iot_limit[GF_FOP_PRI_HI]);
@@ -1235,7 +1235,7 @@ init(xlator_t *this)
     GF_OPTION_INIT("least-prio-threads", conf->ac_iot_limit[GF_FOP_PRI_LEAST],
                    int32, out);
 
-    GF_OPTION_INIT("idle-time", conf->idle_time, int32, out);
+    GF_OPTION_INIT("idle-time", conf->idle_time, time, out);
 
     GF_OPTION_INIT("enable-least-priority", conf->least_priority, bool, out);
 

--- a/xlators/performance/io-threads/src/io-threads.h
+++ b/xlators/performance/io-threads/src/io-threads.h
@@ -49,7 +49,7 @@ struct iot_conf {
     int32_t curr_count; /* actual number of threads running */
     int32_t sleep_count;
 
-    int32_t idle_time; /* in seconds */
+    time_t idle_time; /* in seconds */
 
     struct list_head clients[GF_FOP_PRI_MAX];
     /*

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -129,7 +129,7 @@ struct mdc_local {
     char *linkname;
     char *key;
     dict_t *xattr;
-    uint64_t incident_time;
+    time_t incident_time;
     bool update_cache;
 };
 
@@ -3609,12 +3609,13 @@ int
 mdc_reconfigure(xlator_t *this, dict_t *options)
 {
     struct mdc_conf *conf = NULL;
-    int timeout = 0, ret = 0;
+    time_t timeout = 0;
     char *tmp_str = NULL;
+    int ret = 0;
 
     conf = this->private;
 
-    GF_OPTION_RECONF("md-cache-timeout", timeout, options, int32, out);
+    GF_OPTION_RECONF("md-cache-timeout", timeout, options, time, out);
 
     GF_OPTION_RECONF("cache-selinux", conf->cache_selinux, options, bool, out);
 

--- a/xlators/performance/nl-cache/src/nl-cache.c
+++ b/xlators/performance/nl-cache/src/nl-cache.c
@@ -676,7 +676,7 @@ nlc_reconfigure(xlator_t *this, dict_t *options)
 
     conf = this->private;
 
-    GF_OPTION_RECONF("nl-cache-timeout", conf->cache_timeout, options, int32,
+    GF_OPTION_RECONF("nl-cache-timeout", conf->cache_timeout, options, time,
                      out);
     GF_OPTION_RECONF("nl-cache-positive-entry", conf->positive_entry_cache,
                      options, bool, out);
@@ -699,7 +699,7 @@ nlc_init(xlator_t *this)
     if (!conf)
         goto out;
 
-    GF_OPTION_INIT("nl-cache-timeout", conf->cache_timeout, int32, out);
+    GF_OPTION_INIT("nl-cache-timeout", conf->cache_timeout, time, out);
     GF_OPTION_INIT("nl-cache-positive-entry", conf->positive_entry_cache, bool,
                    out);
     GF_OPTION_INIT("nl-cache-limit", conf->cache_size, size_uint64, out);

--- a/xlators/performance/nl-cache/src/nl-cache.h
+++ b/xlators/performance/nl-cache/src/nl-cache.h
@@ -110,7 +110,7 @@ struct nlc_statistics {
 };
 
 struct nlc_conf {
-    int32_t cache_timeout;
+    time_t cache_timeout;
     gf_boolean_t positive_entry_cache;
     gf_boolean_t negative_entry_cache;
     gf_boolean_t disable_cache;

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -1074,7 +1074,7 @@ qr_priv_dump(xlator_t *this)
     gf_proc_dump_add_section("%s", key_prefix);
 
     gf_proc_dump_write("max_file_size", "%" PRIu64, conf->max_file_size);
-    gf_proc_dump_write("cache_timeout", "%d", conf->cache_timeout);
+    gf_proc_dump_write("cache_timeout", "%ld", conf->cache_timeout);
 
     if (!table) {
         goto out;
@@ -1199,7 +1199,7 @@ qr_reconfigure(xlator_t *this, dict_t *options)
         goto out;
     }
 
-    GF_OPTION_RECONF("cache-timeout", conf->cache_timeout, options, int32, out);
+    GF_OPTION_RECONF("cache-timeout", conf->cache_timeout, options, time, out);
 
     GF_OPTION_RECONF("quick-read-cache-invalidation", conf->qr_invalidation,
                      options, bool, out);
@@ -1350,7 +1350,7 @@ qr_init(xlator_t *this)
 
     GF_OPTION_INIT("max-file-size", conf->max_file_size, size_uint64, out);
 
-    GF_OPTION_INIT("cache-timeout", conf->cache_timeout, int32, out);
+    GF_OPTION_INIT("cache-timeout", conf->cache_timeout, time, out);
 
     GF_OPTION_INIT("quick-read-cache-invalidation", conf->qr_invalidation, bool,
                    out);

--- a/xlators/performance/quick-read/src/quick-read.h
+++ b/xlators/performance/quick-read/src/quick-read.h
@@ -42,7 +42,7 @@ struct qr_inode {
     time_t last_refresh;
     struct list_head lru;
     uint64_t gen;
-    uint64_t invalidation_time;
+    time_t invalidation_time;
 };
 typedef struct qr_inode qr_inode_t;
 
@@ -55,7 +55,7 @@ typedef struct qr_priority qr_priority_t;
 
 struct qr_conf {
     uint64_t max_file_size;
-    int32_t cache_timeout;
+    time_t cache_timeout;
     uint64_t cache_size;
     int max_pri;
     gf_boolean_t qr_invalidation;

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2411,11 +2411,11 @@ build_client_config(xlator_t *this, clnt_conf_t *conf)
 {
     int ret = -1;
 
-    GF_OPTION_INIT("frame-timeout", conf->rpc_conf.rpc_timeout, int32, out);
+    GF_OPTION_INIT("frame-timeout", conf->rpc_conf.rpc_timeout, time, out);
 
     GF_OPTION_INIT("remote-port", conf->rpc_conf.remote_port, int32, out);
 
-    GF_OPTION_INIT("ping-timeout", conf->opt.ping_timeout, int32, out);
+    GF_OPTION_INIT("ping-timeout", conf->opt.ping_timeout, time, out);
 
     GF_OPTION_INIT("remote-subvolume", conf->opt.remote_subvolume, path, out);
     if (!conf->opt.remote_subvolume)
@@ -2555,10 +2555,10 @@ reconfigure(xlator_t *this, dict_t *options)
 
     conf = this->private;
 
-    GF_OPTION_RECONF("frame-timeout", conf->rpc_conf.rpc_timeout, options,
-                     int32, out);
+    GF_OPTION_RECONF("frame-timeout", conf->rpc_conf.rpc_timeout, options, time,
+                     out);
 
-    GF_OPTION_RECONF("ping-timeout", rpc_config.ping_timeout, options, int32,
+    GF_OPTION_RECONF("ping-timeout", rpc_config.ping_timeout, options, time,
                      out);
 
     GF_OPTION_RECONF("event-threads", new_nthread, options, int32, out);
@@ -2812,7 +2812,7 @@ client_priv_dump(xlator_t *this)
         conn = &conf->rpc->conn;
         gf_proc_dump_write("total_bytes_read", "%" PRIu64,
                            conn->trans->total_bytes_read);
-        gf_proc_dump_write("ping_timeout", "%" PRIu32, conn->ping_timeout);
+        gf_proc_dump_write("ping_timeout", "%ld", conn->ping_timeout);
         gf_proc_dump_write("total_bytes_written", "%" PRIu64,
                            conn->trans->total_bytes_write);
         gf_proc_dump_write("ping_msgs_sent", "%" PRIu64, conn->pingcnt);

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -82,7 +82,7 @@ typedef enum {
 
 struct clnt_options {
     char *remote_subvolume;
-    int ping_timeout;
+    time_t ping_timeout;
 };
 
 typedef struct clnt_conf {

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -893,7 +893,7 @@ do_auth:
     GF_OPTION_RECONF("manage-gids", conf->server_manage_gids, options, bool,
                      do_rpc);
 
-    GF_OPTION_RECONF("gid-timeout", conf->gid_cache_timeout, options, int32,
+    GF_OPTION_RECONF("gid-timeout", conf->gid_cache_timeout, options, time,
                      do_rpc);
     if (gid_cache_reconf(&conf->gid_cache, conf->gid_cache_timeout) < 0) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_GRP_CACHE_ERROR, NULL);
@@ -1193,7 +1193,7 @@ server_init(xlator_t *this)
     } else {
         conf->server_manage_gids = ret;
     }
-    GF_OPTION_INIT("gid-timeout", conf->gid_cache_timeout, int32, err);
+    GF_OPTION_INIT("gid-timeout", conf->gid_cache_timeout, time, err);
     if (gid_cache_init(&conf->gid_cache, conf->gid_cache_timeout) < 0) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_INIT_GRP_CACHE_ERROR, NULL);
         goto err;

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -64,7 +64,7 @@ struct server_conf {
 
     gf_boolean_t server_manage_gids; /* resolve gids on brick */
     gid_cache_t gid_cache;
-    int32_t gid_cache_timeout;
+    time_t gid_cache_timeout;
 
     int event_threads; /* # of event threads
                         * configured */

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -441,9 +441,9 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     }
 
     GF_OPTION_RECONF("health-check-interval", priv->health_check_interval,
-                     options, uint32, out);
+                     options, time, out);
     GF_OPTION_RECONF("health-check-timeout", priv->health_check_timeout,
-                     options, uint32, out);
+                     options, time, out);
     if (priv->health_check_interval) {
         ret = posix_spawn_health_check_thread(this);
         if (ret)
@@ -972,7 +972,7 @@ posix_init(xlator_t *this)
     ret = 0;
 
     GF_OPTION_INIT("janitor-sleep-duration", _private->janitor_sleep_duration,
-                   int32, out);
+                   time, out);
 
     /* performing open dir on brick dir locks the brick dir
      * and prevents it from being unmounted
@@ -1129,9 +1129,9 @@ posix_init(xlator_t *this)
 
     _private->health_check_active = _gf_false;
     GF_OPTION_INIT("health-check-interval", _private->health_check_interval,
-                   uint32, out);
-    GF_OPTION_INIT("health-check-timeout", _private->health_check_timeout,
-                   uint32, out);
+                   time, out);
+    GF_OPTION_INIT("health-check-timeout", _private->health_check_timeout, time,
+                   out);
     if (_private->health_check_interval) {
         ret = posix_spawn_health_check_thread(this);
         if (ret)

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1976,7 +1976,7 @@ posix_fs_health_check(xlator_t *this, char *file_path)
     char *op = NULL;
     int op_errno = 0;
     int cnt;
-    int timeout = 0;
+    time_t timeout = 0;
     struct aiocb aiocb;
 
     priv = this->private;
@@ -2084,7 +2084,7 @@ out:
             ret = 0;
         } else {
             gf_event(EVENT_POSIX_HEALTH_CHECK_FAILED,
-                     "op=%s;path=%s;error=%s;brick=%s:%s timeout is %d", op,
+                     "op=%s;path=%s;error=%s;brick=%s:%s timeout is %ld", op,
                      file_path, strerror(op_errno), priv->hostname,
                      priv->base_path, timeout);
         }

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -182,7 +182,7 @@ struct posix_private {
     pthread_cond_t fd_cond;
     pthread_cond_t disk_cond;
     int fsync_queue_count;
-    int32_t janitor_sleep_duration;
+    time_t janitor_sleep_duration;
 
     enum {
         BATCH_NONE = 0,
@@ -196,9 +196,9 @@ struct posix_private {
     char gfid2path_sep[8];
 
     /* seconds to sleep between health checks */
-    uint32_t health_check_interval;
+    time_t health_check_interval;
     /* seconds to sleep to wait for aio write finish for health checks */
-    uint32_t health_check_timeout;
+    time_t health_check_timeout;
     pthread_t health_check;
 
     double disk_reserve;


### PR DESCRIPTION
Tweak dict and xlator interfaces to allow explicit values of 'time_t' type
and consistently use it for timeouts, time intervals, and whatever similar.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

