### PR TITLE
cli: do not allow to use help as the volume name

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -502,6 +502,7 @@ cli_validate_volname(const char *volname)
     int volname_len;
     static const char *const invalid_volnames[] = {"volume",
                                                    "type",
+                                                   "help",
                                                    "subvolumes",
                                                    "option",
                                                    "end-volume",


### PR DESCRIPTION
Add 'help' to the list of unacceptable volume names because using
it as such silently confuses the most of CLI commands, for example:

$ gluster volume info

Volume Name: abcd
Type: Replicate
Volume ID: db862536-61da-404b-98c9-b5450eb1f80d
Status: Created
Snapshot Count: 0
Number of Bricks: 1 x 3 = 3
Transport-type: tcp
Bricks:
Brick1: 192.168.222.110:/home/pool/3
Brick2: 192.168.222.110:/home/pool/4
Brick3: 192.168.222.110:/home/pool/5
Options Reconfigured:
cluster.granular-entry-heal: on
storage.fips-mode-rchecksum: on
transport.address-family: inet
nfs.disable: on
performance.client-io-threads: off

Volume Name: help
Type: Replicate
Volume ID: 10442b69-18fa-4ad8-8dc9-3867c0598523
Status: Created
Snapshot Count: 0
Number of Bricks: 1 x 3 = 3
Transport-type: tcp
Bricks:
Brick1: 192.168.222.110:/home/pool/0
Brick2: 192.168.222.110:/home/pool/1
Brick3: 192.168.222.110:/home/pool/2
Options Reconfigured:
cluster.granular-entry-heal: on
storage.fips-mode-rchecksum: on
transport.address-family: inet
nfs.disable: on
performance.client-io-threads: off

$ gluster volume set abcd performance.cache-size 256MB

volume set: success

$ gluster volume set help performance.cache-size 256MB
volume set: failed

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

