### PR TITLE
glusterd: drop glusterd_op_sm_state_info_t and simplify related code

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
@@ -85,12 +85,12 @@ glusterd_op_state_machine_mgmt_v3_lock(rpcsvc_request_t *req,
     int32_t ret = -1;
     xlator_t *this = THIS;
     glusterd_op_info_t txn_op_info = {
-        {0},
+        GD_OP_STATE_DEFAULT,
     };
 
     GF_ASSERT(req);
 
-    glusterd_txn_opinfo_init(&txn_op_info, NULL, &lock_req->op, ctx->dict, req);
+    glusterd_txn_opinfo_init(&txn_op_info, 0, &lock_req->op, ctx->dict, req);
 
     ret = glusterd_set_txn_opinfo(&lock_req->txn_id, &txn_op_info);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -78,13 +78,8 @@ typedef struct glusterd_op_sm_ {
     glusterd_op_sm_ac_fn handler;
 } glusterd_op_sm_t;
 
-typedef struct glusterd_op_sm_state_info_ {
-    glusterd_op_sm_state_t state;
-    struct timeval time;
-} glusterd_op_sm_state_info_t;
-
 struct glusterd_op_info_ {
-    glusterd_op_sm_state_info_t state;
+    glusterd_op_sm_state_t state;
     int32_t pending_count;
     int32_t brick_pending_count;
     int32_t op_count;
@@ -289,6 +284,17 @@ glusterd_get_txn_opinfo(uuid_t *txn_id, glusterd_op_info_t *opinfo);
 
 int32_t
 glusterd_set_txn_opinfo(uuid_t *txn_id, glusterd_op_info_t *opinfo);
+
+void
+glusterd_txn_opinfo_init(glusterd_op_info_t *opinfo,
+                         glusterd_op_sm_state_t state, int *op,
+                         dict_t *op_ctx, rpcsvc_request_t *req);
+
+int32_t
+glusterd_txn_opinfo_dict_init(void);
+
+void
+glusterd_txn_opinfo_dict_fini(void);
 
 int32_t
 glusterd_clear_txn_opinfo(uuid_t *txn_id);

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -1275,7 +1275,7 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     glusterd_conf_t *priv = NULL;
     uuid_t *txn_id = NULL;
     glusterd_op_info_t txn_op_info = {
-        {0},
+        GD_OP_STATE_DEFAULT,
     };
     call_frame_t *frame = NULL;
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1808,7 +1808,7 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
     gf_boolean_t is_global = _gf_false;
     uuid_t *txn_id = NULL;
     glusterd_op_info_t txn_opinfo = {
-        {0},
+        GD_OP_STATE_DEFAULT,
     };
     uint32_t op_errno = 0;
     gf_boolean_t cluster_lock = _gf_false;
@@ -1835,8 +1835,8 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
         goto out;
     }
 
-    /* Save opinfo for this transaction with the transaction id */
-    glusterd_txn_opinfo_init(&txn_opinfo, NULL, &op, NULL, NULL);
+    /* Save opinfo for this transaction with the transaction id. */
+    glusterd_txn_opinfo_init(&txn_opinfo, 0, (int *)&op, NULL, NULL);
     ret = glusterd_set_txn_opinfo(txn_id, &txn_opinfo);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_TRANS_OPINFO_SET_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -11588,7 +11588,7 @@ glusterd_volume_heal_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     dict_t *ctx_dict = NULL;
     uuid_t *txn_id = NULL;
     glusterd_op_info_t txn_op_info = {
-        {0},
+        GD_OP_STATE_DEFAULT,
     };
     glusterd_op_t op = GD_OP_NONE;
 

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -1057,10 +1057,6 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
 int
 glusterd_restart_bricks(void *opaque);
 
-int32_t
-glusterd_volume_txn(rpcsvc_request_t *req, char *volname, int flags,
-                    glusterd_op_t op);
-
 int
 glusterd_peer_dump_version(xlator_t *this, struct rpc_clnt *rpc,
                            glusterd_peerctx_t *peerctx);
@@ -1275,15 +1271,6 @@ int32_t
 glusterd_op_begin_synctask(rpcsvc_request_t *req, glusterd_op_t op, void *dict);
 int32_t
 glusterd_defrag_event_notify_handle(dict_t *dict);
-
-int32_t
-glusterd_txn_opinfo_dict_init();
-
-void
-glusterd_txn_opinfo_dict_fini();
-
-void
-glusterd_txn_opinfo_init();
 
 /* snapshot */
 glusterd_snap_t *


### PR DESCRIPTION
Drop 'glusterd_op_sm_state_info_t' since its 'time' field is not
used anymore, adjust related code and comments here and there.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

