### PR TITLE
libglusterfs, xlators: add and use range info option flag

### DIFF
--- a/libglusterfs/src/glusterfs/options.h
+++ b/libglusterfs/src/glusterfs/options.h
@@ -46,13 +46,27 @@ typedef enum {
 
 typedef enum {
     OPT_FLAG_NONE = 0,
-    OPT_FLAG_SETTABLE = 1 << 0,   /* can be set using volume set */
-    OPT_FLAG_CLIENT_OPT = 1 << 1, /* affects clients */
-    OPT_FLAG_GLOBAL = 1
-                      << 2, /* affects all instances of the particular xlator */
-    OPT_FLAG_FORCE = 1 << 3,       /* needs force to be reset */
-    OPT_FLAG_NEVER_RESET = 1 << 4, /* which should not be reset */
-    OPT_FLAG_DOC = 1 << 5,         /* can be shown in volume set help */
+
+    /* Can be set using 'gluster volume set' command. */
+    OPT_FLAG_SETTABLE = 1 << 0,
+
+    /* Affects clients. */
+    OPT_FLAG_CLIENT_OPT = 1 << 1,
+
+    /* Affects all instances of the particular xlator. */
+    OPT_FLAG_GLOBAL = 1 << 2,
+
+    /* Needs to be forced for reset. */
+    OPT_FLAG_FORCE = 1 << 3,
+
+    /* Should be never reset. */
+    OPT_FLAG_NEVER_RESET = 1 << 4,
+
+    /* Documented to be shown in 'gluster volume set help'. */
+    OPT_FLAG_DOC = 1 << 5,
+
+    /* Numerical with specified mininum and maximum values. */
+    OPT_FLAG_RANGE = 1 << 6
 } opt_flags_t;
 
 typedef enum {

--- a/libglusterfs/src/options.c
+++ b/libglusterfs/src/options.c
@@ -1167,8 +1167,15 @@ xlator_option_info_list(volume_opt_list_t *list, char *key, char **def_val,
 
     if (def_val)
         *def_val = opt->default_value;
-    if (descr)
-        *descr = opt->description;
+    if (descr) {
+        if (opt->flags & OPT_FLAG_RANGE)
+            gf_asprintf(descr,
+                        "%s Minimum value is %.0lf, maximum value "
+                        "is %.0lf.",
+                        opt->description, opt->min, opt->max);
+        else
+            *descr = gf_strdup(opt->description);
+    }
 
     ret = 0;
 out:

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -1242,12 +1242,13 @@ struct volume_options options[] = {
      .max = SHD_MAX_THREADS,
      .default_value = TOSTRING(SHD_DEFAULT_THREADS),
      .op_version = {GD_OP_VERSION_3_7_12},
-     .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC |
+              OPT_FLAG_RANGE,
      .tags = {"replicate"},
-     .description = "Maximum number of parallel heals SHD can do per "
-                    "local brick. This can substantially lower heal times"
-                    ", but can also crush your bricks if you don't have "
-                    "the storage hardware to support this."},
+     .description = "Maximum number of parallel heals SHD can do per local "
+                    "brick. This can substantially lower heal times, but can "
+                    "also crush your bricks if you don't have the storage "
+                    "hardware to support this."},
     {
         .key = {"shd-wait-qlength"},
         .type = GF_OPTION_TYPE_INT,

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -1765,12 +1765,12 @@ struct volume_options options[] = {
      .max = SHD_MAX_THREADS,
      .default_value = TOSTRING(SHD_DEFAULT_THREADS),
      .op_version = {GD_OP_VERSION_3_9_0},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"disperse"},
      .description = "Maximum number of parallel heals SHD can do per local "
-                    "brick.  This can substantially lower heal times, "
-                    "but can also crush your bricks if you don't have "
-                    "the storage hardware to support this."},
+                    "brick. This can substantially lower heal times, but can "
+                    "also crush your bricks if you don't have the storage "
+                    "hardware to support this."},
     {.key = {"shd-wait-qlength"},
      .type = GF_OPTION_TYPE_INT,
      .min = 1,

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -4453,20 +4453,22 @@ struct volume_options options[] = {
      .min = GF_ASYNC_MIN_THREADS,
      .max = GF_ASYNC_MAX_THREADS,
      .op_version = {GD_OP_VERSION_6_0},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-stats", "threading"},
      .description = "When global threading is used, this value determines the "
-                    "maximum amount of threads that can be created on bricks"},
+                    "maximum amount of threads that can be created on bricks."},
     {.key = {"client-threads"},
      .type = GF_OPTION_TYPE_INT,
      .default_value = TOSTRING(GF_ASYNC_DEFAULT_THREADS),
      .min = GF_ASYNC_MIN_THREADS,
      .max = GF_ASYNC_MAX_THREADS,
      .op_version = {GD_OP_VERSION_6_0},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_CLIENT_OPT,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_CLIENT_OPT |
+              OPT_FLAG_RANGE,
      .tags = {"io-stats", "threading"},
-     .description = "When global threading is used, this value determines the "
-                    "maximum amount of threads that can be created on clients"},
+     .description =
+         "When global threading is used, this value determines the "
+         "maximum amount of threads that can be created on clients."},
     {.key = {"volume-id"},
      .type = GF_OPTION_TYPE_STR,
      .op_version = {GD_OP_VERSION_7_1},

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -2071,12 +2071,11 @@ struct volume_options options[] = {
         .min = NFS_MIN_EVENT_THREADS,
         .max = NFS_MAX_EVENT_THREADS,
         .default_value = TOSTRING(STARTING_EVENT_THREADS),
-        .description = "Specifies the number of event threads to execute in"
-                       "in parallel. Larger values would help process"
-                       " responses faster, depending on available processing"
-                       " power. Range 1-32 threads.",
+        .description = "Specifies the number of event threads to execute in "
+                       "parallel. Larger values would help process responses "
+                       "faster, depending on available processing power.",
         .op_version = {GD_OP_VERSION_4_0_0},
-        .flags = OPT_FLAG_SETTABLE,
+        .flags = OPT_FLAG_SETTABLE | OPT_FLAG_RANGE,
     },
     {.key = {NULL}},
 };

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -1479,11 +1479,10 @@ struct volume_options options[] = {
      .max = IOT_MAX_THREADS,
      .default_value = TOSTRING(IOT_DEFAULT_THREADS),
      .op_version = {1},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-threads"},
-     /*.option = "thread-count"*/
      .description = "Number of threads in IO threads translator which "
-                    "perform concurrent IO operations"
+                    "perform concurrent IO operations."
 
     },
     {.key = {"high-prio-threads"},
@@ -1492,46 +1491,40 @@ struct volume_options options[] = {
      .max = IOT_MAX_THREADS,
      .default_value = TOSTRING(IOT_DEFAULT_THREADS),
      .op_version = {1},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-threads"},
      .description = "Max number of threads in IO threads translator which "
-                    "perform high priority IO operations at a given time"
-
-    },
+                    "perform high priority IO operations at a given time."},
     {.key = {"normal-prio-threads"},
      .type = GF_OPTION_TYPE_INT,
      .min = IOT_MIN_THREADS,
      .max = IOT_MAX_THREADS,
      .default_value = TOSTRING(IOT_DEFAULT_THREADS),
      .op_version = {1},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-threads"},
      .description = "Max number of threads in IO threads translator which "
-                    "perform normal priority IO operations at a given time"
-
-    },
+                    "perform normal priority IO operations at a given time."},
     {.key = {"low-prio-threads"},
      .type = GF_OPTION_TYPE_INT,
      .min = IOT_MIN_THREADS,
      .max = IOT_MAX_THREADS,
      .default_value = TOSTRING(IOT_DEFAULT_THREADS),
      .op_version = {1},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-threads"},
      .description = "Max number of threads in IO threads translator which "
-                    "perform low priority IO operations at a given time"
-
-    },
+                    "perform low priority IO operations at a given time."},
     {.key = {"least-prio-threads"},
      .type = GF_OPTION_TYPE_INT,
      .min = IOT_MIN_THREADS,
      .max = IOT_MAX_THREADS,
      .default_value = TOSTRING(IOT_MIN_THREADS),
      .op_version = {1},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE,
      .tags = {"io-threads"},
      .description = "Max number of threads in IO threads translator which "
-                    "perform least priority IO operations at a given time"},
+                    "perform least priority IO operations at a given time."},
     {.key = {"enable-least-priority"},
      .type = GF_OPTION_TYPE_BOOL,
      .default_value = SITE_H_ENABLE_LEAST_PRIORITY,

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2972,12 +2972,11 @@ struct volume_options options[] = {
      .min = CLIENT_MIN_EVENT_THREADS,
      .max = CLIENT_MAX_EVENT_THREADS,
      .default_value = TOSTRING(STARTING_EVENT_THREADS),
-     .description = "Specifies the number of event threads to execute "
-                    "in parallel. Larger values would help process"
-                    " responses faster, depending on available processing"
-                    " power. Range 1-32 threads.",
+     .description = "Specifies the number of event threads to execute in "
+                    "parallel. Larger values would help process responses "
+                    "faster, depending on available processing power.",
      .op_version = {GD_OP_VERSION_3_7_0},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE},
 
     /* This option is required for running code-coverage tests with
        old protocol */

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1931,12 +1931,11 @@ struct volume_options server_options[] = {
      .min = SERVER_MIN_EVENT_THREADS,
      .max = SERVER_MAX_EVENT_THREADS,
      .default_value = TOSTRING(STARTING_EVENT_THREADS),
-     .description = "Specifies the number of event threads to execute "
-                    "in parallel. Larger values would help process"
-                    " responses faster, depending on available processing"
-                    " power.",
+     .description = "Specifies the number of event threads to execute in "
+                    "parallel. Larger values would help process responses "
+                    "faster, depending on available processing power.",
      .op_version = {GD_OP_VERSION_3_7_0},
-     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC},
+     .flags = OPT_FLAG_SETTABLE | OPT_FLAG_DOC | OPT_FLAG_RANGE},
     {.key = {"dynamic-auth"},
      .type = GF_OPTION_TYPE_BOOL,
      .default_value = "on",


### PR DESCRIPTION
Add OPT_FLAG_RANGE flag to denote the numerical volume option
with specified minimum and maximum values, display an allowed
range as a part of option's help text, and use new flag for
some threading-related options here and there. Adjust option
descriptions and comments as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

