### PR TITLE
1000 glusterd fix invalid pointer dereference on volume stop

### DIFF
--- a/cli/src/cli-cmd-global.c
+++ b/cli/src/cli-cmd-global.c
@@ -140,6 +140,9 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
     return ret;
 }
 
@@ -190,6 +193,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }

--- a/cli/src/cli-cmd-peer.c
+++ b/cli/src/cli-cmd-peer.c
@@ -89,6 +89,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     if (ret == 0) {
         gf_event(EVENT_PEER_ATTACH, "host=%s", (char *)words[2]);
@@ -176,6 +178,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     if (ret == 0) {
         gf_event(EVENT_PEER_DETACH, "host=%s", (char *)words[2]);

--- a/cli/src/cli-cmd-snapshot.c
+++ b/cli/src/cli-cmd-snapshot.c
@@ -63,6 +63,8 @@ out:
         cli_out("Snapshot command failed");
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -68,10 +68,10 @@ out:
             cli_out("Fetching spec for volume %s failed", (char *)words[2]);
     }
 
+    CLI_STACK_DESTROY(frame);
     if (dict)
         dict_unref(dict);
 
-    CLI_STACK_DESTROY(frame);
     return ret;
 }
 
@@ -113,10 +113,10 @@ out:
             cli_out("Fetching spec for volume %s failed", (char *)words[3]);
     }
 
+    CLI_STACK_DESTROY(frame);
     if (dict)
         dict_unref(dict);
 
-    CLI_STACK_DESTROY(frame);
     return ret;
 }
 
@@ -325,10 +325,10 @@ out:
             cli_out("uuid get failed");
     }
 
+    CLI_STACK_DESTROY(frame);
     if (dict)
         dict_unref(dict);
 
-    CLI_STACK_DESTROY(frame);
     return ret;
 }
 
@@ -389,10 +389,9 @@ out:
             cli_out("uuid reset failed");
     }
 
+    CLI_STACK_DESTROY(frame);
     if (dict)
         dict_unref(dict);
-
-    CLI_STACK_DESTROY(frame);
 
     return ret;
 }
@@ -534,12 +533,10 @@ cli_cmd_sys_exec_cbk(struct cli_state *state, struct cli_cmd_word *word,
          * still need to destroy the stack if proc->fn returns an
          * error. */
         CLI_STACK_DESTROY(frame);
-        dict = NULL;
     }
 out:
-    if (dict != NULL) {
+    if (dict)
         dict_unref(dict);
-    }
 
     return ret;
 }

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -192,6 +192,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     return ret;
 }
@@ -262,6 +264,9 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
     return ret;
 }
 
@@ -338,6 +343,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     if (ret == 0 && GF_ANSWER_YES == answer) {
         gf_event(EVENT_VOLUME_DELETE, "name=%s", (char *)words[2]);
@@ -418,6 +425,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     if (ret == 0) {
         gf_event(EVENT_VOLUME_START, "name=%s;force=%d", (char *)words[2],
@@ -632,6 +641,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     return ret;
 }
@@ -692,6 +703,8 @@ out:
 #endif
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -740,6 +753,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -854,6 +869,8 @@ out:
 
 end:
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -1049,10 +1066,13 @@ out:
 #endif
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
     return ret;
 }
 
-int
+static int
 cli_get_soft_limit(dict_t *options, const char **words, dict_t *xdata)
 {
     call_frame_t *frame = NULL;
@@ -1068,10 +1088,8 @@ cli_get_soft_limit(dict_t *options, const char **words, dict_t *xdata)
         goto out;
     }
 
-    // We need a ref on @options to prevent CLI_STACK_DESTROY
-    // from destroying it prematurely.
-    dict_ref(options);
     CLI_LOCAL_INIT(local, words, frame, options);
+
     proc = &cli_rpc_prog->proctable[GLUSTER_CLI_QUOTA];
     ret = proc->fn(frame, THIS, options);
 
@@ -1155,7 +1173,7 @@ out:
     return limits_set;
 }
 
-int
+static int
 cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
 {
     int all_failed = 1;
@@ -1367,8 +1385,6 @@ out:
                    "xml format");
         }
     }
-    if (xdata)
-        dict_unref(xdata);
 
     if (fd != -1) {
         sys_close(fd);
@@ -1379,7 +1395,11 @@ out:
                "Could not fetch and display quota"
                " limits");
     }
+
     CLI_STACK_DESTROY(frame);
+    if (xdata)
+        dict_unref(xdata);
+
     return ret;
 }
 
@@ -1495,6 +1515,9 @@ out:
 #endif
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
 out2:
     return ret;
 }
@@ -1589,8 +1612,6 @@ out:
                 "Quota command failed. Please check the cli "
                 "logs for more details");
     }
-    if (options)
-        dict_unref(options);
 
     /* Events for Quota */
     if (ret == 0) {
@@ -1651,6 +1672,9 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
     return ret;
 }
 
@@ -1841,7 +1865,10 @@ out:
                      (char *)words[2], (char *)words[3]);
         }
     }
+
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -1895,7 +1922,10 @@ out:
                  "Volume=%s;source-brick=%s;destination-brick=%s",
                  (char *)words[2], (char *)words[3], (char *)words[4]);
     }
+
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -1943,6 +1973,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -1996,7 +2028,10 @@ out:
         if ((sent == 0) && (parse_error == 0))
             cli_out("Volume log rotate failed");
     }
+
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -2229,6 +2264,8 @@ out:
 #endif
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -2281,6 +2318,8 @@ cli_cmd_volume_status_cbk(struct cli_state *state, struct cli_cmd_word *word,
 
 out:
     CLI_STACK_DESTROY(frame);
+    if (dict)
+        dict_unref(dict);
 
     return ret;
 }
@@ -2595,10 +2634,9 @@ out:
         }
     }
 
+    CLI_STACK_DESTROY(frame);
     if (options)
         dict_unref(options);
-
-    CLI_STACK_DESTROY(frame);
 
     return ret;
 }
@@ -2660,6 +2698,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -2752,6 +2792,8 @@ out:
     }
 
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -2806,7 +2848,10 @@ out:
         if ((sent == 0) && (parse_error == 0))
             cli_err("Volume barrier failed");
     }
+
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
 
     return ret;
 }
@@ -2860,7 +2905,11 @@ out:
         if ((sent == 0) && (parse_err == 0))
             cli_err("Volume get option failed");
     }
+
     CLI_STACK_DESTROY(frame);
+    if (options)
+        dict_unref(options);
+
     return ret;
 }
 

--- a/cli/src/cli-cmd.h
+++ b/cli/src/cli-cmd.h
@@ -24,7 +24,7 @@
         if (local) {                                                           \
             local->words = words;                                              \
             if (dictionary)                                                    \
-                local->dict = dictionary;                                      \
+                local->dict = dict_ref(dictionary);                            \
             if (frame)                                                         \
                 frame->local = local;                                          \
         }                                                                      \

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -435,8 +435,9 @@ glusterd_muxsvc_common_rpc_notify(glusterd_svc_proc_t *mux_proc,
                 }
             }
             if (mux_proc->status != GF_SVC_DIED) {
-                svc = cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
-                                     mux_svc);
+                svc = (cds_list_empty(&mux_proc->svcs) ? NULL :
+                       cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
+                                      mux_svc));
                 if (svc && !glusterd_proc_is_running(&svc->proc)) {
                     mux_proc->status = GF_SVC_DIED;
                 } else {


### PR DESCRIPTION
    glusterd: fix invalid pointer dereference during volume stop
    
    When handling RPC_CLNT_DISCONNECT event, glustershd may be already
    disconnected and removed from the list of services, and an attempt
    to extract an entry from empty list causes the following error:
    
    ==1364671==ERROR: AddressSanitizer: heap-buffer-overflow on address ...
    
    READ of size 1 at 0x60d00001c48f thread T23
        #0 0x7ff1a5f6db8c in __interceptor_fopen64.part.0 (/lib64/libasan.so.6+0x53b8c)
        #1 0x7ff1a5c63717 in gf_is_service_running libglusterfs/src/common-utils.c:4180
        #2 0x7ff190178ad3 in glusterd_proc_is_running xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c:157
        #3 0x7ff19017ce29 in glusterd_muxsvc_common_rpc_notify xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c:440
        #4 0x7ff190176e75 in __glusterd_muxsvc_conn_common_notify xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c:172
        #5 0x7ff18fee0940 in glusterd_big_locked_notify xlators/mgmt/glusterd/src/glusterd-handler.c:66
        #6 0x7ff190176ec7 in glusterd_muxsvc_conn_common_notify xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c:183
        #7 0x7ff1a5b57b60 in rpc_clnt_handle_disconnect rpc/rpc-lib/src/rpc-clnt.c:821
        #8 0x7ff1a5b58082 in rpc_clnt_notify rpc/rpc-lib/src/rpc-clnt.c:882
        #9 0x7ff1a5b4da47 in rpc_transport_notify rpc/rpc-lib/src/rpc-transport.c:520
        #10 0x7ff18fba1d4f in socket_event_poll_err rpc/rpc-transport/socket/src/socket.c:1370
        #11 0x7ff18fbb223c in socket_event_handler rpc/rpc-transport/socket/src/socket.c:2971
        #12 0x7ff1a5d646ff in event_dispatch_epoll_handler libglusterfs/src/event-epoll.c:638
        #13 0x7ff1a5d6539c in event_dispatch_epoll_worker libglusterfs/src/event-epoll.c:749
        #14 0x7ff1a5917298 in start_thread /usr/src/debug/glibc-2.33-20.fc34.x86_64/nptl/pthread_create.c:481
        #15 0x7ff1a5551352 in clone (/lib64/libc.so.6+0x100352)
    
    0x60d00001c48f is located 12 bytes to the right of 131-byte region [0x60d00001c400,0x60d00001c483)
    freed by thread T19 here:
        #0 0x7ff1a5fc8647 in free (/lib64/libasan.so.6+0xae647)
    
    Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
    Updates: #1000
