### PR TITLE
glusterd: fix invalid pointer dereference during volume stop

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -435,8 +435,9 @@ glusterd_muxsvc_common_rpc_notify(glusterd_svc_proc_t *mux_proc,
                 }
             }
             if (mux_proc->status != GF_SVC_DIED) {
-                svc = cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
-                                     mux_svc);
+                svc = (cds_list_empty(&mux_proc->svcs) ? NULL :
+                       cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
+                                      mux_svc));
                 if (svc && !glusterd_proc_is_running(&svc->proc)) {
                     mux_proc->status = GF_SVC_DIED;
                 } else {


### PR DESCRIPTION
When handling RPC_CLNT_DISCONNECT event, glustershd may be already
disconnected and removed from the list of services, and an attempt
to extract an entry from empty list causes the following error:

==1364671==ERROR: AddressSanitizer: heap-buffer-overflow on address ...

READ of size 1 at 0x60d00001c48f thread T23
    #0 0x7ff1a5f6db8c in __interceptor_fopen64.part.0 (/lib64/libasan.so.6+0x53b8c)
    #1 0x7ff1a5c63717 in gf_is_service_running libglusterfs/src/common-utils.c:4180
    #2 0x7ff190178ad3 in glusterd_proc_is_running xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c:157
    #3 0x7ff19017ce29 in glusterd_muxsvc_common_rpc_notify xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c:440
    #4 0x7ff190176e75 in __glusterd_muxsvc_conn_common_notify xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c:172
    #5 0x7ff18fee0940 in glusterd_big_locked_notify xlators/mgmt/glusterd/src/glusterd-handler.c:66
    #6 0x7ff190176ec7 in glusterd_muxsvc_conn_common_notify xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c:183
    #7 0x7ff1a5b57b60 in rpc_clnt_handle_disconnect rpc/rpc-lib/src/rpc-clnt.c:821
    #8 0x7ff1a5b58082 in rpc_clnt_notify rpc/rpc-lib/src/rpc-clnt.c:882
    #9 0x7ff1a5b4da47 in rpc_transport_notify rpc/rpc-lib/src/rpc-transport.c:520
    #10 0x7ff18fba1d4f in socket_event_poll_err rpc/rpc-transport/socket/src/socket.c:1370
    #11 0x7ff18fbb223c in socket_event_handler rpc/rpc-transport/socket/src/socket.c:2971
    #12 0x7ff1a5d646ff in event_dispatch_epoll_handler libglusterfs/src/event-epoll.c:638
    #13 0x7ff1a5d6539c in event_dispatch_epoll_worker libglusterfs/src/event-epoll.c:749
    #14 0x7ff1a5917298 in start_thread /usr/src/debug/glibc-2.33-20.fc34.x86_64/nptl/pthread_create.c:481
    #15 0x7ff1a5551352 in clone (/lib64/libc.so.6+0x100352)

0x60d00001c48f is located 12 bytes to the right of 131-byte region [0x60d00001c400,0x60d00001c483)
freed by thread T19 here:
    #0 0x7ff1a5fc8647 in free (/lib64/libasan.so.6+0xae647)

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

