### PR TITLE
build: check for legacy RPC header if libtirpc is disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -366,6 +366,12 @@ AC_ARG_WITH([libtirpc],
         [AC_HELP_STRING([--without-libtirpc], [Use legacy glibc RPC.])],
         [with_libtirpc="no"], [with_libtirpc="yes"])
 
+dnl For --without-libtirpc, check whether legacy glibc rpc is available.
+if test "x$with_libtirpc" = "xno"; then
+    AC_CHECK_HEADER([rpc/types.h], ,
+        AC_MSG_ERROR([Your C library lacks support for RPC. Please use libtirpc instead.]))
+fi
+
 dnl ipv6-default is off by default
 dnl
 dnl ipv6-default requires libtirpc. (glibc rpc does not support IPv6.)


### PR DESCRIPTION
Since modern Linux distributions tends to remove glibc RPC code,
for example https://fedoraproject.org/wiki/Changes/SunRPCRemoval,
using '--without-libtirpc' on such systems causes compilation
errors due to missing RPC headers. So here is a configure check
whether one of the legacy RPC core headers is present.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

