### PR TITLE
glusterd: fix for starting brick on new port (#2090)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2153,6 +2153,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
         ret = -1;
         goto out;
     }
+
     /* Build the exp_path, before starting the glusterfsd even in
        valgrind mode. Otherwise all the glusterfsd processes start
        writing the valgrind log to the same file.
@@ -2305,13 +2306,10 @@ retry:
 
     if (wait) {
         synclock_unlock(&priv->big_lock);
-        errno = 0;
         ret = runner_run(&runner);
-        if (errno != 0)
-            ret = errno;
         synclock_lock(&priv->big_lock);
 
-        if (ret == EADDRINUSE) {
+        if (ret == -EADDRINUSE) {
             /* retry after getting a new port */
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    GD_MSG_SRC_BRICK_PORT_UNAVAIL,


### PR DESCRIPTION
The Errno set by the runner code was not correct when the bind() fails
to assign an already occupied port in the __socket_server_bind().

Fix:
Updated the code to return the correct errno from the
__socket_server_bind() if the bind() fails due to EADDRINUSE error. And,
use the returned errno from runner_run() to retry allocating a new port
to the brick process.

> Fixes: #1101

> Change-Id: If124337f41344a04f050754e402490529ef4ecdc
> Signed-off-by: nik-redhat nladha@redhat.com

Change-Id: Ib6b3ffaeefc6bfd1bc010cc623b70696e539a54a
Signed-off-by: nik-redhat <nladha@redhat.com>

