### PR TITLE
glusterd: fix for starting brick on new port (#2090)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -2089,6 +2089,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
         ret = -1;
         goto out;
     }
+
     /* Build the exp_path, before starting the glusterfsd even in
        valgrind mode. Otherwise all the glusterfsd processes start
        writing the valgrind log to the same file.
@@ -2239,7 +2240,7 @@ retry:
         ret = runner_run(&runner);
         synclock_lock(&priv->big_lock);
 
-        if (ret == EADDRINUSE) {
+        if (ret == -EADDRINUSE) {
             /* retry after getting a new port */
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    GD_MSG_SRC_BRICK_PORT_UNAVAIL,


### PR DESCRIPTION
The Errno set by the runner code was not correct when the bind() fails
to assign an already occupied port in the __socket_server_bind().

Fix:
Updated the code to return the correct errno from the
__socket_server_bind() if the bind() fails due to EADDRINUSE error. And,
use the returned errno from runner_run() to retry allocating a new port
to the brick process.

> Fixes: #1101

> Change-Id: If124337f41344a04f050754e402490529ef4ecdc
> Signed-off-by: nik-redhat nladha@redhat.com

Change-Id: I83bd857e3169b208fdd2be581f4db9a0897cc7e5
Signed-off-by: nik-redhat <nladha@redhat.com>

