### PR TITLE
glusterd, cli: more time_t usage where appropriate

### DIFF
--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -246,14 +246,14 @@ cli_cmd_unlock()
 }
 
 static void
-seconds_from_now(unsigned secs, struct timespec *ts)
+seconds_from_now(time_t secs, struct timespec *ts)
 {
     timespec_now_realtime(ts);
     ts->tv_sec += secs;
 }
 
 int
-cli_cmd_await_response(unsigned time)
+cli_cmd_await_response(time_t time)
 {
     struct timespec ts = {
         0,
@@ -354,7 +354,7 @@ cli_cmd_submit(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
                xlator_t *this, fop_cbk_fn_t cbkfn, xdrproc_t xdrproc)
 {
     int ret = -1;
-    unsigned timeout = 0;
+    time_t timeout = 0;
 
     if ((GLUSTER_CLI_PROFILE_VOLUME == procnum) ||
         (GLUSTER_CLI_HEAL_VOLUME == procnum) ||

--- a/cli/src/cli-cmd.h
+++ b/cli/src/cli-cmd.h
@@ -96,7 +96,7 @@ void
 cli_cmd_tokens_destroy(char **tokens);
 
 int
-cli_cmd_await_response(unsigned time);
+cli_cmd_await_response(time_t time);
 
 int
 cli_cmd_broadcast_response(int32_t status);

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -10397,7 +10397,7 @@ add_cli_cmd_timeout_to_dict(dict_t *dict)
     int ret = 0;
 
     if (cli_default_conn_timeout > 120) {
-        ret = dict_set_uint32(dict, "timeout", cli_default_conn_timeout);
+        ret = dict_set_time(dict, "timeout", cli_default_conn_timeout);
         if (ret) {
             gf_log("cli", GF_LOG_INFO, "Failed to save timeout to dict");
         }

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -43,8 +43,8 @@ enum argp_option_keys {
     ARGP_PORT_KEY = 'p',
 };
 
-extern int cli_default_conn_timeout;
-extern int cli_ten_minutes_timeout;
+extern time_t cli_default_conn_timeout;
+extern time_t cli_ten_minutes_timeout;
 
 typedef enum {
     COLD_BRICK_COUNT,

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -610,7 +610,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
     };
     glusterd_op_sm_event_type_t event_type = GD_OP_EVENT_NONE;
     uint32_t op_errno = 0;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     GF_ASSERT(req);
     GF_ASSERT((op > GD_OP_NONE) && (op < GD_OP_MAX));
@@ -676,7 +676,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
          * mgmt_v3_lock_timeout should be set to default value or we
          * need to change the value according to timeout value
          * i.e, timeout + 120 seconds. */
-        ret = dict_get_uint32(dict, "timeout", &timeout);
+        ret = dict_get_time(dict, "timeout", &timeout);
         if (!ret)
             priv->mgmt_v3_lock_timeout = timeout + 120;
 

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
@@ -124,7 +124,7 @@ glusterd_handle_mgmt_v3_lock_fn(rpcsvc_request_t *req)
     gf_boolean_t is_synctasked = _gf_false;
     gf_boolean_t free_ctx = _gf_false;
     glusterd_conf_t *conf = NULL;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     conf = this->private;
     GF_ASSERT(conf);
@@ -184,7 +184,7 @@ glusterd_handle_mgmt_v3_lock_fn(rpcsvc_request_t *req)
      * mgmt_v3_lock_timeout should be set to default value or we
      * need to change the value according to timeout value
      * i.e, timeout + 120 seconds. */
-    ret = dict_get_uint32(ctx->dict, "timeout", &timeout);
+    ret = dict_get_time(ctx->dict, "timeout", &timeout);
     if (!ret)
         conf->mgmt_v3_lock_timeout = timeout + 120;
 

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -668,7 +668,7 @@ glusterd_mgmt_v3_initiate_lockdown(glusterd_op_t op, dict_t *dict,
     uuid_t peer_uuid = {0};
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     conf = this->private;
     GF_ASSERT(conf);
@@ -682,7 +682,7 @@ glusterd_mgmt_v3_initiate_lockdown(glusterd_op_t op, dict_t *dict,
      * mgmt_v3_lock_timeout should be set to default value or we
      * need to change the value according to timeout value
      * i.e, timeout + 120 seconds. */
-    ret = dict_get_uint32(dict, "timeout", &timeout);
+    ret = dict_get_time(dict, "timeout", &timeout);
     if (!ret)
         conf->mgmt_v3_lock_timeout = timeout + 120;
 

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -4045,7 +4045,7 @@ glusterd_op_ac_lock(glusterd_op_sm_event_t *event, void *ctx)
     xlator_t *this = THIS;
     uint32_t op_errno = 0;
     glusterd_conf_t *conf = NULL;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     GF_ASSERT(event);
     GF_ASSERT(ctx);
@@ -4067,7 +4067,7 @@ glusterd_op_ac_lock(glusterd_op_sm_event_t *event, void *ctx)
          * mgmt_v3_lock_timeout should be set to default value or we
          * need to change the value according to timeout value
          * i.e, timeout + 120 seconds. */
-        ret = dict_get_uint32(lock_ctx->dict, "timeout", &timeout);
+        ret = dict_get_time(lock_ctx->dict, "timeout", &timeout);
         if (!ret)
             conf->mgmt_v3_lock_timeout = timeout + 120;
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1812,7 +1812,7 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
     };
     uint32_t op_errno = 0;
     gf_boolean_t cluster_lock = _gf_false;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
 
     conf = this->private;
     GF_ASSERT(conf);
@@ -1872,7 +1872,7 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
          * mgmt_v3_lock_timeout should be set to default value or we
          * need to change the value according to timeout value
          * i.e, timeout + 120 seconds. */
-        ret = dict_get_uint32(op_ctx, "timeout", &timeout);
+        ret = dict_get_time(op_ctx, "timeout", &timeout);
         if (!ret)
             conf->mgmt_v3_lock_timeout = timeout + 120;
 

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -59,7 +59,7 @@ struct mdc_statistics {
 };
 
 struct mdc_conf {
-    uint32_t timeout;
+    time_t timeout;
     gf_boolean_t cache_posix_acl;
     gf_boolean_t cache_glusterfs_acl;
     gf_boolean_t cache_selinux;
@@ -377,8 +377,7 @@ __is_cache_valid(xlator_t *this, time_t mdc_time)
 {
     gf_boolean_t ret = _gf_true;
     struct mdc_conf *conf = NULL;
-    uint32_t timeout = 0;
-    time_t last_child_down = 0;
+    time_t timeout = 0, last_child_down = 0;
 
     conf = this->private;
 
@@ -1067,7 +1066,7 @@ int
 mdc_load_statfs_info_from_cache(xlator_t *this, struct statvfs **buf)
 {
     struct mdc_conf *conf = this->private;
-    uint32_t cache_age = 0;
+    time_t cache_age = 0;
     int ret = 0;
 
     if (!buf || !conf) {
@@ -1087,12 +1086,12 @@ mdc_load_statfs_info_from_cache(xlator_t *this, struct statvfs **buf)
 
         cache_age = (gf_time() - conf->statfs_cache.last_refreshed);
 
-        gf_log(this->name, GF_LOG_DEBUG, "STATFS cache age = %u secs",
+        gf_log(this->name, GF_LOG_DEBUG, "STATFS cache age = %ld secs",
                cache_age);
         if (cache_age > conf->timeout) {
             /* Expire the cache. */
             gf_log(this->name, GF_LOG_DEBUG,
-                   "Cache age %u secs exceeded timeout %u secs", cache_age,
+                   "Cache age %ld secs exceeded timeout %ld secs", cache_age,
                    conf->timeout);
             ret = -1;
             goto unlock;
@@ -3681,7 +3680,7 @@ int
 mdc_init(xlator_t *this)
 {
     struct mdc_conf *conf = NULL;
-    uint32_t timeout = 0;
+    time_t timeout = 0;
     char *tmp_str = NULL;
 
     conf = GF_CALLOC(sizeof(*conf), 1, gf_mdc_mt_mdc_conf_t);
@@ -3693,7 +3692,7 @@ mdc_init(xlator_t *this)
 
     LOCK_INIT(&conf->lock);
 
-    GF_OPTION_INIT("md-cache-timeout", timeout, uint32, out);
+    GF_OPTION_INIT("md-cache-timeout", timeout, time, out);
 
     GF_OPTION_INIT("cache-selinux", conf->cache_selinux, bool, out);
 


### PR DESCRIPTION
More time_t values for time intervals and timeouts,
drop weird is_valid_int() since strtol() is capable
enough to handle errors, adjust relevant comments.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

