### PR TITLE
glusterfsd started unsuccessfully because of the port was occupied #2745

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -6990,7 +6990,7 @@ glusterd_restart_bricks(void *opaque)
                 if (!brickinfo->start_triggered) {
                     pthread_mutex_lock(&brickinfo->restart_mutex);
                     {
-                        glusterd_brick_start(volinfo, brickinfo, _gf_false,
+                        glusterd_brick_start(volinfo, brickinfo, _gf_true,
                                              _gf_false);
                     }
                     pthread_mutex_unlock(&brickinfo->restart_mutex);


### PR DESCRIPTION
when one node reboot, glusterfsd may start unsuccessfully.
glusterd started brick process unsuccessfully due to the port
was occupied, becuase runner_run_nowait() will not wait to get
the return/exit code of the executed command (brick process).
Hence as of now in such case, we cannot know with what error
the brick has failed to connect.

