### PR TITLE
cli: drop global state variable

### DIFF
--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -1156,7 +1156,8 @@ out:
 }
 
 int
-cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
+cli_cmd_quota_handle_list_all(cli_state_t *state, const char **words,
+                              dict_t *options)
 {
     int all_failed = 1;
     int count = 0;
@@ -1220,7 +1221,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
                  "No%s quota configured on"
                  " volume %s",
                  (type == GF_QUOTA_OPTION_TYPE_LIST) ? "" : " inode", volname);
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             xml_err_flag = _gf_true;
         } else {
             cli_out("quota: %s", err_str);
@@ -1342,7 +1343,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
         all_failed = all_failed && ret;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_quota_limit_list_end(local);
         if (ret) {
             gf_log("cli", GF_LOG_ERROR,
@@ -1557,7 +1558,7 @@ cli_cmd_quota_cbk(struct cli_state *state, struct cli_cmd_word *word,
         case GF_QUOTA_OPTION_TYPE_LIST_OBJECTS:
             if (wordcount != 4)
                 break;
-            ret = cli_cmd_quota_handle_list_all(words, options);
+            ret = cli_cmd_quota_handle_list_all(state, words, options);
             goto out;
         default:
             break;
@@ -2461,7 +2462,7 @@ cli_print_brick_status(cli_volume_status_t *status)
      (op == GF_SHD_OP_HEAL_SUMMARY))
 
 int
-cli_launch_glfs_heal(int heal_op, dict_t *options)
+cli_launch_glfs_heal(cli_state_t *state, int heal_op, dict_t *options)
 {
     char buff[PATH_MAX] = {0};
     runner_t runner = {0};
@@ -2479,7 +2480,7 @@ cli_launch_glfs_heal(int heal_op, dict_t *options)
 
     switch (heal_op) {
         case GF_SHD_OP_INDEX_SUMMARY:
-            if (global_state->mode & GLUSTER_MODE_XML) {
+            if (state->mode & GLUSTER_MODE_XML) {
                 runner_add_args(&runner, "--xml", NULL);
             }
             break;
@@ -2501,7 +2502,7 @@ cli_launch_glfs_heal(int heal_op, dict_t *options)
             break;
         case GF_SHD_OP_SPLIT_BRAIN_FILES:
             runner_add_args(&runner, "split-brain-info", NULL);
-            if (global_state->mode & GLUSTER_MODE_XML) {
+            if (state->mode & GLUSTER_MODE_XML) {
                 runner_add_args(&runner, "--xml", NULL);
             }
             break;
@@ -2511,7 +2512,7 @@ cli_launch_glfs_heal(int heal_op, dict_t *options)
             break;
         case GF_SHD_OP_HEAL_SUMMARY:
             runner_add_args(&runner, "info-summary", NULL);
-            if (global_state->mode & GLUSTER_MODE_XML) {
+            if (state->mode & GLUSTER_MODE_XML) {
                 runner_add_args(&runner, "--xml", NULL);
             }
             break;
@@ -2519,7 +2520,7 @@ cli_launch_glfs_heal(int heal_op, dict_t *options)
             ret = -1;
             goto out;
     }
-    if (global_state->mode & GLUSTER_MODE_GLFSHEAL_NOLOG)
+    if (state->mode & GLUSTER_MODE_GLFSHEAL_NOLOG)
         runner_add_args(&runner, "--nolog", NULL);
     ret = runner_start(&runner);
     if (ret == -1)
@@ -2566,7 +2567,7 @@ cli_cmd_volume_heal_cbk(struct cli_state *state, struct cli_cmd_word *word,
     if (ret < 0)
         goto out;
     if (NEEDS_GLFS_HEAL(heal_op)) {
-        ret = cli_launch_glfs_heal(heal_op, options);
+        ret = cli_launch_glfs_heal(state, heal_op, options);
         if (ret < 0)
             goto out;
         if (heal_op != GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE)
@@ -2590,7 +2591,7 @@ out:
     if (ret) {
         cli_cmd_sent_status_get(&sent);
         if ((sent == 0) && (parse_error == 0) &&
-            !(global_state->mode & GLUSTER_MODE_XML)) {
+            !(state->mode & GLUSTER_MODE_XML)) {
             cli_out("Volume heal failed.");
         }
     }

--- a/cli/src/cli-rl.c
+++ b/cli/src/cli-rl.c
@@ -86,10 +86,10 @@ cli_rl_err(struct cli_state *state, const char *fmt, va_list ap)
 void
 cli_rl_process_line(char *line)
 {
-    struct cli_state *state = NULL;
+    cli_state_t *state = THIS->private;
     int ret = 0;
 
-    state = global_state;
+    GF_ASSERT(state);
 
     state->rl_processing = 1;
     {
@@ -106,9 +106,9 @@ void
 cli_rl_stdin(int fd, int idx, int gen, void *data, int poll_out, int poll_in,
              int poll_err, char event_thread_died)
 {
-    struct cli_state *state = NULL;
+    struct cli_state *state = data;
 
-    state = data;
+    GF_ASSERT(state);
 
     rl_callback_read_char();
 
@@ -120,10 +120,10 @@ cli_rl_stdin(int fd, int idx, int gen, void *data, int poll_out, int poll_in,
 char *
 cli_rl_autocomplete_entry(const char *text, int times)
 {
-    struct cli_state *state = NULL;
+    cli_state_t *state = THIS->private;
     char *retp = NULL;
 
-    state = global_state;
+    GF_ASSERT(state);
 
     if (!state->matchesp)
         return NULL;
@@ -309,11 +309,11 @@ cli_rl_autocomplete_cleanup(struct cli_state *state)
 char **
 cli_rl_autocomplete(const char *text, int start, int end)
 {
-    struct cli_state *state = NULL;
+    cli_state_t *state = THIS->private;
     char **matches = NULL;
     char save = 0;
 
-    state = global_state;
+    GF_ASSERT(state);
 
     /* hack to make the autocompletion code neater */
     /* fake it as though the cursor is at the end of line */
@@ -341,10 +341,10 @@ complete_none(const char *txt, int times)
 void *
 cli_rl_input(void *_data)
 {
-    struct cli_state *state = NULL;
+    cli_state_t *state = _data;
     char *line = NULL;
 
-    state = _data;
+    GF_ASSERT(state);
 
     fprintf(stderr,
             "Welcome to gluster prompt, type 'help' to see the available "
@@ -364,7 +364,7 @@ cli_rl_input(void *_data)
 }
 
 int
-cli_rl_enable(struct cli_state *state)
+cli_rl_enable(cli_state_t *state)
 {
     int ret = 0;
 
@@ -394,7 +394,7 @@ out:
 #else /* HAVE_READLINE */
 
 int
-cli_rl_enable(struct cli_state *state)
+cli_rl_enable(cli_state_t *state)
 {
     return 0;
 }

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -139,8 +139,12 @@ gf_cli_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = -1;
     char msg[1024] = "success";
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     if (-1 == req->rpc_status) {
         goto out;
@@ -164,7 +168,7 @@ gf_cli_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str(NULL, (rsp.op_ret) ? NULL : msg, rsp.op_ret,
                                  rsp.op_errno, (rsp.op_ret) ? msg : NULL);
         if (ret)
@@ -194,8 +198,12 @@ gf_cli_deprobe_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = -1;
     char msg[1024] = "success";
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     if (-1 == req->rpc_status) {
         goto out;
@@ -219,7 +227,7 @@ gf_cli_deprobe_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str(NULL, (rsp.op_ret) ? NULL : msg, rsp.op_ret,
                                  rsp.op_errno, (rsp.op_ret) ? msg : NULL);
         if (ret)
@@ -416,6 +424,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
     cli_friend_output_fn friend_output_fn;
     call_frame_t *frame = NULL;
     unsigned long flags = 0;
+    cli_state_t *state = NULL;
 
     if (-1 == req->rpc_status) {
         goto out;
@@ -424,6 +433,9 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(myframe);
 
     frame = myframe;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     flags = (long)frame->local;
 
@@ -451,7 +463,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (!rsp.op_ret) {
         if (!rsp.friends.friends_len) {
             snprintf(msg, sizeof(msg), "%s: No peers present", cmd);
-            if (global_state->mode & GLUSTER_MODE_XML) {
+            if (state->mode & GLUSTER_MODE_XML) {
                 ret = cli_xml_output_peer_status(dict, rsp.op_ret, rsp.op_errno,
                                                  msg);
                 if (ret)
@@ -478,7 +490,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
             goto out;
         }
 
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             ret = cli_xml_output_peer_status(dict, rsp.op_ret, rsp.op_errno,
                                              msg);
             if (ret)
@@ -496,7 +508,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
             goto out;
         }
     } else {
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             ret = cli_xml_output_peer_status(dict, rsp.op_ret, rsp.op_errno,
                                              NULL);
             if (ret)
@@ -731,6 +743,7 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *caps __attribute__((unused)) = NULL;
     int k __attribute__((unused)) = 0;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
@@ -740,8 +753,10 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
 
     GF_ASSERT(frame->local);
-
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -752,7 +767,7 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gf_log("cli", GF_LOG_INFO, "Received resp to get vol: %d", rsp.op_ret);
 
     if (!rsp.dict.dict_len) {
-        if (global_state->mode & GLUSTER_MODE_XML)
+        if (state->mode & GLUSTER_MODE_XML)
             goto xml_output;
         cli_err("No volumes present");
         ret = 0;
@@ -789,20 +804,20 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 snprintf(err_str, sizeof(err_str), "Volume %s does not exist",
                          local->get_vol.volname);
                 ret = -1;
-                if (!(global_state->mode & GLUSTER_MODE_XML))
+                if (!(state->mode & GLUSTER_MODE_XML))
                     goto out;
         }
     }
 
     if (rsp.op_ret) {
-        if (global_state->mode & GLUSTER_MODE_XML)
+        if (state->mode & GLUSTER_MODE_XML)
             goto xml_output;
         ret = -1;
         goto out;
     }
 
 xml_output:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         /* For GET_NEXT_VOLUME output is already begun in
          * and will also end in gf_cli_get_next_volume()
          */
@@ -974,6 +989,7 @@ gf_cli_create_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *volname = NULL;
     dict_t *rsp_dict = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
@@ -987,6 +1003,9 @@ gf_cli_create_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -995,7 +1014,7 @@ gf_cli_create_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_log("cli", GF_LOG_INFO, "Received resp to create volume");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (rsp.op_ret == 0) {
             rsp_dict = dict_new();
             ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len,
@@ -1050,6 +1069,7 @@ gf_cli_delete_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *volname = NULL;
     call_frame_t *frame = NULL;
     dict_t *rsp_dict = NULL;
+    cli_state_t *state = NULL;
 
     if (-1 == req->rpc_status) {
         goto out;
@@ -1062,6 +1082,9 @@ gf_cli_delete_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -1070,7 +1093,7 @@ gf_cli_delete_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_log("cli", GF_LOG_INFO, "Received resp to delete volume");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (rsp.op_ret == 0) {
             rsp_dict = dict_new();
             ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len,
@@ -1124,6 +1147,7 @@ gf_cli3_1_uuid_get_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = -1;
     cli_local_t *local = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
     dict_t *dict = NULL;
 
     GF_ASSERT(myframe);
@@ -1136,6 +1160,9 @@ gf_cli3_1_uuid_get_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -1159,7 +1186,7 @@ gf_cli3_1_uuid_get_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_dict("uuidGenerate", dict, rsp.op_ret,
                                   rsp.op_errno, rsp.op_errstr);
         if (ret)
@@ -1205,6 +1232,7 @@ gf_cli3_1_uuid_reset_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = -1;
     cli_local_t *local = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
@@ -1218,6 +1246,9 @@ gf_cli3_1_uuid_reset_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -1228,7 +1259,7 @@ gf_cli3_1_uuid_reset_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_log("cli", GF_LOG_INFO, "Received resp to uuid reset");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_dict("uuidReset", NULL, rsp.op_ret, rsp.op_errno,
                                   rsp.op_errstr);
         if (ret)
@@ -1264,6 +1295,7 @@ gf_cli_start_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *volname = NULL;
     call_frame_t *frame = NULL;
     dict_t *rsp_dict = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
@@ -1277,6 +1309,9 @@ gf_cli_start_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -1285,7 +1320,7 @@ gf_cli_start_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_log("cli", GF_LOG_INFO, "Received resp to start volume");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (rsp.op_ret == 0) {
             rsp_dict = dict_new();
             ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len,
@@ -1338,6 +1373,7 @@ gf_cli_stop_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     cli_local_t *local = NULL;
     char *volname = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
     dict_t *rsp_dict = NULL;
 
     GF_ASSERT(myframe);
@@ -1352,6 +1388,9 @@ gf_cli_stop_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -1360,7 +1399,7 @@ gf_cli_stop_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_log("cli", GF_LOG_INFO, "Received resp to stop volume");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (rsp.op_ret == 0) {
             rsp_dict = dict_new();
             ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len,
@@ -1648,6 +1687,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     cli_local_t *local = NULL;
     char *volname = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
     int cmd = 0;
     int ret = -1;
     dict_t *dict = NULL;
@@ -1667,6 +1707,9 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -1699,7 +1742,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (!((cmd == GF_DEFRAG_CMD_STOP) || (cmd == GF_DEFRAG_CMD_STATUS)) &&
-        !(global_state->mode & GLUSTER_MODE_XML)) {
+        !(state->mode & GLUSTER_MODE_XML)) {
         ret = dict_get_str_sizen(dict, GF_REBALANCE_TID_KEY, &task_id_str);
         if (ret) {
             gf_log("cli", GF_LOG_WARNING, "failed to get %s from dict",
@@ -1765,7 +1808,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_rebalance(cmd, dict, rsp.op_ret, rsp.op_errno,
                                            rsp.op_errstr);
         goto out;
@@ -1776,7 +1819,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         gf_log("cli", GF_LOG_ERROR, "Failed to print rebalance status");
 
 done:
-    if (global_state->mode & GLUSTER_MODE_XML)
+    if (state->mode & GLUSTER_MODE_XML)
         cli_xml_output_str("volRebalance", msg, rsp.op_ret, rsp.op_errno,
                            rsp.op_errstr);
     else {
@@ -1808,8 +1851,12 @@ gf_cli_reset_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char msg[1024] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     if (-1 == req->rpc_status) {
         goto out;
@@ -1830,7 +1877,7 @@ gf_cli_reset_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         snprintf(msg, sizeof(msg), "reset volume %s",
                  (rsp.op_ret) ? "unsuccessful" : "successful");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volReset", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -2051,12 +2098,16 @@ gf_cli_set_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char tmp_str[512] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2104,7 +2155,7 @@ gf_cli_set_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                  added_xlator);
     }
 
-    if ((global_state->mode & GLUSTER_MODE_XML) && (help_str == NULL)) {
+    if ((state->mode & GLUSTER_MODE_XML) && (help_str == NULL)) {
         ret = cli_xml_output_str("volSet", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -2150,12 +2201,16 @@ gf_cli_add_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char msg[1024] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2172,7 +2227,7 @@ gf_cli_add_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
         snprintf(msg, sizeof(msg), "Add Brick %s",
                  (rsp.op_ret) ? "unsuccessful" : "successful");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volAddBrick", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -2207,6 +2262,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
     int32_t command = 0;
     gf1_op_commands cmd = GF_OP_CMD_NONE;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     call_frame_t *frame = NULL;
     const char *cmd_str;
 
@@ -2221,6 +2277,9 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2255,7 +2314,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
             snprintf(msg, sizeof(msg), "volume remove-brick %s: failed",
                      cmd_str);
 
-        if (global_state->mode & GLUSTER_MODE_XML)
+        if (state->mode & GLUSTER_MODE_XML)
             goto xml_output;
 
         cli_err("%s", msg);
@@ -2270,7 +2329,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
         if (ret < 0) {
             strncpy(msg, DICT_UNSERIALIZE_FAIL, sizeof(msg));
 
-            if (global_state->mode & GLUSTER_MODE_XML) {
+            if (state->mode & GLUSTER_MODE_XML) {
                 rsp.op_ret = -1;
                 goto xml_output;
             }
@@ -2281,7 +2340,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
 xml_output:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (strcmp(rsp.op_errstr, "")) {
             ret = cli_xml_output_vol_remove_brick(_gf_true, dict, rsp.op_ret,
                                                   rsp.op_errno, rsp.op_errstr,
@@ -2334,6 +2393,7 @@ gf_cli_remove_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *cmd_str = "unknown";
     cli_local_t *local = NULL;
     call_frame_t *frame = NULL;
+    cli_state_t *state = NULL;
     char *task_id_str = NULL;
     dict_t *rsp_dict = NULL;
 
@@ -2348,6 +2408,9 @@ gf_cli_remove_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2406,7 +2469,7 @@ gf_cli_remove_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
         snprintf(msg, sizeof(msg), "Remove Brick %s %s", cmd_str,
                  (rsp.op_ret) ? "unsuccessful" : "successful");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_remove_brick(_gf_false, rsp_dict, rsp.op_ret,
                                               rsp.op_errno, msg,
                                               "volRemoveBrick");
@@ -2451,6 +2514,7 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     call_frame_t *frame = NULL;
     const char *rb_operation_str = NULL;
     dict_t *rsp_dict = NULL;
@@ -2470,6 +2534,9 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2527,7 +2594,7 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     snprintf(msg, sizeof(msg), "%s",
              rb_operation_str ? rb_operation_str : "Unknown operation");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_replace_brick(rsp_dict, rsp.op_ret,
                                                rsp.op_errno, msg);
         if (ret)
@@ -2563,6 +2630,7 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = -1;
+    cli_state_t *state = NULL;
     cli_local_t *local = NULL;
     call_frame_t *frame = NULL;
     const char *rb_operation_str = NULL;
@@ -2583,6 +2651,9 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(frame->local);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2625,7 +2696,7 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     snprintf(msg, sizeof(msg), "%s",
              rb_operation_str ? rb_operation_str : "Unknown operation");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_replace_brick(rsp_dict, rsp.op_ret,
                                                rsp.op_errno, msg);
         if (ret)
@@ -2665,12 +2736,16 @@ gf_cli_log_rotate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char msg[1024] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2687,7 +2762,7 @@ gf_cli_log_rotate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         snprintf(msg, sizeof(msg), "log rotate %s",
                  (rsp.op_ret) ? "unsuccessful" : "successful");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volLogRotate", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -2719,12 +2794,16 @@ gf_cli_sync_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char msg[1024] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -2741,7 +2820,7 @@ gf_cli_sync_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         snprintf(msg, sizeof(msg), "volume sync: %s",
                  (rsp.op_ret) ? "failed" : "success");
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volSync", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -2762,10 +2841,10 @@ out:
 }
 
 static int
-print_quota_list_usage_output(cli_local_t *local, char *path, int64_t avail,
-                              char *sl_str, quota_limits_t *limits,
-                              quota_meta_t *used_space, gf_boolean_t sl,
-                              gf_boolean_t hl, double sl_num,
+print_quota_list_usage_output(cli_local_t *local, cli_state_t *state,
+                              char *path, int64_t avail, char *sl_str,
+                              quota_limits_t *limits, quota_meta_t *used_space,
+                              gf_boolean_t sl, gf_boolean_t hl, double sl_num,
                               gf_boolean_t limit_set)
 {
     int32_t ret = -1;
@@ -2774,7 +2853,7 @@ print_quota_list_usage_output(cli_local_t *local, char *path, int64_t avail,
     char *hl_str = NULL;
     char *sl_val = NULL;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_quota_xml_output(local, path, limits->hl, sl_str, sl_num,
                                    used_space->size, avail, sl ? "Yes" : "No",
                                    hl ? "Yes" : "No", limit_set);
@@ -2819,16 +2898,16 @@ out:
 }
 
 static int
-print_quota_list_object_output(cli_local_t *local, char *path, int64_t avail,
-                               char *sl_str, quota_limits_t *limits,
-                               quota_meta_t *used_space, gf_boolean_t sl,
-                               gf_boolean_t hl, double sl_num,
+print_quota_list_object_output(cli_local_t *local, cli_state_t *state,
+                               char *path, int64_t avail, char *sl_str,
+                               quota_limits_t *limits, quota_meta_t *used_space,
+                               gf_boolean_t sl, gf_boolean_t hl, double sl_num,
                                gf_boolean_t limit_set)
 {
     int32_t ret = -1;
     int64_t sl_val = sl_num;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_quota_object_xml_output(local, path, sl_str, sl_val, limits,
                                           used_space, avail, sl ? "Yes" : "No",
                                           hl ? "Yes" : "No", limit_set);
@@ -2859,9 +2938,10 @@ out:
 }
 
 static int
-print_quota_list_output(cli_local_t *local, char *path, char *default_sl,
-                        quota_limits_t *limits, quota_meta_t *used_space,
-                        int type, gf_boolean_t limit_set)
+print_quota_list_output(cli_local_t *local, cli_state_t *state, char *path,
+                        char *default_sl, quota_limits_t *limits,
+                        quota_meta_t *used_space, int type,
+                        gf_boolean_t limit_set)
 {
     int64_t avail = 0;
     char percent_str[20] = {0};
@@ -2912,20 +2992,21 @@ print_quota_list_output(cli_local_t *local, char *path, char *default_sl,
     }
 
     if (type == GF_QUOTA_OPTION_TYPE_LIST)
-        ret = print_quota_list_usage_output(local, path, avail, sl_final,
+        ret = print_quota_list_usage_output(local, state, path, avail, sl_final,
                                             limits, used_space, sl, hl, sl_num,
                                             limit_set);
     else
-        ret = print_quota_list_object_output(local, path, avail, sl_final,
-                                             limits, used_space, sl, hl, sl_num,
-                                             limit_set);
+        ret = print_quota_list_object_output(local, state, path, avail,
+                                             sl_final, limits, used_space, sl,
+                                             hl, sl_num, limit_set);
 out:
     return ret;
 }
 
 static int
-print_quota_list_from_mountdir(cli_local_t *local, char *mountdir,
-                               char *default_sl, char *path, int type)
+print_quota_list_from_mountdir(cli_local_t *local, cli_state_t *state,
+                               char *mountdir, char *default_sl, char *path,
+                               int type)
 {
     int ret = -1;
     ssize_t xattr_size = 0;
@@ -3020,8 +3101,8 @@ enoattr:
     used_space.file_count = ntoh64(used_space.file_count);
     used_space.dir_count = ntoh64(used_space.dir_count);
 
-    ret = print_quota_list_output(local, path, default_sl, &limits, &used_space,
-                                  type, limit_set);
+    ret = print_quota_list_output(local, state, path, default_sl, &limits,
+                                  &used_space, type, limit_set);
 out:
     return ret;
 }
@@ -3049,9 +3130,10 @@ gluster_remove_auxiliary_mount(char *volname)
 }
 
 static int
-gf_cli_print_limit_list_from_dict(cli_local_t *local, char *volname,
-                                  dict_t *dict, char *default_sl, int count,
-                                  int op_ret, int op_errno, char *op_errstr)
+gf_cli_print_limit_list_from_dict(cli_local_t *local, cli_state_t *state,
+                                  char *volname, dict_t *dict, char *default_sl,
+                                  int count, int op_ret, int op_errno,
+                                  char *op_errstr)
 {
     int ret = -1;
     int i = 0;
@@ -3074,7 +3156,7 @@ gf_cli_print_limit_list_from_dict(cli_local_t *local, char *volname,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_quota_limit_list_begin(local, op_ret, op_errno,
                                                         op_errstr);
         if (ret) {
@@ -3098,8 +3180,8 @@ gf_cli_print_limit_list_from_dict(cli_local_t *local, char *volname,
         if (ret)
             goto out;
         GLUSTERD_GET_QUOTA_LIST_MOUNT_PATH(mountdir, volname, path);
-        ret = print_quota_list_from_mountdir(local, mountdir, default_sl, path,
-                                             type);
+        ret = print_quota_list_from_mountdir(local, state, mountdir, default_sl,
+                                             path, type);
     }
 
 out:
@@ -3113,6 +3195,7 @@ print_quota_list_from_quotad(call_frame_t *frame, dict_t *rsp_dict)
     char *default_sl = NULL;
     int ret = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     dict_t *gd_rsp_dict = NULL;
     quota_meta_t used_space = {
         0,
@@ -3128,6 +3211,9 @@ print_quota_list_from_quotad(call_frame_t *frame, dict_t *rsp_dict)
 
     local = frame->local;
     gd_rsp_dict = local->dict;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = dict_get_int32_sizen(rsp_dict, "type", &type);
     if (ret) {
@@ -3199,7 +3285,7 @@ print_quota_list_from_quotad(call_frame_t *frame, dict_t *rsp_dict)
     }
 
     if (success_count == 0) {
-        if (!(global_state->mode & GLUSTER_MODE_XML)) {
+        if (!(state->mode & GLUSTER_MODE_XML)) {
             print_quota_list_header(type);
         } else {
             ret = cli_xml_output_vol_quota_limit_list_begin(local, 0, 0, NULL);
@@ -3210,8 +3296,8 @@ print_quota_list_from_quotad(call_frame_t *frame, dict_t *rsp_dict)
         }
     }
 
-    ret = print_quota_list_output(local, path, default_sl, &limits, &used_space,
-                                  type, _gf_true);
+    ret = print_quota_list_output(local, state, path, default_sl, &limits,
+                                  &used_space, type, _gf_true);
 out:
     return ret;
 }
@@ -3426,9 +3512,9 @@ out:
 }
 
 static void
-gf_cli_quota_list(cli_local_t *local, char *volname, dict_t *dict,
-                  char *default_sl, int count, int op_ret, int op_errno,
-                  char *op_errstr)
+gf_cli_quota_list(cli_local_t *local, cli_state_t *state, char *volname,
+                  dict_t *dict, char *default_sl, int count, int op_ret,
+                  int op_errno, char *op_errstr)
 {
     if (!cli_cmd_connected())
         goto out;
@@ -3436,8 +3522,9 @@ gf_cli_quota_list(cli_local_t *local, char *volname, dict_t *dict,
     if (count > 0) {
         GF_VALIDATE_OR_GOTO("cli", volname, out);
 
-        gf_cli_print_limit_list_from_dict(local, volname, dict, default_sl,
-                                          count, op_ret, op_errno, op_errstr);
+        gf_cli_print_limit_list_from_dict(local, state, volname, dict,
+                                          default_sl, count, op_ret, op_errno,
+                                          op_errstr);
     }
 out:
     return;
@@ -3457,6 +3544,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
     char *default_sl = NULL;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     char *default_sl_dup = NULL;
     int32_t entry_count = 0;
 
@@ -3472,6 +3560,9 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
@@ -3480,7 +3571,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (rsp.op_ret) {
         ret = -1;
-        if (global_state->mode & GLUSTER_MODE_XML)
+        if (state->mode & GLUSTER_MODE_XML)
             goto xml_output;
 
         if (strcmp(rsp.op_errstr, "")) {
@@ -3543,10 +3634,10 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if ((type == GF_QUOTA_OPTION_TYPE_LIST) ||
         (type == GF_QUOTA_OPTION_TYPE_LIST_OBJECTS)) {
-        gf_cli_quota_list(local, volname, dict, default_sl, entry_count,
+        gf_cli_quota_list(local, state, volname, dict, default_sl, entry_count,
                           rsp.op_ret, rsp.op_errno, rsp.op_errstr);
 
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             ret = cli_xml_output_vol_quota_limit_list_end(local);
             if (ret < 0) {
                 ret = -1;
@@ -3558,7 +3649,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 xml_output:
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volQuota", NULL, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -3826,6 +3917,7 @@ gf_cli_get_next_volume(call_frame_t *frame, xlator_t *this, void *data)
     int ret = 0;
     cli_cmd_volume_get_ctx_t *ctx = NULL;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
 
     if (!frame || !this || !data) {
         ret = -1;
@@ -3835,7 +3927,10 @@ gf_cli_get_next_volume(call_frame_t *frame, xlator_t *this, void *data)
     ctx = data;
     local = frame->local;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    state = frame->this->private;
+    GF_ASSERT(state);
+
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_info_begin(local, 0, 0, "");
         if (ret) {
             gf_log("cli", GF_LOG_ERROR, XML_ERROR);
@@ -3846,7 +3941,7 @@ gf_cli_get_next_volume(call_frame_t *frame, xlator_t *this, void *data)
     ret = gf_cli_get_volume(frame, this, data);
 
     if (!local || !local->get_vol.volname) {
-        if ((global_state->mode & GLUSTER_MODE_XML))
+        if ((state->mode & GLUSTER_MODE_XML))
             goto end_xml;
 
         if (ret)
@@ -3866,7 +3961,7 @@ gf_cli_get_next_volume(call_frame_t *frame, xlator_t *this, void *data)
     }
 
 end_xml:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_info_end(local);
         if (ret)
             gf_log("cli", GF_LOG_ERROR, XML_ERROR);
@@ -5118,6 +5213,7 @@ gf_cli_gsync_set_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *primary = NULL;
     char *secondary = NULL;
     int32_t type = 0;
+    cli_state_t *state = NULL;
     gf_boolean_t status_detail = _gf_false;
 
     GF_ASSERT(myframe);
@@ -5125,6 +5221,9 @@ gf_cli_gsync_set_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (req->rpc_status == -1) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -5145,7 +5244,7 @@ gf_cli_gsync_set_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (ret)
         goto out;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_gsync(dict, rsp.op_ret, rsp.op_errno,
                                        rsp.op_errstr);
         if (ret)
@@ -5541,6 +5640,7 @@ gf_cli_profile_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int stats_cleared = 0;
+    cli_state_t *state = NULL;
     gf1_cli_info_op info_op = GF_CLI_INFO_NONE;
 
     GF_ASSERT(myframe);
@@ -5548,6 +5648,9 @@ gf_cli_profile_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     gf_log("cli", GF_LOG_DEBUG, "Received resp to profile");
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
@@ -5571,7 +5674,7 @@ gf_cli_profile_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_profile(dict, rsp.op_ret, rsp.op_errno,
                                          rsp.op_errstr);
         if (ret)
@@ -5733,6 +5836,7 @@ gf_cli_top_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char timestr[GF_TIMESTR_SIZE] = {
         0,
     };
+    cli_state_t *state = NULL;
     char *openfd_str = NULL;
     gf_boolean_t nfs = _gf_false;
     gf_boolean_t clear_stats = _gf_false;
@@ -5743,6 +5847,9 @@ gf_cli_top_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (-1 == req->rpc_status) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     gf_log("cli", GF_LOG_DEBUG, "Received resp to top");
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
@@ -5781,7 +5888,7 @@ gf_cli_top_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_top(dict, rsp.op_ret, rsp.op_errno,
                                      rsp.op_errstr);
         if (ret) {
@@ -7185,6 +7292,7 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     cli_volume_status_t status = {0};
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     gf_boolean_t wipe_local = _gf_false;
     char msg[1024] = {
         0,
@@ -7194,6 +7302,9 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (req->rpc_status == -1)
         goto out;
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -7222,7 +7333,7 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
             snprintf(msg, sizeof(msg),
                      "Unable to obtain volume status information.");
 
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             if (!local->all)
                 cli_xml_output_str("volStatus", msg, rsp.op_ret, rsp.op_errno,
                                    rsp.op_errstr);
@@ -7267,7 +7378,7 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         if (!local->all) {
             ret = cli_xml_output_vol_status_begin(local, rsp.op_ret,
                                                   rsp.op_errno, rsp.op_errstr);
@@ -7494,6 +7605,7 @@ gf_cli_status_volume_all(call_frame_t *frame, xlator_t *this, void *data)
     void *vol_dict = NULL;
     dict_t *dict = NULL;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
 
     if (!frame)
         goto out;
@@ -7502,6 +7614,9 @@ gf_cli_status_volume_all(call_frame_t *frame, xlator_t *this, void *data)
         goto out;
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = dict_get_uint32(local->dict, "cmd", &cmd);
     if (ret)
@@ -7528,7 +7643,7 @@ gf_cli_status_volume_all(call_frame_t *frame, xlator_t *this, void *data)
     cmd &= ~GF_CLI_STATUS_ALL;
     cmd |= GF_CLI_STATUS_VOL;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         // TODO: Pass proper op_* values
         ret = cli_xml_output_vol_status_begin(local, 0, 0, NULL);
         if (ret) {
@@ -7537,7 +7652,7 @@ gf_cli_status_volume_all(call_frame_t *frame, xlator_t *this, void *data)
         }
     }
 
-    if (vol_count == 0 && !(global_state->mode & GLUSTER_MODE_XML)) {
+    if (vol_count == 0 && !(state->mode & GLUSTER_MODE_XML)) {
         cli_err("No volumes present");
         ret = 0;
         goto out;
@@ -7569,7 +7684,7 @@ gf_cli_status_volume_all(call_frame_t *frame, xlator_t *this, void *data)
     }
 
 xml_end:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_status_end(local);
     }
 
@@ -7921,16 +8036,17 @@ gf_cli_heal_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = dict_get_int32_sizen(local->dict, "heal-op", (int32_t *)&heal_op);
+
     // TODO: Proper XML output
-    //#if (HAVE_LIB_XML)
-    //        if (global_state->mode & GLUSTER_MODE_XML) {
+    // #if (HAVE_LIB_XML)
+    //        if (state->mode & GLUSTER_MODE_XML) {
     //                ret = cli_xml_output_dict ("volHeal", dict, rsp.op_ret,
     //                                           rsp.op_errno, rsp.op_errstr);
     //                if (ret)
     //                        gf_log ("cli", GF_LOG_ERROR, XML_ERROR);
     //                goto out;
     //        }
-    //#endif
+    // #endif
 
     ret = dict_get_str_sizen(local->dict, "volname", &volname);
     if (ret) {
@@ -8093,8 +8209,12 @@ gf_cli_statedump_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = -1;
     char msg[1024] = "Volume statedump successful";
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     if (-1 == req->rpc_status)
         goto out;
@@ -8109,7 +8229,7 @@ gf_cli_statedump_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (rsp.op_ret)
         snprintf(msg, sizeof(msg), "%s", rsp.op_errstr);
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_str("volStatedump", msg, rsp.op_ret, rsp.op_errno,
                                  rsp.op_errstr);
         if (ret)
@@ -8165,11 +8285,15 @@ gf_cli_list_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int i = 0;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status)
         goto out;
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -8190,7 +8314,7 @@ gf_cli_list_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_list(dict, rsp.op_ret, rsp.op_errno,
                                       rsp.op_errstr);
         if (ret)
@@ -8340,6 +8464,7 @@ cli_snapshot_remove_reply(gf_cli_rsp *rsp, dict_t *dict, call_frame_t *frame)
     char *snap_name = NULL;
     int32_t delete_cmd = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(frame);
     GF_ASSERT(rsp);
@@ -8347,13 +8472,16 @@ cli_snapshot_remove_reply(gf_cli_rsp *rsp, dict_t *dict, call_frame_t *frame)
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     ret = dict_get_int32_sizen(dict, "sub-cmd", &delete_cmd);
     if (ret) {
         gf_log("cli", GF_LOG_ERROR, "Could not get sub-cmd");
         goto end;
     }
 
-    if ((global_state->mode & GLUSTER_MODE_XML) &&
+    if ((state->mode & GLUSTER_MODE_XML) &&
         (delete_cmd == GF_SNAP_DELETE_TYPE_SNAP)) {
         ret = cli_xml_output_snap_delete_begin(local, rsp->op_ret,
                                                rsp->op_errno, rsp->op_errstr);
@@ -8364,7 +8492,7 @@ cli_snapshot_remove_reply(gf_cli_rsp *rsp, dict_t *dict, call_frame_t *frame)
         }
     }
 
-    if (rsp->op_ret && !(global_state->mode & GLUSTER_MODE_XML)) {
+    if (rsp->op_ret && !(state->mode & GLUSTER_MODE_XML)) {
         cli_err("snapshot delete: failed: %s",
                 rsp->op_errstr ? rsp->op_errstr
                                : "Please check log file for details");
@@ -8391,7 +8519,7 @@ cli_snapshot_remove_reply(gf_cli_rsp *rsp, dict_t *dict, call_frame_t *frame)
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_snapshot_delete(local, dict, rsp);
         if (ret) {
             gf_log("cli", GF_LOG_ERROR,
@@ -8415,7 +8543,7 @@ cli_snapshot_remove_reply(gf_cli_rsp *rsp, dict_t *dict, call_frame_t *frame)
     ret = 0;
 
 out:
-    if ((global_state->mode & GLUSTER_MODE_XML) &&
+    if ((state->mode & GLUSTER_MODE_XML) &&
         (delete_cmd == GF_SNAP_DELETE_TYPE_SNAP)) {
         ret = cli_xml_output_snap_delete_end(local);
     }
@@ -9203,6 +9331,7 @@ cli_snapshot_status(dict_t *dict, gf_cli_rsp *rsp, call_frame_t *frame)
     int ret = -1;
     int status_cmd = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(dict);
     GF_ASSERT(rsp);
@@ -9213,6 +9342,9 @@ cli_snapshot_status(dict_t *dict, gf_cli_rsp *rsp, call_frame_t *frame)
         gf_log("cli", GF_LOG_ERROR, "frame->local is NULL");
         goto out;
     }
+
+    state = ((call_frame_t *)frame)->this->private;
+    GF_ASSERT(state);
 
     if (rsp->op_ret) {
         if (rsp->op_errstr) {
@@ -9240,7 +9372,7 @@ cli_snapshot_status(dict_t *dict, gf_cli_rsp *rsp, call_frame_t *frame)
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_snapshot_status_single_snap(local, dict, "status.snap0");
         if (ret) {
             gf_log("cli", GF_LOG_ERROR,
@@ -9615,6 +9747,7 @@ gf_cli_snapshot_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int8_t soft_limit_flag = -1;
     char *volname = NULL;
     char *snap_uuid = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
@@ -9623,6 +9756,9 @@ gf_cli_snapshot_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     frame = myframe;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -9665,9 +9801,9 @@ gf_cli_snapshot_cbk(struct rpc_req *req, struct iovec *iov, int count,
 #endif
 
     /* Snapshot status and delete command is handled separately */
-    if (global_state->mode & GLUSTER_MODE_XML &&
-        GF_SNAP_OPTION_TYPE_STATUS != type &&
-        GF_SNAP_OPTION_TYPE_DELETE != type) {
+    if ((state->mode & GLUSTER_MODE_XML) &&
+        (GF_SNAP_OPTION_TYPE_STATUS != type) &&
+        (GF_SNAP_OPTION_TYPE_DELETE != type)) {
         ret = cli_xml_output_snapshot(type, dict, rsp.op_ret, rsp.op_errno,
                                       rsp.op_errstr);
         if (ret) {
@@ -9887,6 +10023,7 @@ gf_cli_snapshot_for_delete(call_frame_t *frame, xlator_t *this, void *data)
     int32_t ret = -1;
     int32_t cmd = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     dict_t *snap_dict = NULL;
     int32_t snapcount = 0;
     int i = 0;
@@ -9900,6 +10037,9 @@ gf_cli_snapshot_for_delete(call_frame_t *frame, xlator_t *this, void *data)
     GF_VALIDATE_OR_GOTO("cli", data, out);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = dict_get_int32_sizen(local->dict, "sub-cmd", &cmd);
     if (ret) {
@@ -9919,7 +10059,7 @@ gf_cli_snapshot_for_delete(call_frame_t *frame, xlator_t *this, void *data)
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
 #ifdef HAVE_LIB_XML
         ret = xmlTextWriterWriteFormatElement(
             local->writer, (xmlChar *)"snapCount", "%d", snapcount);
@@ -9953,7 +10093,7 @@ gf_cli_snapshot_for_delete(call_frame_t *frame, xlator_t *this, void *data)
                  volname, snapcount);
     }
 
-    answer = cli_cmd_get_confirmation(global_state, question);
+    answer = cli_cmd_get_confirmation(state, question);
     if (GF_ANSWER_NO == answer) {
         ret = 0;
         gf_log("cli", GF_LOG_DEBUG,
@@ -10007,6 +10147,7 @@ gf_cli_snapshot_for_status(call_frame_t *frame, xlator_t *this, void *data)
     int ret = -1;
     int32_t cmd = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     dict_t *snap_dict = NULL;
     int snapcount = 0;
     int i = 0;
@@ -10017,6 +10158,9 @@ gf_cli_snapshot_for_status(call_frame_t *frame, xlator_t *this, void *data)
     GF_VALIDATE_OR_GOTO("cli", data, out);
 
     local = frame->local;
+
+    state = frame->this->private;
+    GF_ASSERT(state);
 
     ret = dict_get_int32_sizen(local->dict, "sub-cmd", &cmd);
     if (ret) {
@@ -10040,7 +10184,7 @@ gf_cli_snapshot_for_status(call_frame_t *frame, xlator_t *this, void *data)
         goto out;
     }
 
-    if (snapcount == 0 && !(global_state->mode & GLUSTER_MODE_XML)) {
+    if (snapcount == 0 && !(state->mode & GLUSTER_MODE_XML)) {
         cli_out("No snapshots present");
     }
 
@@ -10101,6 +10245,7 @@ gf_cli_snapshot(call_frame_t *frame, xlator_t *this, void *data)
     int ret = -1;
     int tmp_ret = -1;
     cli_local_t *local = NULL;
+    cli_state_t *state = NULL;
     char *err_str = NULL;
     int type = -1;
 
@@ -10109,9 +10254,12 @@ gf_cli_snapshot(call_frame_t *frame, xlator_t *this, void *data)
 
     local = frame->local;
 
+    state = frame->this->private;
+    GF_ASSERT(state);
+
     options = data;
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_snapshot_begin_composite_op(local);
         if (ret) {
             gf_log("cli", GF_LOG_ERROR,
@@ -10153,7 +10301,7 @@ gf_cli_snapshot(call_frame_t *frame, xlator_t *this, void *data)
     ret = 0;
 
 xmlend:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_snapshot_end_composite_op(local);
         if (ret) {
             gf_log("cli", GF_LOG_ERROR,
@@ -10177,7 +10325,7 @@ out:
 
     GF_FREE(req.dict.dict_val);
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         /* XML mode handles its own error */
         ret = 0;
     }
@@ -10261,11 +10409,15 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char dict_key[50] = {
         0,
     };
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (-1 == req->rpc_status)
         goto out;
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -10282,7 +10434,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         else
             snprintf(msg, sizeof(msg), "volume get option: failed");
 
-        if (global_state->mode & GLUSTER_MODE_XML) {
+        if (state->mode & GLUSTER_MODE_XML) {
             ret = cli_xml_output_str("volGetopts", msg, rsp.op_ret,
                                      rsp.op_errno, rsp.op_errstr);
             if (ret) {
@@ -10307,7 +10459,7 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_getopts(dict, rsp.op_ret, rsp.op_errno,
                                          rsp.op_errstr);
         if (ret) {
@@ -10653,12 +10805,16 @@ gf_cli_bitrot_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char *volname = NULL;
     char *cmd_str = NULL;
     char *cmd_op = NULL;
+    cli_state_t *state = NULL;
 
     GF_ASSERT(myframe);
 
     if (req->rpc_status == -1) {
         goto out;
     }
+
+    state = ((call_frame_t *)myframe)->this->private;
+    GF_ASSERT(state);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
     if (ret < 0) {
@@ -10669,7 +10825,7 @@ gf_cli_bitrot_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (rsp.op_ret) {
         ret = -1;
-        if (global_state->mode & GLUSTER_MODE_XML)
+        if (state->mode & GLUSTER_MODE_XML)
             goto xml_output;
 
         if (strcmp(rsp.op_errstr, ""))
@@ -10706,7 +10862,7 @@ gf_cli_bitrot_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if ((type == GF_BITROT_CMD_SCRUB_STATUS) &&
-        !(global_state->mode & GLUSTER_MODE_XML)) {
+        !(state->mode & GLUSTER_MODE_XML)) {
         ret = gf_cli_print_bitrot_scrub_status(dict);
         if (ret) {
             gf_log("cli", GF_LOG_ERROR, "Failed to print bitrot scrub status");
@@ -10772,7 +10928,7 @@ gf_cli_bitrot_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 xml_output:
-    if (global_state->mode & GLUSTER_MODE_XML) {
+    if (state->mode & GLUSTER_MODE_XML) {
         ret = cli_xml_output_vol_profile(dict, rsp.op_ret, rsp.op_errno,
                                          rsp.op_errstr);
         if (ret)

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -188,9 +188,9 @@ typedef struct cli_volume_status cli_volume_status_t;
 
 typedef struct cli_local cli_local_t;
 
-typedef ssize_t (*cli_serialize_t)(struct iovec outmsg, void *args);
+typedef struct cli_state cli_state_t;
 
-extern struct cli_state *global_state; /* use only in readline callback */
+typedef ssize_t (*cli_serialize_t)(struct iovec outmsg, void *args);
 
 extern struct rpc_clnt *global_quotad_rpc;
 


### PR DESCRIPTION
Drop 'global_state' and pass CLI state as a parameter
or indirectly via call frame or THIS where appropriate.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

