### PR TITLE
build: use pkg-config to check whether readline is available

### DIFF
--- a/cli/src/Makefile.am
+++ b/cli/src/Makefile.am
@@ -6,9 +6,9 @@ gluster_SOURCES = cli.c registry.c input.c cli-cmd.c cli-rl.c cli-cmd-global.c \
 
 gluster_LDADD = $(top_builddir)/libglusterfs/src/libglusterfs.la $(GF_LDADD) \
 		$(top_builddir)/libglusterd/src/libglusterd.la \
-		$(RLLIBS) $(top_builddir)/rpc/xdr/src/libgfxdr.la \
+		$(top_builddir)/rpc/xdr/src/libgfxdr.la \
 		$(top_builddir)/rpc/rpc-lib/src/libgfrpc.la \
-		$(XML_LIBS)
+		$(READLINE_LIBS) $(XML_LIBS)
 
 gluster_LDFLAGS = $(GF_LDFLAGS)
 noinst_HEADERS = cli.h cli-mem-types.h cli-cmd.h cli-quotad-client.h
@@ -23,7 +23,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) \
 	-DGLFSHEAL_PREFIX=\"$(GLUSTERFS_LIBEXECDIR)\"\
 	-DSYNCDAEMON_COMPILE=$(SYNCDAEMON_COMPILE)
 
-AM_CFLAGS = -Wall $(GF_CFLAGS) $(XML_CFLAGS)
+AM_CFLAGS = -Wall $(GF_CFLAGS) $(XML_CFLAGS) $(READLINE_CFLAGS)
 
 CLEANFILES =
 

--- a/configure.ac
+++ b/configure.ac
@@ -553,8 +553,6 @@ AC_CHECK_LIB([pthread], [pthread_mutex_init], , AC_MSG_ERROR([Posix threads libr
 
 AC_CHECK_FUNC([dlopen], [has_dlopen=yes], AC_CHECK_LIB([dl], [dlopen], , AC_MSG_ERROR([Dynamic linking library required to build glusterfs])))
 
-AC_CHECK_LIB([readline], [rl_do_undo], [RL_UNDO="yes"], [RL_UNDO="no"])
-
 AC_CHECK_LIB([intl], [gettext])
 
 AC_CHECK_HEADERS([sys/xattr.h])
@@ -1496,19 +1494,11 @@ if test "x$enable_mempool" = "xno"; then
         AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
 fi
 
-BUILD_READLINE=no
-AC_CHECK_LIB([readline -lcurses],[readline],[RLLIBS="-lreadline -lcurses"])
-AC_CHECK_LIB([readline -ltermcap],[readline],[RLLIBS="-lreadline -ltermcap"])
-AC_CHECK_LIB([readline -lncurses],[readline],[RLLIBS="-lreadline -lncurses"])
-
-if test -n "$RLLIBS"; then
-   if test "x$RL_UNDO" = "xyes"; then
-      AC_DEFINE(HAVE_READLINE, 1, [readline enabled CLI])
-      BUILD_READLINE=yes
-   else
-      BUILD_READLINE="no (present but missing undo)"
-   fi
-
+dnl Add readline support in CLI if available.
+PKG_CHECK_MODULES([READLINE], [readline], [BUILD_READLINE="yes"],
+                  [BUILD_READLINE="no"])
+if test x$BUILD_READLINE = xyes; then
+    AC_DEFINE(HAVE_READLINE, 1, [Enable CLI readline support.])
 fi
 
 BUILD_LIBAIO=no


### PR DESCRIPTION
Use convenient PKG_CHECK_MODULES macro to check whether readline
library is present, drop specific check for rl_do_undo() since
it is available since ancient readiline 2.0 or maybe even older.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

