### PR TITLE
glusterd:  cache the non local node's hostname

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-mem-types.h
+++ b/xlators/mgmt/glusterd/src/glusterd-mem-types.h
@@ -56,6 +56,7 @@ typedef enum gf_gld_mem_types_ {
     gf_gld_mt_hostname_t,
     gf_gld_mt_pmap_reg_t,
     gf_gld_mt_pmap_port_t,
+    gf_gld_mt_remote_hostname_t,
     gf_gld_mt_end,
 } gf_gld_mem_types_t;
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -91,6 +91,11 @@ typedef struct glusterd_hostname_ {
     struct list_head hostname_list;
 } glusterd_hostname_t;
 
+typedef struct glusterd_remote_hostname_ {
+    char *remote_hostname;
+    struct list_head remote_hostname_list;
+} glusterd_remote_hostname_t;
+
 gf_boolean_t
 is_brick_mx_enabled(void);
 

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1387,6 +1387,17 @@ out:
 }
 
 void
+glusterd_destroy_remote_hostname_list(glusterd_conf_t *priv) {
+    glusterd_remote_hostname_t *remote_hostname_obj = NULL;
+    list_for_each_entry(remote_hostname_obj, &priv->remote_hostnames, remote_hostname_list) {
+        list_del_init(&remote_hostname_obj->remote_hostname_list);
+        GF_FREE(remote_hostname_obj->remote_hostname);
+        GF_FREE(remote_hostname_obj);
+    }
+
+}
+
+void
 glusterd_destroy_hostname_list(glusterd_conf_t *priv)
 {
     glusterd_hostname_t *hostname_obj = NULL;
@@ -1879,6 +1890,7 @@ init(xlator_t *this)
     CDS_INIT_LIST_HEAD(&conf->brick_procs);
     CDS_INIT_LIST_HEAD(&conf->shd_procs);
     CDS_INIT_LIST_HEAD(&conf->hostnames);
+    CDS_INIT_LIST_HEAD(&conf->remote_hostnames);
     pthread_mutex_init(&conf->attach_lock, NULL);
     pthread_mutex_init(&conf->volume_lock, NULL);
 
@@ -2129,6 +2141,7 @@ fini(xlator_t *this)
     glusterd_stop_uds_listener(this);              /*stop unix socket rpc*/
     glusterd_stop_listener(this);                  /*stop tcp/ip socket rpc*/
     glusterd_destroy_hostname_list(this->private); /*Destroy hostname list */
+    glusterd_destroy_remote_hostname_list(this->private); /*Destroy client hostname list*/
 
 #if 0
        /* Running threads might be using these resourses, we have to cancel/stop

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -241,6 +241,7 @@ typedef struct {
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
     struct list_head hostnames;
+    struct list_head remote_hostnames;
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {


### PR DESCRIPTION
In order to solve the time-consuming problem of DNS caused by the non local node's hostname, cache the non local node's hostname.
The solution refers to the modification idea of #1663

Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>

