### PR TITLE
mem-pool: remove unneeded atomic counters

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -306,16 +306,6 @@ typedef struct per_thread_pool_list {
 /* actual pool structure, shared between different mem_pools */
 struct mem_pool_shared {
     unsigned int power_of_two;
-    /*
-     * Updates to these are *not* protected by a global lock, so races
-     * could occur and the numbers might be slightly off.  Don't expect
-     * them to line up exactly.  It's the general trends that matter, and
-     * it's not worth the locked-bus-cycle overhead to make these precise.
-     */
-    gf_atomic_t allocs_hot;
-    gf_atomic_t allocs_cold;
-    gf_atomic_t allocs_stdc;
-    gf_atomic_t frees_to_list;
 };
 
 void

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -549,11 +549,6 @@ mem_pools_preinit(void)
 
     for (i = 0; i < NPOOLS; ++i) {
         pools[i].power_of_two = POOL_SMALLEST + i;
-
-        GF_ATOMIC_INIT(pools[i].allocs_hot, 0);
-        GF_ATOMIC_INIT(pools[i].allocs_cold, 0);
-        GF_ATOMIC_INIT(pools[i].allocs_stdc, 0);
-        GF_ATOMIC_INIT(pools[i].frees_to_list, 0);
     }
 
     pool_list_size = sizeof(per_thread_pool_list_t) +
@@ -798,16 +793,13 @@ mem_get_from_pool(struct mem_pool *mem_pool)
     if (retval) {
         pt_pool->hot_list = retval->next;
         (void)pthread_spin_unlock(&pool_list->lock);
-        GF_ATOMIC_INC(pt_pool->parent->allocs_hot);
     } else {
         retval = pt_pool->cold_list;
         if (retval) {
             pt_pool->cold_list = retval->next;
             (void)pthread_spin_unlock(&pool_list->lock);
-            GF_ATOMIC_INC(pt_pool->parent->allocs_cold);
         } else {
             (void)pthread_spin_unlock(&pool_list->lock);
-            GF_ATOMIC_INC(pt_pool->parent->allocs_stdc);
             retval = malloc(1 << pt_pool->parent->power_of_two);
 #ifdef DEBUG
             hit = _gf_false;
@@ -900,7 +892,6 @@ mem_put_pool(void *ptr)
         hdr->next = pt_pool->hot_list;
         pt_pool->hot_list = hdr;
         (void)pthread_spin_unlock(&pool_list->lock);
-        GF_ATOMIC_INC(pt_pool->parent->frees_to_list);
     } else {
         /* If the owner thread of this element has terminated, we simply
          * release its memory. */


### PR DESCRIPTION
They don't seem to be used, but they are incremented and
decremented in the 'hot' paths. Just removed them.

Next patch may be to move that single parameter left in the structure,
to reduce indirection.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

