### PR TITLE
glusterd: cache the non local node's hostname

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-mem-types.h
+++ b/xlators/mgmt/glusterd/src/glusterd-mem-types.h
@@ -56,6 +56,7 @@ typedef enum gf_gld_mem_types_ {
     gf_gld_mt_hostname_t,
     gf_gld_mt_pmap_reg_t,
     gf_gld_mt_pmap_port_t,
+    gf_gld_mt_remote_hostname_t,
     gf_gld_mt_end,
 } gf_gld_mem_types_t;
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -204,6 +204,20 @@ is_brick_graceful_cleanup_enabled(dict_t *opts)
 }
 
 static gf_boolean_t
+gd_has_remote_address(glusterd_conf_t *priv, const char *hostname)
+{
+    glusterd_remote_hostname_t *remote_hostname_obj = NULL;
+    list_for_each_entry(remote_hostname_obj, &priv->remote_hostnames,
+                        remote_hostname_list)
+    {
+        if (strcmp(remote_hostname_obj->remote_hostname, hostname) == 0) {
+            return _gf_true;
+        }
+    }
+    return _gf_false;
+}
+
+static gf_boolean_t
 gd_has_local_address(glusterd_conf_t *priv, const char *hostname)
 {
     glusterd_hostname_t *hostname_obj = NULL;
@@ -216,6 +230,36 @@ gd_has_local_address(glusterd_conf_t *priv, const char *hostname)
     }
 
     return _gf_false;
+}
+
+static int
+glusterd_remote_hostname_new(xlator_t *this, const char *hostname,
+                             glusterd_remote_hostname_t **name)
+{
+
+    glusterd_remote_hostname_t *remote_hostname_obj = NULL;
+    int32_t ret = -1;
+
+    GF_ASSERT(hostname);
+    GF_ASSERT(name);
+
+    remote_hostname_obj = GF_MALLOC(sizeof(*remote_hostname_obj),
+                                    gf_gld_mt_remote_hostname_t);
+    if (!remote_hostname_obj) {
+        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_NO_MEMORY,
+                "Memory allocation is failed for client_hostname");
+        goto out;
+    }
+
+    remote_hostname_obj->remote_hostname = gf_strdup(hostname);
+    CDS_INIT_LIST_HEAD(&remote_hostname_obj->remote_hostname_list);
+
+    *name = remote_hostname_obj;
+    ret = 0;
+
+out:
+    gf_msg_debug("glusterd", 0, "Returning %d", ret);
+    return ret;
 }
 
 static int
@@ -252,6 +296,7 @@ glusterd_gf_is_local_addr(char *hostname)
     xlator_t *this = THIS;
     glusterd_conf_t *priv = NULL;
     glusterd_hostname_t *hostname_obj = NULL;
+    glusterd_remote_hostname_t *remote_hostname_obj = NULL;
     gf_boolean_t found = _gf_false;
     int ret = 1;
 
@@ -259,6 +304,11 @@ glusterd_gf_is_local_addr(char *hostname)
 
     if (gd_has_local_address(priv, hostname)) {
         found = _gf_true;
+        goto out;
+    }
+
+    if (gd_has_remote_address(priv, hostname)) {
+        found = _gf_false;
         goto out;
     }
 
@@ -270,6 +320,16 @@ glusterd_gf_is_local_addr(char *hostname)
         }
         found = _gf_true;
         list_add_tail(&hostname_obj->hostname_list, &priv->hostnames);
+    } else {
+        ret = glusterd_remote_hostname_new(this, hostname,
+                                           &remote_hostname_obj);
+        if (ret) {
+            goto out;
+        }
+
+        found = _gf_false;
+        list_add_tail(&remote_hostname_obj->remote_hostname_list,
+                      &priv->remote_hostnames);
     }
 
 out:

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -91,6 +91,11 @@ typedef struct glusterd_hostname_ {
     struct list_head hostname_list;
 } glusterd_hostname_t;
 
+typedef struct glusterd_remote_hostname_ {
+    char *remote_hostname;
+    struct list_head remote_hostname_list;
+} glusterd_remote_hostname_t;
+
 gf_boolean_t
 is_brick_mx_enabled(void);
 

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -935,7 +935,7 @@ out:
     return ret ? -1 : 0;
 }
 #undef RUN_GSYNCD_CMD
-#else /* SYNCDAEMON_COMPILE */
+#else  /* SYNCDAEMON_COMPILE */
 static int
 configure_syncdaemon(glusterd_conf_t *conf)
 {
@@ -1384,6 +1384,20 @@ is_downgrade(dict_t *options, gf_boolean_t *downgrade)
     ret = 0;
 out:
     return ret;
+}
+
+void
+glusterd_destroy_remote_hostname_list(glusterd_conf_t *priv)
+{
+    glusterd_remote_hostname_t *remote_hostname_obj = NULL;
+    list_for_each_entry(remote_hostname_obj, &priv->remote_hostnames,
+                        remote_hostname_list)
+    {
+        list_del_init(&remote_hostname_obj->remote_hostname_list);
+        GF_FREE(remote_hostname_obj->remote_hostname);
+        GF_FREE(remote_hostname_obj);
+    }
+
 }
 
 void
@@ -1879,6 +1893,7 @@ init(xlator_t *this)
     CDS_INIT_LIST_HEAD(&conf->brick_procs);
     CDS_INIT_LIST_HEAD(&conf->shd_procs);
     CDS_INIT_LIST_HEAD(&conf->hostnames);
+    CDS_INIT_LIST_HEAD(&conf->remote_hostnames);
     pthread_mutex_init(&conf->attach_lock, NULL);
     pthread_mutex_init(&conf->volume_lock, NULL);
 
@@ -2129,6 +2144,8 @@ fini(xlator_t *this)
     glusterd_stop_uds_listener(this);              /*stop unix socket rpc*/
     glusterd_stop_listener(this);                  /*stop tcp/ip socket rpc*/
     glusterd_destroy_hostname_list(this->private); /*Destroy hostname list */
+    glusterd_destroy_remote_hostname_list(
+            this->private); /*Destroy client hostname list*/
 
 #if 0
        /* Running threads might be using these resourses, we have to cancel/stop

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -241,6 +241,7 @@ typedef struct {
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
     struct list_head hostnames;
+    struct list_head remote_hostnames;
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {


### PR DESCRIPTION
In order to solve the time-consuming problem of DNS caused by the non local node's hostname, cache the non local node's hostname.
The solution refers to the modification idea of #1663

It took up to 58 seconds to run the "gluster volume set "command before the code modification. The test case is as follows.
[root@paas-controller-1:~]$ time gluster --log-level=ERROR volume set ebf69045-0087-49df-bcd0-5e8b75288764 diagnostics.brick-log-level WARNING
volume set: success

real    0m58.209s
user    0m0.044s
sys     0m0.050s

It takes about 1 second after the code modification.  The test case is as follows.
[root@paas-controller-1:~]$ time gluster --log-level=ERROR volume set ebf69045-0087-49df-bcd0-5e8b75288764 diagnostics.brick-log-level WARNING
volume set: success

real    0m0.660s
user    0m0.043s
sys     0m0.062s




Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>

