### PR TITLE
glusterd: cache the non local node's hostname 

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -204,11 +204,11 @@ is_brick_graceful_cleanup_enabled(dict_t *opts)
 }
 
 static gf_boolean_t
-gd_has_local_address(glusterd_conf_t *priv, const char *hostname)
+gd_has_address(struct list_head *hostnames_list_head, const char *hostname)
 {
     glusterd_hostname_t *hostname_obj = NULL;
 
-    list_for_each_entry(hostname_obj, &priv->hostnames, hostname_list)
+    list_for_each_entry(hostname_obj, hostnames_list_head, hostname_list)
     {
         if (strcmp(hostname_obj->hostname, hostname) == 0) {
             return _gf_true;
@@ -257,19 +257,28 @@ glusterd_gf_is_local_addr(char *hostname)
 
     priv = this->private;
 
-    if (gd_has_local_address(priv, hostname)) {
+    if (gd_has_address(&priv->hostnames, hostname)) {
         found = _gf_true;
         goto out;
     }
 
+    if (gd_has_address(&priv->remote_hostnames, hostname)) {
+        found = _gf_false;
+        goto out;
+    }
+
+    ret = glusterd_hostname_new(this, hostname, &hostname_obj);
+    if (ret) {
+        gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY, NULL);
+        goto out;
+    }
+
     if (gf_is_local_addr(hostname)) {
-        ret = glusterd_hostname_new(this, hostname, &hostname_obj);
-        if (ret) {
-            gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY, NULL);
-            goto out;
-        }
         found = _gf_true;
         list_add_tail(&hostname_obj->hostname_list, &priv->hostnames);
+    } else {
+        found = _gf_false;
+        list_add_tail(&hostname_obj->hostname_list, &priv->remote_hostnames);
     }
 
 out:

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -241,6 +241,7 @@ typedef struct {
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
     struct list_head hostnames;
+    struct list_head remote_hostnames;
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {


### PR DESCRIPTION
In order to solve the time-consuming problem of DNS caused by the non local node's hostname, cache the non local node's hostname.
The solution refers to the modification idea of #1663

It took up to 58 seconds to run the "gluster volume set "command before the code modification. The test case is as follows.
[root@paas-controller-1:~]$ time gluster --log-level=ERROR volume set ebf69045-0087-49df-bcd0-5e8b75288764 diagnostics.brick-log-level WARNING
volume set: success

real 0m58.209s
user 0m0.044s
sys 0m0.050s

It takes about 1 second after the code modification. The test case is as follows.
[root@paas-controller-1:~]$ time gluster --log-level=ERROR volume set ebf69045-0087-49df-bcd0-5e8b75288764 diagnostics.brick-log-level WARNING
volume set: success

real 0m0.660s
user 0m0.043s
sys 0m0.062s

Signed-off-by: JamesWSWu 

