### PR TITLE
io_uring: fix signature of io_uring_enter()

### DIFF
--- a/libglusterfs/src/gf-io-uring.c
+++ b/libglusterfs/src/gf-io-uring.c
@@ -120,9 +120,10 @@ io_uring_setup(uint32_t entries, struct io_uring_params *params)
 /* io_uring_enter() system call. */
 static int32_t
 io_uring_enter(uint32_t fd, uint32_t to_submit, uint32_t min_complete,
-               uint32_t flags, sigset_t *sig)
+               uint32_t flags, void *arg, size_t size)
 {
-    return syscall(SYS_io_uring_enter, fd, to_submit, min_complete, flags, sig);
+    return syscall(SYS_io_uring_enter, fd, to_submit, min_complete, flags, arg,
+                   size);
 }
 
 /* io_uring_register() system call. */
@@ -536,7 +537,7 @@ gf_io_uring_enter(uint32_t submit, bool wait)
     }
 
     do {
-        res = io_uring_enter(gf_io_uring.fd, submit, recv, flags, NULL);
+        res = io_uring_enter(gf_io_uring.fd, submit, recv, flags, NULL, 0);
         if (caa_likely(res >= 0)) {
             return submit - res;
         }


### PR DESCRIPTION
The signature of io_uring_enter() defined in the man page is not
correct. This patch fixes the signature by adding the last argument.

Change-Id: Ia6da98f04ba5f55fe19a3a0d21792cf9e7f5e7f1
Updates: #2123
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

