### PR TITLE
rpc, api, cli, xlators, libglusterfs, glusterfsd: tweak RPC API

### DIFF
--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -1013,7 +1013,7 @@ glfs_mgmt_init(struct glfs *fs)
     if (ret)
         goto out;
 
-    rpc = rpc_clnt_new(options, THIS, THIS->name, 8);
+    rpc = rpc_clnt_new(options, THIS, THIS->name);
     if (!rpc) {
         ret = -1;
         gf_smsg(THIS->name, GF_LOG_WARNING, 0, API_MSG_CREATE_RPC_CLIENT_FAILED,

--- a/cli/src/cli-quotad-client.c
+++ b/cli/src/cli-quotad-client.c
@@ -64,7 +64,7 @@ cli_quotad_clnt_init(xlator_t *this, dict_t *options)
     if (ret)
         goto out;
 
-    rpc = rpc_clnt_new(options, this, this->name, 16);
+    rpc = rpc_clnt_new(options, this, this->name);
     if (!rpc)
         goto out;
 

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -728,7 +728,7 @@ cli_rpc_init(struct cli_state *state)
             goto out;
     }
 
-    rpc = rpc_clnt_new(options, this, this->name, 16);
+    rpc = rpc_clnt_new(options, this, this->name);
     if (!rpc)
         goto out;
 

--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -274,7 +274,7 @@ done_parsing:
         return EXIT_FAILURE;
     }
 
-    rpc = rpc_clnt_new(options, fs->ctx->root, "gf-attach-rpc", 0);
+    rpc = rpc_clnt_new(options, fs->ctx->root, "gf-attach-rpc");
     if (!rpc) {
         fprintf(stderr, "rpc_clnt_new failed\n");
         return EXIT_FAILURE;

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2807,7 +2807,7 @@ glusterfs_listener_init(glusterfs_ctx_t *ctx)
     if (ret)
         goto out;
 
-    rpc = rpcsvc_init(THIS, ctx, options, 8);
+    rpc = rpcsvc_init(THIS, ctx, options);
     if (rpc == NULL) {
         goto out;
     }
@@ -2905,7 +2905,7 @@ glusterfs_mgmt_init(glusterfs_ctx_t *ctx)
         ctx->ssl_cert_depth = glusterfs_read_secure_access_file();
     }
 
-    rpc = rpc_clnt_new(options, THIS, THIS->name, 8);
+    rpc = rpc_clnt_new(options, THIS, THIS->name);
     if (!rpc) {
         ret = -1;
         gf_log(THIS->name, GF_LOG_WARNING, "failed to create rpc clnt");

--- a/libglusterfs/src/glusterfs/memory.h
+++ b/libglusterfs/src/glusterfs/memory.h
@@ -172,6 +172,10 @@ mem_pool_new_fn(glusterfs_ctx_t *ctx, size_t sizeof_type, size_t count,
 #define mem_pool_new_ctx(ctx, type, count)                                     \
     mem_pool_new_fn(ctx, sizeof(type), count, #type)
 
+/* Since memory pools are gone, COUNT is meaningless. */
+#define mem_pool_stub(type) \
+    mem_pool_new_fn(THIS->ctx, sizeof(type), 0, #type)
+
 static inline void
 mem_pool_destroy(struct mem_pool *pool)
 {

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -189,8 +189,7 @@ typedef struct rpc_clnt {
 } rpc_clnt_t;
 
 struct rpc_clnt *
-rpc_clnt_new(dict_t *options, xlator_t *owner, char *name,
-             uint32_t reqpool_size);
+rpc_clnt_new(dict_t *options, xlator_t *owner, char *name);
 
 int
 rpc_clnt_start(struct rpc_clnt *rpc);

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -2784,8 +2784,7 @@ rpcsvc_destroy(rpcsvc_t *svc)
 /* The global RPC service initializer.
  */
 rpcsvc_t *
-rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
-            uint32_t poolcount)
+rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options)
 {
     rpcsvc_t *svc = NULL;
     int ret = -1;
@@ -2809,16 +2808,7 @@ rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
         goto free_svc;
     }
 
-    if (!poolcount)
-        poolcount = RPCSVC_POOLCOUNT_MULT * svc->memfactor;
-
-    gf_log(GF_RPCSVC, GF_LOG_TRACE, "rx pool: %d", poolcount);
-    svc->rxpool = mem_pool_new(rpcsvc_request_t, poolcount);
-    /* TODO: leak */
-    if (!svc->rxpool) {
-        gf_log(GF_RPCSVC, GF_LOG_ERROR, "mem pool allocation failed");
-        goto free_svc;
-    }
+    svc->rxpool = mem_pool_stub(rpcsvc_request_t);
 
     ret = rpcsvc_auth_init(svc, options);
     if (ret == -1) {

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -47,7 +47,6 @@ typedef enum {
 #define RPCSVC_DEFAULT_LISTEN_PORT GF_DEFAULT_BASE_PORT
 #define RPCSVC_DEFAULT_MEMFACTOR 8
 #define RPCSVC_EVENTPOOL_SIZE_MULT 1024
-#define RPCSVC_POOLCOUNT_MULT 64
 #define RPCSVC_CONN_READ (128 * GF_UNIT_KB)
 #define RPCSVC_PAGE_SIZE (128 * GF_UNIT_KB)
 #define RPC_ROOT_UID 0
@@ -503,8 +502,7 @@ rpcsvc_register_portmap_enabled(rpcsvc_t *svc);
  * Called in main.
  */
 extern rpcsvc_t *
-rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
-            uint32_t poolcount);
+rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options);
 
 extern int
 rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options);

--- a/xlators/features/changelog/src/changelog-rpc-common.c
+++ b/xlators/features/changelog/src/changelog-rpc-common.c
@@ -54,7 +54,7 @@ changelog_rpc_client_init(xlator_t *this, void *cbkdata, char *sockfile,
         goto dealloc_dict;
     }
 
-    rpc = rpc_clnt_new(options, this, this->name, 16);
+    rpc = rpc_clnt_new(options, this, this->name);
     if (!rpc)
         goto dealloc_dict;
 
@@ -314,7 +314,7 @@ changelog_rpc_server_init(xlator_t *this, char *sockfile, void *cbkdata,
     if (ret)
         goto dealloc_dict;
 
-    rpc = rpcsvc_init(this, this->ctx, options, 8);
+    rpc = rpcsvc_init(this, this->ctx, options);
     if (rpc == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_RPC_START_ERROR,
                 NULL);

--- a/xlators/features/quota/src/quota-enforcer-client.c
+++ b/xlators/features/quota/src/quota-enforcer-client.c
@@ -461,7 +461,7 @@ quota_enforcer_init(xlator_t *this, dict_t *options)
     if (ret)
         goto out;
 
-    rpc = rpc_clnt_new(options, this, this->name, 16);
+    rpc = rpc_clnt_new(options, this, this->name);
     if (!rpc) {
         ret = -1;
         goto out;

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -437,7 +437,7 @@ quotad_aggregator_init(xlator_t *this)
         goto out;
 
     /* RPC related */
-    priv->rpcsvc = rpcsvc_init(this, this->ctx, this->options, 0);
+    priv->rpcsvc = rpcsvc_init(this, this->ctx, this->options);
     if (priv->rpcsvc == NULL) {
         gf_msg(this->name, GF_LOG_WARNING, 0, Q_MSG_RPCSVC_INIT_FAILED,
                "creation of rpcsvc failed");

--- a/xlators/features/snapview-server/src/snapview-server-mgmt.c
+++ b/xlators/features/snapview-server/src/snapview-server-mgmt.c
@@ -115,7 +115,7 @@ svs_mgmt_init(xlator_t *this)
         goto out;
     }
 
-    priv->rpc = rpc_clnt_new(options, this, this->name, 8);
+    priv->rpc = rpc_clnt_new(options, this, this->name);
     if (!priv->rpc) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SVS_MSG_RPC_INIT_FAILED,
                "failed to initialize RPC");

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -52,7 +52,7 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, time_t frame_timeout,
     }
 
     /* @options is free'd by rpc_transport when destroyed */
-    rpc = rpc_clnt_new(options, this, (char *)svc->name, 16);
+    rpc = rpc_clnt_new(options, this, (char *)svc->name);
     if (!rpc) {
         ret = -1;
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -3349,8 +3349,7 @@ glusterd_rpc_create(struct rpc_clnt **rpc, dict_t *options,
         *rpc = NULL;
     }
 
-    /* TODO: is 32 enough? or more ? */
-    new_rpc = rpc_clnt_new(options, this, this->name, 16);
+    new_rpc = rpc_clnt_new(options, this, this->name);
     if (!new_rpc)
         goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -492,7 +492,7 @@ glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
         goto out;
 
     /* @options is free'd by rpc_transport when destroyed */
-    rpc = rpc_clnt_new(options, this, (char *)svc->name, 16);
+    rpc = rpc_clnt_new(options, this, (char *)svc->name);
     if (!rpc) {
         ret = -1;
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1144,7 +1144,7 @@ glusterd_init_uds_listener(xlator_t *this)
     if (ret)
         goto out;
 
-    rpc = rpcsvc_init(this, this->ctx, options, 8);
+    rpc = rpcsvc_init(this, this->ctx, options);
     if (rpc == NULL) {
         ret = -1;
         goto out;
@@ -1783,7 +1783,7 @@ init(xlator_t *this)
     ret = glusterd_rpcsvc_options_build(this->options);
     if (ret)
         goto out;
-    rpc = rpcsvc_init(this, this->ctx, this->options, 64);
+    rpc = rpcsvc_init(this, this->ctx, this->options);
     if (rpc == NULL) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_INIT_FAIL,
                "failed to init rpc");

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -724,7 +724,6 @@ nfs_init_state(xlator_t *this)
 {
     struct nfs_state *nfs = NULL;
     int i = 0, ret = -1;
-    unsigned int fopspoolsize = 0;
     char *optstr = NULL;
     gf_boolean_t boolt = _gf_false;
     struct stat stbuf = {
@@ -765,9 +764,8 @@ nfs_init_state(xlator_t *this)
         }
     }
 
-    fopspoolsize = nfs->memfactor * GF_NFS_CONCURRENT_OPS_MULT;
     /* FIXME: Really saddens me to see this as xlator wide. */
-    nfs->foppool = mem_pool_new(struct nfs_fop_local, fopspoolsize);
+    nfs->foppool = mem_pool_stub(struct nfs_fop_local);
     if (!nfs->foppool) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, ENOMEM, NFS_MSG_NO_MEMORY,
                "Failed to allocate fops local pool");
@@ -1088,7 +1086,7 @@ nfs_init_state(xlator_t *this)
         nfs->enable_nlm = _gf_false;
     }
 
-    nfs->rpcsvc = rpcsvc_init(this, this->ctx, this->options, fopspoolsize);
+    nfs->rpcsvc = rpcsvc_init(this, this->ctx, this->options);
     if (!nfs->rpcsvc) {
         ret = -1;
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_RPC_INIT_FAIL,

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -1108,8 +1108,7 @@ nlm4_establish_callback(nfs3_call_state_t *cs, call_frame_t *cbk_frame)
     ncf->frame = cbk_frame;
     ncf->frame->local = ncf;
 
-    /* TODO: is 32 frames in transit enough ? */
-    rpc_clnt = rpc_clnt_new(options, cs->nfsx, "NLM-client", 32);
+    rpc_clnt = rpc_clnt_new(options, cs->nfsx, "NLM-client");
     if (rpc_clnt == NULL) {
         gf_msg(GF_NLM, GF_LOG_ERROR, EINVAL, NFS_MSG_INVALID_ENTRY,
                "rpc_clnt NULL");

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2498,7 +2498,7 @@ client_init_rpc(xlator_t *this)
         goto out;
     }
 
-    conf->rpc = rpc_clnt_new(this->options, this, this->name, 0);
+    conf->rpc = rpc_clnt_new(this->options, this, this->name);
     if (!conf->rpc) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_RPC_INIT_FAILED, NULL);
         goto out;

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1212,7 +1212,7 @@ server_init(xlator_t *this)
         conf->dync_auth = ret;
 
     /* RPC related */
-    conf->rpc = rpcsvc_init(this, this->ctx, this->options, 0);
+    conf->rpc = rpcsvc_init(this, this->ctx, this->options);
     if (conf->rpc == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_RPCSVC_CREATE_FAILED, NULL);
         ret = -1;


### PR DESCRIPTION
rpc, api, cli, xlators, libglusterfs, glusterfsd: tweak RPC API
    
Since memory pools are gone, using request count of rpc_clnt_new()
and pool count of rpcsvc_init() as the memory pool size defaults
becomes meaningless and can be dropped.
    
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
