### PR TITLE
Add missing dependency on glusterfs-selinux

### DIFF
--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -692,8 +692,8 @@ Requires:         %{name}%{?_isa} = %{version}-%{release}
 Requires:         %{name}-cli%{?_isa} = %{version}-%{release}
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 Requires:         libgfchangelog0%{?_isa} = %{version}-%{release}
-%if ( 0%{?fedora} && 0%{?fedora} >= 30  || ( 0%{?rhel} && 0%{?rhel} >= 8 ) )
-Requires:         glusterfs-selinux >= 0.1.0-2
+%if 0%{?fedora} >= 30  || 0%{?rhel} >= 8
+Requires:         (glusterfs-selinux >= 0.1.0-2 if selinux-policy-targeted)
 %endif
 # some daemons (like quota) use a fuse-mount, glusterfsd is part of -fuse
 Requires:         %{name}-fuse%{?_isa} = %{version}-%{release}

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -692,6 +692,9 @@ Requires:         %{name}%{?_isa} = %{version}-%{release}
 Requires:         %{name}-cli%{?_isa} = %{version}-%{release}
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 Requires:         libgfchangelog0%{?_isa} = %{version}-%{release}
+%if ( 0%{?fedora} && 0%{?fedora} >= 30  || ( 0%{?rhel} && 0%{?rhel} >= 8 ) )
+Requires:         glusterfs-selinux >= 0.1.0-2
+%endif
 # some daemons (like quota) use a fuse-mount, glusterfsd is part of -fuse
 Requires:         %{name}-fuse%{?_isa} = %{version}-%{release}
 # self-heal daemon, rebalance, nfs-server etc. are actually clients


### PR DESCRIPTION
Add missing dependency on glusterfs-selinux.
Fixes: #2780
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2002178

