### PR TITLE
afr: fix possible string buffer overflow and format truncation

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -808,8 +808,9 @@ unlock:
             goto unwind;
         }
 
-        ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
-                                                  UUID0_STR, &tlen, ' ');
+        ret = afr_serialize_xattrs_with_delimiter(
+            frame, this, xattr_serz, local->cont.getxattr.xattr_len, UUID0_STR,
+            &tlen, ' ');
         if (ret) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -141,16 +141,18 @@ afr_handle_anon_inode_options(afr_private_t *priv, dict_t *options)
     char *volfile_id_str = NULL;
     uuid_t anon_inode_gfid = {0};
 
-    /*If volume id is not present don't enable anything*/
+    /* If volume id is not present don't enable anything. */
     if (dict_get_str(options, "volume-id", &volfile_id_str))
         return;
-    GF_ASSERT(strlen(AFR_ANON_DIR_PREFIX) + strlen(volfile_id_str) <= NAME_MAX);
-    /*anon_inode_name is not supposed to change once assigned*/
+
+    /* Note anon_inode_name is not supposed to change once assigned. */
     if (!priv->anon_inode_name[0]) {
-        snprintf(priv->anon_inode_name, sizeof(priv->anon_inode_name), "%s-%s",
-                 AFR_ANON_DIR_PREFIX, volfile_id_str);
+        int nr = snprintf(priv->anon_inode_name, NAME_MAX, "%s-%s",
+                          AFR_ANON_DIR_PREFIX, volfile_id_str);
+        /* Check whether an output was not truncated. */
+        GF_ASSERT(nr < NAME_MAX);
         gf_uuid_parse(volfile_id_str, anon_inode_gfid);
-        /*Flip a bit to make sure volfile-id and anon-gfid are not same*/
+        /* Flip a bit to make sure volfile-id and anon-gfid are not same. */
         anon_inode_gfid[0] ^= 1;
         uuid_utoa_r(anon_inode_gfid, priv->anon_gfid_str);
     }

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1339,8 +1339,9 @@ afr_is_inode_refresh_reqd(inode_t *inode, xlator_t *this, int event_gen1,
 
 int
 afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
-                                    char *buf, const char *default_str,
-                                    int32_t *serz_len, char delimiter);
+                                    char *buf, size_t size,
+                                    const char *default_str, int32_t *serz_len,
+                                    char delimiter);
 gf_boolean_t
 afr_is_symmetric_error(call_frame_t *frame, xlator_t *this);
 


### PR DESCRIPTION
Fix -Wstringop-overflow and -Wformat-truncation warnings reported
as below, adjust related comments.
```
In file included from afr.c:18:
afr-common.c: In function ‘afr_serialize_xattrs_with_delimiter’:
afr-common.c:7519:19: warning: ‘strncat’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 7519 |             buf = strncat(buf, xattr, str_len);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
afr-common.c:7518:23: note: length computed here
 7518 |             str_len = strlen(xattr);
      |                       ^~~~~~~~~~~~~
afr-common.c:7504:19: warning: ‘strncat’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 7504 |             buf = strncat(buf, default_str, str_len);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
afr-common.c:7503:23: note: length computed here
 7503 |             str_len = strlen(default_str);
      |                       ^~~~~~~~~~~~~~~~~~~
afr.c: In function ‘afr_handle_anon_inode_options’:
afr.c:150:78: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  150 |         snprintf(priv->anon_inode_name, sizeof(priv->anon_inode_name), "%s-%s",
      |                                                                              ^
afr.c:150:9: note: ‘snprintf’ output between 28 and 257 bytes into a destination of size 256
  150 |         snprintf(priv->anon_inode_name, sizeof(priv->anon_inode_name), "%s-%s",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  151 |                  AFR_ANON_DIR_PREFIX, volfile_id_str);
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

