### PR TITLE
configure: Enable tcmalloc and disable mempool as a default option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,15 +339,18 @@ fi
 
 # Initialize CFLAGS before usage
 BUILD_TCMALLOC=no
-AC_ARG_ENABLE([tcmalloc],
-              AC_HELP_STRING([--enable-tcmalloc],
-                             [Enable linking with tcmalloc library.]))
-if test "x$enable_tcmalloc" = "xyes"; then
+USE_MEMPOOL=yes
+AC_ARG_WITH([tcmalloc],
+        [AC_HELP_STRING([--without-tcmalloc], [Use gluster based mempool])],
+        [with_tcmalloc="no"], [with_tcmalloc="yes"])
+if test "x$with_tcmalloc" = "xyes"; then
+    AC_CHECK_LIB([tcmalloc], [malloc], [],
+                 [AC_MSG_ERROR([tcmalloc library needs to be present])])
     BUILD_TCMALLOC=yes
     GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
-    AC_CHECK_LIB([tcmalloc], [malloc], [],
-                 [AC_MSG_ERROR([when --enable-tcmalloc is used, tcmalloc library needs to be present])])
     GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+    AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
+    USE_MEMPOOL=no
 fi
 
 
@@ -1491,16 +1494,6 @@ AC_SUBST(UMOUNTD_SUBDIR)
 AC_ARG_ENABLE([debug],
               AC_HELP_STRING([--enable-debug],
                              [Enable debug build options.]))
-
-AC_ARG_ENABLE([mempool],
-              AC_HELP_STRING([--disable-mempool],
-                             [Disable the Gluster memory pooler.]))
-
-USE_MEMPOOL="yes"
-if test "x$enable_mempool" = "xno"; then
-        USE_MEMPOOL="no"
-        AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
-fi
 
 dnl Add readline support in CLI if available.
 PKG_CHECK_MODULES([READLINE], [readline], [BUILD_READLINE="yes"],

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -68,6 +68,11 @@
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without libtirpc
 %{?_without_libtirpc:%global _without_libtirpc --without-libtirpc}
 
+# libtcmalloc
+# if you wish to compile an rpm without tcmalloc (i.e. use gluster mempool)
+# rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without tcmalloc
+%{?_without_tcmalloc:%global _without_libtcmalloc --without-tcmalloc}
+
 # Do not use libtirpc on EL6, it does not have xdr_uint64_t() and xdr_uint32_t
 # Do not use libtirpc on EL7, it does not have xdr_sizeof()
 %if ( 0%{?rhel} && 0%{?rhel} <= 7 )
@@ -248,6 +253,10 @@ Requires(pre):    shadow-utils
 BuildRequires:    systemd
 %endif
 
+%if ( 0%{?_with_tcmalloc:1} )
+Requires:         gperftools-libs%{?_isa}
+%endif
+
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 Requires:         libgfrpc0%{?_isa} = %{version}-%{release}
 Requires:         libgfxdr0%{?_isa} = %{version}-%{release}
@@ -266,6 +275,9 @@ BuildRequires:    ncurses-devel readline-devel
 BuildRequires:    libxml2-devel openssl-devel
 BuildRequires:    libaio-devel libacl-devel
 BuildRequires:    python%{_pythonver}-devel
+%if ( 0%{?_with_tcmalloc:1} )
+BuildRequires:    gperftools-devel
+%endif
 %if ( 0%{?rhel} && 0%{?rhel} < 8 )
 BuildRequires:    python-ctypes
 %endif
@@ -858,7 +870,8 @@ done
         %{?_without_syslog} \
         %{?_with_ipv6default} \
         %{?_without_linux_io_uring} \
-        %{?_without_libtirpc}
+        %{?_without_libtirpc} \
+        %{?_without_tcmalloc}
 
 # fix hardening and remove rpath in shlibs
 %if ( 0%{?fedora} && 0%{?fedora} > 17 ) || ( 0%{?rhel} && 0%{?rhel} > 6 )


### PR DESCRIPTION
The data is already available on github issue(#2771)
specific to getting improvement after enable tcmalloc and
disable mempool so enable tcmalloc and disable mempool
as a default option.

Updates: #2771
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

