### PR TITLE
RELEASE-9: mem-pool.c, .h: remove unused variables

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -225,7 +225,6 @@ struct mem_pool {
 struct mem_pool {
     /* object size, without pooled_obj_hdr_t */
     unsigned long sizeof_type;
-    unsigned long count; /* requested pool size (unused) */
     char *name;
     char *xl_name;
     gf_atomic_t active;     /* current allocations */
@@ -289,16 +288,6 @@ typedef struct per_thread_pool_list {
 /* actual pool structure, shared between different mem_pools */
 struct mem_pool_shared {
     unsigned int power_of_two;
-    /*
-     * Updates to these are *not* protected by a global lock, so races
-     * could occur and the numbers might be slightly off.  Don't expect
-     * them to line up exactly.  It's the general trends that matter, and
-     * it's not worth the locked-bus-cycle overhead to make these precise.
-     */
-    gf_atomic_t allocs_hot;
-    gf_atomic_t allocs_cold;
-    gf_atomic_t allocs_stdc;
-    gf_atomic_t frees_to_list;
 };
 
 void

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -220,8 +220,6 @@ struct mem_pool {
 
 #else /* !GF_DISABLE_MEMPOOL */
 
-/* kind of 'header' for the actual mem_pool_shared structure, this might make
- * it possible to dump some more details in a statedump */
 struct mem_pool {
     /* object size, without pooled_obj_hdr_t */
     unsigned long sizeof_type;
@@ -235,7 +233,7 @@ struct mem_pool {
     struct list_head owner; /* glusterfs_ctx_t->mempool_list */
     glusterfs_ctx_t *ctx;   /* take ctx->lock when updating owner */
 
-    struct mem_pool_shared *pool; /* the initial pool that was returned */
+    unsigned int pool_power_of_two;
 };
 
 typedef struct pooled_obj_hdr {
@@ -254,8 +252,7 @@ typedef struct pooled_obj_hdr {
 #define AVAILABLE_SIZE(p2) ((1UL << (p2)) - sizeof(pooled_obj_hdr_t))
 
 typedef struct per_thread_pool {
-    /* the pool that was used to request this allocation */
-    struct mem_pool_shared *parent;
+    unsigned int parent_power_of_two;
     /* Everything else is protected by our own lock. */
     pooled_obj_hdr_t *hot_list;
     pooled_obj_hdr_t *cold_list;
@@ -284,11 +281,6 @@ typedef struct per_thread_pool_list {
      */
     per_thread_pool_t pools[1];
 } per_thread_pool_list_t;
-
-/* actual pool structure, shared between different mem_pools */
-struct mem_pool_shared {
-    unsigned int power_of_two;
-};
 
 void
 mem_pools_init(void); /* start the pool_sweeper thread */

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -402,10 +402,9 @@ gf_proc_dump_mempool_info(glusterfs_ctx_t *ctx)
             gf_proc_dump_write("active-count", "%" GF_PRI_ATOMIC, active);
             gf_proc_dump_write("sizeof-type", "%lu", pool->sizeof_type);
             gf_proc_dump_write("padded-sizeof", "%d",
-                               1 << pool->pool->power_of_two);
+                               1 << pool->pool_power_of_two);
             gf_proc_dump_write("size", "%" PRId64,
-                               (1 << pool->pool->power_of_two) * active);
-            gf_proc_dump_write("shared-pool", "%p", pool->pool);
+                               (1 << pool->pool_power_of_two) * active);
         }
     }
     UNLOCK(&ctx->lock);
@@ -448,18 +447,13 @@ gf_proc_dump_mempool_info_to_dict(glusterfs_ctx_t *ctx, dict_t *dict)
                 goto out;
 
             snprintf(key, sizeof(key), "pool%d.padded-sizeof", count);
-            ret = dict_set_uint64(dict, key, 1 << pool->pool->power_of_two);
+            ret = dict_set_uint64(dict, key, 1 << pool->pool_power_of_two);
             if (ret)
                 goto out;
 
             snprintf(key, sizeof(key), "pool%d.size", count);
             ret = dict_set_uint64(dict, key,
-                                  (1 << pool->pool->power_of_two) * active);
-            if (ret)
-                goto out;
-
-            snprintf(key, sizeof(key), "pool%d.shared-pool", count);
-            ret = dict_set_static_ptr(dict, key, pool->pool);
+                                  (1 << pool->pool_power_of_two) * active);
             if (ret)
                 goto out;
         }


### PR DESCRIPTION
There were few atomic counters that were not used at all anywhere, removed them.
There were other global static variables without any use, removed them.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

