### PR TITLE
build, libglusterfs: detect function to set thread name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1180,6 +1180,77 @@ if test "x${have_paccept}" = "xyes"; then
 AC_DEFINE(HAVE_PACCEPT, 1, [define if paccept exists])
 fi
 
+dnl Looking for OS-dependent non-POSIX function to set thread name.
+
+PTHREAD_SETNAME_FOUND=no
+
+dnl Linux-like version assuming glibc (so _GNU_SOURCE).
+if test x$PTHREAD_SETNAME_FOUND = xno; then
+   AC_MSG_CHECKING([for pthread_setname_np(thread, name)])
+   saved_CFLAGS=${CFLAGS}
+   CFLAGS="-D_GNU_SOURCE -pthread"
+   AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([
+         [#include <pthread.h>]],
+         [[pthread_t t; pthread_setname_np(t, "name");]])],
+         [pthread_setname_np_two_args=yes], [pthread_setname_np_two_args=no])
+   AC_MSG_RESULT([$pthread_setname_np_two_args])
+   CFLAGS="$saved_CFLAGS"
+
+   if test x$pthread_setname_np_two_args = xyes; then
+      AC_DEFINE(HAVE_PTHREAD_SETNAME_NP_TWO_ARGS, 1,
+                [Define if 'pthread_setname_np(thread, name)' is present.])
+      PTHREAD_SETNAME_FOUND=yes
+   fi
+fi
+
+dnl NetBSD-like version with three arguments.
+if test x$PTHREAD_SETNAME_FOUND = xno; then
+   AC_MSG_CHECKING([for pthread_setname_np(thread, name, arg)])
+   saved_CFLAGS=${CFLAGS}
+   CFLAGS="-pthread"
+   AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([
+         [#include <pthread.h>]],
+         [[pthread_t t; pthread_setname_np(t, "name", NULL);]])],
+         [pthread_setname_np_three_args=yes], [pthread_setname_np_three_args=no])
+   AC_MSG_RESULT([$pthread_setname_np_three_args])
+   CFLAGS="$saved_CFLAGS"
+
+   if test x$pthread_setname_np_three_args = xyes; then
+      AC_DEFINE(HAVE_PTHREAD_SETNAME_NP_THREE_ARGS, 1,
+                [Define if 'pthread_setname_np(thread, name, arg)' is present.])
+      PTHREAD_SETNAME_FOUND=yes
+   fi
+fi
+
+dnl FreeBSD provides pthread_np.h header file and both (not sure
+dnl for versions older than 13.0) 'pthread_setname_np(thread, name)'
+dnl and 'pthread_set_name_np(thread, name)'.
+
+if test x$PTHREAD_SETNAME_FOUND = xno; then
+   AC_MSG_CHECKING([for pthread_set_name_np(thread, name)])
+   saved_CFLAGS=${CFLAGS}
+   CFLAGS="-pthread"
+   AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([
+         [#include <pthread_np.h>]],
+         [[pthread_t t; pthread_set_name_np(t, "name");]])],
+         [pthread_set_name_np=yes], [pthread_set_name_np=no])
+   AC_MSG_RESULT([$pthread_set_name_np])
+   CFLAGS="$saved_CFLAGS"
+
+   if test x$pthread_set_name_np = xyes; then
+      AC_DEFINE(HAVE_PTHREAD_SET_NAME_NP, 1,
+                [Define if 'pthread_set_name_np(thread, name)' is present.])
+      PTHREAD_SETNAME_FOUND=yes
+   fi
+fi
+
+if test x$PTHREAD_SETNAME_FOUND = xno; then
+   AC_MSG_WARN([Unable to detect function to set thread name])
+fi
+
 # Check the distribution where you are compiling glusterfs on.
 # For cross-compiling, you're advised to specify it manually.
 

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4023,16 +4023,8 @@ gf_thread_set_vname(pthread_t thread, const char *name, va_list args)
                 "name=%s", thread_name, NULL);
     }
 
-#ifdef GF_LINUX_HOST_OS
-    ret = pthread_setname_np(thread, thread_name);
-#elif defined(__NetBSD__)
-    ret = pthread_setname_np(thread, thread_name, NULL);
-#elif defined(__FreeBSD__)
-    pthread_set_name_np(thread, thread_name);
-    ret = 0;
-#else
-    ret = ENOSYS;
-#endif
+    ret = __gf_thread_set_name(thread, thread_name);
+
     if (ret != 0) {
         gf_smsg(THIS->name, GF_LOG_WARNING, ret, LG_MSG_SET_THREAD_FAILED,
                 "name=%s", thread_name, NULL);

--- a/libglusterfs/src/gf-io-common.c
+++ b/libglusterfs/src/gf-io-common.c
@@ -234,15 +234,7 @@ gf_io_thread_name(pthread_t id, const char *code, uint32_t index)
         return -EINVAL;
     }
 
-#ifdef GF_LINUX_HOST_OS
-    return gf_io_call_ret(pthread_setname_np, id, name);
-#elif defined(__NetBSD__)
-    return gf_io_call_ret(pthread_setname_np, id, name, NULL);
-#elif defined(__FreeBSD__)
-    pthread_set_name_np(id, name);
-
-    return 0;
-#endif
+    return __gf_thread_set_name(id, name);
 }
 
 /* Sets the signal mask of the thread. */

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1094,6 +1094,21 @@ gf_gfid_generate_from_xxh64(uuid_t gfid, char *key);
 int
 gf_set_timestamp(const char *src, const char *dest);
 
+static inline int
+__gf_thread_set_name(pthread_t thread, const char *name)
+{
+#if defined(HAVE_PTHREAD_SETNAME_NP_TWO_ARGS)
+    return pthread_setname_np(thread, name);
+#elif defined(HAVE_PTHREAD_SETNAME_NP_THREE_ARGS)
+    return pthread_setname_np(thread, name, NULL);
+#elif defined(HAVE_PTHREAD_SET_NAME_NP)
+    pthread_set_name_np(thread, name);
+    return 0;
+#else /* none found */
+    return -ENOSYS;
+#endif /* set name */
+}
+
 int
 gf_thread_create(pthread_t *thread, const pthread_attr_t *attr,
                  void *(*start_routine)(void *), void *arg, const char *name,


### PR DESCRIPTION
Avoid hardcoded OS-specific #ifdefs and attempt to detect
OS-specfic function to set thread name, move platform-
dependent quirks to '__gf_thread_set_name()' and use it
where appropriate.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

