### PR TITLE
iobuf: Call standard allocation api in iobuf if page_size is less than equal to 128KB

### DIFF
--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -142,8 +142,7 @@ iobuf_to_iovec(struct iobuf *iob, struct iovec *iov);
 
 #define iobuf_ptr(iob) ((iob)->ptr)
 #define iobpool_default_pagesize(iobpool) ((iobpool)->default_page_size)
-#define iobuf_pagesize(iob)                                                    \
-    (iob->iobuf_arena ? iob->iobuf_arena->page_size : iob->page_size)
+#define iobuf_pagesize(iob) (iob->page_size)
 
 struct iobref {
     gf_lock_t lock;

--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -35,6 +35,7 @@
     ((void *)((unsigned long)(ptr + bound - 1) & (unsigned long)(~(bound - 1))))
 
 #define GF_IOBUF_ALIGN_SIZE 512
+#define USE_IOBUF_POOL_IF_SIZE_GREATER_THAN 131072
 
 /* one allocatable unit for the consumers of the IOBUF API */
 /* each unit hosts @page_size bytes of memory */
@@ -68,8 +69,9 @@ struct iobuf {
 
     void *ptr; /* usable memory region by the consumer */
 
-    void *free_ptr; /* in case of stdalloc, this is the
-                       one to be freed */
+    void *free_ptr;   /* in case of stdalloc, this is the
+                         one to be freed */
+    size_t page_size; /* The size is set only in case of stdalloc */
 };
 
 struct iobuf_arena {
@@ -140,7 +142,8 @@ iobuf_to_iovec(struct iobuf *iob, struct iovec *iov);
 
 #define iobuf_ptr(iob) ((iob)->ptr)
 #define iobpool_default_pagesize(iobpool) ((iobpool)->default_page_size)
-#define iobuf_pagesize(iob) (iob->iobuf_arena->page_size)
+#define iobuf_pagesize(iob)                                                    \
+    (iob->iobuf_arena ? iob->iobuf_arena->page_size : iob->page_size)
 
 struct iobref {
     gf_lock_t lock;

--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -71,7 +71,7 @@ struct iobuf {
 
     void *free_ptr;   /* in case of stdalloc, this is the
                          one to be freed */
-    size_t page_size; /* The size is set only in case of stdalloc */
+    size_t page_size;
 };
 
 struct iobuf_arena {

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -708,15 +708,10 @@ iobuf_put(struct iobuf *iobuf)
 
     GF_VALIDATE_OR_GOTO("iobuf", iobuf, out);
 
-    if (!iobuf->iobuf_arena) {
-        GF_FREE(iobuf->free_ptr);
-        GF_FREE(iobuf);
-        return;
-    }
-
     iobuf_arena = iobuf->iobuf_arena;
     if (!iobuf_arena) {
-        gf_smsg(THIS->name, GF_LOG_WARNING, 0, LG_MSG_ARENA_NOT_FOUND, NULL);
+        GF_FREE(iobuf->free_ptr);
+        GF_FREE(iobuf);
         return;
     }
 


### PR DESCRIPTION

During smallfile testing we have observed the performance
has been improved significantly in case while iobuf use standard
allocation api to allocate buffer while requested page_size is less
than or equal to 128KB.The performance data is available at the
github issue https://github.com/gluster/glusterfs/issues/2771

Updates: #2771
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

