### PR TITLE
glusterfsd, client, server: use common socket window size limits

### DIFF
--- a/glusterfsd/src/Makefile.am
+++ b/glusterfsd/src/Makefile.am
@@ -23,6 +23,7 @@ AM_CPPFLAGS = $(GF_CPPFLAGS) \
 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" $(GF_GLUSTERFS_CFLAGS) \
 	-DXLATORDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator\" \
 	-DLIBEXECDIR=\"$(GLUSTERFS_LIBEXECDIR)\"\
+	-I$(top_srcdir)/rpc/rpc-transport/socket/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/xdr/src \
 	-I$(top_builddir)/rpc/xdr/src \

--- a/xlators/protocol/client/src/Makefile.am
+++ b/xlators/protocol/client/src/Makefile.am
@@ -16,6 +16,7 @@ noinst_HEADERS = client.h client-mem-types.h client-messages.h client-common.h
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \
+	-I$(top_srcdir)/rpc/rpc-transport/socket/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src/
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -14,6 +14,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include "socket.h"
 #include "rpc-clnt.h"
 #include <glusterfs/list.h>
 #include <glusterfs/inode.h>
@@ -30,10 +31,7 @@
 #define CLIENT_MIN_EVENT_THREADS 1
 #define CLIENT_MAX_EVENT_THREADS 32
 
-/* FIXME: Needs to be defined in a common file */
 #define CLIENT_DUMP_LOCKS "trusted.glusterfs.clientlk-dump"
-#define GF_MAX_SOCKET_WINDOW_SIZE (1 * GF_UNIT_MB)
-#define GF_MIN_SOCKET_WINDOW_SIZE (0)
 
 typedef enum {
     DEFAULT_REMOTE_FD = 0,

--- a/xlators/protocol/server/src/Makefile.am
+++ b/xlators/protocol/server/src/Makefile.am
@@ -22,6 +22,7 @@ server_ladir = $(includedir)/glusterfs/server
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" \
 	-DLIBDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/auth\" \
+	-I$(top_srcdir)/rpc/rpc-transport/socket/src \
 	-I$(top_srcdir)/xlators/protocol/lib/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -15,7 +15,7 @@
 
 #include <glusterfs/fd.h>
 #include "rpcsvc.h"
-
+#include "socket.h"
 #include <glusterfs/fd.h>
 #include "protocol-common.h"
 #include "server-mem-types.h"
@@ -31,8 +31,6 @@
 #define SERVER_MAX_EVENT_THREADS 1024
 
 #define DEFAULT_VOLUME_FILE_PATH CONFDIR "/glusterfs.vol"
-#define GF_MAX_SOCKET_WINDOW_SIZE (1 * GF_UNIT_MB)
-#define GF_MIN_SOCKET_WINDOW_SIZE (0)
 
 typedef enum {
     INTERNAL_LOCKS = 1,


### PR DESCRIPTION
Drop duplicated GF_{MIN,MAX}_SOCKET_WINDOW_SIZE definitions and
use them from the socket header, adjust related Makefile.am files.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

