### PR TITLE
mem_acct: Make mem_accounting lock free

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -45,10 +45,10 @@ typedef uint32_t gf_mem_magic_t;
 struct mem_acct_rec {
     const char *typestr;
     uint64_t size;
-    uint64_t max_size;
-    uint32_t max_num_allocs;
     gf_atomic_t num_allocs;
 #ifdef DEBUG
+    uint64_t max_size;
+    uint32_t max_num_allocs;
     gf_lock_t lock;
     struct list_head obj_list;
 #endif

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -48,8 +48,8 @@ struct mem_acct_rec {
     uint64_t max_size;
     uint32_t max_num_allocs;
     gf_atomic_t num_allocs;
-    gf_lock_t lock;
 #ifdef DEBUG
+    gf_lock_t lock;
     struct list_head obj_list;
 #endif
 };

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -46,9 +46,8 @@ struct mem_acct_rec {
     const char *typestr;
     uint64_t size;
     uint64_t max_size;
-    uint64_t total_allocs;
-    uint32_t num_allocs;
     uint32_t max_num_allocs;
+    gf_atomic_t num_allocs;
     gf_lock_t lock;
 #ifdef DEBUG
     struct list_head obj_list;

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -91,35 +91,28 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
                      size_t size, uint32_t type, const char *typestr)
 {
     struct mem_acct_rec *rec = NULL;
-    bool new_ref = false;
+    uint64_t num_allocs;
 
     if (mem_acct != NULL) {
         GF_ASSERT(type <= mem_acct->num_types);
 
         rec = &mem_acct->rec[type];
+        if (!rec->typestr) {
+            rec->typestr = typestr;
+        }
+        num_allocs = GF_ATOMIC_INC(rec->num_allocs);
+        rec->max_size = max(rec->max_size, (num_allocs * size));
+        rec->max_num_allocs = max(rec->max_num_allocs, num_allocs);
+        if (num_allocs == 1)
+            GF_ATOMIC_INC(mem_acct->refcnt);
+#ifdef DEBUG
         LOCK(&rec->lock);
         {
-            if (!rec->typestr) {
-                rec->typestr = typestr;
-            }
-            rec->size += size;
-            new_ref = (rec->num_allocs == 0);
-            rec->num_allocs++;
-            rec->total_allocs++;
-            rec->max_size = max(rec->max_size, rec->size);
-            rec->max_num_allocs = max(rec->max_num_allocs, rec->num_allocs);
-
-#ifdef DEBUG
             list_add(&header->acct_list, &rec->obj_list);
-#endif
         }
         UNLOCK(&rec->lock);
+#endif
 
-        /* We only take a reference for each memory type used, not for each
-         * allocation. This minimizes the use of atomic operations. */
-        if (new_ref) {
-            GF_ATOMIC_INC(mem_acct->refcnt);
-        }
     }
 
     header->mem_acct = mem_acct;
@@ -137,23 +130,14 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 
     if (mem_acct != NULL) {
         rec = &mem_acct->rec[header->type];
+        rec->max_size = max(rec->max_size, rec->size);
+#ifdef DEBUG
         LOCK(&rec->lock);
         {
-            rec->size += size - header->size;
-            rec->total_allocs++;
-            rec->max_size = max(rec->max_size, rec->size);
-
-#ifdef DEBUG
-            /* The old 'header' already was present in 'obj_list', but
-             * realloc() could have changed its address. We need to remove
-             * the old item from the list and add the new one. This can be
-             * done this way because list_move() doesn't use the pointers
-             * to the old location (which are not valid anymore) already
-             * present in the list, it simply overwrites them. */
             list_move(&header->acct_list, &rec->obj_list);
-#endif
         }
         UNLOCK(&rec->lock);
+#endif
     }
 
     return gf_mem_header_prepare(header, size);
@@ -344,7 +328,7 @@ __gf_free(void *free_ptr)
     void *ptr = NULL;
     struct mem_acct *mem_acct;
     struct mem_header *header = NULL;
-    bool last_ref = false;
+    uint64_t num_allocs = 0;
 
     if (!free_ptr)
         return;
@@ -373,23 +357,18 @@ __gf_free(void *free_ptr)
         GF_ASSERT(GF_MEM_TRAILER_MAGIC == __gf_mem_trailer_read(trailer));
     }
 
+    num_allocs = GF_ATOMIC_DEC(mem_acct->rec[header->type].num_allocs);
+    if (!num_allocs) {
+        mem_acct->rec[header->type].typestr = NULL;
+    }
+#ifdef DEBUG
     LOCK(&mem_acct->rec[header->type].lock);
     {
-        mem_acct->rec[header->type].size -= header->size;
-        mem_acct->rec[header->type].num_allocs--;
-        /* If all the instances are freed up then ensure typestr is set
-         * to NULL */
-        if (!mem_acct->rec[header->type].num_allocs) {
-            last_ref = true;
-            mem_acct->rec[header->type].typestr = NULL;
-        }
-#ifdef DEBUG
         list_del(&header->acct_list);
-#endif
     }
     UNLOCK(&mem_acct->rec[header->type].lock);
-
-    if (last_ref) {
+#endif
+    if (!num_allocs) {
         xlator_mem_acct_unref(mem_acct);
     }
 

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -97,12 +97,12 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
         GF_ASSERT(type <= mem_acct->num_types);
 
         rec = &mem_acct->rec[type];
-        if (!rec->typestr) {
-            rec->typestr = typestr;
-        }
         num_allocs = GF_ATOMIC_INC(rec->num_allocs);
-        if (num_allocs == 1)
+        if (num_allocs == 1) {
             GF_ATOMIC_INC(mem_acct->refcnt);
+            if (!rec->typestr)
+                rec->typestr = typestr;
+        }
 #ifdef DEBUG
         LOCK(&rec->lock);
         {
@@ -364,9 +364,6 @@ __gf_free(void *free_ptr)
     }
 
     num_allocs = GF_ATOMIC_DEC(mem_acct->rec[header->type].num_allocs);
-    if (!num_allocs) {
-        mem_acct->rec[header->type].typestr = NULL;
-    }
 #ifdef DEBUG
     LOCK(&mem_acct->rec[header->type].lock);
     {

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -32,12 +32,12 @@ dump_mem_acct_details(xlator_t *xl, int fd)
 
     for (i = 0; i < xl->mem_acct->num_types; i++) {
         mem_rec = &xl->mem_acct->rec[i];
-        if (mem_rec->num_allocs == 0)
+        if (!GF_ATOMIC_GET(mem_rec->num_allocs))
             continue;
-        dprintf(fd, "# %s, %" PRIu64 ", %u, %" PRIu64 ", %u, %" PRIu64 "\n",
-                mem_rec->typestr, mem_rec->size, mem_rec->num_allocs,
-                mem_rec->max_size, mem_rec->max_num_allocs,
-                mem_rec->total_allocs);
+        dprintf(fd, "# %s, %lu, %lu, %u, %" PRIu64 "\n", mem_rec->typestr,
+                mem_rec->size, mem_rec->max_size, mem_rec->max_num_allocs,
+                GF_ATOMIC_GET(mem_rec->num_allocs));
+
     }
 }
 

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -34,15 +34,14 @@ dump_mem_acct_details(xlator_t *xl, int fd)
         mem_rec = &xl->mem_acct->rec[i];
         if (!GF_ATOMIC_GET(mem_rec->num_allocs))
             continue;
-        #ifdef DEBUG
-            dprintf(fd, "# %s, %lu, %lu, %u, %" PRIu64 "\n", mem_rec->typestr,
-                    mem_rec->size, mem_rec->max_size, mem_rec->max_num_allocs,
-                    GF_ATOMIC_GET(mem_rec->num_allocs));
-        #else
-            dprintf(fd, "# %s, %lu, %" PRIu64 "\n", mem_rec->typestr,
-                    mem_rec->size, GF_ATOMIC_GET(mem_rec->num_allocs));
-        #endif
-
+#ifdef DEBUG
+        dprintf(fd, "# %s, %lu, %lu, %u, %" PRIu64 "\n", mem_rec->typestr,
+                mem_rec->size, mem_rec->max_size, mem_rec->max_num_allocs,
+                GF_ATOMIC_GET(mem_rec->num_allocs));
+#else
+        dprintf(fd, "# %s, %lu, %" PRIu64 "\n", mem_rec->typestr, mem_rec->size,
+                GF_ATOMIC_GET(mem_rec->num_allocs));
+#endif
     }
 }
 

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -34,9 +34,14 @@ dump_mem_acct_details(xlator_t *xl, int fd)
         mem_rec = &xl->mem_acct->rec[i];
         if (!GF_ATOMIC_GET(mem_rec->num_allocs))
             continue;
-        dprintf(fd, "# %s, %lu, %lu, %u, %" PRIu64 "\n", mem_rec->typestr,
-                mem_rec->size, mem_rec->max_size, mem_rec->max_num_allocs,
-                GF_ATOMIC_GET(mem_rec->num_allocs));
+        #ifdef DEBUG
+            dprintf(fd, "# %s, %lu, %lu, %u, %" PRIu64 "\n", mem_rec->typestr,
+                    mem_rec->size, mem_rec->max_size, mem_rec->max_num_allocs,
+                    GF_ATOMIC_GET(mem_rec->num_allocs));
+        #else
+            dprintf(fd, "# %s, %lu, %" PRIu64 "\n", mem_rec->typestr,
+                    mem_rec->size, GF_ATOMIC_GET(mem_rec->num_allocs));
+        #endif
 
     }
 }

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -255,10 +255,12 @@ gf_proc_dump_xlator_mem_info(xlator_t *xl)
                                  xl->name, xl->mem_acct->rec[i].typestr);
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
         gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
-        gf_proc_dump_write("max_size", "%" PRIu64,
-                           xl->mem_acct->rec[i].max_size);
-        gf_proc_dump_write("max_num_allocs", "%u",
-                           xl->mem_acct->rec[i].max_num_allocs);
+        #ifdef DEBUG
+             gf_proc_dump_write("max_size", "%" PRIu64,
+                                xl->mem_acct->rec[i].max_size);
+             gf_proc_dump_write("max_num_allocs", "%u",
+                                xl->mem_acct->rec[i].max_num_allocs);
+        #endif
     }
 
     return;
@@ -286,11 +288,15 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
                                  i);
 
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
-        gf_proc_dump_write("max_size", "%" PRIu64,
-                           xl->mem_acct->rec[i].max_size);
+        #ifdef DEBUG
+            gf_proc_dump_write("max_size", "%" PRIu64,
+                               xl->mem_acct->rec[i].max_size);
+        #endif
         gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
-        gf_proc_dump_write("max_num_allocs", "%u",
-                           xl->mem_acct->rec[i].max_num_allocs);
+        #ifdef DEBUG
+            gf_proc_dump_write("max_num_allocs", "%u",
+                               xl->mem_acct->rec[i].max_num_allocs);
+        #endif
     }
 
     return;

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -248,19 +248,17 @@ gf_proc_dump_xlator_mem_info(xlator_t *xl)
     gf_proc_dump_write("num_types", "%d", xl->mem_acct->num_types);
 
     for (i = 0; i < xl->mem_acct->num_types; i++) {
-        if (xl->mem_acct->rec[i].num_allocs == 0)
+        if (!GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs))
             continue;
 
         gf_proc_dump_add_section("%s.%s - usage-type %s memusage", xl->type,
                                  xl->name, xl->mem_acct->rec[i].typestr);
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
-        gf_proc_dump_write("num_allocs", "%u", xl->mem_acct->rec[i].num_allocs);
+        gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
         gf_proc_dump_write("max_size", "%" PRIu64,
                            xl->mem_acct->rec[i].max_size);
         gf_proc_dump_write("max_num_allocs", "%u",
                            xl->mem_acct->rec[i].max_num_allocs);
-        gf_proc_dump_write("total_allocs", "%" PRIu64,
-                           xl->mem_acct->rec[i].total_allocs);
     }
 
     return;
@@ -290,11 +288,9 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
         gf_proc_dump_write("max_size", "%" PRIu64,
                            xl->mem_acct->rec[i].max_size);
-        gf_proc_dump_write("num_allocs", "%u", xl->mem_acct->rec[i].num_allocs);
+        gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
         gf_proc_dump_write("max_num_allocs", "%u",
                            xl->mem_acct->rec[i].max_num_allocs);
-        gf_proc_dump_write("total_allocs", "%" PRIu64,
-                           xl->mem_acct->rec[i].total_allocs);
     }
 
     return;

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -254,13 +254,14 @@ gf_proc_dump_xlator_mem_info(xlator_t *xl)
         gf_proc_dump_add_section("%s.%s - usage-type %s memusage", xl->type,
                                  xl->name, xl->mem_acct->rec[i].typestr);
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
-        gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
-        #ifdef DEBUG
-             gf_proc_dump_write("max_size", "%" PRIu64,
-                                xl->mem_acct->rec[i].max_size);
-             gf_proc_dump_write("max_num_allocs", "%u",
-                                xl->mem_acct->rec[i].max_num_allocs);
-        #endif
+        gf_proc_dump_write("num_allocs", "%" PRIu64,
+                           GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
+#ifdef DEBUG
+        gf_proc_dump_write("max_size", "%" PRIu64,
+                           xl->mem_acct->rec[i].max_size);
+        gf_proc_dump_write("max_num_allocs", "%u",
+                           xl->mem_acct->rec[i].max_num_allocs);
+#endif
     }
 
     return;
@@ -288,15 +289,16 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
                                  i);
 
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
-        #ifdef DEBUG
-            gf_proc_dump_write("max_size", "%" PRIu64,
-                               xl->mem_acct->rec[i].max_size);
-        #endif
-        gf_proc_dump_write("num_allocs", "%" PRIu64, GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
-        #ifdef DEBUG
-            gf_proc_dump_write("max_num_allocs", "%u",
-                               xl->mem_acct->rec[i].max_num_allocs);
-        #endif
+#ifdef DEBUG
+        gf_proc_dump_write("max_size", "%" PRIu64,
+                           xl->mem_acct->rec[i].max_size);
+#endif
+        gf_proc_dump_write("num_allocs", "%" PRIu64,
+                           GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
+#ifdef DEBUG
+        gf_proc_dump_write("max_num_allocs", "%u",
+                           xl->mem_acct->rec[i].max_num_allocs);
+#endif
     }
 
     return;

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -742,12 +742,12 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
 
     for (i = 0; i < num_types; i++) {
         memset(&xl->mem_acct->rec[i], 0, sizeof(struct mem_acct_rec));
+#ifdef DEBUG
+        INIT_LIST_HEAD(&(xl->mem_acct->rec[i].obj_list));
         ret = LOCK_INIT(&(xl->mem_acct->rec[i].lock));
         if (ret) {
             fprintf(stderr, "Unable to lock..errno : %d", errno);
         }
-#ifdef DEBUG
-        INIT_LIST_HEAD(&(xl->mem_acct->rec[i].obj_list));
 #endif
     }
 
@@ -760,9 +760,11 @@ xlator_mem_acct_unref(struct mem_acct *mem_acct)
     uint32_t i;
 
     if (GF_ATOMIC_DEC(mem_acct->refcnt) == 0) {
+#ifdef DEBUG
         for (i = 0; i < mem_acct->num_types; i++) {
             LOCK_DESTROY(&(mem_acct->rec[i].lock));
         }
+#endif
         FREE(mem_acct);
     }
 }


### PR DESCRIPTION
The __gf_(c|m)alloc and __gf_free memory allocation api calls
gf_mem_set_acct_info function to save memory accounting
on xlator and to update the record it takes lock.During
testing we have observed the mem_acct mutex has contention.

Solution: To avoid contention make it lock free and the data
          is available at github issue #2771

Updates #2771
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
Credits: Xavi Hernandez <xhernandez@redhat.com>
Change-Id: I9ab2a2e5b7d64e98aad92cecaa3bebc914e0a55b