### PR TITLE
mount: expose the localtime-logging option to mount-helper

### DIFF
--- a/doc/mount.glusterfs.8
+++ b/doc/mount.glusterfs.8
@@ -68,6 +68,9 @@ Enable file capability setting and retrival
 .TP
 \fBthin-client
 Enables thin mount and connects via gfproxyd daemon
+.TP
+\fBlocaltime-logging
+Use local timestamps instead of UTC in mount log entries
 
 .PP
 .SS "Advanced options"

--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -205,6 +205,10 @@ start_glusterfs ()
         cmd_line=$(echo "$cmd_line --global-threading");
     fi
 
+    if [ -n "$localtime_logging" ]; then
+         cmd_line=$(echo "$cmd_line --localtime-logging");
+    fi
+
 #options with optional values start here
     if [ -n "$fopen_keep_cache" ]; then
         cmd_line=$(echo "$cmd_line --fopen-keep-cache=$fopen_keep_cache");
@@ -691,6 +695,9 @@ without_options()
             ;;
         "global-threading")
             global_threading=1
+            ;;
+        "localtime-logging")
+            localtime_logging=1
             ;;
          # TODO: not sure how to handle this yet
         "async"|"sync"|"dirsync"|\


### PR DESCRIPTION
...in order for it to be recognized as a valid option.
i.e. mount -t glusterfs $IP:$VOLUME -o localtime-logging /path/to/mount

Change-Id: I8859b31d92b54d1e0f877728a1bfff8b4ac37e56
Fixes: #2798
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

