### PR TITLE
glusterd: cache the non local node's hostname

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1389,12 +1389,13 @@ out:
 }
 
 void
-glusterd_destroy_hostname_list(glusterd_conf_t *priv)
+glusterd_destroy_hostname_list(struct list_head *hostname_list_head)
 {
     glusterd_hostname_t *hostname_obj = NULL;
     glusterd_hostname_t *tmp = NULL;
 
-    list_for_each_entry_safe(hostname_obj, tmp, &priv->hostnames, hostname_list)
+    list_for_each_entry_safe(hostname_obj, tmp, hostname_list_head,
+                             hostname_list)
     {
         list_del_init(&hostname_obj->hostname_list);
         GF_FREE(hostname_obj->hostname);
@@ -1881,6 +1882,7 @@ init(xlator_t *this)
     CDS_INIT_LIST_HEAD(&conf->brick_procs);
     CDS_INIT_LIST_HEAD(&conf->shd_procs);
     CDS_INIT_LIST_HEAD(&conf->hostnames);
+    INIT_LIST_HEAD(&conf->remote_hostnames);
     pthread_mutex_init(&conf->attach_lock, NULL);
     pthread_mutex_init(&conf->volume_lock, NULL);
 
@@ -2128,9 +2130,14 @@ fini(xlator_t *this)
     if (!this || !this->private)
         goto out;
 
-    glusterd_stop_uds_listener(this);              /*stop unix socket rpc*/
-    glusterd_stop_listener(this);                  /*stop tcp/ip socket rpc*/
-    glusterd_destroy_hostname_list(this->private); /*Destroy hostname list */
+    glusterd_conf_t *priv = NULL;
+    priv = this->private;
+
+    glusterd_stop_uds_listener(this);                 /*stop unix socket rpc*/
+    glusterd_stop_listener(this);                     /*stop tcp/ip socket rpc*/
+    glusterd_destroy_hostname_list(&priv->hostnames); /*Destroy hostname list */
+    glusterd_destroy_hostname_list(
+        &priv->remote_hostnames); /*Destroy remote hostname list*/
 
 #if 0
        /* Running threads might be using these resourses, we have to cancel/stop

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -237,6 +237,7 @@ typedef struct {
     char rundir[VALID_GLUSTERD_PATHMAX];
     char logdir[VALID_GLUSTERD_PATHMAX];
     struct list_head hostnames;
+    struct list_head remote_hostnames;
 } glusterd_conf_t;
 
 typedef struct glusterd_add_dict_args {


### PR DESCRIPTION
glusterd: cache the non local node's hostname
Fixes: #2754
> Cherry pick from commit eef89978f6d835bfb16343c8a5ddc74e2620bf91
> Reviwed on upstream link https://github.com/gluster/glusterfs/pull/2759
> Signed-off-by: JamesWSWu wu.shiwei@zte.com.cn

Change-Id: I9a01a1748db1d9ffdae813812b36d030bf51c309
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

