### PR TITLE
cli: move RPC call timeouts to state data

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -74,9 +74,6 @@ rpc_clnt_prog_t *cli_rpc_prog;
 
 extern struct rpc_clnt_program cli_prog;
 
-time_t cli_default_conn_timeout = 120;
-time_t cli_ten_minutes_timeout = 600;
-
 static int
 glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
 {
@@ -440,7 +437,7 @@ cli_opt_parse(char *opt, struct cli_state *state)
             /* Use -2 to not confuse with unknown option error. */
             return -2;
         }
-        cli_default_conn_timeout = val;
+        state->default_conn_timeout = val;
         return 0;
     }
 
@@ -544,6 +541,8 @@ cli_state_init(struct cli_state *state)
 {
     struct cli_cmd_tree *tree = NULL;
     int ret = 0;
+
+    state->default_conn_timeout = CLI_DEFAULT_CONN_TIMEOUT;
 
     state->log_level = GF_LOG_NONE;
 
@@ -806,9 +805,6 @@ main(int argc, char *argv[])
     ret = glusterfs_ctx_defaults_init(ctx);
     if (ret)
         goto out;
-
-    cli_default_conn_timeout = 120;
-    cli_ten_minutes_timeout = 600;
 
     ret = cli_state_init(&state);
     if (ret)

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -38,13 +38,17 @@
 #define GEO_REP_CMD_INDEX 1
 #define GEO_REP_CMD_CONFIG_INDEX 4
 
+/* Default RPC call timeout, in seconds. */
+#define CLI_DEFAULT_CONN_TIMEOUT 120
+
+/* Special timeout for volume profile, volume
+   heal and ganesha RPC calls, in seconds. */
+#define CLI_TEN_MINUTES_TIMEOUT 600
+
 enum argp_option_keys {
     ARGP_DEBUG_KEY = 133,
     ARGP_PORT_KEY = 'p',
 };
-
-extern time_t cli_default_conn_timeout;
-extern time_t cli_ten_minutes_timeout;
 
 typedef enum {
     COLD_BRICK_COUNT,
@@ -142,6 +146,8 @@ struct cli_state {
     int remote_port;
     int mode;
     int await_connected;
+
+    time_t default_conn_timeout;
 
     char *log_file;
     gf_loglevel_t log_level;


### PR DESCRIPTION
Move default and special RPC call timeouts to `struct cli_state`,
provide meaningful macros and adjust related bits here and there.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

