### PR TITLE
shard: add option for the background deletion thread interval runs

### DIFF
--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -20,6 +20,8 @@
 #define GF_SHARD_REMOVE_ME_DIR ".remove_me"
 #define SHARD_MIN_BLOCK_SIZE (4 * GF_UNIT_MB)
 #define SHARD_MAX_BLOCK_SIZE (4 * GF_UNIT_TB)
+#define SHARD_MIN_DELETION_INTERVAL 10
+#define SHARD_MAX_DELETION_INTERVAL 3600
 #define SHARD_XATTR_PREFIX "trusted.glusterfs.shard."
 #define GF_XATTR_SHARD_BLOCK_SIZE "trusted.glusterfs.shard.block-size"
 /**
@@ -227,6 +229,7 @@ typedef struct shard_priv {
     int inode_count;
     struct list_head ilist_head;
     uint32_t deletion_rate;
+    time_t deletion_interval;
     shard_bg_deletion_state_t bg_del_state;
     gf_boolean_t first_lookup_done;
     uint64_t lru_limit;

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -2619,6 +2619,10 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .voltype = "features/shard",
      .op_version = GD_OP_VERSION_5_0,
      .flags = VOLOPT_FLAG_CLIENT_OPT},
+    {.key = "features.shard-deletion-interval",
+     .voltype = "features/shard",
+     .op_version = GD_OP_VERSION_10_0,
+     .flags = VOLOPT_FLAG_CLIENT_OPT},
     {
         .key = "features.scrub-throttle",
         .voltype = "features/bit-rot",


### PR DESCRIPTION
Avoid hardcoded constant and provide the convenient configuration
option for an interval between the background shard deletion thread
runs, denote relevant options with `OPT_FLAG_RANGE` flag and adjust
option descriptions.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

