### PR TITLE
Fix broken gf_history_b_search with geo replication (#2400)

### DIFF
--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -439,6 +439,10 @@ gf_history_b_search(int fd, unsigned long value, unsigned long from,
         goto out;
     if (cur_value == value) {
         return m_index;
+    } else if (cur_value == 0) {
+        // 0 is returned if the timestamp isn't found in the htime file
+        // In this case we need to search backward
+        return gf_history_b_search(fd, value, from, m_index - 1, len);
     } else if (value > cur_value) {
         ret = gf_history_get_timestamp(fd, m_index + 1, len, &cur_value);
         if (ret == -1)


### PR DESCRIPTION
For some weird reasons, sometimes the last entries of the htime file don't match the index value from the trusted.glusterfs.htime xattr.
So if we try to search a value from an out of bound index in the file, it returns the end index because of a wrong check.

> Fixes: #2400
> Signed-off-by: Yoann Laissus <yoann.laissus@gmail.com>
> Change-Id: I627aa6109e137c1259f30e8a1fa7a4a5ba7944b1
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/2400)

Change-Id: I627aa6109e137c1259f30e8a1fa7a4a5ba7944b1
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

