### PR TITLE
configure.ac: Configure HAVE_PTHREAD_SETNAME_NP correctly during rpmbuild

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,7 +1192,7 @@ if test x$PTHREAD_SETNAME_FOUND = xno; then
    AC_MSG_CHECKING([for pthread_setname_np(thread, name)])
    saved_CFLAGS=${CFLAGS}
    CFLAGS="-D_GNU_SOURCE -pthread"
-   AC_LINK_IFELSE(
+   AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM([
          [#include <pthread.h>]],
          [[pthread_t t; pthread_setname_np(t, "name");]])],
@@ -1212,7 +1212,7 @@ if test x$PTHREAD_SETNAME_FOUND = xno; then
    AC_MSG_CHECKING([for pthread_setname_np(thread, name, arg)])
    saved_CFLAGS=${CFLAGS}
    CFLAGS="-pthread"
-   AC_LINK_IFELSE(
+   AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM([
          [#include <pthread.h>]],
          [[pthread_t t; pthread_setname_np(t, "name", NULL);]])],
@@ -1235,7 +1235,7 @@ if test x$PTHREAD_SETNAME_FOUND = xno; then
    AC_MSG_CHECKING([for pthread_set_name_np(thread, name)])
    saved_CFLAGS=${CFLAGS}
    CFLAGS="-pthread"
-   AC_LINK_IFELSE(
+   AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM([
          [#include <pthread_np.h>]],
          [[pthread_t t; pthread_set_name_np(t, "name");]])],


### PR DESCRIPTION
Currently rpmbuild does not configure HAVE_PTHREAD_SETNAME_NP
correctly on rhel-8 environment it is throwing an error during
rpmbuild "relocation R_X86_64_32 against `.rodata can not
be used when making a shared object; recompile with -fPIC"

Solution: Use AC_COMPILE_IFELSE instead of using AC_LINK_IFELSE
          to avoid an issue.

Fixes: #2820
Change-Id: I28ce34fbc89a76be6d0e3dd9ba3433d5b9de3e31
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

