### PR TITLE
Coverity: API usage error

### DIFF
--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -2528,12 +2528,12 @@ init(xlator_t *this)
 
     GF_OPTION_INIT("timeout", priv->timeout, time, out);
     GF_OPTION_INIT("failover-hosts", priv->failover_hosts, str, out);
+    LOCK_INIT(&priv->lock);
     gf_quiesce_populate_failover_hosts(this, priv, priv->failover_hosts);
 
     priv->local_pool = mem_pool_new(quiesce_local_t,
                                     GF_FOPS_EXPECTED_IN_PARALLEL);
 
-    LOCK_INIT(&priv->lock);
     priv->pass_through = _gf_false;
 
     INIT_LIST_HEAD(&priv->req);


### PR DESCRIPTION
Problem:
Lock is taken on priv->lock before initializing the variable
in function gf_quiesce_populate_failover_hosts() and in the later
stage it is being initialized.
CID: 1462030

Fix:
Initialize the priv->lock variable before trying to take a lock
in function  gf_quiesce_populate_failover_hosts().

Change-Id: Id2450310b84fca407fe34af7c16e419829f2a2a0
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Updates: #1060

