### PR TITLE
server: glusterfsd has memory leak while mount a subdir volume

### DIFF
--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -122,6 +122,7 @@ do_path_lookup(xlator_t *xl, dict_t *dict, inode_t *parinode, char *basename)
     inode_ref(inode);
 
 out:
+    loc_wipe(&loc);
     return inode;
 }
 

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -93,7 +93,7 @@ do_path_lookup(xlator_t *xl, dict_t *dict, inode_t *parinode, char *basename)
     };
     inode_t *inode = NULL;
 
-    loc.parent = parinode;
+    loc.parent = inode_ref(parinode);
     loc_touchup(&loc, basename);
     loc.inode = inode_new(xl->itable);
 


### PR DESCRIPTION
The do_path_lookup has leak while a client has tried to mount
a volume with subdir mount.During path lookup the function has
populated a loc_t object for every inode but it forgot to cleanup
loc_t object.

Solution: Cleanup loc_t object to avoid a leak
Fixes: #2816
Credits: wenxiaobao <1187873955@qq.com>
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

