### PR TITLE
geo-rep: Changelog History Crawl failure (#2768)

### DIFF
--- a/extras/glusterfs-georep-upgrade.py
+++ b/extras/glusterfs-georep-upgrade.py
@@ -52,8 +52,12 @@ def modify_htime_file(brick_path):
                     os.makedirs(path, mode = 0o600, exist_ok = True)
 
                     #copy existing changelogs to new directory structure, delete old changelog files
-                    shutil.copyfile(pth, os.path.join(path, changelog))
-                    os.remove(pth)
+                    try:
+                        shutil.copyfile(pth, os.path.join(path, changelog))
+                    except shutil.SameFileError:
+                        pass
+                    else:
+                        os.remove(pth)
 
         #rename temp_htime_file with htime file
         os.rename(htime_file_path, os.path.join('%s.bak'%htime_file_path))

--- a/tests/00-geo-rep/00-georep-verify-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-setup.t
@@ -17,7 +17,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 master=$GMV0
-SH0="192.168.122.1"
+SH0="127.0.0.1"
 slave=${SH0}::${GSV0}
 num_active=2
 num_passive=2
@@ -86,7 +86,7 @@ TEST pidof glusterd
 
 TEST $CLI get-state detail
 TEST pidof glusterd
-exit
+
 #Pause geo-replication session
 TEST $GEOREP_CLI  $master $slave pause
 

--- a/tests/00-geo-rep/00-georep-verify-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-setup.t
@@ -17,7 +17,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 master=$GMV0
-SH0="127.0.0.1"
+SH0="192.168.122.1"
 slave=${SH0}::${GSV0}
 num_active=2
 num_passive=2
@@ -86,7 +86,7 @@ TEST pidof glusterd
 
 TEST $CLI get-state detail
 TEST pidof glusterd
-
+exit
 #Pause geo-replication session
 TEST $GEOREP_CLI  $master $slave pause
 


### PR DESCRIPTION
* geo-rep: Changelog History Crawl failure

Issue:

glusterfs-georep-upgrade.py is designed to be run
before the upgrade.

However, many users missed to run it before the
upgrade. When they ran it after the upgrade, following issue
was encountered:

Traceback (most recent call last):
  File "./glusterfs-georep-upgrade.py", line 77, in <module>
    modify_htime_file(args.brick_path)
  File "./glusterfs-georep-upgrade.py", line 61, in modify_htime_file
    shutil.copyfile(pth, os.path.join(path, changelog))
  File "/usr/lib/python3.7/shutil.py", line 104, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
shutil.SameFileError: '/storage/glusterfs/guacamole/.glusterfs/changelogs/
2020/12/30/CHANGELOG.1609357688' and '/storage/glusterfs/guacamole/.glusterfs/
changelogs/2020/12/30/CHANGELOG.1609357688' are the same file

This happened because, new changelogs formed after the
upgrade were already in required directories, thus making
the source and destination same for shutil.copyfile

Solution:

Added exception handling for shutil.copyfile inorder to pass the
situation where source and destination are same.

> Fixes: #2133
> Change-Id: I3752ac304bd393f6b786bd67a63360f68bf8b8db
> Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>
> Reviewed upstream on: https://github.com/gluster/glusterfs/pull/2768

Fixes: #2133
Change-Id: I3752ac304bd393f6b786bd67a63360f68bf8b8db
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

