### PR TITLE
mem_acct: Move size variable to debug build from mem_acct_rec

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -44,9 +44,9 @@ typedef uint32_t gf_mem_magic_t;
 
 struct mem_acct_rec {
     const char *typestr;
-    uint64_t size;
     gf_atomic_t num_allocs;
 #ifdef DEBUG
+    uint64_t size;
     uint64_t max_size;
     uint32_t max_num_allocs;
     gf_lock_t lock;

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -105,6 +105,7 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 #ifdef DEBUG
         LOCK(&rec->lock);
         {
+            rec->size += size;
             rec->max_size = max(rec->max_size, (num_allocs * size));
             rec->max_num_allocs = max(rec->max_num_allocs, num_allocs);
             list_add(&header->acct_list, &rec->obj_list);
@@ -129,9 +130,10 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
     if (mem_acct != NULL) {
         rec = &mem_acct->rec[header->type];
 #ifdef DEBUG
-        rec->max_size = max(rec->max_size, rec->size);
         LOCK(&rec->lock);
         {
+            rec->size += size - header->size;
+            rec->max_size = max(rec->max_size, rec->size);
             /* The old 'header' already was present in 'obj_list', but
              * realloc() could have changed its address. We need to remove
              * the old item from the list and add the new one. This can be

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -39,8 +39,8 @@ dump_mem_acct_details(xlator_t *xl, int fd)
                 mem_rec->typestr, mem_rec->size, mem_rec->max_size,
                 mem_rec->max_num_allocs, GF_ATOMIC_GET(mem_rec->num_allocs));
 #else
-        dprintf(fd, "# %s, %" PRIu64 ", %" PRIu64 "\n", mem_rec->typestr,
-                mem_rec->size, GF_ATOMIC_GET(mem_rec->num_allocs));
+        dprintf(fd, "# %s, %" PRIu64 "\n", mem_rec->typestr,
+                GF_ATOMIC_GET(mem_rec->num_allocs));
 #endif
     }
 }

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -253,7 +253,9 @@ gf_proc_dump_xlator_mem_info(xlator_t *xl)
 
         gf_proc_dump_add_section("%s.%s - usage-type %s memusage", xl->type,
                                  xl->name, xl->mem_acct->rec[i].typestr);
+#ifdef DEBUG
         gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
+#endif
         gf_proc_dump_write("num_allocs", "%" PRIu64,
                            GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs));
 #ifdef DEBUG
@@ -282,14 +284,14 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
     gf_proc_dump_write("num_types", "%d", xl->mem_acct->num_types);
 
     for (i = 0; i < xl->mem_acct->num_types; i++) {
+#ifdef DEBUG
         if (!xl->mem_acct->rec[i].size)
             continue;
-
+#endif
         gf_proc_dump_add_section("%s.%s - usage-type %d", xl->type, xl->name,
                                  i);
-
-        gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
 #ifdef DEBUG
+        gf_proc_dump_write("size", "%" PRIu64, xl->mem_acct->rec[i].size);
         gf_proc_dump_write("max_size", "%" PRIu64,
                            xl->mem_acct->rec[i].max_size);
 #endif

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -284,10 +284,9 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
     gf_proc_dump_write("num_types", "%d", xl->mem_acct->num_types);
 
     for (i = 0; i < xl->mem_acct->num_types; i++) {
-#ifdef DEBUG
-        if (!xl->mem_acct->rec[i].size)
+        if (!GF_ATOMIC_GET(xl->mem_acct->rec[i].num_allocs))
             continue;
-#endif
+
         gf_proc_dump_add_section("%s.%s - usage-type %d", xl->type, xl->name,
                                  i);
 #ifdef DEBUG


### PR DESCRIPTION
The size variable does not necessary to debug mem leak from
mem_acct so move the variable for debug build.

Updates: #2771
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

