### PR TITLE
rpc: bind retry when EADDRINUSE

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -983,6 +983,8 @@ __socket_server_bind(rpc_transport_t *this)
                    cmd_args->brick_port);
         }
     } else {
+        retries = 3;
+    retry:
         ret = bind(priv->sock, (struct sockaddr *)&this->myinfo.sockaddr,
                    this->myinfo.sockaddr_len);
 
@@ -991,6 +993,11 @@ __socket_server_bind(rpc_transport_t *this)
                    this->myinfo.identifier, strerror(errno));
             if (errno == EADDRINUSE) {
                 gf_log(this->name, GF_LOG_ERROR, "Port is already in use");
+                retries--;
+                if (retries) {
+                    sleep(1);
+                    goto retry;
+                }
             }
         }
     }


### PR DESCRIPTION
Socket release is asynchronous in kernel.
If failed with "already in use", better retry.

> Fixes: #2649
> (Cherry picked from upstram 230caac41126ff4bb7081c5db782ce816e8ae652)
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/2650)
> Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>

Fixes: #2649
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

