### PR TITLE
WIP: add internal lock debugging

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -682,6 +682,8 @@ glfs_fd_destroy(struct glfs_fd *glfd)
 
     GF_FREE(glfd->readdirbuf);
 
+    LOCK_DESTROY(&glfd->lock);
+
     GF_FREE(glfd);
 }
 
@@ -699,6 +701,8 @@ glfs_fd_new(struct glfs *fs)
     INIT_LIST_HEAD(&glfd->openfds);
 
     GF_REF_INIT(glfd, glfs_fd_destroy);
+
+    LOCK_INIT(&glfd->lock);
 
     return glfd;
 }
@@ -1207,6 +1211,8 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     GF_FREE(ctx->cmd_args.process_name);
 
     LOCK_DESTROY(&ctx->lock);
+    LOCK_DESTROY(&ctx->volfile_lock);
+
     pthread_mutex_destroy(&ctx->notify_lock);
     pthread_cond_destroy(&ctx->notify_cond);
 
@@ -1221,6 +1227,7 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     }
 
     GF_FREE(ctx->statedump_path);
+    FREE(ctx->hostname);
     FREE(ctx);
 
     return ret;

--- a/configure.ac
+++ b/configure.ac
@@ -281,6 +281,16 @@ else
         BUILD_DEBUG=no
 fi
 
+AC_ARG_ENABLE([lock-debug],
+              AC_HELP_STRING([--enable-lock-debug],
+                             [Enable lock debugging.]))
+if test "x$enable_lock_debug" = "xyes"; then
+        AC_DEFINE(GF_LOCK_DEBUG, 1, [Define if lock debugging is enabled.])
+        DEBUG_LOCKS=yes
+else
+        DEBUG_LOCKS=no
+fi
+
 SANITIZER=none
 
 AC_ARG_ENABLE([asan],
@@ -1872,6 +1882,7 @@ echo "Linux-AIO            : $BUILD_LIBAIO"
 echo "Linux io_uring       : $BUILD_LINUX_IO_URING"
 echo "Use liburing         : $BUILD_LIBURING"
 echo "Enable Debug         : $BUILD_DEBUG"
+echo "Debug locks          : $DEBUG_LOCKS"
 echo "Run with Valgrind    : $VALGRIND_TOOL"
 echo "Sanitizer enabled    : $SANITIZER"
 echo "XML output           : $BUILD_XML_OUTPUT"

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2875,8 +2875,6 @@ glusterfs_mgmt_init(glusterfs_ctx_t *ctx)
     if (!options)
         goto out;
 
-    LOCK_INIT(&ctx->volfile_lock);
-
     if (cmd_args->volfile_server_port)
         port = cmd_args->volfile_server_port;
 

--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -944,7 +944,8 @@ event_pool_destroy_epoll(struct event_pool *event_pool)
             table = event_pool->ereg[i];
             event_pool->ereg[i] = NULL;
             for (j = 0; j < EVENT_EPOLL_SLOTS; j++) {
-                LOCK_DESTROY(&table[j].lock);
+                if (table[j].fd != -1)
+                    LOCK_DESTROY(&table[j].lock);
             }
             GF_FREE(table);
         }

--- a/libglusterfs/src/glusterfs/locking.h
+++ b/libglusterfs/src/glusterfs/locking.h
@@ -22,12 +22,68 @@
 #define pthread_spin_init(l, v) (*l = v)
 #endif
 
+#if defined(GF_LOCK_DEBUG)
+
+/* Use assert() just to avoid chicken-egg problem
+   with defining GF_ASSERT() through the headers. */
+
+#include <assert.h>
+
+#define DEBUG_LOCK_INIT 0xfadebead
+#define DEBUG_LOCK_DEAD 0xdeadbeef
+
+typedef struct gf_debug_lock {
+    pthread_mutex_t mutex;
+    int tag;
+} gf_lock_t;
+
+static inline int
+LOCK_INIT(gf_lock_t *lock)
+{
+    assert(lock->tag != DEBUG_LOCK_INIT);
+    lock->tag = DEBUG_LOCK_INIT;
+    return pthread_mutex_init(&lock->mutex, NULL);
+}
+
+static inline int
+LOCK(gf_lock_t *lock)
+{
+    assert(lock->tag == DEBUG_LOCK_INIT);
+    return pthread_mutex_lock(&lock->mutex);
+}
+
+static inline int
+TRY_LOCK(gf_lock_t *lock)
+{
+    assert(lock->tag == DEBUG_LOCK_INIT);
+    return pthread_mutex_trylock(&lock->mutex);
+}
+
+static inline int
+UNLOCK(gf_lock_t *lock)
+{
+    assert(lock->tag == DEBUG_LOCK_INIT);
+    return pthread_mutex_unlock(&lock->mutex);
+}
+
+static inline int
+LOCK_DESTROY(gf_lock_t *lock)
+{
+    assert(lock->tag == DEBUG_LOCK_INIT);
+    lock->tag = DEBUG_LOCK_DEAD;
+    return pthread_mutex_destroy(&lock->mutex);
+}
+
+#else /* not GF_LOCK_DEBUG */
+
 typedef pthread_mutex_t gf_lock_t;
 
-#define LOCK_INIT(x) pthread_mutex_init(x, 0)
+#define LOCK_INIT(x) pthread_mutex_init(x, NULL)
 #define LOCK(x) pthread_mutex_lock(x)
 #define TRY_LOCK(x) pthread_mutex_trylock(x)
 #define UNLOCK(x) pthread_mutex_unlock(x)
 #define LOCK_DESTROY(x) pthread_mutex_destroy(x)
+
+#endif /* GF_LOCK_DEBUG */
 
 #endif /* _LOCKING_H */

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -710,6 +710,7 @@ iobuf_put(struct iobuf *iobuf)
 
     iobuf_arena = iobuf->iobuf_arena;
     if (!iobuf_arena) {
+        LOCK_DESTROY(&iobuf->lock);
         GF_FREE(iobuf->free_ptr);
         GF_FREE(iobuf);
         return;
@@ -808,6 +809,8 @@ iobref_destroy(struct iobref *iobref)
         if (iobuf)
             iobuf_unref(iobuf);
     }
+
+    LOCK_DESTROY(&iobref->lock);
 
     GF_FREE(iobref->iobrefs);
     GF_FREE(iobref);

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -1377,8 +1377,6 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     } else
         local->ctr_link_count_req = _gf_true;
 
-    LOCK_INIT(&frame->lock);
-
     STACK_WIND(frame, trash_unlink_stat_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->stat, loc, xdata);
 out:
@@ -2001,8 +1999,6 @@ trash_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
                    FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
         goto out;
     }
-
-    LOCK_INIT(&frame->lock);
 
     local = mem_get0(this->local_pool);
     if (!local) {

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -1346,6 +1346,7 @@ qr_init(xlator_t *this)
     }
 
     LOCK_INIT(&priv->table.lock);
+    LOCK_INIT(&priv->lock);
     conf = &priv->conf;
 
     GF_OPTION_INIT("max-file-size", conf->max_file_size, size_uint64, out);
@@ -1534,6 +1535,7 @@ qr_fini(xlator_t *this)
 
     qr_inode_table_destroy(priv);
     qr_conf_destroy(&priv->conf);
+    LOCK_DESTROY(&priv->lock);
 
     this->private = NULL;
 


### PR DESCRIPTION
Add `--enable-log-debug` build option to enable simple
debugging around `LOCK_INIT()`, `LOCK()`, `TRY_LOCK()`,
`UNLOCK()` and `LOCK_DESTROY()` calls, fix a few (most
probably not all) typical usage errors (double init,
double destroy, attempt to lock an uninitialized etc).

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000