### PR TITLE
dht: found anomalies in dht_layout

### DIFF
--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -406,10 +406,14 @@ static int
 dht_layout_entry_cmp(const void *p, const void *q)
 {
     const dht_layout_entry_t *x = p, *y = q;
+    int64_t diff = 0;
 
-    /* Swap zero'ed out layouts to front if needed. */
-    return (!y->start && !y->stop) ? (x->stop - y->stop) :
-        (x->start - y->start);
+    if (!y->start && !y->stop)
+        diff = (int64_t)x->stop - (int64_t)y->stop;
+    else
+        diff = (int64_t)x->start - (int64_t)y->start;
+
+    return (diff == 0 ? 0 : (diff < 0 ? -1 : 1));
 }
 
 static int


### PR DESCRIPTION
In the recent commit c4cbdbcb3d02fb56a62effda7ff90ae97f89546c we
have changed the sorting algorithm to qsort from selection sort
to sort the layout but the qsort comparison function has a bug.
Current dht_layout_entry_t has start/stop variable data type is
unit32_t and comparison function (dht_layout_entry_cmp) consider
difference of start/stop is integer so in case of overflow of value
the behavior of the comparison function changed due to that layout
has not set first time.After found the anomaly the layout has been
set but performance has been reduced significantly.

Solution: Correct the data type in comparison function
          (dht_layout_entry_cmp) to avoid an issue.
Fixes: #2835
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: I1a9bf458757fdf07bd409b6eebad347427f33f1e

