### PR TITLE
api, xlators, glusterfsd, libglusterfs: fix locking

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -682,6 +682,8 @@ glfs_fd_destroy(struct glfs_fd *glfd)
 
     GF_FREE(glfd->readdirbuf);
 
+    LOCK_DESTROY(&glfd->lock);
+
     GF_FREE(glfd);
 }
 
@@ -699,6 +701,8 @@ glfs_fd_new(struct glfs *fs)
     INIT_LIST_HEAD(&glfd->openfds);
 
     GF_REF_INIT(glfd, glfs_fd_destroy);
+
+    LOCK_INIT(&glfd->lock);
 
     return glfd;
 }
@@ -1207,6 +1211,8 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     GF_FREE(ctx->cmd_args.process_name);
 
     LOCK_DESTROY(&ctx->lock);
+    LOCK_DESTROY(&ctx->volfile_lock);
+
     pthread_mutex_destroy(&ctx->notify_lock);
     pthread_cond_destroy(&ctx->notify_cond);
 
@@ -1221,6 +1227,7 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     }
 
     GF_FREE(ctx->statedump_path);
+    FREE(ctx->hostname);
     FREE(ctx);
 
     return ret;

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2875,8 +2875,6 @@ glusterfs_mgmt_init(glusterfs_ctx_t *ctx)
     if (!options)
         goto out;
 
-    LOCK_INIT(&ctx->volfile_lock);
-
     if (cmd_args->volfile_server_port)
         port = cmd_args->volfile_server_port;
 

--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -944,7 +944,8 @@ event_pool_destroy_epoll(struct event_pool *event_pool)
             table = event_pool->ereg[i];
             event_pool->ereg[i] = NULL;
             for (j = 0; j < EVENT_EPOLL_SLOTS; j++) {
-                LOCK_DESTROY(&table[j].lock);
+                if (table[j].fd != -1)
+                    LOCK_DESTROY(&table[j].lock);
             }
             GF_FREE(table);
         }

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -710,6 +710,7 @@ iobuf_put(struct iobuf *iobuf)
 
     iobuf_arena = iobuf->iobuf_arena;
     if (!iobuf_arena) {
+        LOCK_DESTROY(&iobuf->lock);
         GF_FREE(iobuf->free_ptr);
         GF_FREE(iobuf);
         return;
@@ -808,6 +809,8 @@ iobref_destroy(struct iobref *iobref)
         if (iobuf)
             iobuf_unref(iobuf);
     }
+
+    LOCK_DESTROY(&iobref->lock);
 
     GF_FREE(iobref->iobrefs);
     GF_FREE(iobref);

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -1377,8 +1377,6 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     } else
         local->ctr_link_count_req = _gf_true;
 
-    LOCK_INIT(&frame->lock);
-
     STACK_WIND(frame, trash_unlink_stat_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->stat, loc, xdata);
 out:
@@ -2001,8 +1999,6 @@ trash_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
                    FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
         goto out;
     }
-
-    LOCK_INIT(&frame->lock);
 
     local = mem_get0(this->local_pool);
     if (!local) {

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -1346,6 +1346,7 @@ qr_init(xlator_t *this)
     }
 
     LOCK_INIT(&priv->table.lock);
+    LOCK_INIT(&priv->lock);
     conf = &priv->conf;
 
     GF_OPTION_INIT("max-file-size", conf->max_file_size, size_uint64, out);
@@ -1534,6 +1535,7 @@ qr_fini(xlator_t *this)
 
     qr_inode_table_destroy(priv);
     qr_conf_destroy(&priv->conf);
+    LOCK_DESTROY(&priv->lock);
 
     this->private = NULL;
 


### PR DESCRIPTION
Fix a few typical locking errors, including double initialization,
double destroy, and an attempt to use an unitialized lock here and
there. Free the hostname in `glusterfs_ctx_destroy()` as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

