### PR TITLE
server: fix memory leak during reconfiguration

### DIFF
--- a/xlators/protocol/server/src/authenticate.c
+++ b/xlators/protocol/server/src/authenticate.c
@@ -105,8 +105,14 @@ static int
 fini(dict_t *this, char *key, data_t *value, void *data)
 {
     auth_handle_t *handle = data_to_ptr(value);
+
     if (handle) {
         dlclose(handle->handle);
+
+        if (handle->vol_opt) {
+            list_del_init(&handle->vol_opt->list);
+            GF_FREE(handle->vol_opt);
+        }
     }
     return 0;
 }

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -871,7 +871,9 @@ server_reconfigure(xlator_t *this, dict_t *options)
     this->ctx->statedump_path = gf_strdup(statedump_path);
 
 do_auth:
-    if (!conf->auth_modules)
+    if (conf->auth_modules)
+        gf_auth_fini(conf->auth_modules);
+    else
         conf->auth_modules = dict_new();
 
     dict_foreach(options, get_auth_types, conf->auth_modules);


### PR DESCRIPTION
Free previously initialized authentication modules in
`server_reconfigure()` and so avoid memory leak during
the volume file change.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

