### PR TITLE
Added quick links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+<h1 align="center"><img src="https://www.gluster.org/wp-content/uploads/2016/03/gluster-ant.png" width="320" height="240" alt="Gluster is a free and open source software scalable network filesystem."></h1>
+
+<h4 align="center">
+    <a href="https://gluster.slack.com/">Slack</a> |
+    <a href="https://lists.gluster.org/mailman/listinfo">Mailing list</a> |
+    <a href="https://twitter.com/gluster">Twitter</a><br/><br/>
+    <a href="https://docs.gluster.org/en/latest/Quick-Start-Guide/Quickstart/">Quick Start Guide</a> |
+    <a href="https://docs.gluster.org/en/latest/release-notes/">Release Notes</a> |
+    <a href="https://www.gluster.org/community/">Community</a><br/><br/>
+    <a href="https://docs.gluster.org/en/latest/Contributors-Guide/Index/">Contribute to this project!</a>
+</h4>
+
+---
+
+<p align="left">
+    <a href="https://github.com/gluster/Gluster-Builds/actions"><img src="https://github.com/gluster/Gluster-Builds/actions/workflows/Nightly_Build_Fedora_Latest.yml/badge.svg" alt="Build Status"></a>
+    <a href="https://github.com/gluster/Gluster-Builds/actions"> <img src="https://github.com/gluster/Gluster-Builds/actions/workflows/Nightly_Build_Centos7.yml/badge.svg" alt="Coverage Status"></a>
+    <a href="https://github.com/gluster/Gluster-Builds/actions"><img src="https://github.com/gluster/Gluster-Builds/actions/workflows/Nightly_Build_Centos8.yml/badge.svg"></a>
+    <a href="https://github.com/gluster/Gluster-Builds/actions"><img src="https://github.com/gluster/Gluster-Builds/actions/workflows/nightly-build-debian.yml/badge.svg"></a>
+    <a href="https://github.com/gluster/Gluster-Builds/actions"><img src="https://github.com/gluster/Gluster-Builds/actions/workflows/nightly-build-ubuntu.yml/badge.svg"></a>
+    <a href="https://ci.centos.org/view/Gluster/job/gluster_build-rpms/"><img src="https://ci.centos.org/buildStatus/icon?job=gluster_build-rpms"></a>
+    <a href="https://scan.coverity.com/projects/gluster-glusterfs"><img src="https://scan.coverity.com/projects/987/badge.svg"></a>
+ </p>
+ 
 # Gluster
   Gluster is a software defined distributed storage that can scale to several
   petabytes. It provides interfaces for object, block and file storage.


### PR DESCRIPTION
Added quick links for various Gluster details like - Slack channel, mailing list, twitter, documentation(release notes, quick start guide, community) as well as daily nightly build status and coverity details.