### PR TITLE
iobuf: Call iobuf_get_from_small to allocate buffer by iobuf_get_from…

### DIFF
--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -451,7 +451,7 @@ iobuf_get_from_stdalloc(const size_t page_size, gf_boolean_t align_flag)
         goto out;
 
     if (align_flag)
-        align_size = page_size + GF_IOBUF_ALIGN_SIZE;
+        align_size = page_size + GF_IOBUF_ALIGN_SIZE - 1;
 
     iobuf->free_ptr = GF_MALLOC(align_size, gf_common_mt_iobuf_pool);
     if (!iobuf->free_ptr) {

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -4225,6 +4225,9 @@ ssl_setup_connection_params(rpc_transport_t *this)
         return 0;
     }
 
+    /* Load a SSL library only while ssl is enabled */
+    init_openssl_mt();
+
     if (!ssl_check_aes_bit()) {
         cipher_list = "AES128:" DEFAULT_CIPHER_LIST;
     }
@@ -4673,8 +4676,6 @@ int32_t
 init(rpc_transport_t *this)
 {
     int ret = -1;
-
-    init_openssl_mt();
 
     ret = socket_init(this);
 


### PR DESCRIPTION
…_stdalloc

The function iobuf_get_from_stdalloc call while a buffer_size is
greater than 1M and the function iobuf_get_from_small call
while size is less than 128k the only difference is iobuf_get_from_small
does not aligned the buffer so call iobuf_get_from_small to allocate
a buffer and realigned the buffer separately

Fixes: #2850
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

