### PR TITLE
posix: fix O_DIRECT usage

### DIFF
--- a/tests/bugs/glusterfs/bug-866459.t
+++ b/tests/bugs/glusterfs/bug-866459.t
@@ -21,7 +21,11 @@ TEST $CLI volume start $V0
 ## Mount FUSE with caching disabled
 TEST glusterfs --entry-timeout=0 --attribute-timeout=0 -s $H0 --volfile-id $V0 $M0;
 
+# Allocate test file and make sure it is not truncated
 dd of=$M0/a if=/dev/urandom bs=1024k count=1 2>&1 > /dev/null
+nbytes=`stat -c %s $M0/a`
+TEST [ $nbytes -eq 1048576 ]
+
 B0_hiphenated=`echo $B0 | tr '/' '-'`
 ## Bring a brick down
 TEST kill_brick $V0 $H0 $B0/${V0}1

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -639,6 +639,9 @@ posix_init(xlator_t *this)
     struct stat buf = {
         0,
     };
+    struct statvfs fs = {
+        0,
+    };
     gf_boolean_t tmp_bool = 0;
     int ret = 0;
     int op_ret = -1;
@@ -713,6 +716,13 @@ posix_init(xlator_t *this)
 
     _private->base_path = gf_strdup(dir_data->data);
     _private->base_path_length = dir_data->len - 1;
+
+    if (sys_statvfs(_private->base_path, &fs) < 0) {
+        ret = -1;
+        goto out;
+    }
+    GF_ASSERT((fs.f_bsize & (fs.f_bsize - 1)) == 0);
+    _private->base_bsize = fs.f_bsize;
 
     _private->dirfd = -1;
     _private->mount_lock = -1;

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -5954,7 +5954,10 @@ posix_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     LOCK(&fd->lock);
     {
         if (priv->aio_capable && priv->aio_init_done)
-            __posix_fd_set_odirect(fd, pfd, 0, offset, len);
+            __posix_fd_set_odirect(
+                fd, pfd, 0,
+                (DIRECT_ALIGNED(buf, priv) && DIRECT_ALIGNED(offset, priv) &&
+                 DIRECT_ALIGNED(len, priv)));
 
         bytes_read = sys_pread(_fd, buf, len, offset);
         if (bytes_read < 0) {


### PR DESCRIPTION
On Linux, `O_DIRECT` requires the buffer to be aligned at logical sector
size boundary, and both buffer size and file offset should be multiple
of the logical sector size as well. Usually it is equal to 512 bytes and
may be obtained by `BLKBSZGET` `ioctl()` on a device special file. On the
other side `O_DIRECT` may give better performance with chunks aligned/sized
to multiple of the logical filesystem block size. The latter is obtained
via `statvfs()` in `posix_init()` and used to check whether the chunk is
suitable for `O_DIRECT` where applicable.

Also fix false positive `tests/bugs/glusterfs/bug-866459.t` to check
whether the test file is not truncated.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000