### PR TITLE
snapshots: Support for ZFS Snapshots

### DIFF
--- a/tests/basic/volume-snapshot-clone-zfs.t
+++ b/tests/basic/volume-snapshot-clone-zfs.t
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+. $(dirname $0)/../volume.rc
+. $(dirname $0)/../cluster.rc
+. $(dirname $0)/../snapshot.rc
+. $(dirname $0)/../snapshot_zfs.rc
+
+
+V1="patchy2"
+
+function create_volumes() {
+        $CLI_1 volume create $V0 $H1:$L1 &
+        PID_1=$!
+
+        $CLI_2 volume create $V1 $H2:$L2 $H3:$L3 &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function create_snapshots() {
+
+        $CLI_1 snapshot create $1 $2 no-timestamp&
+        PID_1=$!
+
+        wait $PID_1
+}
+
+
+
+function delete_snapshot() {
+        $CLI_1 snapshot delete $1 &
+        PID_1=$!
+
+        wait $PID_1
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version;
+#Create cluster with 3 nodes
+TEST launch_cluster 3;
+TEST setup_zfs 3
+
+TEST $CLI_1 peer probe $H2;
+TEST $CLI_1 peer probe $H3;
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+
+create_volumes
+EXPECT 'Created' volinfo_field $V0 'Status';
+EXPECT 'Created' volinfo_field $V1 'Status';
+
+start_volumes 2
+EXPECT 'Started' volinfo_field $V0 'Status';
+EXPECT 'Started' volinfo_field $V1 'Status';
+
+TEST $CLI_1 snapshot config activate-on-create enable
+
+#Snapshot Operations
+create_snapshots ${V0}_snap ${V0};
+create_snapshots ${V1}_snap ${V1};
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+sleep 5
+TEST $CLI_1 snapshot clone ${V0}_clone ${V0}_snap
+TEST $CLI_1 snapshot clone ${V1}_clone ${V1}_snap
+
+EXPECT 'Created' volinfo_field ${V0}_clone 'Status';
+EXPECT 'Created' volinfo_field ${V1}_clone 'Status';
+
+TEST $CLI_1 volume start ${V0}_clone force;
+TEST $CLI_1 volume start ${V1}_clone force;
+
+EXPECT 'Started' volinfo_field ${V0}_clone 'Status';
+EXPECT 'Started' volinfo_field ${V1}_clone 'Status';
+
+
+TEST glusterfs -s $H1 --volfile-id=/${V0}_clone $M0
+TEST glusterfs -s $H2 --volfile-id=/${V1}_clone $M1
+
+TEST touch $M0/file1
+TEST touch $M1/file1
+
+TEST echo "Hello world" $M0/file1
+TEST echo "Hello world" $M1/file1
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M1
+
+TEST kill_glusterd 2;
+sleep 15
+TEST $glusterd_2;
+sleep 15
+
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field ${V0}_clone 'Status';
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field ${V1}_clone 'Status';
+
+TEST $CLI_1 volume stop ${V0}_clone
+TEST $CLI_1 volume stop ${V1}_clone
+
+TEST $CLI_1 volume delete ${V0}_clone
+TEST $CLI_1 volume delete ${V1}_clone
+
+TEST $CLI_1 snapshot clone ${V0}_clone ${V0}_snap
+TEST $CLI_1 snapshot clone ${V1}_clone ${V1}_snap
+
+EXPECT 'Created' volinfo_field ${V0}_clone 'Status';
+EXPECT 'Created' volinfo_field ${V1}_clone 'Status';
+
+#Clean up
+stop_force_volumes 2
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT 'Stopped' volinfo_field $V0 'Status';
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT 'Stopped' volinfo_field $V1 'Status';
+
+TEST delete_snapshot ${V0}_snap
+TEST delete_snapshot ${V1}_snap
+
+TEST ! snapshot_exists 1 ${V0}_snap
+TEST ! snapshot_exists 1 ${V1}_snap
+
+delete_volumes 2
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT "N" volume_exists $V0
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT "N" volume_exists $V1
+
+cleanup;

--- a/tests/basic/volume-snapshot-xml-zfs.t
+++ b/tests/basic/volume-snapshot-xml-zfs.t
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+. $(dirname $0)/../volume.rc
+. $(dirname $0)/../snapshot.rc
+. $(dirname $0)/../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+
+# Snapshot config xmls
+EXPECT "enable" get-xml "snapshot config activate-on-create enable" "activateOnCreate"
+EXPECT "100" get-xml "snapshot config $V0 snap-max-hard-limit 100" "newHardLimit"
+EXPECT "70" get-xml "snapshot config snap-max-soft-limit 70" "newSoftLimit"
+EXPECT "enable" get-xml "snapshot config auto-delete enable" "autoDelete"
+
+# Snapshot create, activate, deactivate xmls
+EXPECT "snap1" get-xml "snapshot create snap1 $V0 no-timestamp" "name"
+EXPECT "snap1" get-xml "snapshot deactivate snap1" "name"
+EXPECT "snap1" get-xml "snapshot activate snap1" "name"
+EXPECT "snap2" get-xml "snapshot create snap2 $V0 no-timestamp" "name"
+
+# Snapshot info xmls
+EXPECT "2" get-xml "snapshot info" "count"
+EXPECT "Started" get-xml "snapshot info" "status"
+EXPECT "2" get-xml "snapshot info volume $V0" "count"
+EXPECT "Started" get-xml "snapshot info volume $V0" "status"
+EXPECT "1" get-xml "snapshot info snap1" "count"
+EXPECT "2" get-xml "snapshot info snap1" "snapCount"
+EXPECT "Started" get-xml "snapshot info snap1" "status"
+
+# Snapshot list xmls
+EXPECT "2" get-xml "snapshot list" "count"
+EXPECT "snap2" get-xml "snapshot list $V0" "snapshot"
+
+# Snapshot status xmls
+EXPECT "snap2" get-xml "snapshot status" "name"
+EXPECT "snap2" get-xml "snapshot deactivate snap2" "name"
+#XPECT "N/A" get-xml "snapshot status" "pid"
+EXPECT "snap1" get-xml "snapshot status snap1" "name"
+EXPECT "Yes" get-xml "snapshot status snap1" "brick_running"
+
+# Snapshot restore xmls
+TEST $CLI volume stop $V0
+EXPECT "snap2" get-xml "snapshot restore snap2" "name"
+EXPECT "30807" get-xml "snapshot restore snap2" "opErrno"
+EXPECT "0" get-xml "snapshot restore snap1" "opErrno"
+
+# Snapshot delete xmls
+TEST $CLI volume start $V0 force
+EXPECT "snap1" get-xml "snapshot create snap1 $V0 no-timestamp" "name"
+EXPECT "snap2" get-xml "snapshot create snap2 $V0 no-timestamp" "name"
+EXPECT "snap3" get-xml "snapshot create snap3 $V0 no-timestamp" "name"
+EXPECT "Success" get-xml "snapshot delete snap3" "status"
+EXPECT "Success" get-xml "snapshot delete all" "status"
+EXPECT "0" get-xml "snapshot list" "count"
+#XPECT "snap1" get-xml "snapshot create snap1 $V0 no-timestamp" "name"
+#XPECT "snap2" get-xml "snapshot create snap2 $V0 no-timestamp" "name"
+#XPECT "snap3" get-xml "snapshot create snap3 $V0 no-timestamp" "name"
+#XPECT "Success" get-xml "snapshot delete volume $V0" "status"
+#XPECT "0" get-xml "snapshot list" "count"
+
+# Snapshot clone xmls
+# Snapshot clone xml is broken. Once it is fixed it will be added here.
+
+cleanup;

--- a/tests/basic/volume-snapshot-zfs.t
+++ b/tests/basic/volume-snapshot-zfs.t
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+. $(dirname $0)/../include.rc
+. $(dirname $0)/../volume.rc
+. $(dirname $0)/../cluster.rc
+. $(dirname $0)/../snapshot.rc
+. $(dirname $0)/../snapshot_zfs.rc
+
+
+V1="patchy2"
+
+function create_volumes() {
+        $CLI_1 volume create $V0 $H1:$L1 &
+        PID_1=$!
+
+        $CLI_2 volume create $V1 $H2:$L2 $H3:$L3 &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function create_snapshots() {
+        $CLI_1 snapshot create ${V0}_snap ${V0} no-timestamp &
+        PID_1=$!
+
+        $CLI_1 snapshot create ${V1}_snap ${V1} no-timestamp &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function create_snapshots_with_timestamp() {
+        $CLI_1 snapshot create ${V0}_snap1 ${V0}&
+        PID_1=$!
+        $CLI_1 snapshot create ${V1}_snap1 ${V1}&
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+
+function activate_snapshots() {
+        $CLI_1 snapshot activate ${V0}_snap &
+        PID_1=$!
+
+        $CLI_1 snapshot activate ${V1}_snap &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function deactivate_snapshots() {
+        $CLI_1 snapshot deactivate ${V0}_snap &
+        PID_1=$!
+
+        $CLI_1 snapshot deactivate ${V1}_snap &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function delete_snapshots() {
+        $CLI_1 snapshot delete $1 &
+        PID_1=$!
+
+        $CLI_1 snapshot delete $2 &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function restore_snapshots() {
+        $CLI_1 snapshot restore ${V0}_snap &
+        PID_1=$!
+
+        $CLI_1 snapshot restore ${V1}_snap &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version;
+#Create cluster with 3 nodes
+TEST launch_cluster 3;
+TEST setup_zfs 3
+
+TEST $CLI_1 peer probe $H2;
+TEST $CLI_1 peer probe $H3;
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+
+create_volumes
+EXPECT 'Created' volinfo_field $V0 'Status';
+EXPECT 'Created' volinfo_field $V1 'Status';
+
+start_volumes 2
+EXPECT 'Started' volinfo_field $V0 'Status';
+EXPECT 'Started' volinfo_field $V1 'Status';
+
+TEST $CLI_1 snapshot config activate-on-create enable
+
+#Snapshot Operations
+create_snapshots
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+EXPECT '1' volinfo_field $V0 'Snapshot Count';
+EXPECT '1' volinfo_field $V1 'Snapshot Count';
+EXPECT "1" get-cmd-field-xml "volume info $V0" "snapshotCount"
+EXPECT "1" get-cmd-field-xml "volume info $V1" "snapshotCount"
+
+deactivate_snapshots
+
+EXPECT 'Stopped' snapshot_status ${V0}_snap;
+EXPECT 'Stopped' snapshot_status ${V1}_snap;
+
+activate_snapshots
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+deactivate_snapshots
+activate_snapshots
+
+TEST snapshot_exists 1 ${V0}_snap
+TEST snapshot_exists 1 ${V1}_snap
+TEST $CLI_1 snapshot config $V0 snap-max-hard-limit 100
+TEST $CLI_1 snapshot config $V1 snap-max-hard-limit 100
+
+TEST glusterfs -s $H1 --volfile-id=/snaps/${V0}_snap/${V0} $M0
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+TEST glusterfs -s $H2 --volfile-id=/snaps/${V1}_snap/${V1} $M0
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+#create timestamp appended snaps
+create_snapshots_with_timestamp;
+new_name1=`$CLI_1 snapshot list ${V0} | grep ${V0}_snap1`;
+new_name2=`$CLI_1 snapshot list ${V1} | grep ${V1}_snap1`;
+
+EXPECT '2' volinfo_field $V0 'Snapshot Count';
+EXPECT '2' volinfo_field $V1 'Snapshot Count';
+EXPECT "2" get-cmd-field-xml "volume info $V0" "snapshotCount"
+EXPECT "2" get-cmd-field-xml "volume info $V1" "snapshotCount"
+
+EXPECT_NOT "{V0}_snap1" echo $new_name1;
+EXPECT_NOT "{V1}_snap1" echo $new_name1;
+delete_snapshots $new_name1 $new_name2;
+
+EXPECT '1' volinfo_field $V0 'Snapshot Count';
+EXPECT '1' volinfo_field $V1 'Snapshot Count';
+EXPECT "1" get-cmd-field-xml "volume info $V0" "snapshotCount"
+EXPECT "1" get-cmd-field-xml "volume info $V1" "snapshotCount"
+
+#Clean up
+stop_force_volumes 2
+EXPECT 'Stopped' volinfo_field $V0 'Status';
+EXPECT 'Stopped' volinfo_field $V1 'Status';
+
+restore_snapshots
+TEST ! snapshot_exists 1 ${V0}_snap
+TEST ! snapshot_exists 1 ${V1}_snap
+
+EXPECT '0' volinfo_field $V0 'Snapshot Count';
+EXPECT '0' volinfo_field $V1 'Snapshot Count';
+EXPECT "0" get-cmd-field-xml "volume info $V0" "snapshotCount"
+EXPECT "0" get-cmd-field-xml "volume info $V1" "snapshotCount"
+
+delete_volumes 2
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT "N" volume_exists $V0
+EXPECT_WITHIN $CONFIG_UPDATE_TIMEOUT "N" volume_exists $V1
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1045333-zfs.t
+++ b/tests/bugs/snapshot/bug-1045333-zfs.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+
+
+S1="${V0}-snap1"    #Create snapshot with name contains hyphen(-)
+S2="-${V0}-snap2"   #Create snapshot with name starts with hyphen(-)
+#Create snapshot with a long name
+S3="${V0}_single_gluster_volume_is_accessible_by_multiple_clients_offline_snapshot_is_a_long_name"
+
+TEST $CLI snapshot create $S1 $V0 no-timestamp
+TEST snapshot_exists 0 $S1
+
+TEST $CLI snapshot create $S2 $V0 no-timestamp
+TEST snapshot_exists 0 $S2
+
+TEST $CLI snapshot create $S3 $V0 no-timestamp
+TEST snapshot_exists 0 $S3
+
+
+TEST glusterfs -s $H0 --volfile-id=/snaps/$S1/$V0 $M0
+TEST glusterfs -s $H0 --volfile-id=/snaps/$S2/$V0 $M1
+TEST glusterfs -s $H0 --volfile-id=/snaps/$S3/$V0 $M2
+
+#Clean up
+#TEST $CLI snapshot delete $S1
+#TEST $CLI snapshot delete $S2
+#TEST $CLI snapshot delete $S3
+
+TEST $CLI volume stop $V0 force
+#TEST $CLI volume delete $V0
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1049834-zfs.t
+++ b/tests/bugs/snapshot/bug-1049834-zfs.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version
+TEST launch_cluster 2
+TEST setup_zfs 2
+
+TEST $CLI_1 peer probe $H2
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+TEST $CLI_1 volume create $V0 $H1:$L1 $H2:$L2
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status'
+
+#Setting the snap-max-hard-limit to 4
+TEST $CLI_1 snapshot config $V0 snap-max-hard-limit 4
+PID_1=$!
+wait $PID_1
+
+#Creating 3 snapshots on the volume (which is the soft-limit)
+TEST create_n_snapshots $V0 3 $V0_snap
+TEST snapshot_n_exists $V0 3 $V0_snap
+
+#Creating the 4th snapshot on the volume and expecting it to be created
+# but with the deletion of the oldest snapshot i.e 1st snapshot
+TEST  $CLI_1 snapshot create ${V0}_snap4 ${V0} no-timestamp
+TEST  snapshot_exists 1 ${V0}_snap4
+TEST ! snapshot_exists 1 ${V0}_snap1
+TEST $CLI_1 snapshot delete ${V0}_snap4
+TEST $CLI_1 snapshot create ${V0}_snap1 ${V0} no-timestamp
+TEST snapshot_exists 1 ${V0}_snap1
+
+#Deleting the 4 snaps
+#TEST delete_n_snapshots $V0 4 $V0_snap
+#TEST ! snapshot_n_exists $V0 4 $V0_snap
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1087203-zfs.t
+++ b/tests/bugs/snapshot/bug-1087203-zfs.t
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../cluster.rc
+
+function get_volume_info ()
+{
+        local var=$1
+        $CLI_1 volume info $V0 | grep "^$var" | sed 's/.*: //'
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version
+TEST launch_cluster 2
+TEST setup_zfs 2
+
+TEST $CLI_1 peer probe $H2;
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count;
+
+TEST $CLI_1 volume create $V0 $H1:$L1 $H2:$L2
+EXPECT "$V0" get_volume_info 'Volume Name';
+EXPECT 'Created' get_volume_info 'Status';
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' get_volume_info 'Status';
+
+
+# Setting system limit
+TEST $CLI_1 snapshot config snap-max-hard-limit 100
+
+# Volume limit cannot exceed system limit, as limit is set to 100,
+# this should fail.
+TEST ! $CLI_1 snapshot config $V0 snap-max-hard-limit 101
+
+# Following are the invalid cases
+TEST ! $CLI_1 snapshot config $V0 snap-max-hard-limit a10
+TEST ! $CLI_1 snapshot config snap-max-hard-limit 10a
+TEST ! $CLI_1 snapshot config snap-max-hard-limit 10%
+TEST ! $CLI_1 snapshot config snap-max-soft-limit 50%1
+TEST ! $CLI_1 snapshot config snap-max-soft-limit 0111
+TEST ! $CLI_1 snapshot config snap-max-hard-limit OXA
+TEST ! $CLI_1 snapshot config snap-max-hard-limit 11.11
+TEST ! $CLI_1 snapshot config snap-max-soft-limit 50%
+TEST ! $CLI_1 snapshot config snap-max-hard-limit -100
+TEST ! $CLI_1 snapshot config snap-max-soft-limit -90
+
+# Soft limit cannot be assigned to volume
+TEST ! $CLI_1 snapshot config $V0 snap-max-soft-limit 10
+
+# Valid case
+TEST $CLI_1 snapshot config snap-max-soft-limit 50
+TEST $CLI_1 snapshot config $V0 snap-max-hard-limit 10
+
+# Validating auto-delete feature
+# Make sure auto-delete is disabled by default
+EXPECT 'disable' snap_config CLI_1 'auto-delete'
+
+# Test for invalid value for auto-delete
+TEST ! $CLI_1 snapshot config auto-delete test
+
+TEST $CLI_1 snapshot config snap-max-hard-limit 6
+TEST $CLI_1 snapshot config snap-max-soft-limit 50
+
+# Create 4 snapshots
+snap_index=1
+snap_count=4
+TEST snap_create CLI_1 $V0 $snap_index $snap_count
+
+# If auto-delete is disabled then oldest snapshot
+# should not be deleted automatically.
+EXPECT '4' get_snap_count CLI_1;
+
+TEST snap_delete CLI_1 $snap_index $snap_count;
+
+# After all those 4 snaps are deleted, There will not be any snaps present
+EXPECT '0' get_snap_count CLI_1;
+
+TEST $CLI_1 snapshot config auto-delete enable
+
+# auto-delete is already enabled, Hence expect a failure.
+TEST ! $CLI_1 snapshot config auto-delete on
+
+# Testing other boolean values with auto-delete
+TEST $CLI_1 snapshot config auto-delete off
+EXPECT 'off' snap_config CLI_1 'auto-delete'
+
+TEST $CLI_1 snapshot config auto-delete true
+EXPECT 'true' snap_config CLI_1 'auto-delete'
+
+# Try to create 4 snaps again, As auto-delete is enabled
+# oldest snap should be deleted and snapcount should be 3
+
+TEST snap_create CLI_1 $V0 $snap_index $snap_count;
+EXPECT '3' get_snap_count CLI_1;
+
+TEST $CLI_1 snapshot config auto-delete disable
+EXPECT 'disable' snap_config CLI_1 'auto-delete'
+
+cleanup;
+

--- a/tests/bugs/snapshot/bug-1090042-zfs.t
+++ b/tests/bugs/snapshot/bug-1090042-zfs.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+TEST glusterd;
+
+TEST $CLI volume create $V0 replica 3 $H0:$L1 $H0:$L2 $H0:$L3;
+TEST $CLI volume start $V0;
+
+TEST kill_brick $V0 $H0 $L1;
+
+#Normal snap create should fail
+TEST !  $CLI snapshot create ${V0}_snap1 $V0 no-timestamp;
+TEST !  snapshot_exists 0 ${V0}_snap1;
+
+#With changes introduced in BZ #1184344 force snap create should fail too
+TEST  ! $CLI snapshot create ${V0}_snap1 $V0 no-timestamp;
+TEST  ! snapshot_exists 0 ${V0}_snap1;
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1109770-zfs.t
+++ b/tests/bugs/snapshot/bug-1109770-zfs.t
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../fileio.rc
+. $(dirname $0)/../../nfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+
+TEST glusterd;
+
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+
+TEST $CLI volume start $V0;
+
+TEST glusterfs --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+for i in {1..10} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+
+for i in {11..20} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot create snap2 $V0 no-timestamp;
+
+mkdir $M0/dir1;
+mkdir $M0/dir2;
+
+for i in {1..10} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {1..10} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+TEST $CLI snapshot create snap3 $V0 no-timestamp;
+
+for i in {11..20} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {11..20} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+TEST $CLI snapshot create snap4 $V0 no-timestamp;
+
+TEST $CLI volume set $V0 features.uss enable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+TEST $CLI volume set $V0 features.uss disable;
+
+SNAPD_PID=$(ps auxww | grep snapd | grep -v grep | awk '{print $2}');
+
+TEST ! [ $SNAPD_PID -gt 0 ];
+
+TEST $CLI volume set $V0 features.uss enable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+TEST $CLI volume stop $V0;
+
+SNAPD_PID=$(ps auxww | grep snapd | grep -v grep | awk '{print $2}');
+
+TEST ! [ $SNAPD_PID -gt 0 ];
+
+cleanup  ;

--- a/tests/bugs/snapshot/bug-1109889-zfs.t
+++ b/tests/bugs/snapshot/bug-1109889-zfs.t
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../fileio.rc
+. $(dirname $0)/../../nfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+
+TEST glusterd;
+
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+
+TEST $CLI volume start $V0;
+
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+MOUNT_PID=$(get_mount_process_pid $V0 $M0)
+
+for i in {1..10} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot config activate-on-create enable
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+
+for i in {11..20} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot create snap2 $V0 no-timestamp;
+
+mkdir $M0/dir1;
+mkdir $M0/dir2;
+
+for i in {1..10} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {1..10} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+TEST $CLI snapshot create snap3 $V0 no-timestamp;
+
+for i in {11..20} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {11..20} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+TEST $CLI snapshot create snap4 $V0 no-timestamp;
+
+TEST $CLI volume set $V0 features.uss enable;
+
+#let snapd get started properly and client connect to snapd
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" snap_client_connected_status $V0
+
+SNAPD_PID=$(ps auxww | grep snapd | grep -v grep | awk '{print $2}');
+
+TEST [ $SNAPD_PID -gt 0 ];
+
+TEST stat $M0/.snaps;
+
+kill -KILL $SNAPD_PID;
+
+# let snapd die properly
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "0" snap_client_connected_status $V0
+
+TEST ! stat $M0/.snaps;
+
+TEST $CLI volume start $V0 force;
+
+# let client get the snapd port from glusterd and connect
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" snap_client_connected_status $V0
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/.snaps
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1112613-zfs.t
+++ b/tests/bugs/snapshot/bug-1112613-zfs.t
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../cluster.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+V1="patchy2"
+
+TEST verify_zfs_version;
+TEST launch_cluster 2
+TEST setup_zfs 2
+
+TEST $CLI_1 peer probe $H2
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+TEST $CLI_1 volume create $V0 $H1:$L1
+TEST $CLI_1 volume start $V0
+TEST $CLI_1 volume create $V1 $H2:$L2
+TEST $CLI_1 volume start $V1
+
+# Create 3 snapshots for volume $V0
+snap_count=3
+snap_index=1
+TEST snap_create CLI_1 $V0 $snap_index $snap_count;
+
+# Create 3 snapshots for volume $V1
+snap_count=4
+snap_index=11
+TEST snap_create CLI_1 $V1 $snap_index $snap_count;
+
+EXPECT '3' get_snap_count CLI_1 $V0;
+EXPECT '4' get_snap_count CLI_1 $V1;
+EXPECT '7' get_snap_count CLI_1
+
+TEST $CLI_1 snapshot delete volume $V0
+EXPECT '0' get_snap_count CLI_1 $V0;
+EXPECT '4' get_snap_count CLI_1 $V1;
+EXPECT '4' get_snap_count CLI_1
+
+TEST $CLI_1 snapshot delete all
+EXPECT '0' get_snap_count CLI_1 $V0;
+EXPECT '0' get_snap_count CLI_1 $V1;
+EXPECT '0' get_snap_count CLI_1
+
+cleanup;
+

--- a/tests/bugs/snapshot/bug-1113975-zfs.t
+++ b/tests/bugs/snapshot/bug-1113975-zfs.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+
+TEST glusterd;
+
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+
+TEST $CLI volume start $V0;
+
+TEST glusterfs --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+for i in {1..10} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+
+for i in {11..20} ; do echo "file" > $M0/file$i ; done
+
+TEST $CLI snapshot create snap2 $V0 no-timestamp;
+
+TEST $CLI volume stop $V0
+
+TEST $CLI snapshot restore snap1;
+
+TEST $CLI snapshot restore snap2;
+
+TEST $CLI volume start $V0
+
+cleanup  ;

--- a/tests/bugs/snapshot/bug-1155042-dont-display-deactivated-snapshots-zfs.t
+++ b/tests/bugs/snapshot/bug-1155042-dont-display-deactivated-snapshots-zfs.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 2
+TEST setup_zfs 2
+TEST glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2
+TEST $CLI volume start $V0
+
+# enable uss and mount the volume
+TEST $CLI volume set $V0 features.uss enable
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
+
+# create 10 snapshots and check if all are being reflected
+# in the USS world
+gluster snapshot config activate-on-create enable
+for i in {1..10}; do $CLI snapshot create snap$i $V0 no-timestamp; done
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 10 uss_count_snap_displayed $M0
+
+# snapshots should not be displayed after deactivation
+for i in {1..10}; do $CLI snapshot deactivate snap$i --mode=script; done
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 0 uss_count_snap_displayed $M0
+
+# activate all the snapshots and check if all the activated snapshots
+# are displayed again
+for i in {1..10}; do $CLI snapshot activate snap$i --mode=script; done
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 10 uss_count_snap_displayed $M0
+
+cleanup;
+

--- a/tests/bugs/snapshot/bug-1157991-zfs.t
+++ b/tests/bugs/snapshot/bug-1157991-zfs.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+EXPECT 'Stopped' snapshot_status snap1;
+
+TEST $CLI snapshot config activate-on-create enable
+TEST $CLI snapshot create snap2 $V0 no-timestamp
+EXPECT 'Started' snapshot_status snap2;
+
+#Clean up
+TEST $CLI snapshot delete snap1
+TEST $CLI snapshot delete snap2
+
+TEST $CLI volume stop $V0 force
+TEST $CLI volume delete $V0
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1162462-zfs.t
+++ b/tests/bugs/snapshot/bug-1162462-zfs.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+TEST $CLI volume start $V0;
+TEST $CLI volume set $V0 features.uss enable;
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+mkdir $M0/test
+echo "file1" > $M0/file1
+ln -s $M0/file1 $M0/test/file_symlink
+ls -l $M0/ > /dev/null
+ls -l $M0/test/ > /dev/null
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+$CLI snapshot activate snap1;
+EXPECT 'Started' snapshot_status snap1;
+
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" snap_client_connected_status $V0
+ls $M0/.snaps/snap1/test/ > /dev/null
+ls -l $M0/.snaps/snap1/test/ > /dev/null
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" snap_client_connected_status $V0
+
+TEST $CLI snapshot delete snap1;
+TEST $CLI volume stop $V0;
+TEST $CLI volume delete $V0;
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1162498-zfs.t
+++ b/tests/bugs/snapshot/bug-1162498-zfs.t
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+
+TEST $CLI snapshot config activate-on-create enable
+TEST $CLI volume set $V0 features.uss enable
+
+TEST glusterfs -s $H0 --volfile-id=$V0 $M0
+
+TEST mkdir $M0/xyz
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+TEST $CLI snapshot create snap2 $V0 no-timestamp
+
+TEST rmdir $M0/xyz
+
+TEST $CLI snapshot create snap3 $V0 no-timestamp
+TEST $CLI snapshot create snap4 $V0 no-timestamp
+
+TEST mkdir $M0/xyz
+TEST ls $M0/xyz/.snaps/
+
+TEST $CLI volume stop $V0
+TEST $CLI snapshot restore snap2
+TEST $CLI volume start $V0
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+TEST glusterfs -s $H0 --volfile-id=$V0 $M0
+
+#Dir xyz exists in snap1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/xyz
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "3" count_snaps $M0/xyz
+TEST mkdir $M0/abc
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "3" count_snaps $M0/abc
+
+#Clean up
+TEST $CLI snapshot delete snap1
+TEST $CLI snapshot delete snap3
+TEST $CLI snapshot delete snap4
+TEST $CLI volume stop $V0 force
+TEST $CLI volume delete $V0
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1166197-zfs.t
+++ b/tests/bugs/snapshot/bug-1166197-zfs.t
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../nfs.rc
+
+#G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+CURDIR=`pwd`
+
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume set $V0 nfs.disable false
+TEST $CLI volume start $V0
+TEST $CLI snapshot config activate-on-create enable
+TEST $CLI volume set $V0 features.uss enable
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field $V0 'Status';
+EXPECT_WITHIN $NFS_EXPORT_TIMEOUT "1" is_nfs_export_available;
+TEST mount_nfs $H0:/$V0 $N0 nolock
+TEST mkdir $N0/testdir
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+TEST $CLI snapshot create snap2 $V0 no-timestamp
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $N0/testdir/.snaps
+
+TEST cd $N0/testdir
+TEST cd .snaps
+TEST ls
+
+TEST $CLI snapshot deactivate snap2
+TEST ls
+
+TEST cd $CURDIR
+
+#Clean up
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" umount_nfs $N0
+TEST $CLI snapshot delete snap1
+TEST $CLI snapshot delete snap2
+TEST $CLI volume stop $V0 force
+TEST $CLI volume delete $V0
+
+cleanup;
+

--- a/tests/bugs/snapshot/bug-1167580-set-proper-uid-and-gid-during-nfs-access-zfs.t
+++ b/tests/bugs/snapshot/bug-1167580-set-proper-uid-and-gid-during-nfs-access-zfs.t
@@ -1,0 +1,211 @@
+#!/bin/bash
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../nfs.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+#G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
+
+# This function returns a value "Y" if user can execute
+# the given command. Else it will return "N"
+# @arg-1 : Name of the user
+# @arg-2 : Path of the file
+# @arg-3 : command to be executed
+function check_if_permitted () {
+        local usr=$1
+        local path=$2
+        local cmd=$3
+        local var
+        local ret
+        var=$(su - $usr -c "$cmd $path")
+        ret=$?
+
+        if [ "$cmd" == "cat" ]
+        then
+                if [ "$var" == "Test" ]
+                then
+                        echo "Y"
+                else
+                        echo "N"
+                fi
+        else
+                if [ "$ret" == "0" ]
+                then
+                        echo "Y"
+                else
+                        echo "N"
+                fi
+        fi
+}
+
+# Create a directory in /tmp to specify which directory to make
+# as home directory for user
+home_dir=$(mktemp -d)
+chmod 777 $home_dir
+
+function get_new_user() {
+        local temp=$(uuidgen | tr -dc 'a-zA-Z' | head -c 8)
+        id $temp
+        if [ "$?" == "0" ]
+        then
+                get_new_user
+        else
+                echo $temp
+        fi
+}
+
+function create_user() {
+        local user=$1
+        local group=$2
+
+        if [ "$group" == "" ]
+        then
+                /usr/sbin/useradd -d $home_dir/$user $user
+        else
+                /usr/sbin/useradd -d $home_dir/$user -G $group $user
+        fi
+
+        return $?
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST setup_zfs 1
+TEST glusterd
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume set $V0 nfs.disable false
+TEST $CLI volume start $V0
+
+# Mount the volume as both fuse and nfs mount
+EXPECT_WITHIN $NFS_EXPORT_TIMEOUT "1" is_nfs_export_available
+TEST glusterfs -s $H0 --volfile-id $V0 $M0
+TEST mount_nfs $H0:/$V0 $N0 nolock
+
+# Create 2 user
+user1=$(get_new_user)
+create_user $user1
+user2=$(get_new_user)
+create_user $user2
+
+# create a file for which only user1 has access
+echo "Test" > $M0/README
+chown $user1 $M0/README
+chmod 700 $M0/README
+
+# enable uss and take a snapshot
+TEST $CLI volume set $V0 uss enable
+TEST $CLI snapshot config activate-on-create on
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+
+# try to access the file using user1 account.
+# It should succeed with both normal mount and snapshot world.
+# There is time delay in which snapd might not have got the notification
+# from glusterd about snapshot create hence using "EXPECT_WITHIN"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user1 $M0/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user1 $N0/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user1 $M0/.snaps/snap1/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user1 $N0/.snaps/snap1/README cat
+
+
+# try to access the file using user2 account
+# It should fail from both normal mount and snapshot world
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user2 $M0/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user2 $N0/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user2 $M0/.snaps/snap1/README cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user2 $N0/.snaps/snap1/README cat
+
+# We need to test another scenario where user belonging to one group
+# tries to access files from user belonging to another group
+# instead of using the already created users and making the test case look complex
+# I thought of using two different users.
+
+# The test case written below does the following things
+# 1) Create 2 users (user{3,4}), belonging to 2 different groups (group{3,4})
+# 2) Take a snapshot "snap2"
+# 3) Create a file for which only users belonging to group3 have
+# permission to read
+# 4) Test various combinations of Read-Write, Fuse-NFS mount, User{3,4,5}
+#    from both normal mount, and USS world.
+
+echo "Test" > $M0/file3
+
+chmod 740 $M0/file3
+
+group3=$(get_new_user)
+groupadd $group3
+
+group4=$(get_new_user)
+groupadd $group4
+
+user3=$(get_new_user)
+create_user $user3 $group3
+
+user4=$(get_new_user)
+create_user $user4 $group4
+
+user5=$(get_new_user)
+create_user $user5
+
+chgrp $group3 $M0/file3
+
+TEST $CLI snapshot create snap2 $V0 no-timestamp
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user3 $M0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user3 $M0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user3 $M0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user3 $M0/.snaps/snap2/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user3 $N0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" check_if_permitted $user3 $N0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user3 $N0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user3 $N0/.snaps/snap2/file3 "echo Hello >"
+
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $M0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $M0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $M0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $M0/.snaps/snap2/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $N0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $N0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $N0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user4 $N0/.snaps/snap2/file3 "echo Hello >"
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $M0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $M0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $M0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $M0/.snaps/snap2/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $N0/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $N0/.snaps/snap2/file3 cat
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $N0/file3 "echo Hello >"
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "N" check_if_permitted $user5 $N0/.snaps/snap2/file3 "echo Hello >"
+
+# cleanup
+/usr/sbin/userdel -f -r $user1
+/usr/sbin/userdel -f -r $user2
+/usr/sbin/userdel -f -r $user3
+/usr/sbin/userdel -f -r $user4
+/usr/sbin/userdel -f -r $user5
+
+#cleanup all the home directory which is created as part of this test case
+if [ -d "$home_dir" ]
+then
+        rm -rf $home_dir
+fi
+
+
+groupdel $group3
+groupdel $group4
+
+TEST $CLI snapshot delete all
+
+cleanup;
+
+
+#G_TESTDEF_TEST_STATUS_NETBSD7=BAD_TEST,BUG=000000
+#G_TESTDEF_TEST_STATUS_CENTOS6=BAD_TEST,BUG=000000

--- a/tests/bugs/snapshot/bug-1168875-zfs.t
+++ b/tests/bugs/snapshot/bug-1168875-zfs.t
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../fileio.rc
+. $(dirname $0)/../../nfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+function check_entry_point_exists ()
+{
+        local entry_point=$1;
+        local _path=$2;
+
+        ls -a $_path | grep $entry_point;
+
+        if [ $? -eq 0 ]; then
+            echo 'Y';
+        else
+            echo 'N';
+        fi
+}
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+
+TEST glusterd;
+
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+
+TEST $CLI volume start $V0;
+
+TEST glusterfs --volfile-server=$H0 --volfile-id=$V0 --xlator-option *-snapview-client.snapdir-entry-path=/dir $M0;
+
+TEST glusterfs --volfile-server=$H0 --volfile-id=$V0 $N0;
+for i in {1..10} ; do echo "file" > $M0/file$i ; done
+
+
+for i in {11..20} ; do echo "file" > $M0/file$i ; done
+
+mkdir $M0/dir;
+
+for i in {1..10} ; do echo "file" > $M0/dir/file$i ; done
+
+mkdir $M0/dir1;
+mkdir $M0/dir2;
+
+for i in {1..10} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {1..10} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+for i in {11..20} ; do echo "foo" > $M0/dir1/foo$i ; done
+for i in {11..20} ; do echo "foo" > $M0/dir2/foo$i ; done
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+TEST $CLI snapshot activate snap1;
+
+TEST $CLI volume set $V0 features.uss enable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists .snaps $M0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists .snaps $N0/dir
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists .snaps $M0/dir1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists .snaps $N0/dir1
+
+TEST $CLI volume set $V0 features.show-snapshot-directory enable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $N0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/dir1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $N0/dir1
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_entry_point_exists ".snaps" $M0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $N0/dir
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $M0/dir1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $N0/dir1
+
+TEST $CLI volume set $V0 features.show-snapshot-directory disable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $N0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $M0/dir1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" STAT $N0/dir1
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $M0/dir
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $N0/dir
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $M0/dir1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'N' check_entry_point_exists ".snaps" $N0/dir1
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1202436-calculate-quota-cksum-during-snap-restore-zfs.t
+++ b/tests/bugs/snapshot/bug-1202436-calculate-quota-cksum-during-snap-restore-zfs.t
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version
+TEST launch_cluster 2
+TEST setup_zfs 1
+
+TEST $CLI_1 volume create $V0 $H1:$L1
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status'
+
+# Quota is not working with cluster test framework
+# Need to check why, Until then commenting out this
+#TEST $CLI_1 volume quota $V0 enable
+#EXPECT 'on' volinfo_field $V0 'features.quota'
+
+TEST $CLI_1 snapshot create ${V0}_snap $V0
+EXPECT '1' get_snap_count CLI_1 $V0
+
+TEST $CLI_1 volume stop $V0
+EXPECT 'Stopped' volinfo_field $V0 'Status'
+
+TEST $CLI_1 snapshot restore $($CLI_1 snapshot list)
+EXPECT '0' get_snap_count CLI_1 $V0
+
+TEST $CLI_1 peer probe $H2
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1205592-zfs.t
+++ b/tests/bugs/snapshot/bug-1205592-zfs.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version
+TEST launch_cluster 3
+TEST setup_zfs 3
+
+TEST $CLI_1 peer probe $H2
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+TEST $CLI_1 peer probe $H3
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count
+
+TEST $CLI_1 volume create $V0 $H1:$L1 $H2:$L2 $H3:$L3
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status'
+
+
+kill_glusterd 3
+# If glusterd-quorum is not met then snapshot-create should fail
+TEST ! $CLI_1 snapshot create ${V0}_snap1 ${V0} no-timestamp
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1227646-zfs.t
+++ b/tests/bugs/snapshot/bug-1227646-zfs.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../include.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+
+TEST glusterd;
+TEST pidof glusterd;
+
+#TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+TEST $CLI volume create $V0 $H0:$L2 $H0:$L3;
+TEST $CLI volume start $V0;
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+TEST $CLI volume stop $V0
+TEST $CLI snapshot restore snap1;
+TEST $CLI volume start $V0
+
+TEST pkill gluster
+TEST glusterd
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field $V0 'Status'
+
+TEST $CLI volume stop $V0
+
+cleanup  ;
+

--- a/tests/bugs/snapshot/bug-1232430-zfs.t
+++ b/tests/bugs/snapshot/bug-1232430-zfs.t
@@ -16,7 +16,7 @@ TEST pidof glusterd;
 
 TEST setup_zfs 1
 
-TEST $CLI volume create $V0 $H0:$L1/brick_dir
+TEST $CLI volume create $V0 $H0:$L1
 TEST $CLI volume start $V0
 
 TEST $CLI snapshot create snap1 $V0 no-timestamp

--- a/tests/bugs/snapshot/bug-1232430-zfs.t
+++ b/tests/bugs/snapshot/bug-1232430-zfs.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd -LDEBUG;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1/brick_dir
+TEST $CLI volume start $V0
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+
+TEST $CLI snapshot delete snap1
+
+TEST $CLI volume stop $V0 force
+TEST $CLI volume delete $V0
+cleanup

--- a/tests/bugs/snapshot/bug-1250387-zfs.t
+++ b/tests/bugs/snapshot/bug-1250387-zfs.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 1;
+TEST setup_zfs 1;
+
+TEST glusterd;
+
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1;
+
+TEST $CLI volume start $V0;
+
+TEST glusterfs --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+
+EXPECT "description" get-cmd-field-xml "snapshot info snap1" "description"
+
+cleanup  ;

--- a/tests/bugs/snapshot/bug-1275616-zfs.t
+++ b/tests/bugs/snapshot/bug-1275616-zfs.t
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST setup_zfs 1
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+TEST $CLI snapshot config activate-on-create enable
+
+TEST $CLI snapshot config $V0 snap-max-hard-limit 100
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+
+TEST $CLI snapshot config $V0 snap-max-hard-limit 150
+TEST $CLI snapshot create snap2 $V0 no-timestamp
+
+TEST $CLI snapshot config $V0 snap-max-hard-limit 200
+TEST $CLI snapshot create snap3 $V0 no-timestamp
+EXPECT '197' snap_info_volume CLI "Snaps Available" $V0;
+
+TEST $CLI volume stop $V0
+
+# Restore the snapshots and verify the snap-max-hard-limit
+# and the Snaps Available
+TEST $CLI snapshot restore snap1
+EXPECT '98' snap_info_volume CLI "Snaps Available" $V0;
+EXPECT '100' snap_config_volume CLI 'snap-max-hard-limit' $V0
+
+TEST $CLI snapshot restore snap2
+EXPECT '149' snap_info_volume CLI "Snaps Available" $V0;
+EXPECT '150' snap_config_volume CLI 'snap-max-hard-limit' $V0
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Yes" get_snap_brick_status snap3
+
+#Take a clone and verify it inherits snapshot's snap-max-hard-limit
+TEST $CLI snapshot clone clone1 snap3
+
+EXPECT '149' snap_info_volume CLI "Snaps Available" $V0;
+EXPECT '150' snap_config_volume CLI 'snap-max-hard-limit' $V0
+
+EXPECT '200' snap_info_volume CLI "Snaps Available" clone1
+EXPECT '200' snap_config_volume CLI 'snap-max-hard-limit' clone1
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1279327-zfs.t
+++ b/tests/bugs/snapshot/bug-1279327-zfs.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../volume.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST init_n_bricks 3
+TEST setup_zfs 3
+
+TEST $CLI volume create $V0 $H0:$L1
+TEST $CLI volume start $V0
+TEST $CLI volume quota $V0 enable
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp
+TEST $CLI snapshot activate snap1
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Yes" get_snap_brick_status snap1
+
+#Take a clone and verify it inherits snapshot's snap-max-hard-limit
+TEST $CLI snapshot clone clone1 snap1
+TEST $CLI volume start clone1
+EXPECT 'Started' volinfo_field clone1 'Status';
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1316437-zfs.t
+++ b/tests/bugs/snapshot/bug-1316437-zfs.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST glusterd
+
+# Intentionally not carving zfs for this as we will not be taking
+# snapshots in this testcase
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{1,2,3,4,5,6};
+
+TEST $CLI volume start $V0;
+
+TEST $CLI volume set $V0 features.uss enable;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+killall glusterd glusterfsd glusterfs
+
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 'N' check_if_snapd_exist
+
+glusterd
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1322772-real-path-fix-for-snapshot-zfs.t
+++ b/tests/bugs/snapshot/bug-1322772-real-path-fix-for-snapshot-zfs.t
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../include.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TESTS_EXPECTED_IN_LOOP=2
+
+TEST verify_zfs_version
+TEST init_n_bricks 2
+TEST setup_zfs 2
+
+TEST glusterd
+TEST pidof glusterd
+
+TEST $CLI volume create $V0 $H0:$L1
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+TEST $CLI volume create $V1 $H0:$L2
+EXPECT 'Created' volinfo_field $V1 'Status'
+
+TEST $CLI volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status'
+
+TEST $CLI volume start $V1
+EXPECT 'Started' volinfo_field $V1 'Status'
+
+TEST $CLI snapshot config activate-on-create enable
+TEST $CLI snapshot create ${V0}_snap $V0 no-timestamp
+TEST $CLI snapshot create ${V1}_snap $V1 no-timestamp
+
+# Simulate a node reboot by unmounting the brick, snap_brick and followed by
+# deleting the brick. Now once glusterd restarts, it should be able to construct
+# and remount the snap brick
+snap_bricks=`gluster snap status | grep "Brick Path" | awk -F ":"  '{print $3}'`
+
+TEST $CLI volume stop $V1
+TEST $CLI snapshot restore ${V1}_snap;
+
+pkill gluster
+for snap_brick in $snap_bricks
+do
+    echo "Unmounting snap brick" $snap_brick
+    EXPECT_WITHIN_TEST_IN_LOOP $UMOUNT_TIMEOUT "Y" force_umount $snap_brick
+done
+
+rm -rf $snap_brick
+
+TEST glusterd
+TEST pidof glusterd
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $L1
+
+cleanup
+

--- a/tests/bugs/snapshot/bug-1322772-real-path-fix-for-snapshot-zfs.t
+++ b/tests/bugs/snapshot/bug-1322772-real-path-fix-for-snapshot-zfs.t
@@ -12,8 +12,6 @@ fi
 
 cleanup;
 
-TESTS_EXPECTED_IN_LOOP=2
-
 TEST verify_zfs_version
 TEST init_n_bricks 2
 TEST setup_zfs 2
@@ -46,13 +44,6 @@ TEST $CLI volume stop $V1
 TEST $CLI snapshot restore ${V1}_snap;
 
 pkill gluster
-for snap_brick in $snap_bricks
-do
-    echo "Unmounting snap brick" $snap_brick
-    EXPECT_WITHIN_TEST_IN_LOOP $UMOUNT_TIMEOUT "Y" force_umount $snap_brick
-done
-
-rm -rf $snap_brick
 
 TEST glusterd
 TEST pidof glusterd

--- a/tests/bugs/snapshot/bug-1399598-uss-with-ssl-zfs.t
+++ b/tests/bugs/snapshot/bug-1399598-uss-with-ssl-zfs.t
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../traps.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../ssl.rc
+
+function file_exists
+{
+        if [ -f $1 ]; then echo "Y"; else echo "N"; fi
+}
+
+function volume_online_brick_count
+{
+        $CLI volume status $V0 | awk '$1 == "Brick" &&  $6 != "N/A" { print $6}' | wc -l;
+}
+
+function total_online_bricks
+{
+        # This will count snapd, which isn't really a brick, but callers can
+        # account for that so it's OK.
+        find $GLUSTERD_PIDFILEDIR -name '*.pid' | wc -l
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+# Initialize the test setup
+TEST setup_zfs 1;
+
+TEST create_self_signed_certs
+
+# Start glusterd
+TEST glusterd
+TEST pidof glusterd;
+#EST $CLI volume set all cluster.brick-multiplex on
+
+# Create and start the volume
+TEST $CLI volume create $V0 $H0:$L1/b1;
+
+TEST $CLI volume start $V0;
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" volume_online_brick_count
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" total_online_bricks
+
+# Mount the volume and create some files
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+TEST touch $M0/file;
+
+# Enable activate-on-create
+TEST $CLI snapshot config activate-on-create enable;
+
+# Create a snapshot
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "2" total_online_bricks
+
+TEST $CLI volume set $V0 features.uss enable;
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "3" total_online_bricks
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/file
+# Volume set can trigger graph switch therefore chances are we send this
+# req to old graph. Old graph will not have .snaps. Therefore we should
+# wait for some time.
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/.snaps/snap1/file
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+# Enable management encryption
+touch  $GLUSTERD_WORKDIR/secure-access
+killall_gluster
+
+TEST glusterd
+TEST pidof glusterd;
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" volume_online_brick_count
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "3" total_online_bricks
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+# Mount the volume
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/file
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/.snaps/snap1/file
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+# Enable I/O encryption
+TEST $CLI volume set $V0 client.ssl on
+TEST $CLI volume set $V0 server.ssl on
+
+killall_gluster
+
+TEST glusterd
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" volume_online_brick_count
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "3" total_online_bricks
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Y' check_if_snapd_exist
+
+# Mount the volume
+TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/file
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" file_exists $M0/.snaps/snap1/file
+
+TEST $CLI snapshot delete all
+TEST $CLI volume stop $V0
+TEST $CLI volume delete $V0
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1399598-uss-with-ssl-zfs.t
+++ b/tests/bugs/snapshot/bug-1399598-uss-with-ssl-zfs.t
@@ -42,7 +42,7 @@ TEST pidof glusterd;
 #EST $CLI volume set all cluster.brick-multiplex on
 
 # Create and start the volume
-TEST $CLI volume create $V0 $H0:$L1/b1;
+TEST $CLI volume create $V0 $H0:$L1;
 
 TEST $CLI volume start $V0;
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" volume_online_brick_count

--- a/tests/bugs/snapshot/bug-1482023-snpashot-issue-with-other-processes-accessing-mounted-path-zfs.t
+++ b/tests/bugs/snapshot/bug-1482023-snpashot-issue-with-other-processes-accessing-mounted-path-zfs.t
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+
+function create_snapshots() {
+        $CLI_1 snapshot create ${V0}_snap ${V0} no-timestamp &
+        PID_1=$!
+
+        $CLI_1 snapshot create ${V1}_snap ${V1} no-timestamp &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function activate_snapshots() {
+        $CLI_1 snapshot activate ${V0}_snap &
+        PID_1=$!
+
+        $CLI_1 snapshot activate ${V1}_snap &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+function deactivate_snapshots() {
+        $CLI_1 snapshot deactivate ${V0}_snap &
+        PID_1=$!
+
+        $CLI_1 snapshot deactivate ${V1}_snap &
+        PID_2=$!
+
+        wait $PID_1 $PID_2
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version;
+# Create cluster with 3 nodes
+TEST launch_cluster 3;
+TEST setup_zfs 3
+
+TEST $CLI_1 peer probe $H2;
+TEST $CLI_1 peer probe $H3;
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+
+# Create volumes
+TEST $CLI_1 volume create $V0 $H1:$L1
+TEST $CLI_2 volume create $V1 $H2:$L2 $H3:$L3
+
+# Start volumes
+TEST $CLI_1 volume start $V0
+TEST $CLI_2 volume start $V1
+
+TEST $CLI_1 snapshot config activate-on-create enable
+
+# Snapshot Operations
+create_snapshots
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+deactivate_snapshots
+
+EXPECT 'Stopped' snapshot_status ${V0}_snap;
+EXPECT 'Stopped' snapshot_status ${V1}_snap;
+
+activate_snapshots
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+# This Function will get snap id form snap info command and will
+# check for mount point in system against snap id.
+function mounted_snaps
+{
+        snap_id=`$CLI_1 snap info $1_snap | grep "Snap Volume Name" |
+                  awk -F ":" '{print $2}'`
+        echo `mount | grep $snap_id | wc -l`
+}
+
+EXPECT "1" mounted_snaps ${V0}
+EXPECT "2" mounted_snaps ${V1}
+
+deactivate_snapshots
+
+EXPECT "0" mounted_snaps ${V0}
+EXPECT "0" mounted_snaps ${V1}
+
+# This part of test is designed to validate that updates are properly being
+# handled during handshake.
+
+activate_snapshots
+
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+
+kill_glusterd 2
+
+deactivate_snapshots
+EXPECT 'Stopped' snapshot_status ${V0}_snap;
+EXPECT 'Stopped' snapshot_status ${V1}_snap;
+
+TEST start_glusterd 2
+
+# Updates form friend should reflect as snap was deactivated while glusterd
+# process was inactive and mount point should also not exist.
+
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" mounted_snaps ${V0}
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "0" mounted_snaps ${V1}
+
+# It might be possible that the import snap synctask is still updating the data,
+# we need to allow a buffer time to be on the safer side
+sleep 2
+
+kill_glusterd 2
+activate_snapshots
+EXPECT 'Started' snapshot_status ${V0}_snap;
+EXPECT 'Started' snapshot_status ${V1}_snap;
+TEST start_glusterd 2
+
+EXPECT_WITHIN $PROBE_TIMEOUT 2 peer_count;
+
+# Updates form friend should reflect as snap was activated while glusterd
+# process was inactive and mount point should exist.
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" mounted_snaps ${V0}
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "2" mounted_snaps ${V1}
+
+cleanup;
+# run first!
+#G_TESTDEF_TEST_STATUS_CENTOS6=BRICK_MUX_BAD_TEST,BUG=1743069

--- a/tests/bugs/snapshot/bug-1512451-snapshot-creation-failed-after-brick-reset-zfs.t
+++ b/tests/bugs/snapshot/bug-1512451-snapshot-creation-failed-after-brick-reset-zfs.t
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+TEST verify_zfs_version
+TEST launch_cluster 2
+TEST setup_zfs 2
+
+TEST $CLI_1 peer probe $H2
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
+
+TEST $CLI_1 volume create $V0 $H1:$L1/B1 $H2:$L2/B1
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status'
+
+TEST $CLI_1 snapshot create ${V0}_snap1 ${V0} no-timestamp
+TEST snapshot_exists 1 ${V0}_snap1
+
+TEST $CLI_1 snapshot delete ${V0}_snap1
+TEST ! snapshot_exists 1 ${V0}_snap1
+
+TEST $CLI_1 volume reset-brick $V0 $H1:$L1/B1 start
+TEST $CLI_1 volume reset-brick $V0 $H1:$L1/B1 $H1:$L1/B1 commit force
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" cluster_brick_up_status 1 $V0 $H1 $L1/B1
+
+TEST $CLI_1 snapshot create ${V0}_snap1 ${V0} no-timestamp
+TEST snapshot_exists 1 ${V0}_snap1
+
+TEST $CLI_1 snapshot delete ${V0}_snap1
+TEST ! snapshot_exists 1 ${V0}_snap1
+
+cleanup;

--- a/tests/bugs/snapshot/bug-1512451-snapshot-creation-failed-after-brick-reset-zfs.t
+++ b/tests/bugs/snapshot/bug-1512451-snapshot-creation-failed-after-brick-reset-zfs.t
@@ -19,7 +19,7 @@ TEST setup_zfs 2
 TEST $CLI_1 peer probe $H2
 EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count
 
-TEST $CLI_1 volume create $V0 $H1:$L1/B1 $H2:$L2/B1
+TEST $CLI_1 volume create $V0 $H1:$L1 $H2:$L2
 EXPECT 'Created' volinfo_field $V0 'Status'
 
 TEST $CLI_1 volume start $V0
@@ -31,10 +31,10 @@ TEST snapshot_exists 1 ${V0}_snap1
 TEST $CLI_1 snapshot delete ${V0}_snap1
 TEST ! snapshot_exists 1 ${V0}_snap1
 
-TEST $CLI_1 volume reset-brick $V0 $H1:$L1/B1 start
-TEST $CLI_1 volume reset-brick $V0 $H1:$L1/B1 $H1:$L1/B1 commit force
+TEST $CLI_1 volume reset-brick $V0 $H1:$L1 start
+TEST $CLI_1 volume reset-brick $V0 $H1:$L1 $H1:$L1 commit force
 
-EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" cluster_brick_up_status 1 $V0 $H1 $L1/B1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" cluster_brick_up_status 1 $V0 $H1 $L1
 
 TEST $CLI_1 snapshot create ${V0}_snap1 ${V0} no-timestamp
 TEST snapshot_exists 1 ${V0}_snap1

--- a/tests/bugs/snapshot/bug-1597662-zfs.t
+++ b/tests/bugs/snapshot/bug-1597662-zfs.t
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST init_n_bricks 3;
+TEST setup_zfs 3;
+TEST glusterd;
+TEST pidof glusterd;
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2 $H0:$L3;
+TEST $CLI volume start $V0;
+
+snap_path=/var/run/gluster/snaps
+
+TEST $CLI snapshot create snap1 $V0 no-timestamp;
+
+$CLI snapshot activate snap1;
+
+EXPECT 'Started' snapshot_status snap1;
+
+# This Function will check for entry /var/run/gluster/snaps/<snap-name>
+# against snap-name
+
+function is_snap_path
+{
+        echo `ls $snap_path | grep snap1 | wc -l`
+}
+
+# snap is active so snap_path should exist
+EXPECT "1" is_snap_path
+
+$CLI snapshot deactivate snap1;
+EXPECT_WITHIN ${PROCESS_DOWN_TIMEOUT} 'Stopped' snapshot_status snap1
+# snap is deactivated so snap_path should not exist
+EXPECT "0" is_snap_path
+
+# activate snap again
+$CLI snapshot activate snap1;
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} 'Started' snapshot_status snap1
+
+# snap is active so snap_path should exist
+EXPECT "1" is_snap_path
+
+# delete snap now
+TEST $CLI snapshot delete snap1;
+
+# snap is deleted so snap_path should not exist
+EXPECT "0" is_snap_path
+
+TEST $CLI volume stop $V0;
+TEST $CLI volume delete $V0;
+
+cleanup;
+

--- a/tests/bugs/snapshot/bug-1618004-fix-memory-corruption-in-snap-import-zfs.t
+++ b/tests/bugs/snapshot/bug-1618004-fix-memory-corruption-in-snap-import-zfs.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+. $(dirname $0)/../../cluster.rc
+
+function get_volume_info ()
+{
+        local var=$1
+        $CLI_1 volume info $V0 | grep "^$var" | sed 's/.*: //'
+}
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+TEST verify_zfs_version
+TEST launch_cluster 2
+TEST setup_zfs 2
+
+TEST $CLI_1 peer probe $H2;
+EXPECT_WITHIN $PROBE_TIMEOUT 1 peer_count;
+
+TEST $CLI_1 volume create $V0 $H1:$L1 $H2:$L2
+EXPECT "$V0" get_volume_info 'Volume Name';
+EXPECT 'Created' get_volume_info 'Status';
+
+TEST $CLI_1 volume start $V0
+EXPECT 'Started' get_volume_info 'Status';
+
+
+# Setting system limit
+TEST $CLI_1 snapshot config activate-on-create enable
+
+TEST $CLI_1 snapshot create snap1 $V0 no-timestamp description "test"
+TEST kill_glusterd 1
+#deactivate snapshot for changing snap version, so that handshake will
+#happen when glusterd is restarted
+TEST $CLI_2 snapshot deactivate snap1
+TEST start_glusterd 1
+
+#Wait till handshake complete
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} 'Stopped' snapshot_status snap1
+
+#Delete the snapshot, without this fix, delete will lead to assertion failure
+$CLI_1 snapshot delete all
+EXPECT '0' get_snap_count CLI_1;
+cleanup;
+

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -123,6 +123,7 @@ function _create_zfs_vhd() {
     local num=$2
     local loop_num=`expr $2 + 8`
 
+    mkdir -p $dir
     fallocate -l${VHD_SIZE} $dir/${ZFS_PREFIX}_vhd
     mknod -m660 $dir/${ZFS_PREFIX}_loop b 7 $loop_num
     /sbin/losetup $dir/${ZFS_PREFIX}_loop $dir/${ZFS_PREFIX}_vhd

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -30,17 +30,8 @@ function init_zfs() {
             echo "Please run launch_cluster with atleast $ZFS_COUNT nodes"
             return 1
         fi
-        eval "L$i=/${ZFS_PREFIX}_pool_${i}/brick"
-        eval "LM$i=/${ZFS_PREFIX}_pool_${i}"
-        l="LM$i"
-        mkdir -p ${!l}
-        mkdir -p ${!b}
-        if [ $? -ne 0 ]; then
-            echo "Error: failed to create dir ${!l}"
-            return 1
-        fi
-
-        eval "POOL$i=${ZFS_PREFIX}_pool_${i}"
+        eval "L$i=/${ZFS_PREFIX}_pool_${i}/bricks/brick"
+        eval "LM$i=/${ZFS_PREFIX}_pool_${i}/bricks"
     done
 
     ZFS_DEFINED=1
@@ -94,6 +85,7 @@ function _setup_zfs() {
 
         _create_zfs_vhd ${!b} $i
         _create_zpool ${!b} $i
+        _create_zfs_dataset ${!b} $i
     done
 }
 
@@ -104,6 +96,7 @@ function _cleanup_zfs() {
 
     for i in `seq 1 $count`; do
         b="B$i"
+        _remove_zfs_dataset $i
         _remove_zpool $i
         _remove_zfs_vhd ${!b}
     done
@@ -143,11 +136,26 @@ function _create_zpool() {
     /sbin/zpool create ${zpool} $dir/${ZFS_PREFIX}_loop
 }
 
+function _create_zfs_dataset() {
+    local dir=$1
+    local num=$2
+    local dataset="${ZFS_PREFIX}_pool_${num}/bricks"
+
+    /sbin/zfs create ${dataset}
+}
+
 function _remove_zpool() {
     local num=$1
     local zpool="${ZFS_PREFIX}_pool_${num}"
 
     /sbin/zpool destroy -f ${!zpool}
+}
+
+function _remove_zfs_dataset() {
+    local num=$1
+    local dataset="${ZFS_PREFIX}_pool_${num}/bricks"
+
+    /sbin/zfs destroy -f ${!dataset}
 }
 
 function _remove_zfs_vhd() {

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+ZFS_DEFINED=0
+ZFS_PREFIX="patchy_snap"
+ZFS_COUNT=0
+VHD_SIZE="300M"
+
+function init_zfs() {
+    if [ "$1" == "" ]; then
+        echo "Error: Invalid argument supplied"
+        return 1
+    fi
+    ZFS_COUNT=$1
+
+    if [ "$2" != "" ]; then
+        VHD_SIZE=$2
+    fi
+
+    local b
+    local i
+
+    if [ "$B1" = "" ]; then
+        B1=$B0
+    fi
+
+    for i in `seq 1 $ZFS_COUNT`; do
+        b="B$i"
+        if [ "${!b}" = "" ]; then
+            echo "Error: $b not defined."
+            echo "Please run launch_cluster with atleast $ZFS_COUNT nodes"
+            return 1
+        fi
+        eval "L$i=/${ZFS_PREFIX}_pool_${i}/brick"
+        eval "LM$i=/${ZFS_PREFIX}_pool_${i}"
+        l="LM$i"
+        mkdir -p ${!l}
+        mkdir -p ${!b}
+        if [ $? -ne 0 ]; then
+            echo "Error: failed to create dir ${!l}"
+            return 1
+        fi
+
+        eval "POOL$i=${ZFS_PREFIX}_pool_${i}"
+    done
+
+    ZFS_DEFINED=1
+    return 0
+}
+
+function verify_zfs_version() {
+    if command -v zfs &> /dev/null; then
+        return 0;
+    fi
+    return 1;
+}
+
+function setup_zfs() {
+    _cleanup_zfs
+    init_zfs $@ || return 1
+    _setup_zfs
+    return 0
+}
+
+function cleanup_zfs() {
+    pkill gluster
+    sleep 2
+
+    if [ "$ZFS_DEFINED" = "1" ]; then
+        _cleanup_zfs >/dev/null 2>&1
+    fi
+
+    _cleanup_zfs_again >/dev/null 2>&1
+    \rm -rf /var/run/gluster/snaps/*
+    zfs list | grep "patchy_snap" | awk '{print $1}'| xargs -L 1 -r zpool destroy -f 2>/dev/null
+    \rm -rf /patchy*
+    return 0
+}
+
+# Find out how this file was sourced, source traps.rc the same way, and use
+# push_trapfunc to make sure cleanup_lvm gets called before we exit.
+. $(dirname ${BASH_SOURCE[0]})/traps.rc
+push_trapfunc cleanup_zfs
+
+########################################################
+# Private Functions
+########################################################
+function _setup_zfs() {
+    local count=$ZFS_COUNT
+    local b
+    local i
+
+    for i in `seq 1 $count`; do
+        b="B$i"
+
+        _create_zfs_vhd ${!b} $i
+        _create_zpool ${!b} $i
+    done
+}
+
+function _cleanup_zfs() {
+    local count=$ZFS_COUNT
+    local b
+    local i
+
+    for i in `seq 1 $count`; do
+        b="B$i"
+        _remove_zpool $i
+        _remove_zfs_vhd ${!b}
+    done
+}
+
+function _cleanup_zfs_again() {
+    local file
+
+    /sbin/zfs list | grep $ZFS_PREFIX | awk '{print $1}' | xargs -r -L 1 zpool destroy -f
+
+    find $B0 -name "${ZFS_PREFIX}_loop" | xargs -r losetup -d
+
+    find /run/gluster/snaps -name "*${ZFS_PREFIX}*" | xargs -r rm -rf
+
+    for file in `ls /run/gluster/snaps`; do
+        find /run/gluster/snaps/$file -mmin -2 | xargs -r rm -rf
+    done
+}
+
+########################################################
+########################################################
+function _create_zfs_vhd() {
+    local dir=$1
+    local num=$2
+    local loop_num=`expr $2 + 8`
+
+    fallocate -l${VHD_SIZE} $dir/${ZFS_PREFIX}_vhd
+    mknod -m660 $dir/${ZFS_PREFIX}_loop b 7 $loop_num
+    /sbin/losetup $dir/${ZFS_PREFIX}_loop $dir/${ZFS_PREFIX}_vhd
+}
+
+function _create_zpool() {
+    local dir=$1
+    local num=$2
+    local zpool="${ZFS_PREFIX}_pool_${num}"
+
+    /sbin/zpool create ${zpool} $dir/${ZFS_PREFIX}_loop
+}
+
+function _remove_zpool() {
+    local num=$1
+    local zpool="${ZFS_PREFIX}_pool_${num}"
+
+    /sbin/zpool destroy -f ${!zpool}
+}
+
+function _remove_zfs_vhd() {
+    local dir=$1
+
+    losetup -d $dir/${ZFS_PREFIX}_loop
+    rm -f $dir/${ZFS_PREFIX}_loop
+    rm -f $dir/${ZFS_PREFIX}_vhd
+}

--- a/xlators/mgmt/glusterd/src/Makefile.am
+++ b/xlators/mgmt/glusterd/src/Makefile.am
@@ -26,7 +26,7 @@ glusterd_la_SOURCES = glusterd.c glusterd-handler.c glusterd-sm.c \
 	glusterd-bitd-svc.c glusterd-scrub-svc.c glusterd-server-quorum.c \
 	glusterd-reset-brick.c glusterd-shd-svc.c glusterd-shd-svc-helper.c \
         glusterd-gfproxyd-svc.c glusterd-gfproxyd-svc-helper.c glusterd-ganesha.c \
-	snapshot/glusterd-lvm-snapshot.c \
+	snapshot/glusterd-lvm-snapshot.c snapshot/glusterd-zfs-snapshot.c \
 	$(CONTRIBDIR)/mount/mntent.c
 
 glusterd_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la \

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -4133,6 +4133,8 @@ glusterd_snapshot_plugin_by_name(char *name,
 
     if (strcmp(name, "LVM") == 0)
         *snap_ops = &lvm_snap_ops;
+    else if (strcmp(name, "ZFS") == 0)
+        *snap_ops = &zfs_snap_ops;
 
     gf_msg_debug(this->name, 0, "Loaded Snapshot plugin %s", name);
 }
@@ -4142,6 +4144,7 @@ glusterd_snapshot_probe(char *brick_path, glusterd_brickinfo_t *brickinfo)
 {
     struct glusterd_snap_ops *glusterd_snap_backend[] = {
         &lvm_snap_ops,
+        &zfs_snap_ops,
         0,
     };
     xlator_t *this = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -124,6 +124,7 @@ struct glusterd_snap_ops {
 };
 
 extern struct glusterd_snap_ops lvm_snap_ops;
+extern struct glusterd_snap_ops zfs_snap_ops;
 
 gf_boolean_t
 glusterd_mntopts_exists(const char *str, const char *opts);

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -1,0 +1,528 @@
+/*
+   Copyright (c) 2021 iXsystems, Inc <https://www.ixsystems.com>
+   This file is part of GlusterFS.
+
+   This file is licensed to you under your choice of the GNU Lesser
+   General Public License, version 3 or any later version (LGPLv3 or
+   later), or the GNU General Public License, version 2 (GPLv2), in all
+   cases as published by the Free Software Foundation.
+*/
+
+#include <inttypes.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "glusterd-messages.h"
+#include "glusterd-errno.h"
+
+#include "glusterd.h"
+#include "glusterd-utils.h"
+#include "glusterd-snapshot-utils.h"
+
+#include <glusterfs/dict.h>
+#include <glusterfs/run.h>
+
+#if defined(GF_LINUX_HOST_OS)
+#include <mntent.h>
+#else
+#include "mntent_compat.h"
+#endif
+
+#define ZFS_COMMAND "/sbin/zfs"
+#define ZPOOL_COMMAND "/sbin/zpool"
+
+extern char snap_mount_dir[VALID_GLUSTERD_PATHMAX];
+
+int32_t
+glusterd_zfs_zpool(char *brick_path, char **pool_name)
+{
+    char msg[1024] = "";
+    char zpool[PATH_MAX] = "";
+    xlator_t *this = NULL;
+    runner_t runner = {
+        0,
+    };
+    char *ptr = NULL;
+    int32_t ret = 0;
+
+    this = THIS;
+    GF_ASSERT(this);
+
+    runinit(&runner);
+    snprintf(msg, sizeof(msg),
+             "running zfs command, "
+             "for getting zfs pool name from brick path");
+    runner_add_args(&runner, "zfs", "list", "-Ho", "name", brick_path, NULL);
+    runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
+    runner_log(&runner, "", GF_LOG_DEBUG, msg);
+    ret = runner_start(&runner);
+    if (ret == -1) {
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to get pool name "
+               "for the brick_path %s",
+               brick_path);
+        runner_end(&runner);
+        goto out;
+    }
+    ptr = fgets(zpool, sizeof(zpool), runner_chio(&runner, STDOUT_FILENO));
+
+    if (!ptr || !strlen(zpool)) {
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to get pool name "
+               "for the brick_path %s",
+               brick_path);
+        runner_end(&runner);
+        ret = -1;
+        goto out;
+    }
+    runner_end(&runner);
+
+    *pool_name = strtok(zpool, "\n");
+
+out:
+    return ret;
+}
+
+gf_boolean_t
+glusterd_zfs_probe(char *brick_path)
+{
+    int ret = -1;
+    xlator_t *this = NULL;
+    gf_boolean_t is_zfs = _gf_false;
+    char *mnt_pt = NULL;
+    char buff[PATH_MAX] = "";
+    struct mntent *entry = NULL;
+    struct mntent save_entry = {
+        0,
+    };
+
+    this = THIS;
+
+    GF_VALIDATE_OR_GOTO("glusterd", this, out);
+    GF_VALIDATE_OR_GOTO(this->name, brick_path, out);
+
+    if (!glusterd_is_cmd_available(ZFS_COMMAND) ||
+        !glusterd_is_cmd_available(ZPOOL_COMMAND)) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
+               "ZFS commands not found");
+        ret = -1;
+        goto out;
+    }
+
+    ret = glusterd_get_brick_root(brick_path, &mnt_pt);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BRICKPATH_ROOT_GET_FAIL,
+               "getting the root "
+               "of the brick (%s) failed ",
+               brick_path);
+        goto out;
+    }
+
+    entry = glusterd_get_mnt_entry_info(mnt_pt, buff, sizeof(buff),
+                                        &save_entry);
+    if (!entry) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MNTENTRY_GET_FAIL,
+               "getting the mount entry for "
+               "the brick (%s) failed",
+               brick_path);
+        goto out;
+    }
+
+    if (0 == strncmp("zfs", entry->mnt_type, 5)) {
+        is_zfs = _gf_true;
+    }
+
+out:
+    if (mnt_pt)
+        GF_FREE(mnt_pt);
+
+    return is_zfs;
+}
+
+int32_t
+glusterd_zfs_snapshot_create_or_clone(glusterd_brickinfo_t *snap_brickinfo,
+                                      int clone, char *snapname,
+                                      char *snap_volume_id, char *clonename,
+                                      char *clone_volume_id, int32_t brick_num)
+{
+    char msg[4096] = "";
+    int ret = -1;
+    runner_t runner = {
+        0,
+    };
+    xlator_t *this = THIS;
+    char snap_device[NAME_MAX] = "";
+    char clone_device[NAME_MAX] = "";
+    char *zpool = NULL;
+    int32_t len = 0;
+
+    GF_ASSERT(snap_brickinfo);
+
+    ret = glusterd_zfs_zpool(snap_brickinfo->origin_path, &zpool);
+    if (ret)
+        goto out;
+
+    len = snprintf(snap_device, sizeof(snap_device), "%s@%s_%d", zpool,
+                   snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(snap_device))) {
+        goto out;
+    }
+
+    /* Taking the actual snapshot */
+    runinit(&runner);
+    snprintf(msg, sizeof(msg), "taking snapshot of the brick %s",
+             snap_brickinfo->origin_path);
+
+    if (clone) {
+        len = snprintf(clone_device, sizeof(clone_device), "%s/%s_%d", zpool,
+                       clone_volume_id, brick_num);
+        if ((len < 0) || (len >= sizeof(clone_device))) {
+            goto out;
+        }
+
+        runner_add_args(&runner, ZFS_COMMAND, "clone", snap_device,
+                        clone_device, NULL);
+    } else
+        runner_add_args(&runner, ZFS_COMMAND, "snapshot", snap_device, NULL);
+
+    runner_log(&runner, this->name, GF_LOG_DEBUG, msg);
+    ret = runner_run(&runner);
+    if (ret) {
+        if (clone)
+            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_CLONE_FAILED,
+                   "taking clone of the "
+                   "brick (%s) failed",
+                   snap_brickinfo->origin_path);
+        else
+            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_CREATION_FAIL,
+                   "taking snapshot of the "
+                   "brick (%s) failed",
+                   snap_brickinfo->origin_path);
+    }
+
+out:
+    return ret;
+}
+
+/* This function actually calls the command (or the API) for taking the
+   snapshot of the backend brick filesystem. If this is successful,
+   then call the glusterd_snap_create function to create the snap object
+   for glusterd
+*/
+int32_t
+glusterd_zfs_snapshot_create(glusterd_brickinfo_t *snap_brickinfo,
+                             char *snapname, char *snap_volume_id,
+                             int32_t brick_num)
+{
+    return glusterd_zfs_snapshot_create_or_clone(
+        snap_brickinfo, 0, snapname, snap_volume_id, NULL, NULL, brick_num);
+}
+
+/* This function actually calls the command (or the API) for taking the
+   snapshot of the backend brick filesystem. If this is successful,
+   then call the glusterd_snap_create function to create the snap object
+   for glusterd
+*/
+int32_t
+glusterd_zfs_snapshot_clone(glusterd_brickinfo_t *snap_brickinfo,
+                            char *snapname, char *snap_volume_id,
+                            char *clonename, char *clone_volume_id,
+                            int32_t brick_num)
+{
+    return glusterd_zfs_snapshot_create_or_clone(snap_brickinfo, 1, snapname,
+                                                 snap_volume_id, clonename,
+                                                 clone_volume_id, brick_num);
+}
+
+static int
+glusterd_zfs_brick_details(dict_t *rsp_dict,
+                           glusterd_brickinfo_t *snap_brickinfo, char *snapname,
+                           char *snap_volume_id, int32_t brick_num,
+                           char *key_prefix)
+{
+    int ret = -1;
+    glusterd_conf_t *priv = NULL;
+    xlator_t *this = THIS;
+    char key[160] = ""; /* key_prefix is 128 bytes at most */
+    char *zpool = NULL;
+
+    GF_ASSERT(rsp_dict);
+    GF_ASSERT(snap_brickinfo);
+    GF_ASSERT(key_prefix);
+    priv = this->private;
+    GF_ASSERT(priv);
+
+    ret = glusterd_zfs_zpool(snap_brickinfo->origin_path, &zpool);
+    if (ret)
+        goto out;
+
+    ret = snprintf(key, sizeof(key), "%s.vgname", key_prefix);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = dict_set_str(rsp_dict, key, zpool);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
+               "Could not save vgname ");
+        goto out;
+    }
+
+    ret = snprintf(key, sizeof(key), "%s.data", key_prefix);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = dict_set_str(rsp_dict, key, "-");
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
+               "Could not save data percent ");
+        goto out;
+    }
+
+    ret = snprintf(key, sizeof(key), "%s.lvsize", key_prefix);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = dict_set_str(rsp_dict, key, "-");
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
+               "Could not save meta data percent ");
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    return ret;
+}
+
+int
+glusterd_zfs_snapshot_remove(glusterd_brickinfo_t *snap_brickinfo,
+                             char *snapname, char *snap_volume_id,
+                             int32_t brick_num)
+{
+    int ret = -1;
+    xlator_t *this = THIS;
+    glusterd_conf_t *priv = NULL;
+    runner_t runner = {
+        0,
+    };
+    char msg[1024] = "";
+    int len;
+    char snap_device[NAME_MAX] = "";
+    char *zpool = NULL;
+
+    priv = this->private;
+    GF_ASSERT(priv);
+
+    GF_ASSERT(snap_brickinfo);
+
+    ret = glusterd_zfs_zpool(snap_brickinfo->origin_path, &zpool);
+    if (ret)
+        goto out;
+
+    len = snprintf(snap_device, sizeof(snap_device), "%s@%s_%d", zpool,
+                   snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(snap_device))) {
+        goto out;
+    }
+
+    runinit(&runner);
+    len = snprintf(msg, sizeof(msg),
+                   "remove snapshot of the brick %s, "
+                   "snap name: %s",
+                   snap_brickinfo->origin_path, snapname);
+    if (len < 0) {
+        strcpy(msg, "<error>");
+    }
+    runner_add_args(&runner, ZFS_COMMAND, "destroy", snap_device, NULL);
+    runner_log(&runner, "", GF_LOG_DEBUG, msg);
+
+    ret = runner_run(&runner);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_REMOVE_FAIL,
+               "removing snapshot of the "
+               "brick (%s) of snapshot %s failed",
+               snap_brickinfo->origin_path, snapname);
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+/* No op since .zfs directory is used */
+int32_t
+glusterd_zfs_snapshot_activate(glusterd_brickinfo_t *snap_brickinfo,
+                               char *snapname, char *snap_volume_id,
+                               int32_t brick_num)
+{
+    int32_t ret = 0;
+    xlator_t *this = NULL;
+
+    this = THIS;
+    GF_ASSERT(this);
+    GF_ASSERT(snap_brickinfo);
+
+    gf_msg_trace(this->name, 0, "Returning with %d", ret);
+    return ret;
+}
+
+/* No op since .zfs directory is used */
+int32_t
+glusterd_zfs_snapshot_deactivate(glusterd_brickinfo_t *snap_brickinfo,
+                                 char *snapname, char *snap_volume_id,
+                                 int32_t brick_num)
+{
+    int32_t ret = 0;
+    xlator_t *this = NULL;
+
+    this = THIS;
+    GF_ASSERT(this);
+    GF_ASSERT(snap_brickinfo);
+
+    gf_msg_trace(this->name, 0, "Returning with %d", ret);
+    return ret;
+}
+
+int32_t
+glusterd_zfs_snapshot_restore(glusterd_brickinfo_t *snap_brickinfo,
+                              char *snapname, char *snap_volume_id,
+                              int32_t brick_num,
+                              gf_boolean_t *retain_origin_path)
+{
+    int ret = -1;
+    xlator_t *this = THIS;
+    glusterd_conf_t *priv = NULL;
+    runner_t runner = {
+        0,
+    };
+    char msg[1024] = "";
+    int len;
+    char snap_device[NAME_MAX] = "";
+    char clone_device[NAME_MAX] = "";
+    char mnt_pt[PATH_MAX] = "";
+    char *zpool = NULL;
+
+    priv = this->private;
+    GF_ASSERT(priv);
+
+    GF_ASSERT(snap_brickinfo);
+
+    ret = glusterd_zfs_zpool(snap_brickinfo->origin_path, &zpool);
+    if (ret)
+        goto out;
+
+    len = snprintf(snap_device, sizeof(snap_device), "%s@%s_%d", zpool,
+                   snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(snap_device))) {
+        goto out;
+    }
+
+    len = snprintf(clone_device, sizeof(clone_device), "%s/%s_%d", zpool,
+                   snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(clone_device))) {
+        goto out;
+    }
+
+    runinit(&runner);
+    len = snprintf(msg, sizeof(msg),
+                   "restore snapshot of the brick %s, "
+                   "snap name: %s",
+                   snap_brickinfo->origin_path, snapname);
+    if (len < 0) {
+        strcpy(msg, "<error>");
+    }
+    runner_add_args(&runner, ZFS_COMMAND, "clone", snap_device, clone_device,
+                    NULL);
+    runner_log(&runner, "", GF_LOG_DEBUG, msg);
+
+    ret = runner_run(&runner);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_RESTORE_FAIL,
+               "restoring snapshot of the "
+               "brick (%s) of snapshot %s failed",
+               snap_brickinfo->origin_path, snapname);
+        goto out;
+    }
+
+    runinit(&runner);
+    len = snprintf(mnt_pt, sizeof(mnt_pt), "mountpoint=%s/%s/brick%d",
+                   snap_mount_dir, snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(mnt_pt))) {
+        goto out;
+    }
+
+    runner_add_args(&runner, ZFS_COMMAND, "set", mnt_pt, clone_device, NULL);
+    runner_log(&runner, "", GF_LOG_DEBUG, msg);
+
+    ret = runner_run(&runner);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_RESTORE_FAIL,
+               "setting mountpoint of restore of the "
+               "brick (%s) of snapshot %s failed",
+               snap_brickinfo->origin_path, snapname);
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+int32_t
+glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
+                                   char *origin_brick_path, int clone,
+                                   char *snap_clone_name,
+                                   char *snap_clone_volume_id,
+                                   char *snap_brick_dir, int brick_num,
+                                   char **snap_brick_path, int restore)
+{
+    int32_t len = 0;
+    int ret = 0;
+    char brick_path[PATH_MAX] = "";
+    char *origin_brick_mount = NULL;
+    char *origin_brick = NULL;
+
+    origin_brick = gf_strdup(origin_brick_path);
+    origin_brick_mount = dirname(origin_brick);
+
+    if (clone)
+        len = snprintf(brick_path, sizeof(brick_path), "%s/%s_%d/%s",
+                       origin_brick_mount, snap_clone_volume_id, brick_num,
+                       snap_brick_dir);
+    else {
+        if (restore)
+            len = snprintf(brick_path, sizeof(brick_path), "%s/%s/brick%d%s",
+                           snap_mount_dir, snap_clone_volume_id, brick_num,
+                           snap_brick_dir);
+        else
+            len = snprintf(brick_path, sizeof(brick_path),
+                           "%s/.zfs/snapshot/%s_%d/%s", origin_brick_mount,
+                           snap_clone_volume_id, brick_num, snap_brick_dir);
+    }
+
+    if ((len < 0) || (len >= sizeof(brick_path))) {
+        ret = -1;
+    }
+
+    *snap_brick_path = brick_path;
+
+    if (origin_brick)
+        GF_FREE(origin_brick);
+
+    return ret;
+}
+
+struct glusterd_snap_ops zfs_snap_ops = {
+    .name = "ZFS",
+    .probe = glusterd_zfs_probe,
+    .details = glusterd_zfs_brick_details,
+    .create = glusterd_zfs_snapshot_create,
+    .clone = glusterd_zfs_snapshot_clone,
+    .remove = glusterd_zfs_snapshot_remove,
+    .activate = glusterd_zfs_snapshot_activate,
+    .deactivate = glusterd_zfs_snapshot_deactivate,
+    .restore = glusterd_zfs_snapshot_restore,
+    .brick_path = glusterd_zfs_snap_clone_brick_path};

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -204,10 +204,8 @@ out:
     return ret;
 }
 
-/* This function actually calls the command (or the API) for taking the
-   snapshot of the backend brick filesystem. If this is successful,
-   then call the glusterd_snap_create function to create the snap object
-   for glusterd
+/* This function actually calls the command for creating
+   a snapshot of the backend brick filesystem.
 */
 int32_t
 glusterd_zfs_snapshot_create(glusterd_brickinfo_t *snap_brickinfo,
@@ -218,10 +216,8 @@ glusterd_zfs_snapshot_create(glusterd_brickinfo_t *snap_brickinfo,
         snap_brickinfo, 0, snapname, snap_volume_id, NULL, NULL, brick_num);
 }
 
-/* This function actually calls the command (or the API) for taking the
-   snapshot of the backend brick filesystem. If this is successful,
-   then call the glusterd_snap_create function to create the snap object
-   for glusterd
+/* This function actually calls the command for cloning
+   a snapshot of the backend brick filesystem.
 */
 int32_t
 glusterd_zfs_snapshot_clone(glusterd_brickinfo_t *snap_brickinfo,


### PR DESCRIPTION
No seperate mount done for mounting the Snapshot bricks.
`.zfs` virtual directory is used as Snapshot brick path.
For example: If the brick path is `/zpool1/brick1` and Snapshot
name is `s1` then the Snapshot brick path will be
`/zpool1/.zfs/snapshot/s1/brick1`
    
Cloned bricks will have the path similar to original bricks.
`<zpool>/<clone-name>/<brick-dir>`.

Updates: #145     
Change-Id: I912618bdcbaad3f9a971ef9b1fa4c00ef81b1198
Sponsored-By: iXsystems, Inc <https://www.ixsystems.com>
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>