### PR TITLE
The "data" was used twice.

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -4140,7 +4140,7 @@ gf_cli_stop_volume(call_frame_t *frame, xlator_t *this, void *data)
         0,
     }};
     int ret = 0;
-    dict_t *dict = data;
+    dict_t *dict = NULL;
 
     dict = data;
 


### PR DESCRIPTION
dict_t *dict = data;
dict = data;

Change-Id: I578ce05dd5a18b62eac6632778e94044c028951b
Updates: #2857
Signed-off-by: Xi Jinyu <xijinyu_yewu@cmss.chinamobile.com>

