### PR TITLE
core: Configurable option to configure RLIMIT_NOFILE limit

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -1057,7 +1057,7 @@ struct volopt_map_entry glusterd_volopt_map[] = {
     {.key = "cluster.ensure-durability",
      .voltype = "cluster/replicate",
      .op_version = 3,
-    .type = NO_DOC,
+     .type = NO_DOC,
      .flags = VOLOPT_FLAG_CLIENT_OPT},
     {.key = "cluster.consistent-metadata",
      .voltype = "cluster/replicate",
@@ -1494,6 +1494,11 @@ struct volopt_map_entry glusterd_volopt_map[] = {
         .voltype = "protocol/client",
         .op_version = GD_OP_VERSION_3_7_0,
     },
+    {
+        .key = "client.nofile-limit",
+        .voltype = "protocol/client",
+        .op_version = GD_OP_VERSION_10_0,
+    },
     {.key = "client.tcp-user-timeout",
      .voltype = "protocol/client",
      .option = "transport.tcp-user-timeout",
@@ -1645,6 +1650,11 @@ struct volopt_map_entry glusterd_volopt_map[] = {
         .key = "server.event-threads",
         .voltype = "protocol/server",
         .op_version = GD_OP_VERSION_3_7_0,
+    },
+    {
+        .key = "server.nofile-limit",
+        .voltype = "protocol/server",
+        .op_version = GD_OP_VERSION_10_0,
     },
     {
         .key = "server.tcp-user-timeout",
@@ -3105,7 +3115,7 @@ struct volopt_map_entry glusterd_volopt_map[] = {
 
     {.key = "rebalance.ensure-durability",
      .voltype = "cluster/distribute",
-    .type = NO_DOC,
+     .type = NO_DOC,
      .op_version = GD_OP_VERSION_10_0,
      .flags = VOLOPT_FLAG_CLIENT_OPT},
     {.key = NULL}};

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -2088,7 +2088,6 @@ init(xlator_t *this)
     }
 
     GF_OPTION_INIT("nofile-limit", nofile_limit, int32, out);
-    if (nofile_limit > 0) {
 #ifndef GF_DARWIN_HOST_OS
         {
             struct rlimit lim;
@@ -2106,7 +2105,6 @@ init(xlator_t *this)
             }
         }
 #endif
-    }
     ret = 0;
 out:
     if (ret < 0) {

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -44,6 +44,8 @@
 /* Threading limits for glusterd event threads. */
 #define GLUSTERD_MIN_EVENT_THREADS 1
 #define GLUSTERD_MAX_EVENT_THREADS 32
+#define GLUSTERD_MIN_NOFILE_LIMIT 65536
+#define GLUSTERD_MAX_NOFILE_LIMIT 2147483647
 
 #define GLUSTERD_TR_LOG_SIZE 50
 #define GLUSTERD_QUORUM_TYPE_KEY "cluster.server-quorum-type"

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2575,7 +2575,7 @@ reconfigure(xlator_t *this, dict_t *options)
         goto out;
 
     GF_OPTION_RECONF("nofile-limit", nofile_limit, options, int32, out);
-    if (nofile_limit > 0) {
+    if (nofile_limit) {
 #ifndef GF_DARWIN_HOST_OS
         {
             struct rlimit lim;
@@ -2678,7 +2678,6 @@ init(xlator_t *this)
     conf->last_sent_event = -1; /* To start with we don't have any events */
 
     GF_OPTION_INIT("nofile-limit", nofile_limit, int32, out);
-    if (nofile_limit > 0) {
 #ifndef GF_DARWIN_HOST_OS
         {
             struct rlimit lim;
@@ -2696,7 +2695,6 @@ init(xlator_t *this)
             }
         }
 #endif
-    }
 
     this->private = conf;
 

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -29,6 +29,8 @@
 /* Threading limits for client event threads. */
 #define CLIENT_MIN_EVENT_THREADS 1
 #define CLIENT_MAX_EVENT_THREADS 32
+#define CLIENT_MIN_NOFILE_LIMIT 4096
+#define CLIENT_MAX_NOFILE_LIMIT 2147483647
 
 /* FIXME: Needs to be defined in a common file */
 #define CLIENT_DUMP_LOCKS "trusted.glusterfs.clientlk-dump"

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1011,7 +1011,7 @@ do_rpc:
         goto out;
 
     GF_OPTION_RECONF("nofile-limit", nofile_limit, options, int32, out);
-    if (nofile_limit > 0) {
+    if (nofile_limit) {
 #ifndef GF_DARWIN_HOST_OS
         {
             struct rlimit lim;
@@ -1020,21 +1020,9 @@ do_rpc:
             lim.rlim_max = nofile_limit;
 
             if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_smsg(this->name, GF_LOG_WARNING, errno,
-                        PS_MSG_ULIMIT_SET_FAILED, "errno=%s", strerror(errno),
-                        NULL);
-                lim.rlim_cur = 65536;
-                lim.rlim_max = 65536;
-
-                if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                    gf_smsg(this->name, GF_LOG_WARNING, errno,
-                            PS_MSG_FD_NOT_FOUND, "errno=%s", strerror(errno),
-                            NULL);
-                } else {
-                    gf_msg_trace(this->name, 0,
-                                 "max open fd set "
-                                 "to 64k");
-                }
+                gf_log(this->name, GF_LOG_ERROR,
+                       "Failed to set nofile resource limit %d error is %s",
+                       nofile_limit, strerror(errno));
             } else {
                 gf_log(this->name, GF_LOG_INFO,
                        "Maximum allowed open file descriptors %d",
@@ -1343,7 +1331,6 @@ server_init(xlator_t *this)
     }
 
     GF_OPTION_INIT("nofile-limit", nofile_limit, int32, err);
-    if (nofile_limit > 0) {
 #ifndef GF_DARWIN_HOST_OS
         {
             struct rlimit lim;
@@ -1352,21 +1339,9 @@ server_init(xlator_t *this)
             lim.rlim_max = nofile_limit;
 
             if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_smsg(this->name, GF_LOG_WARNING, errno,
-                        PS_MSG_ULIMIT_SET_FAILED, "errno=%s", strerror(errno),
-                        NULL);
-                lim.rlim_cur = 65536;
-                lim.rlim_max = 65536;
-
-                if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                    gf_smsg(this->name, GF_LOG_WARNING, errno,
-                            PS_MSG_FD_NOT_FOUND, "errno=%s", strerror(errno),
-                            NULL);
-                } else {
-                    gf_msg_trace(this->name, 0,
-                                 "max open fd set "
-                                 "to 64k");
-                }
+                gf_log(this->name, GF_LOG_ERROR,
+                       "Failed to set nofile resource limit %d error is %s",
+                       nofile_limit, strerror(errno));
             } else {
                 gf_log(this->name, GF_LOG_INFO,
                        "Maximum allowed open file descriptors %d",
@@ -1374,7 +1349,6 @@ server_init(xlator_t *this)
             }
         }
 #endif
-    }
     if (!this->ctx->cmd_args.volfile_id) {
         /* In some use cases this is a valid case, but
            document this to be annoying log in that case */

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -29,6 +29,8 @@
 /* Threading limits for server event threads. */
 #define SERVER_MIN_EVENT_THREADS 1
 #define SERVER_MAX_EVENT_THREADS 1024
+#define SERVER_MIN_NOFILE_LIMIT 1048576
+#define SERVER_MAX_NOFILE_LIMIT 2147483647
 
 #define DEFAULT_VOLUME_FILE_PATH CONFDIR "/glusterfs.vol"
 #define GF_MAX_SOCKET_WINDOW_SIZE (1 * GF_UNIT_MB)

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -986,32 +986,7 @@ posix_init(xlator_t *this)
                "Could not lock brick directory (%s)", strerror(op_errno));
         goto out;
     }
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
-        lim.rlim_cur = 1048576;
-        lim.rlim_max = 1048576;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_SET_ULIMIT_FAILED,
-                   "Failed to set 'ulimit -n "
-                   " 1048576'");
-            lim.rlim_cur = 65536;
-            lim.rlim_max = 65536;
-
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_msg(this->name, GF_LOG_WARNING, errno,
-                       P_MSG_SET_FILE_MAX_FAILED,
-                       "Failed to set maximum allowed open "
-                       "file descriptors to 64k");
-            } else {
-                gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_MAX_FILE_OPEN,
-                       "Maximum allowed "
-                       "open file descriptors set to 65536");
-            }
-        }
-    }
-#endif
     _private->shared_brick_count = 1;
     ret = dict_get_int32(this->options, "shared-brick-count",
                          &_private->shared_brick_count);


### PR DESCRIPTION
Currently in gluster RLIMIT_NOFILE resource limit is hardcoded.
Sometime a user wants to configure high resource value so in
case while a limit has been reached the hardcoded limit the
gluster process are not able to handle request.

Solution: Provide a configurable option to configure the limit
Fixes: #2848
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

