### PR TITLE
test: test case bug-1702299.t is failing on centos-8

### DIFF
--- a/tests/bugs/bug-1702299.t
+++ b/tests/bugs/bug-1702299.t
@@ -46,6 +46,7 @@ cd -
 
 # Add-brick
 TEST $CLI volume add-brick $V0 $H0:$B0/${V0}{4,5}
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "6" online_brick_count
 
 cd $M0
 ## At this point dht code will heal xattr on down brick only for those dirs


### PR DESCRIPTION
The test case is throwing "No such file or directory"
error while running stat after run add-brick operation.

Solution: Need to check brick_count after run add-brick
          to avoid an issue.
Fixes: #2862
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

