### PR TITLE
test: the test case tests/basic/0symbol-check.t is failing

### DIFF
--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include <glusterfs/glusterfs.h>
+#include <glusterfs/syscall.h>
 #include "glfs-internal.h"
 #include "rpc-clnt.h"
 #include "protocol-common.h"
@@ -171,7 +172,7 @@ sanitize_args(int argc, char **argv)
         0,
     };
 
-    ret = lstat(argv[optind], &statbuf);
+    ret = sys_lstat(argv[optind], &statbuf);
     if (ret == -1) {
         fprintf(stderr, "Unable to stat %s (%s).\n", argv[optind],
                 strerror(errno));
@@ -182,7 +183,7 @@ sanitize_args(int argc, char **argv)
         goto err;
     }
 
-    ret = lstat(argv[optind + 1], &statbuf);
+    ret = sys_lstat(argv[optind + 1], &statbuf);
     if (ret == -1) {
         fprintf(stderr, "Unable to stat %s (%s).\n", argv[optind + 1],
                 strerror(errno));

--- a/libglusterfs/src/gf-io-uring.c
+++ b/libglusterfs/src/gf-io-uring.c
@@ -472,7 +472,7 @@ failed_cq:
 failed_sq:
     gf_io_uring_sq_fini();
 failed_close:
-    gf_io_call_errno0(close, fd);
+    gf_io_call_errno0(sys_close, fd);
 
     return res;
 }
@@ -484,7 +484,7 @@ gf_io_uring_cleanup(void)
     gf_io_uring_sq_fini();
     gf_io_uring_cq_fini();
 
-    gf_io_call_errno0(close, gf_io_uring.fd);
+    gf_io_call_errno0(sys_close, gf_io_uring.fd);
 }
 
 static int32_t

--- a/libglusterfs/src/glusterfs/gf-io.h
+++ b/libglusterfs/src/glusterfs/gf-io.h
@@ -20,6 +20,7 @@
 #include <urcu/uatomic.h>
 
 #include <glusterfs/gf-io-common.h>
+#include <glusterfs/syscall.h>
 
 /* Some macros to deal with request IDs. */
 


### PR DESCRIPTION
The test case is throwing below error
./glusterfsd/src/gf_attach.o should call sys_lstat, not lstat
./libglusterfs/src/.libs/libglusterfs_la-gf-io-uring.o should call sys_close, not close

Solution: Call sys_(lstat|close) to avoid an error
Fixes: #2865
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

