### PR TITLE
Dict.: remove prev

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -688,7 +688,10 @@ dict_deln(dict_t *this, char *key, const int keylen)
             this->totkvlen -= pair->value->len;
             data_unref(pair->value);
 
-            this->members_list = pair->next;
+            if (prev)
+                prev->next = pair->next;
+            else
+                this->members_list = pair->next;
 
             this->totkvlen -= (keylen + 1);
             GF_FREE(pair->key);

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -486,9 +486,6 @@ dict_set_lk(dict_t *this, char *key, const int key_len, data_t *value,
     this->members[hashval] = pair;
 
     pair->next = this->members_list;
-    pair->prev = NULL;
-    if (this->members_list)
-        this->members_list->prev = pair;
     this->members_list = pair;
     this->count++;
 
@@ -691,13 +688,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
             this->totkvlen -= pair->value->len;
             data_unref(pair->value);
 
-            if (pair->prev)
-                pair->prev->next = pair->next;
-            else
-                this->members_list = pair->next;
-
-            if (pair->next)
-                pair->next->prev = pair->prev;
+            this->members_list = pair->next;
 
             this->totkvlen -= (keylen + 1);
             GF_FREE(pair->key);
@@ -2244,9 +2235,6 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
             this->members[hashval] = pair;
 
             pair->next = this->members_list;
-            pair->prev = NULL;
-            if (this->members_list)
-                this->members_list->prev = pair;
             this->members_list = pair;
             this->count++;
 

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -16,13 +16,11 @@
 #include <limits.h>
 #include <fnmatch.h>
 
-
 /* dict_t is always initialized with hash_size = 1
  * with this usage it's implemented as a doubly-linked list
  * and the hash calculation done per operation is not necessary.
  * using this macro to delimit blocks related to hash imp */
 #define DICT_LIST_IMP 1
-
 
 #include "glusterfs/dict.h"
 #if !DICT_LIST_IMP
@@ -34,7 +32,6 @@
 #include "glusterfs/byte-order.h"
 #include "glusterfs/statedump.h"
 #include "glusterfs/libglusterfs-messages.h"
-
 
 struct dict_cmp {
     dict_t *dict;
@@ -254,6 +251,12 @@ key_value_cmp(dict_t *one, char *key1, data_t *value1, void *data)
     }
 
     return -1;
+}
+
+static inline gf_boolean_t
+dict_match_everything(dict_t *d, char *k, data_t *v, void *data)
+{
+    return _gf_true;
 }
 
 /* If both dicts are NULL then equal. If one of the dicts is NULL but the
@@ -581,7 +584,7 @@ dict_get(dict_t *this, char *key)
     }
 #if !DICT_LIST_IMP
     return dict_getn(this, key, strlen(key));
-#else   
+#else
     return dict_getn(this, key, 0);
 #endif
 }
@@ -696,7 +699,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
             if (pair->next)
                 pair->next->prev = pair->prev;
 
-            this->totkvlen -= (strlen(pair->key) + 1);
+            this->totkvlen -= (keylen + 1);
             GF_FREE(pair->key);
             if (pair == &this->free_pair) {
                 this->free_pair.key = NULL;
@@ -1359,12 +1362,6 @@ dict_remove_foreach_fn(dict_t *d, char *k, data_t *v, void *_tmp)
     return 0;
 }
 
-gf_boolean_t
-dict_match_everything(dict_t *d, char *k, data_t *v, void *data)
-{
-    return _gf_true;
-}
-
 int
 dict_foreach(dict_t *dict,
              int (*fn)(dict_t *this, char *key, data_t *value, void *data),
@@ -1399,7 +1396,7 @@ dict_foreach_match(dict_t *dict,
         return -1;
     }
 
-    int ret = -1;
+    int ret;
     int count = 0;
     data_pair_t *pairs = dict->members_list;
     data_pair_t *next = NULL;

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -3563,11 +3563,7 @@ dict_unserialize_specific_keys(char *orig_buf, int32_t size, dict_t **fill,
     int32_t keylen = 0;
     int32_t vallen = 0;
     int32_t hostord = 0;
-    xlator_t *this = NULL;
     int32_t keylenarr[totkeycount];
-
-    this = THIS;
-    GF_ASSERT(this);
 
     if (!buf) {
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -96,12 +96,11 @@ struct _data {
     gf_atomic_t refcount;
     gf_dict_data_type_t data_type;
     uint32_t len;
-    gf_boolean_t is_static;
+    uint32_t is_static;
 };
 
 struct _data_pair {
     struct _data_pair *hash_next;
-    struct _data_pair *prev;
     struct _data_pair *next;
     data_t *value;
     char *key;
@@ -113,12 +112,12 @@ struct _dict {
     int32_t hash_size;
     int32_t count;
     gf_atomic_t refcount;
+    gf_lock_t lock;
     data_pair_t **members;
     data_pair_t *members_list;
-    char *extra_stdfree;
-    gf_lock_t lock;
-    data_pair_t *members_internal;
     data_pair_t free_pair;
+    data_pair_t *members_internal;
+    char *extra_stdfree;
     /* Variable to store total keylen + value->len */
     uint32_t totkvlen;
 };

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -324,9 +324,9 @@ dict_set_uint64(dict_t *this, char *key, uint64_t val);
 #define dict_get_time(dict, key, val) dict_get_int64((dict), (key), (val))
 #define dict_set_time(dict, key, val) dict_set_int64((dict), (key), (val))
 #elif __WORDSIZE == 32
-#define dict_get_time(dict, key, val)                   \
+#define dict_get_time(dict, key, val)                                          \
     dict_get_int32((dict), (key), ((int32_t *)(val)))
-#define dict_set_time(dict, key, val)                   \
+#define dict_set_time(dict, key, val)                                          \
     dict_set_int32((dict), (key), ((int32_t)(val)))
 #else
 #error "unknown word size"
@@ -413,8 +413,6 @@ dict_dump_to_log(dict_t *dict);
 
 int
 dict_dump_to_str(dict_t *dict, char *dump, int dumpsize, char *format);
-gf_boolean_t
-dict_match_everything(dict_t *d, char *k, data_t *v, void *data);
 
 dict_t *
 dict_for_key_value(const char *name, const char *value, size_t size,


### PR DESCRIPTION
We don't need the prev pointer - we only iterate in a single direction.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>