### PR TITLE
Multiple files: call logger function for TRACE and DEBUG levels only …

### DIFF
--- a/libglusterfs/src/fd-lk.c
+++ b/libglusterfs/src/fd-lk.c
@@ -385,26 +385,31 @@ fd_lk_insert_and_merge(fd_t *fd, int32_t cmd, struct gf_flock *flock)
     int32_t ret = -1;
     fd_lk_ctx_t *lk_ctx = NULL;
     fd_lk_ctx_node_t *lk = NULL;
+    gf_boolean_t debug_log;
 
     GF_VALIDATE_OR_GOTO("fd-lk", fd, out);
     GF_VALIDATE_OR_GOTO("fd-lk", flock, out);
 
+    debug_log = DO_LOGGING((THIS), GF_LOG_DEBUG);
     lk_ctx = fd_lk_ctx_ref(fd->lk_ctx);
     lk = fd_lk_ctx_node_new(cmd, flock);
 
-    gf_msg_debug("fd-lk", 0,
-                 "new lock request: owner = %s, fl_type = %s"
-                 ", fs_start = %" PRId64 ", fs_end = %" PRId64
-                 ", user_flock:"
-                 " l_type = %s, l_start = %" PRId64 ", l_len = %" PRId64,
-                 lkowner_utoa(&flock->l_owner), get_lk_type(lk->fl_type),
-                 lk->fl_start, lk->fl_end, get_lk_type(lk->user_flock.l_type),
-                 lk->user_flock.l_start, lk->user_flock.l_len);
+    if (debug_log)
+        gf_msg_debug("fd-lk", 0,
+                     "new lock request: owner = %s, fl_type = %s"
+                     ", fs_start = %" PRId64 ", fs_end = %" PRId64
+                     ", user_flock:"
+                     " l_type = %s, l_start = %" PRId64 ", l_len = %" PRId64,
+                     lkowner_utoa(&flock->l_owner), get_lk_type(lk->fl_type),
+                     lk->fl_start, lk->fl_end,
+                     get_lk_type(lk->user_flock.l_type), lk->user_flock.l_start,
+                     lk->user_flock.l_len);
 
     LOCK(&lk_ctx->lock);
     {
         _fd_lk_insert_and_merge(lk_ctx, lk);
-        print_lock_list(lk_ctx);
+        if (debug_log)
+            print_lock_list(lk_ctx);
     }
     UNLOCK(&lk_ctx->lock);
 

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -186,6 +186,23 @@ int
 _gf_log_eh(const char *function, const char *fmt, ...)
     __attribute__((__format__(__printf__, 2, 3)));
 
+#define DO_LOGGING(_xl, level)                                                 \
+    ({                                                                         \
+        gf_boolean_t to_log = _gf_false;                                       \
+        if (_xl->loglevel) {                                                   \
+            if (level <= _xl->loglevel)                                        \
+                to_log = _gf_true;                                             \
+            else                                                               \
+                to_log = _gf_false;                                            \
+        } else if (_xl->ctx) {                                                 \
+            if (level <= _xl->ctx->log.loglevel)                               \
+                to_log = _gf_true;                                             \
+            else                                                               \
+                to_log = _gf_false;                                            \
+        }                                                                      \
+        to_log;                                                                \
+    })
+
 /* treat GF_LOG_TRACE and GF_LOG_NONE as LOG_DEBUG and
  * other level as is */
 #define SET_LOG_PRIO(level, priority)                                          \

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -751,17 +751,7 @@ set_sys_log_level(gf_loglevel_t level)
 static gf_boolean_t
 skip_logging(xlator_t *this, gf_loglevel_t level)
 {
-    gf_loglevel_t existing_level = this->loglevel ? this->loglevel
-                                                  : this->ctx->log.loglevel;
-    if (level > existing_level) {
-        return _gf_true;
-    }
-
-    if (level == GF_LOG_NONE) {
-        return _gf_true;
-    }
-
-    return _gf_false;
+    return !(DO_LOGGING(this, level));
 }
 
 int

--- a/rpc/rpc-lib/src/auth-glusterfs.c
+++ b/rpc/rpc-lib/src/auth-glusterfs.c
@@ -290,6 +290,7 @@ auth_glusterfs_v3_authenticate(rpcsvc_request_t *req, void *priv)
     int i = 0;
     int max_groups = 0;
     int max_lk_owner_len = 0;
+    xlator_t *this;
 
     if (!req)
         return ret;
@@ -355,11 +356,13 @@ auth_glusterfs_v3_authenticate(rpcsvc_request_t *req, void *priv)
     req->ctime.tv_sec = au.ctime_sec;
     req->ctime.tv_nsec = au.ctime_nsec;
 
-    gf_log(GF_RPCSVC, GF_LOG_TRACE,
-           "Auth Info: pid: %u, uid: %d"
-           ", gid: %d, owner: %s, flags: %d",
-           req->pid, req->uid, req->gid, lkowner_utoa(&req->lk_owner),
-           req->flags);
+    this = THIS;
+    if (DO_LOGGING(this, GF_LOG_TRACE))
+        gf_log(GF_RPCSVC, GF_LOG_TRACE,
+               "Auth Info: pid: %u, uid: %d"
+               ", gid: %d, owner: %s, flags: %d",
+               req->pid, req->uid, req->gid, lkowner_utoa(&req->lk_owner),
+               req->flags);
     ret = RPCSVC_AUTH_ACCEPT;
 err:
     /* TODO: instead use alloca() for these variables */

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -651,12 +651,13 @@ rpc_clnt_reply_init(rpc_clnt_connection_t *conn, rpc_transport_pollin_t *msg,
         goto out;
     }
 
-    gf_log(conn->name, GF_LOG_TRACE,
-           "received rpc message (RPC XID: 0x%x"
-           " Program: %s, ProgVers: %d, Proc: %d) from rpc-transport (%s)",
-           saved_frame->rpcreq->xid, saved_frame->rpcreq->prog->progname,
-           saved_frame->rpcreq->prog->progver, saved_frame->rpcreq->procnum,
-           conn->name);
+    if (DO_LOGGING((THIS), GF_LOG_TRACE))
+        gf_log(conn->name, GF_LOG_TRACE,
+               "received rpc message (RPC XID: 0x%x"
+               " Program: %s, ProgVers: %d, Proc: %d) from rpc-transport (%s)",
+               saved_frame->rpcreq->xid, saved_frame->rpcreq->prog->progname,
+               saved_frame->rpcreq->prog->progver, saved_frame->rpcreq->procnum,
+               conn->name);
 
 out:
     if (ret != 0) {
@@ -1722,13 +1723,15 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
 
             conn->msgcnt++;
 
-            gf_log("rpc-clnt", GF_LOG_TRACE,
-                   "submitted request "
-                   "(unique: %" PRIu64
-                   ", XID: 0x%x, Program: %s, "
-                   "ProgVers: %d, Proc: %d) to rpc-transport (%s)",
-                   cframe->root->unique, rpcreq->xid, rpcreq->prog->progname,
-                   rpcreq->prog->progver, rpcreq->procnum, conn->name);
+            if (DO_LOGGING((THIS), GF_LOG_TRACE))
+                gf_log("rpc-clnt", GF_LOG_TRACE,
+                       "submitted request "
+                       "(unique: %" PRIu64
+                       ", XID: 0x%x, Program: %s, "
+                       "ProgVers: %d, Proc: %d) to rpc-transport (%s)",
+                       cframe->root->unique, rpcreq->xid,
+                       rpcreq->prog->progname, rpcreq->prog->progver,
+                       rpcreq->procnum, conn->name);
         }
     }
 unlock:

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -165,7 +165,7 @@ struct rpc_transport {
 
     void *private;
     struct _client *xl_private;
-    void *xl; /* Used for THIS */
+    xlator_t *xl; /* Used for THIS */
     void *mydata;
     pthread_mutex_t lock;
     gf_atomic_t refcount;

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -1565,13 +1565,14 @@ rpcsvc_submit_generic(rpcsvc_request_t *req, struct iovec *proghdr,
                req->prog ? req->prog->progver : 0, req->procnum,
                trans ? trans->name : "");
     } else {
-        gf_log(GF_RPCSVC, GF_LOG_TRACE,
-               "submitted reply for rpc-message (XID: 0x%x, "
-               "Program: %s, ProgVers: %d, Proc: %d) to rpc-transport "
-               "(%s)",
-               req->xid, req->prog ? req->prog->progname : "-",
-               req->prog ? req->prog->progver : 0, req->procnum,
-               trans ? trans->name : "");
+        if (DO_LOGGING((THIS), GF_LOG_TRACE))
+            gf_log(GF_RPCSVC, GF_LOG_TRACE,
+                   "submitted reply for rpc-message (XID: 0x%x, "
+                   "Program: %s, ProgVers: %d, Proc: %d) to rpc-transport "
+                   "(%s)",
+                   req->xid, req->prog ? req->prog->progname : "-",
+                   req->prog ? req->prog->progver : 0, req->procnum,
+                   trans ? trans->name : "");
     }
 
 disconnect_exit:

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -433,6 +433,7 @@ pl_inode_get(xlator_t *this, inode_t *inode, pl_local_t *local)
     uint64_t tmp_pl_inode = 0;
     pl_inode_t *pl_inode = NULL;
     int ret = 0;
+    gf_boolean_t log_allocation = _gf_false;
 
     LOCK(&inode->lock);
     {
@@ -447,7 +448,7 @@ pl_inode_get(xlator_t *this, inode_t *inode, pl_local_t *local)
             goto unlock;
         }
 
-        gf_log(this->name, GF_LOG_TRACE, "Allocating new pl inode");
+        log_allocation = _gf_true;
 
         pthread_mutex_init(&pl_inode->mutex, NULL);
         pthread_cond_init(&pl_inode->check_fop_wind_count, 0);
@@ -478,6 +479,9 @@ pl_inode_get(xlator_t *this, inode_t *inode, pl_local_t *local)
     }
 unlock:
     UNLOCK(&inode->lock);
+
+    if (log_allocation && DO_LOGGING(this, GF_LOG_TRACE))
+        gf_log(this->name, GF_LOG_TRACE, "Allocated new pl inode");
 
     if ((pl_inode != NULL) && pl_is_mandatory_locking_enabled(pl_inode) &&
         pl_inode->check_mlock_info && local) {

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -371,8 +371,9 @@ send_fuse_iov(xlator_t *this, fuse_in_header_t *finh, struct iovec *iov_out,
     fouh->unique = finh->unique;
 
     res = sys_writev(priv->fd, iov_out, count);
-    gf_log("glusterfs-fuse", GF_LOG_TRACE, "writev() result %d/%d %s", res,
-           fouh->len, res == -1 ? strerror(errno) : "");
+    if (DO_LOGGING(this, GF_LOG_TRACE))
+        gf_log("glusterfs-fuse", GF_LOG_TRACE, "writev() result %d/%d %s", res,
+               fouh->len, res == -1 ? strerror(errno) : "");
 
     return check_and_dump_fuse_W(priv, iov_out, count, res, NULL);
 }

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -365,8 +365,9 @@ iot_schedule(call_frame_t *frame, xlator_t *this, call_stub_t *stub)
             return -EINVAL;
     }
 out:
-    gf_msg_debug(this->name, 0, "%s scheduled as %s priority fop",
-                 gf_fop_list[stub->fop], iot_get_pri_meaning(pri));
+    if (DO_LOGGING(this, GF_LOG_DEBUG))
+        gf_msg_debug(this->name, 0, "%s scheduled as %s priority fop",
+                     gf_fop_list[stub->fop], iot_get_pri_meaning(pri));
     ret = do_iot_schedule(conf, stub, pri);
     return ret;
 }

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -502,10 +502,11 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
     LOCK(&mdc->lock);
     {
         if (!iatt || !iatt->ia_ctime) {
-            gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
-                             "invalidating iatt(NULL)"
-                             "(%s)",
-                             uuid_utoa(inode->gfid));
+            if (DO_LOGGING(this, GF_LOG_TRACE))
+                gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
+                                 "invalidating iatt(NULL)"
+                                 "(%s)",
+                                 uuid_utoa(inode->gfid));
             mdc->ia_time = 0;
             mdc->valid = 0;
 
@@ -523,21 +524,23 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
          * changes, hence check for ctime only.
          */
         if (mdc->md_ctime > iatt->ia_ctime) {
-            gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
-                             MD_CACHE_MSG_DISCARD_UPDATE,
-                             "discarding the iatt validate "
-                             "request (%s)",
-                             uuid_utoa(inode->gfid));
+            if (DO_LOGGING(this, GF_LOG_DEBUG))
+                gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
+                                 MD_CACHE_MSG_DISCARD_UPDATE,
+                                 "discarding the iatt validate "
+                                 "request (%s)",
+                                 uuid_utoa(inode->gfid));
             ret = -1;
             goto unlock;
         }
         if ((mdc->md_ctime == iatt->ia_ctime) &&
             (mdc->md_ctime_nsec > iatt->ia_ctime_nsec)) {
-            gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
-                             MD_CACHE_MSG_DISCARD_UPDATE,
-                             "discarding the iatt validate "
-                             "request(ctime_nsec) (%s)",
-                             uuid_utoa(inode->gfid));
+            if (DO_LOGGING(this, GF_LOG_DEBUG))
+                gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
+                                 MD_CACHE_MSG_DISCARD_UPDATE,
+                                 "discarding the iatt validate "
+                                 "request(ctime_nsec) (%s)",
+                                 uuid_utoa(inode->gfid));
             ret = -1;
             goto unlock;
         }
@@ -558,11 +561,12 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
                  (prebuf->ia_ctime != mdc->md_ctime) ||
                  (prebuf->ia_ctime_nsec != mdc->md_ctime_nsec))) {
                 if (IA_ISREG(inode->ia_type)) {
-                    gf_msg("md-cache", GF_LOG_TRACE, 0,
-                           MD_CACHE_MSG_DISCARD_UPDATE,
-                           "prebuf doesn't match the value we have cached,"
-                           " invalidate the inode(%s)",
-                           uuid_utoa(inode->gfid));
+                    if (DO_LOGGING(this, GF_LOG_TRACE))
+                        gf_msg("md-cache", GF_LOG_TRACE, 0,
+                               MD_CACHE_MSG_DISCARD_UPDATE,
+                               "prebuf doesn't match the value we have cached,"
+                               " invalidate the inode(%s)",
+                               uuid_utoa(inode->gfid));
 
                     inode_invalidate(inode);
                 }
@@ -580,23 +584,24 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
                 if (mdc->xa_time && update_xa_time)
                     mdc->xa_time = mdc->ia_time;
             }
-
-            gf_msg_callingfn(
-                "md-cache", GF_LOG_TRACE, 0, MD_CACHE_MSG_CACHE_UPDATE,
-                "Updated iatt(%s)"
-                " time:%lld generation=%lld",
-                uuid_utoa(iatt->ia_gfid), (unsigned long long)mdc->ia_time,
-                (unsigned long long)mdc->generation);
+            if (DO_LOGGING(this, GF_LOG_TRACE))
+                gf_msg_callingfn(
+                    "md-cache", GF_LOG_TRACE, 0, MD_CACHE_MSG_CACHE_UPDATE,
+                    "Updated iatt(%s)"
+                    " time:%lld generation=%lld",
+                    uuid_utoa(iatt->ia_gfid), (unsigned long long)mdc->ia_time,
+                    (unsigned long long)mdc->generation);
         } else {
-            gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
-                             "not updating cache (%s)"
-                             "mdc-rollover=%u rollover=%u "
-                             "mdc-generation=%llu "
-                             "mdc-ia_time=%llu incident_time=%llu ",
-                             uuid_utoa(iatt->ia_gfid), mdc->gen_rollover,
-                             rollover, (unsigned long long)mdc->generation,
-                             (unsigned long long)mdc->ia_time,
-                             (unsigned long long)incident_time);
+            if (DO_LOGGING(this, GF_LOG_TRACE))
+                gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
+                                 "not updating cache (%s)"
+                                 "mdc-rollover=%u rollover=%u "
+                                 "mdc-generation=%llu "
+                                 "mdc-ia_time=%llu incident_time=%llu ",
+                                 uuid_utoa(iatt->ia_gfid), mdc->gen_rollover,
+                                 rollover, (unsigned long long)mdc->generation,
+                                 (unsigned long long)mdc->ia_time,
+                                 (unsigned long long)incident_time);
         }
     }
 unlock:


### PR DESCRIPTION
…if needed.

Calling logging function costs us the log string creation, even if we end
up not logging at all, as we are not at DEBUG or TRACE log level.
Sometimes, there are costly functions to create the string, such as
uuid_utoa(). Strive to not even call the logging function if we don't have to.

Created a macro that implements skip_logging() and used it in some
functions which I've seem to be costly.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

