### PR TITLE
server-helpers.c: streamline get_frame_from_request() function

### DIFF
--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -57,28 +57,26 @@ struct _child_status {
 struct server_conf {
     rpcsvc_t *rpc;
     int inode_lru_limit;
-    gf_boolean_t trace;
-    char *conf_dir;
-    struct _volfile_ctx *volfile;
-    dict_t *auth_modules;
-    pthread_mutex_t mutex;
-    struct list_head xprt_list;
-
     gf_boolean_t server_manage_gids; /* resolve gids on brick */
-    gid_cache_t gid_cache;
-    time_t gid_cache_timeout;
-
-    int event_threads; /* # of event threads
-                        * configured */
-
+    gf_boolean_t trace;
     gf_boolean_t parent_up;
     gf_boolean_t dync_auth; /* if set authenticate dynamically,
                              * in case if volume set options
                              * (say *.allow | *.reject) are
                              * tweeked */
+    char *conf_dir;
+    struct _volfile_ctx *volfile;
+    dict_t *auth_modules;
+    struct list_head xprt_list;
+    time_t gid_cache_timeout;
     struct _child_status *child_status;
-    gf_lock_t itable_lock;
+    int event_threads; /* # of event threads
+                        * configured */
     gf_boolean_t strict_auth_enabled;
+    pthread_mutex_t mutex;
+
+    gf_lock_t itable_lock;
+    gid_cache_t gid_cache;
 };
 typedef struct server_conf server_conf_t;
 


### PR DESCRIPTION
Remove some unneeded calls and checks and loops.
As an example, once RPC_AUTH_ROOT_SQUASH and RPC_AUTH_ALL_SQUASH are
called once, bail out of the loop.
Call gid_resolve() directly if priv->server_manage_gids is true, etc.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

