### PR TITLE
Multiple files: use lkowner_copy() instead of direct assignment

### DIFF
--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -891,7 +891,7 @@ args_lk_store(default_args_t *args, fd_t *fd, int32_t cmd,
     if (fd)
         args->fd = fd_ref(fd);
     args->cmd = cmd;
-    args->lock = *lock;
+    gf_flock_copy(&args->lock, lock);
     if (xdata)
         args->xdata = dict_ref(xdata);
     return 0;
@@ -904,7 +904,7 @@ args_lk_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
     args->op_ret = op_ret;
     args->op_errno = op_errno;
     if (op_ret == 0)
-        args->lock = *lock;
+        gf_flock_copy(&args->lock, lock);
     if (xdata)
         args->xdata = dict_ref(xdata);
 
@@ -920,7 +920,7 @@ args_inodelk_store(default_args_t *args, const char *volume, loc_t *loc,
 
     loc_copy(&args->loc, loc);
     args->cmd = cmd;
-    args->lock = *lock;
+    gf_flock_copy(&args->lock, lock);
     if (xdata)
         args->xdata = dict_ref(xdata);
     return 0;
@@ -949,7 +949,7 @@ args_finodelk_store(default_args_t *args, const char *volume, fd_t *fd,
         args->volume = gf_strdup(volume);
 
     args->cmd = cmd;
-    args->lock = *lock;
+    gf_flock_copy(&args->lock, lock);
 
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -1428,6 +1428,7 @@ args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
     if (op_ret > 0) {
         list_for_each_entry(entry, &locklist->list, list)
         {
+            /* TODO: move to GF_MALLOC() */
             stub_entry = GF_CALLOC(1, sizeof(*stub_entry), gf_common_mt_char);
             if (!stub_entry) {
                 ret = -1;
@@ -1435,7 +1436,7 @@ args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
             }
 
             INIT_LIST_HEAD(&stub_entry->list);
-            stub_entry->flock = entry->flock;
+            gf_flock_copy(&stub_entry->flock, &entry->flock);
 
             stub_entry->lk_flags = entry->lk_flags;
 
@@ -1465,6 +1466,7 @@ args_setactivelk_store(default_args_t *args, loc_t *loc,
 
     list_for_each_entry(entry, &locklist->list, list)
     {
+        /* TODO: move to GF_MALLOC() */
         stub_entry = GF_CALLOC(1, sizeof(*stub_entry), gf_common_mt_lock_mig);
         if (!stub_entry) {
             ret = -1;
@@ -1472,7 +1474,7 @@ args_setactivelk_store(default_args_t *args, loc_t *loc,
         }
 
         INIT_LIST_HEAD(&stub_entry->list);
-        stub_entry->flock = entry->flock;
+        gf_flock_copy(&stub_entry->flock, &entry->flock);
 
         stub_entry->lk_flags = entry->lk_flags;
 

--- a/libglusterfs/src/fd-lk.c
+++ b/libglusterfs/src/fd-lk.c
@@ -152,7 +152,7 @@ fd_lk_ctx_node_new(int32_t cmd, struct gf_flock *flock)
         else
             new_lock->fl_end = flock->l_start + flock->l_len - 1;
 
-        memcpy(&new_lock->user_flock, flock, sizeof(struct gf_flock));
+        gf_flock_copy(&new_lock->user_flock, flock);
     }
 
     INIT_LIST_HEAD(&new_lock->next);

--- a/libglusterfs/src/glusterfs/fd-lk.h
+++ b/libglusterfs/src/glusterfs/fd-lk.h
@@ -33,11 +33,11 @@ typedef struct fd_lk_ctx fd_lk_ctx_t;
 
 struct fd_lk_ctx_node {
     int32_t cmd;
-    struct gf_flock user_flock;
+    short fl_type;
     off_t fl_start;
     off_t fl_end;
-    short fl_type;
     struct list_head next;
+    struct gf_flock user_flock;
 };
 typedef struct fd_lk_ctx_node fd_lk_ctx_node_t;
 

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -782,11 +782,22 @@ struct gf_flock {
     gf_lkowner_t l_owner;
 };
 
+static inline void
+gf_flock_copy(struct gf_flock *dst, struct gf_flock *src)
+{
+    dst->l_type = src->l_type;
+    dst->l_whence = src->l_whence;
+    dst->l_start = src->l_start;
+    dst->l_len = src->l_len;
+    dst->l_pid = src->l_pid;
+    lk_owner_copy(&dst->l_owner, &src->l_owner);
+}
+
 typedef struct lock_migration_info {
     struct list_head list;
-    struct gf_flock flock;
     char *client_uid;
     uint32_t lk_flags;
+    struct gf_flock flock;
 } lock_migration_info_t;
 
 #define GF_MUST_CHECK __attribute__((warn_unused_result))

--- a/libglusterfs/src/glusterfs/lkowner.h
+++ b/libglusterfs/src/glusterfs/lkowner.h
@@ -88,6 +88,7 @@ static inline void
 lk_owner_copy(gf_lkowner_t *dst, gf_lkowner_t *src)
 {
     dst->len = src->len;
-    memcpy(dst->data, src->data, src->len);
+    if (src->len)
+        memcpy(dst->data, src->data, src->len);
 }
 #endif /* _LK_OWNER_H */

--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -513,7 +513,7 @@ copy_frame(call_frame_t *frame)
     memcpy(newstack->groups, oldstack->groups, sizeof(gid_t) * oldstack->ngrps);
     newstack->unique = oldstack->unique;
     newstack->pool = oldstack->pool;
-    newstack->lk_owner = oldstack->lk_owner;
+    lk_owner_copy(&newstack->lk_owner, &oldstack->lk_owner);
     newstack->ctx = oldstack->ctx;
 
     if (newstack->ctx->measure_latency) {

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -439,7 +439,7 @@ syncop_create_frame(xlator_t *this)
     }
 
     if (opctx && (opctx->valid & SYNCOPCTX_LKOWNER))
-        frame->root->lk_owner = opctx->lk_owner;
+        lk_owner_copy(&frame->root->lk_owner, &opctx->lk_owner);
 
     return frame;
 }

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -3225,7 +3225,7 @@ syncop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         args->xdata = dict_ref(xdata);
 
     if (flock)
-        args->flock = *flock;
+        gf_flock_copy(&args->flock, flock);
     __wake(args);
 
     return 0;
@@ -3242,7 +3242,7 @@ syncop_lk(xlator_t *subvol, fd_t *fd, int cmd, struct gf_flock *flock,
     SYNCOP(subvol, (&args), syncop_lk_cbk, subvol->fops->lk, fd, cmd, flock,
            xdata_in);
 
-    *flock = args.flock;
+    gf_flock_copy(flock, &args.flock);
 
     if (xdata_out)
         *xdata_out = args.xdata;
@@ -3431,6 +3431,7 @@ syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_ret > 0) {
         list_for_each_entry(tmp, &locklist->list, list)
         {
+            /* TODO: move to GF_MALLOC() */
             entry = GF_CALLOC(1, sizeof(lock_migration_info_t),
                               gf_common_mt_char);
 
@@ -3444,7 +3445,7 @@ syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
             INIT_LIST_HEAD(&entry->list);
 
-            entry->flock = tmp->flock;
+            gf_flock_copy(&entry->flock, &tmp->flock);
 
             entry->lk_flags = tmp->lk_flags;
 

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -155,7 +155,7 @@ syncopctx_setfslkowner(gf_lkowner_t *lk_owner)
 
     opctx = syncopctx_getctx();
 
-    opctx->lk_owner = *lk_owner;
+    lk_owner_copy(&opctx->lk_owner, lk_owner);
     opctx->valid |= SYNCOPCTX_LKOWNER;
 
 out:

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -270,7 +270,7 @@ afr_add_lock_to_saved_locks(call_frame_t *frame, xlator_t *this)
     if (!info->xdata_req) {
         goto cleanup;
     }
-    info->lk_owner = frame->root->lk_owner;
+    lk_owner_copy(&info->lk_owner, &frame->root->lk_owner);
     info->locked_nodes = GF_MALLOC(
         sizeof(*info->locked_nodes) * priv->child_count, gf_afr_mt_char);
     if (!info->locked_nodes) {
@@ -7631,9 +7631,7 @@ gf_boolean_t
 afr_ta_is_fop_called_from_synctask(xlator_t *this)
 {
     struct synctask *task = NULL;
-    gf_lkowner_t tmp_owner = {
-        0,
-    };
+    gf_lkowner_t tmp_owner;
 
     task = synctask_get();
     if (!task)

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -265,7 +265,7 @@ afr_add_lock_to_saved_locks(call_frame_t *frame, xlator_t *this)
     info->fd = fd_ref(local->fd);
     info->cmd = local->cont.lk.cmd;
     info->pid = frame->root->pid;
-    info->flock = local->cont.lk.user_flock;
+    gf_flock_copy(&info->flock, &local->cont.lk.user_flock);
     info->xdata_req = dict_copy_with_ref(local->xdata_req, NULL);
     if (!info->xdata_req) {
         goto cleanup;
@@ -329,7 +329,7 @@ static int
 afr_remove_lock_from_saved_locks(afr_local_t *local, xlator_t *this)
 {
     afr_private_t *priv = this->private;
-    struct gf_flock flock = local->cont.lk.user_flock;
+    struct gf_flock *user_flock;
     afr_lk_heal_info_t *info = NULL;
     afr_fd_ctx_t *fd_ctx = NULL;
     int ret = -EINVAL;
@@ -339,10 +339,11 @@ afr_remove_lock_from_saved_locks(afr_local_t *local, xlator_t *this)
         goto out;
     }
 
+    user_flock = &local->cont.lk.user_flock;
     info = fd_ctx->lk_heal_info;
-    if ((info->flock.l_start != flock.l_start) ||
-        (info->flock.l_whence != flock.l_whence) ||
-        (info->flock.l_len != flock.l_len)) {
+    if ((info->flock.l_start != user_flock->l_start) ||
+        (info->flock.l_whence != user_flock->l_whence) ||
+        (info->flock.l_len != user_flock->l_len)) {
         /*TODO: Compare lkowners too.*/
         goto out;
     }
@@ -355,7 +356,7 @@ afr_remove_lock_from_saved_locks(afr_local_t *local, xlator_t *this)
 
     afr_lk_heal_info_cleanup(info);
     fd_ctx->lk_heal_info = NULL;
-    ret = 0;
+    return 0;
 out:
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, -ret, AFR_MSG_LK_HEAL_DOM,
@@ -398,7 +399,7 @@ afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "Failed getlk for %s", uuid_utoa(local->fd->inode->gfid));
     } else {
-        local->cont.lk.getlk_rsp[i] = *lock;
+        gf_flock_copy(&local->cont.lk.getlk_rsp[i], lock);
     }
 
     syncbarrier_wake(&local->barrier);
@@ -411,16 +412,14 @@ afr_does_lk_owner_match(call_frame_t *frame, afr_private_t *priv,
 {
     int i = 0;
     afr_local_t *local = frame->local;
-    struct gf_flock flock = {
-        0,
-    };
+    struct gf_flock flock;
     gf_boolean_t ret = _gf_true;
     char *wind_on = alloca0(priv->child_count);
     unsigned char *success_replies = alloca0(priv->child_count);
     local->cont.lk.getlk_rsp = GF_CALLOC(sizeof(*local->cont.lk.getlk_rsp),
                                          priv->child_count, gf_afr_mt_gf_lock);
 
-    flock = info->flock;
+    gf_flock_copy(&flock, &info->flock);
     for (i = 0; i < priv->child_count; i++) {
         if (info->locked_nodes[i])
             wind_on[i] = 1;
@@ -4509,7 +4508,8 @@ afr_fop_lock_proceed(call_frame_t *frame)
         case GF_FOP_INODELK:
         case GF_FOP_FINODELK:
             local->cont.inodelk.cmd = local->cont.inodelk.in_cmd;
-            local->cont.inodelk.flock = local->cont.inodelk.in_flock;
+            gf_flock_copy(&local->cont.inodelk.flock,
+                          &local->cont.inodelk.in_flock);
             if (local->cont.inodelk.xdata)
                 dict_unref(local->cont.inodelk.xdata);
             local->cont.inodelk.xdata = NULL;
@@ -4865,8 +4865,8 @@ afr_handle_inodelk(call_frame_t *frame, xlator_t *this, glusterfs_fop_t fop,
 
     local->cont.inodelk.in_cmd = cmd;
     local->cont.inodelk.cmd = cmd;
-    local->cont.inodelk.in_flock = *flock;
-    local->cont.inodelk.flock = *flock;
+    gf_flock_copy(&local->cont.inodelk.in_flock, flock);
+    gf_flock_copy(&local->cont.inodelk.flock, flock);
     if (xdata)
         local->xdata_req = dict_ref(xdata);
 
@@ -5146,7 +5146,7 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         local->op_ret = 0;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
-        local->cont.lk.ret_flock = *lock;
+        gf_flock_copy(&local->cont.lk.ret_flock, lock);
     }
 
     child_index++;
@@ -5195,7 +5195,7 @@ afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->op_ret = 0;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
-        local->cont.lk.ret_flock = *lock;
+        gf_flock_copy(&local->cont.lk.ret_flock, lock);
     }
     syncbarrier_wake(&local->barrier);
     return 0;
@@ -5329,8 +5329,8 @@ afr_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     local->fd = fd_ref(fd);
     local->cont.lk.cmd = cmd;
-    local->cont.lk.user_flock = *flock;
-    local->cont.lk.ret_flock = *flock;
+    gf_flock_copy(&local->cont.lk.user_flock, flock);
+    gf_flock_copy(&local->cont.lk.ret_flock, flock);
     if (xdata) {
         local->xdata_req = dict_ref(xdata);
         if (afr_is_lock_mode_mandatory(xdata)) {

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -321,9 +321,7 @@ afr_internal_lock_wind(call_frame_t *frame,
     afr_internal_lock_t *int_lock = &local->internal_lock;
     entrylk_cmd cmd = ENTRYLK_LOCK_NB;
     int32_t cmd1 = F_SETLK;
-    struct gf_flock flock = {
-        0,
-    };
+    struct gf_flock flock;
 
     switch (local->transaction.type) {
         case AFR_ENTRY_TRANSACTION:
@@ -354,7 +352,7 @@ afr_internal_lock_wind(call_frame_t *frame,
 
         case AFR_DATA_TRANSACTION:
         case AFR_METADATA_TRANSACTION:
-            flock = int_lock->lockee[lockee_num].flock;
+            gf_flock_copy(&flock, &int_lock->lockee[lockee_num].flock);
             if (unlock) {
                 flock.l_type = F_UNLCK;
             } else if (blocking) { /*Doesn't make sense to have blocking

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -453,7 +453,7 @@ afr_save_lk_owner(call_frame_t *frame)
 
     local = frame->local;
 
-    local->saved_lk_owner = frame->root->lk_owner;
+    lk_owner_copy(&local->saved_lk_owner, &frame->root->lk_owner);
 }
 
 static void
@@ -463,7 +463,7 @@ afr_restore_lk_owner(call_frame_t *frame)
 
     local = frame->local;
 
-    frame->root->lk_owner = local->saved_lk_owner;
+    lk_owner_copy(&frame->root->lk_owner, &local->saved_lk_owner);
 }
 
 void
@@ -605,7 +605,8 @@ fop:
      *  flush cant clear the  posix-lks without that lk-owner.
      */
     afr_save_lk_owner(frame);
-    frame->root->lk_owner = local->transaction.main_frame->root->lk_owner;
+    lk_owner_copy(&frame->root->lk_owner,
+                  &local->transaction.main_frame->root->lk_owner);
 
     if (priv->arbiter_count == 1) {
         afr_txn_arbitrate_fop(frame, this);

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -330,13 +330,12 @@ afr_index_from_ia_type(ia_type_t type)
 }
 
 typedef struct {
-    struct gf_flock flock;
     loc_t loc;
     fd_t *fd;
     char *basename;
     unsigned char *locked_nodes;
     int locked_count;
-
+    struct gf_flock flock;
 } afr_lockee_t;
 
 int
@@ -776,9 +775,9 @@ typedef struct _afr_local {
             char *volume;
             int32_t cmd;
             int32_t in_cmd;
+            void *xdata;
             struct gf_flock in_flock;
             struct gf_flock flock;
-            void *xdata;
         } inodelk;
 
         struct {

--- a/xlators/cluster/dht/src/dht-inode-read.c
+++ b/xlators/cluster/dht/src/dht-inode-read.c
@@ -1070,7 +1070,7 @@ dht_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int cmd,
     if (xdata)
         local->xattr_req = dict_ref(xdata);
 
-    local->rebalance.flock = *flock;
+    gf_flock_copy(&local->rebalance.flock, flock);
     local->rebalance.lock_cmd = cmd;
 
     local->call_cnt = 1;
@@ -1638,7 +1638,7 @@ dht_finodelk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
             if (ret)
                     goto err;
     */
-    local->rebalance.flock = *lock;
+    gf_flock_copy(&local->rebalance.flock, lock);
     local->rebalance.lock_cmd = cmd;
     local->key = gf_strdup(volume);
 

--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -96,7 +96,7 @@ dht_set_lkowner(dht_lock_t **lk_array, int count, gf_lkowner_t *lkowner)
         goto out;
 
     for (i = 0; i < count; i++) {
-        lk_array[i]->lk_owner = *lkowner;
+        lk_owner_copy(&lk_array[i]->lk_owner, lkowner);
     }
 
 out:
@@ -402,8 +402,8 @@ dht_unlock_entrylk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
         if (!local->lock[0].ns.directory_ns.locks[i]->locked)
             continue;
 
-        lock_frame->root
-            ->lk_owner = local->lock[0].ns.directory_ns.locks[i]->lk_owner;
+        lk_owner_copy(&lock_frame->root->lk_owner,
+                      &local->lock[0].ns.directory_ns.locks[i]->lk_owner);
         STACK_WIND_COOKIE(
             lock_frame, dht_unlock_entrylk_cbk, (void *)(long)i,
             local->lock[0].ns.directory_ns.locks[i]->xl,
@@ -786,8 +786,8 @@ dht_unlock_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
         if (!local->lock[0].layout.my_layout.locks[i]->locked)
             continue;
 
-        lock_frame->root
-            ->lk_owner = local->lock[0].layout.my_layout.locks[i]->lk_owner;
+        lk_owner_copy(&lock_frame->root->lk_owner,
+                      &local->lock[0].layout.my_layout.locks[i]->lk_owner);
         STACK_WIND_COOKIE(
             lock_frame, dht_unlock_inodelk_cbk, (void *)(long)i,
             local->lock[0].layout.my_layout.locks[i]->xl,

--- a/xlators/cluster/ec/src/ec-locks.c
+++ b/xlators/cluster/ec/src/ec-locks.c
@@ -720,18 +720,9 @@ ec_inodelk(call_frame_t *frame, xlator_t *this, gf_lkowner_t *owner,
             goto out;
         }
     }
-    if (flock != NULL) {
-        fop->flock.l_type = flock->l_type;
-        fop->flock.l_whence = flock->l_whence;
-        fop->flock.l_start = flock->l_start;
-        fop->flock.l_len = flock->l_len;
-        fop->flock.l_pid = flock->l_pid;
-        fop->flock.l_owner.len = flock->l_owner.len;
-        if (flock->l_owner.len > 0) {
-            memcpy(fop->flock.l_owner.data, flock->l_owner.data,
-                   flock->l_owner.len);
-        }
-    }
+    if (flock != NULL)
+        gf_flock_copy(&fop->flock, flock);
+
     if (xdata != NULL) {
         fop->xdata = dict_ref(xdata);
         if (fop->xdata == NULL) {
@@ -856,18 +847,9 @@ ec_finodelk(call_frame_t *frame, xlator_t *this, gf_lkowner_t *owner,
             goto out;
         }
     }
-    if (flock != NULL) {
-        fop->flock.l_type = flock->l_type;
-        fop->flock.l_whence = flock->l_whence;
-        fop->flock.l_start = flock->l_start;
-        fop->flock.l_len = flock->l_len;
-        fop->flock.l_pid = flock->l_pid;
-        fop->flock.l_owner.len = flock->l_owner.len;
-        if (flock->l_owner.len > 0) {
-            memcpy(fop->flock.l_owner.data, flock->l_owner.data,
-                   flock->l_owner.len);
-        }
-    }
+    if (flock != NULL)
+        gf_flock_copy(&fop->flock, flock);
+
     if (xdata != NULL) {
         fop->xdata = dict_ref(xdata);
         if (fop->xdata == NULL) {
@@ -926,20 +908,8 @@ ec_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_LK, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
-            if (flock != NULL) {
-                cbk->flock.l_type = flock->l_type;
-                cbk->flock.l_whence = flock->l_whence;
-                cbk->flock.l_start = flock->l_start;
-                cbk->flock.l_len = flock->l_len;
-                cbk->flock.l_pid = flock->l_pid;
-                cbk->flock.l_owner.len = flock->l_owner.len;
-                if (flock->l_owner.len > 0) {
-                    memcpy(cbk->flock.l_owner.data, flock->l_owner.data,
-                           flock->l_owner.len);
-                }
-            }
-        }
+        if (op_ret >= 0 && flock != NULL)
+            gf_flock_copy(&cbk->flock, flock);
         if (xdata != NULL) {
             cbk->xdata = dict_ref(xdata);
             if (cbk->xdata == NULL) {
@@ -1094,18 +1064,9 @@ ec_lk(call_frame_t *frame, xlator_t *this, uintptr_t target, uint32_t fop_flags,
             goto out;
         }
     }
-    if (flock != NULL) {
-        fop->flock.l_type = flock->l_type;
-        fop->flock.l_whence = flock->l_whence;
-        fop->flock.l_start = flock->l_start;
-        fop->flock.l_len = flock->l_len;
-        fop->flock.l_pid = flock->l_pid;
-        fop->flock.l_owner.len = flock->l_owner.len;
-        if (flock->l_owner.len > 0) {
-            memcpy(fop->flock.l_owner.data, flock->l_owner.data,
-                   flock->l_owner.len);
-        }
-    }
+    if (flock != NULL)
+        gf_flock_copy(&fop->flock, flock);
+
     if (xdata != NULL) {
         fop->xdata = dict_ref(xdata);
         if (fop->xdata == NULL) {

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -535,7 +535,7 @@ new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
     lock->fd_num = fd_to_fdnum(fd);
     lock->fd = fd;
     lock->client_pid = client_pid;
-    lock->owner = *owner;
+    lk_owner_copy(&lock->owner, owner);
     lock->lk_flags = lk_flags;
 
     lock->blocking = blocking;
@@ -590,7 +590,7 @@ posix_lock_to_flock(posix_lock_t *lock, struct gf_flock *flock)
     flock->l_pid = lock->user_flock.l_pid;
     flock->l_type = lock->fl_type;
     flock->l_start = lock->fl_start;
-    flock->l_owner = lock->owner;
+    lk_owner_copy(&flock->l_owner, &lock->owner);
 
     if (lock->fl_end == LLONG_MAX)
         flock->l_len = 0;

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -539,7 +539,7 @@ new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
     lock->lk_flags = lk_flags;
 
     lock->blocking = blocking;
-    memcpy(&lock->user_flock, flock, sizeof(lock->user_flock));
+    gf_flock_copy(&lock->user_flock, flock);
 
     INIT_LIST_HEAD(&lock->list);
 
@@ -569,6 +569,9 @@ __copy_lock(posix_lock_t *src)
 
     dst = GF_MALLOC(sizeof(posix_lock_t), gf_locks_mt_posix_lock_t);
     if (dst != NULL) {
+        /* TODO: replace this memcpy with copying individual
+         * variables, and then efficiently copy the owner and
+         * user_owner structures using lk_owner_copy(), gf_flock_copy()*/
         memcpy(dst, src, sizeof(posix_lock_t));
         dst->client_uid = gf_strdup(src->client_uid);
         if (dst->client_uid == NULL) {

--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -61,7 +61,7 @@ new_entrylk_lock(pl_inode_t *pinode, const char *basename, entrylk_type type,
     newlock->client = frame->root->client;
     newlock->client_pid = frame->root->pid;
     newlock->volume = domain;
-    newlock->owner = frame->root->lk_owner;
+    lk_owner_copy(&newlock->owner, &frame->root->lk_owner);
     newlock->frame = frame;
     newlock->this = frame->this;
 

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -921,7 +921,7 @@ new_inode_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
     lock->client = client;
     lock->client_pid = client_pid;
     lock->volume = volume;
-    lock->owner = frame->root->lk_owner;
+    lk_owner_copy(&lock->owner, &frame->root->lk_owner);
     lock->frame = frame;
     lock->this = this;
 

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -288,7 +288,7 @@ inodelk_contention_notify(xlator_t *this, struct list_head *contend)
             lock->contention_time.tv_sec = 0;
             lock->contention_time.tv_nsec = 0;
         } else {
-            memcpy(&lc.flock, &lock->user_flock, sizeof(lc.flock));
+            gf_flock_copy(&lc.flock, &lock->user_flock);
             lc.pid = lock->client_pid;
             lc.domain = lock->volume;
             lc.xdata = NULL;
@@ -1046,7 +1046,7 @@ pl_common_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
 
         case F_SETLK:
             lock_type = flock->l_type;
-            memcpy(&reqlock->user_flock, flock, sizeof(struct gf_flock));
+            gf_flock_copy(&reqlock->user_flock, flock);
             ret = pl_inode_setlk(this, ctx, pinode, reqlock, can_block, dom,
                                  inode);
 

--- a/xlators/features/locks/src/locks.h
+++ b/xlators/features/locks/src/locks.h
@@ -251,13 +251,6 @@ typedef struct {
     struct list_head locks_list;
 } pl_fdctx_t;
 
-struct _locker {
-    struct list_head lockers;
-    char *volume;
-    inode_t *inode;
-    gf_lkowner_t owner;
-};
-
 typedef struct _locks_ctx {
     pthread_mutex_t lock;
     struct list_head inodelk_lockers;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -705,7 +705,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         region.client = frame->root->client;
         region.fd_num = fd_to_fdnum(fd);
         region.client_pid = frame->root->pid;
-        region.owner = frame->root->lk_owner;
+        lk_owner_copy(&region.owner, &frame->root->lk_owner);
 
         pthread_mutex_lock(&pl_inode->mutex);
         {
@@ -831,7 +831,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         region.client = frame->root->client;
         region.fd_num = fd_to_fdnum(fd);
         region.client_pid = frame->root->pid;
-        region.owner = frame->root->lk_owner;
+        lk_owner_copy(&region.owner, &frame->root->lk_owner);
 
         pthread_mutex_lock(&pl_inode->mutex);
         {
@@ -977,7 +977,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         region.client = frame->root->client;
         region.fd_num = fd_to_fdnum(local->fd);
         region.client_pid = frame->root->pid;
-        region.owner = frame->root->lk_owner;
+        lk_owner_copy(&region.owner, &frame->root->lk_owner);
         pthread_mutex_lock(&pl_inode->mutex);
         {
             allowed = pl_is_fop_allowed(pl_inode, &region, local->fd, local->op,
@@ -2202,7 +2202,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         region.client = frame->root->client;
         region.fd_num = fd_to_fdnum(fd);
         region.client_pid = frame->root->pid;
-        region.owner = frame->root->lk_owner;
+        lk_owner_copy(&region.owner, &frame->root->lk_owner);
 
         pthread_mutex_lock(&pl_inode->mutex);
         {
@@ -2320,7 +2320,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
         region.client = frame->root->client;
         region.fd_num = fd_to_fdnum(fd);
         region.client_pid = frame->root->pid;
-        region.owner = frame->root->lk_owner;
+        lk_owner_copy(&region.owner, &frame->root->lk_owner);
 
         pthread_mutex_lock(&pl_inode->mutex);
         {
@@ -2481,7 +2481,7 @@ __set_next_lock_fd(pl_fdctx_t *fdctx, posix_lock_t *reqlock)
     reqlock->fl_start = lock->fl_start;
     reqlock->fl_type = lock->fl_type;
     reqlock->fl_end = lock->fl_end;
-    reqlock->owner = lock->owner;
+    lk_owner_copy(&reqlock->owner, &lock->owner);
 
 out:
     if (lock)
@@ -4215,7 +4215,7 @@ gf_lkmig_info_to_posix_lock(call_frame_t *frame, lock_migration_info_t *lmi)
     }
 
     lock->client_pid = lmi->flock.l_pid;
-    lock->owner = lmi->flock.l_owner;
+    lk_owner_copy(&lock->owner, &lmi->flock.l_owner);
 
     INIT_LIST_HEAD(&lock->list);
 

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2477,7 +2477,7 @@ __set_next_lock_fd(pl_fdctx_t *fdctx, posix_lock_t *reqlock)
         goto out;
     }
 
-    reqlock->user_flock = lock->user_flock;
+    gf_flock_copy(&reqlock->user_flock, &lock->user_flock);
     reqlock->fl_start = lock->fl_start;
     reqlock->fl_type = lock->fl_type;
     reqlock->fl_end = lock->fl_end;

--- a/xlators/features/quota/src/quotad-helpers.c
+++ b/xlators/features/quota/src/quotad-helpers.c
@@ -99,7 +99,7 @@ quotad_aggregator_get_frame_from_req(rpcsvc_request_t *req)
     frame->root->gid = req->gid;
     frame->root->pid = req->pid;
 
-    frame->root->lk_owner = req->lk_owner;
+    lk_owner_copy(&frame->root->lk_owner, &req->lk_owner);
 
     frame->local = req;
 out:

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -206,7 +206,7 @@ nfs_create_frame(xlator_t *xl, nfs_user_t *nfu)
     frame->root->uid = nfu->uid;
     frame->root->gid = nfu->gids[NFS_PRIMGID_IDX];
     memcpy(&frame->root->identifier, &nfu->identifier, UNIX_PATH_MAX);
-    frame->root->lk_owner = nfu->lk_owner;
+    lk_owner_copy(&frame->root->lk_owner, &nfu->lk_owner);
 
     if (nfu->ngrps != 1) {
         frame->root->ngrps = nfu->ngrps - 1;

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -559,7 +559,7 @@ wb_enqueue_common(wb_inode_t *wb_inode, call_stub_t *stub, int tempted)
             req->ordering.append = 1;
     }
 
-    req->lk_owner = stub->frame->root->lk_owner;
+    lk_owner_copy(&req->lk_owner, &stub->frame->root->lk_owner);
     req->client_pid = stub->frame->root->pid;
 
     switch (stub->fop) {
@@ -1146,7 +1146,7 @@ wb_fulfill_head(wb_inode_t *wb_inode, wb_request_t *head)
     if (!frame)
         goto err;
 
-    frame->root->lk_owner = head->lk_owner;
+    lk_owner_copy(&frame->root->lk_owner, &head->lk_owner);
     frame->root->pid = head->client_pid;
     frame->local = head;
 

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -594,6 +594,7 @@ clnt_unserialize_rsp_locklist_v2(xlator_t *this,
         goto out;
 
     while (trav) {
+        /* TODO: move to GF_MALLOC() */
         temp = GF_CALLOC(1, sizeof(*lmi), gf_common_mt_lock_mig);
         if (temp == NULL) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_NO_MEM, NULL);
@@ -868,7 +869,7 @@ client_fdctx_destroy(xlator_t *this, clnt_fd_ctx_t *fdctx)
     int32_t ret = -1;
     char parent_down = 0;
     fd_lk_ctx_t *lk_ctx = NULL;
-    gf_lkowner_t null_owner = {0};
+    gf_lkowner_t null_owner;
     struct list_head deleted_list;
 
     GF_VALIDATE_OR_GOTO("client", this, out);
@@ -889,6 +890,7 @@ client_fdctx_destroy(xlator_t *this, clnt_fd_ctx_t *fdctx)
     pthread_mutex_unlock(&conf->lock);
     lk_ctx = fdctx->lk_ctx;
     fdctx->lk_ctx = NULL;
+    null_owner.len = 0; /* pass null owner to function */
     pthread_spin_lock(&conf->fd_lock);
     {
         __delete_granted_locks_owner_from_fdctx(fdctx, &null_owner,

--- a/xlators/protocol/client/src/client-lk.c
+++ b/xlators/protocol/client/src/client-lk.c
@@ -431,7 +431,7 @@ new_client_lock(struct gf_flock *flock, gf_lkowner_t *owner, int32_t cmd,
 
     INIT_LIST_HEAD(&new_lock->list);
     new_lock->fd = fd;
-    memcpy(&new_lock->user_flock, flock, sizeof(struct gf_flock));
+    gf_flock_copy(&new_lock->user_flock, flock);
 
     new_lock->fl_type = flock->l_type;
     new_lock->fl_start = flock->l_start;

--- a/xlators/protocol/client/src/client-lk.c
+++ b/xlators/protocol/client/src/client-lk.c
@@ -250,7 +250,7 @@ __insert_and_merge(clnt_fd_ctx_t *fdctx, client_posix_lock_t *lock)
                 sum = add_locks(lock, conf);
 
                 sum->fd = lock->fd;
-                sum->owner = conf->owner;
+                lk_owner_copy(&sum->owner, &conf->owner);
 
                 __delete_client_lock(conf);
                 __destroy_client_lock(conf);
@@ -263,7 +263,7 @@ __insert_and_merge(clnt_fd_ctx_t *fdctx, client_posix_lock_t *lock)
                 sum = add_locks(lock, conf);
 
                 sum->fd = conf->fd;
-                sum->owner = conf->owner;
+                lk_owner_copy(&sum->owner, &conf->owner);
 
                 v = subtract_locks(sum, lock);
 
@@ -441,7 +441,7 @@ new_client_lock(struct gf_flock *flock, gf_lkowner_t *owner, int32_t cmd,
     else
         new_lock->fl_end = flock->l_start + flock->l_len - 1;
 
-    new_lock->owner = *owner;
+    lk_owner_copy(&new_lock->owner, owner);
 
     new_lock->cmd = cmd; /* Not really useful */
 

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -4158,7 +4158,7 @@ client3_3_flush(call_frame_t *frame, xlator_t *this, void *data)
     frame->local = local;
 
     local->fd = fd_ref(args->fd);
-    local->owner = frame->root->lk_owner;
+    lk_owner_copy(&local->owner, &frame->root->lk_owner);
     ret = client_pre_flush(this, &req, args->fd, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -5087,7 +5087,7 @@ client3_3_lk(call_frame_t *frame, xlator_t *this, void *data)
     if (ret)
         local->check_reopen = 0;
 
-    local->owner = frame->root->lk_owner;
+    lk_owner_copy(&local->owner, &frame->root->lk_owner);
     local->cmd = args->cmd;
     local->fd = fd_ref(args->fd);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -3964,7 +3964,7 @@ client4_0_flush(call_frame_t *frame, xlator_t *this, void *data)
     frame->local = local;
 
     local->fd = fd_ref(args->fd);
-    local->owner = frame->root->lk_owner;
+    lk_owner_copy(&local->owner, &frame->root->lk_owner);
     ret = client_pre_flush_v2(this, &req, args->fd, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4729,7 +4729,7 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
     if (ret)
         local->check_reopen = 0;
 
-    local->owner = frame->root->lk_owner;
+    lk_owner_copy(&local->owner, &frame->root->lk_owner);
     local->cmd = args->cmd;
     local->fd = fd_ref(args->fd);
 

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -1104,6 +1104,7 @@ common_rsp_locklist(lock_migration_info_t *locklist, gfs3_locklist **reply)
 
     list_for_each_entry(tmp, &locklist->list, list)
     {
+        /* TODO: move to GF_MALLOC() */
         trav = GF_CALLOC(1, sizeof(*trav), gf_server_mt_lock_mig_t);
         if (!trav)
             goto out;
@@ -1416,6 +1417,7 @@ unserialize_req_locklist(gfs3_setactivelk_req *req, lock_migration_info_t *lmi)
     INIT_LIST_HEAD(&lmi->list);
 
     while (trav) {
+        /* TODO: move to GF_MALLOC() */
         temp = GF_CALLOC(1, sizeof(*lmi), gf_common_mt_lock_mig);
         if (temp == NULL) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, PS_MSG_NO_MEM, NULL);
@@ -1453,6 +1455,7 @@ unserialize_req_locklist_v2(gfx_setactivelk_req *req,
     INIT_LIST_HEAD(&lmi->list);
 
     while (trav) {
+        /* TODO: move to GF_MALLOC() */
         temp = GF_CALLOC(1, sizeof(*lmi), gf_common_mt_lock_mig);
         if (temp == NULL) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, PS_MSG_NO_MEM, NULL);

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -542,7 +542,7 @@ get_frame_from_request(rpcsvc_request_t *req)
     frame->root->gid = req->gid;
     frame->root->pid = req->pid;
     frame->root->client = client;
-    frame->root->lk_owner = req->lk_owner;
+    lk_owner_copy(&frame->root->lk_owner, &req->lk_owner);
 
     if (priv->server_manage_gids)
         server_resolve_groups(frame, req);


### PR DESCRIPTION
lk_owner_copy() is more efficient as usually lkowner value is really just 8 bytes.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com> 