### PR TITLE
lkowner.h: improve lkowner_unparse() efficiency

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -2866,16 +2866,6 @@ lkowner_utoa(gf_lkowner_t *lkowner)
     return lkowner_buffer;
 }
 
-/*Re-entrant conversion function*/
-char *
-lkowner_utoa_r(gf_lkowner_t *lkowner, char *dst, int len)
-{
-    if (!dst)
-        return NULL;
-    lkowner_unparse(lkowner, dst, len);
-    return dst;
-}
-
 gf_boolean_t
 is_valid_lease_id(const char *lease_id)
 {
@@ -3325,7 +3315,7 @@ gf_process_reserved_ports(unsigned char *ports, uint32_t ceiling)
 out:
     GF_FREE(ports_info);
 
-#else /* FIXME: Non Linux Host */
+#else  /* FIXME: Non Linux Host */
     ret = 0;
 #endif /* GF_LINUX_HOST_OS */
 
@@ -5170,7 +5160,7 @@ close_fds_except_custom(int *fdv, size_t count, void *prm,
             closer(i, prm);
     }
     sys_closedir(d);
-#else /* !GF_LINUX_HOST_OS */
+#else  /* !GF_LINUX_HOST_OS */
     struct rlimit rl;
     int ret = -1;
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1041,8 +1041,6 @@ uuid_utoa_r(uuid_t uuid, char *dst);
 char *
 lkowner_utoa(gf_lkowner_t *lkowner);
 char *
-lkowner_utoa_r(gf_lkowner_t *lkowner, char *dst, int len);
-char *
 leaseid_utoa(const char *lease_id);
 gf_boolean_t
 is_valid_lease_id(const char *lease_id);

--- a/libglusterfs/src/glusterfs/lkowner.h
+++ b/libglusterfs/src/glusterfs/lkowner.h
@@ -27,13 +27,13 @@ lkowner_unparse(gf_lkowner_t *lkowner, char *buf, int buf_len)
     */
     if (lkowner->len >= 8 && buf_len > 16) {
         for (i = 0; i < 8; i++) {
-            nibble = lkowner->data[i] & 0x0F;
+            nibble = (lkowner->data[i] & 0xF0) >> 4;
             if (nibble < 10)
                 buf[j] = '0' + nibble;
             else
                 buf[j] = 'a' + nibble - 10;
             j++;
-            nibble = (lkowner->data[i] & 0xF0) >> 4;
+            nibble = lkowner->data[i] & 0x0F;
             if (nibble < 10)
                 buf[j] = '0' + nibble;
             else
@@ -99,7 +99,6 @@ is_lk_owner_null(gf_lkowner_t *lkowner)
     for (i = 0; i < lkowner->len; i++) {
         if (lkowner->data[i] != 0) {
             return 0;
-            break;
         }
     }
 

--- a/libglusterfs/src/glusterfs/lkowner.h
+++ b/libglusterfs/src/glusterfs/lkowner.h
@@ -19,8 +19,29 @@ lkowner_unparse(gf_lkowner_t *lkowner, char *buf, int buf_len)
 {
     int i = 0;
     int j = 0;
+    uint8_t nibble;
 
-    for (i = 0; i < lkowner->len; i++) {
+    /* the common case for lkowner is 8 bytes long
+       (a pointer) which will require 16 bytes (+ a NULL termination char)
+       long buffer to convert into.
+    */
+    if (lkowner->len >= 8 && buf_len > 16) {
+        for (i = 0; i < 8; i++) {
+            nibble = lkowner->data[i] & 0x0F;
+            if (nibble < 10)
+                buf[j] = '0' + nibble;
+            else
+                buf[j] = 'a' + nibble - 10;
+            j++;
+            nibble = (lkowner->data[i] & 0xF0) >> 4;
+            if (nibble < 10)
+                buf[j] = '0' + nibble;
+            else
+                buf[j] = 'a' + nibble - 10;
+            j++;
+        }
+    }
+    while (i < lkowner->len) {
         if (i && !(i % 8)) {
             buf[j] = '-';
             j++;
@@ -29,7 +50,9 @@ lkowner_unparse(gf_lkowner_t *lkowner, char *buf, int buf_len)
         j += 2;
         if (j == buf_len)
             break;
+        i++;
     }
+
     if (j < buf_len)
         buf[j] = '\0';
 }
@@ -41,7 +64,7 @@ set_lk_owner_from_ptr(gf_lkowner_t *lkowner, void *data)
     int j = 0;
 
     lkowner->len = sizeof(unsigned long);
-    for (i = 0, j = 0; i < lkowner->len; i++, j += 8) {
+    for (i = 0, j = 0; i < sizeof(unsigned long); i++, j += 8) {
         lkowner->data[i] = (char)((((unsigned long)data) >> j) & 0xff);
     }
 }
@@ -53,7 +76,7 @@ set_lk_owner_from_uint64(gf_lkowner_t *lkowner, uint64_t data)
     int j = 0;
 
     lkowner->len = 8;
-    for (i = 0, j = 0; i < lkowner->len; i++, j += 8) {
+    for (i = 0, j = 0; i < 8; i++, j += 8) {
         lkowner->data[i] = (char)((data >> j) & 0xff);
     }
 }
@@ -68,20 +91,19 @@ is_same_lkowner(gf_lkowner_t *l1, gf_lkowner_t *l2)
 static inline int
 is_lk_owner_null(gf_lkowner_t *lkowner)
 {
-    int is_null = 1;
-    int i = 0;
+    int i;
 
     if (lkowner == NULL || lkowner->len == 0)
-        goto out;
+        return 1;
 
     for (i = 0; i < lkowner->len; i++) {
         if (lkowner->data[i] != 0) {
-            is_null = 0;
+            return 0;
             break;
         }
     }
-out:
-    return is_null;
+
+    return 1;
 }
 
 static inline void


### PR DESCRIPTION
    Given that usually lkowner data is 8 bytes long (from pointer or uint64),
    we can improve lkowner_unparse() and potentially skip some if's and sprintf().
    lkowner_unparse() is called from lkowner_utoa() which is used too often in
    logging calls. Even if those logs eventually are not emitted, the function is
    still called (to construct the full log string), so there's benefit in improving it.
    
    Signed-off-by: Yaniv Kaul <ykaul@redhat.com>
