### PR TITLE
caa_unlikely/likely for some common validations

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -335,7 +335,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define VALIDATE_OR_GOTO(arg, label)                                           \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = EINVAL;                                                    \
             gf_msg_callingfn((this ? (this->name) : "(Govinda! Govinda!)"),    \
                              GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,       \
@@ -346,7 +346,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_VALIDATE_OR_GOTO(name, arg, label)                                  \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = EINVAL;                                                    \
             gf_msg_callingfn(name, GF_LOG_ERROR, errno, LG_MSG_INVALID_ARG,    \
                              "invalid argument: " #arg);                       \
@@ -356,7 +356,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_VALIDATE_OR_GOTO_WITH_ERROR(name, arg, label, errno, error)         \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = error;                                                     \
             gf_msg_callingfn(name, GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG,   \
                              "invalid argument: " #arg);                       \
@@ -366,7 +366,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_CHECK_ALLOC(arg, retval, label)                                     \
     do {                                                                       \
-        if (!(arg)) {                                                          \
+        if (caa_unlikely(!(arg))) {                                            \
             retval = -ENOMEM;                                                  \
             goto label;                                                        \
         }                                                                      \
@@ -383,7 +383,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_ASSERT_AND_GOTO_WITH_ERROR(name, arg, label, errno, error)          \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             GF_ASSERT(0);                                                      \
             errno = error;                                                     \
             goto label;                                                        \
@@ -1104,7 +1104,7 @@ __gf_thread_set_name(pthread_t thread, const char *name)
 #elif defined(HAVE_PTHREAD_SET_NAME_NP)
     pthread_set_name_np(thread, name);
     return 0;
-#else /* none found */
+#else  /* none found */
     return -ENOSYS;
 #endif /* set name */
 }

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -16,6 +16,7 @@
 #include "glusterfs/logging.h"
 #include "glusterfs/mem-types.h"
 #include "glusterfs/glusterfs.h" /* for glusterfs_ctx_t */
+#include <urcu/compiler.h>       /* for caa_likely/unlikely() */
 #include <stdlib.h>
 #include <inttypes.h>
 #include <string.h>
@@ -109,7 +110,7 @@ __gf_default_malloc(size_t size)
     void *ptr = NULL;
 
     ptr = malloc(size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, size);
 
     return ptr;
@@ -121,7 +122,7 @@ __gf_default_calloc(int cnt, size_t size)
     void *ptr = NULL;
 
     ptr = calloc(cnt, size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, (cnt * size));
 
     return ptr;
@@ -133,7 +134,7 @@ __gf_default_realloc(void *oldptr, size_t size)
     void *ptr = NULL;
 
     ptr = realloc(oldptr, size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, size);
 
     return ptr;
@@ -181,17 +182,15 @@ gf_strndup(const char *src, size_t len)
 {
     char *dup_str = NULL;
 
-    if (!src) {
+    if (caa_unlikely(!src)) {
         goto out;
     }
 
     dup_str = GF_MALLOC(len + 1, gf_common_mt_strdup);
-    if (!dup_str) {
-        goto out;
+    if (caa_likely(dup_str)) {
+        memcpy(dup_str, src, len);
+        dup_str[len] = '\0';
     }
-
-    memcpy(dup_str, src, len);
-    dup_str[len] = '\0';
 out:
     return dup_str;
 }
@@ -199,7 +198,7 @@ out:
 static inline char *
 gf_strdup(const char *src)
 {
-    if (!src)
+    if (caa_unlikely(!src))
         return NULL;
 
     return gf_strndup(src, strlen(src));
@@ -211,12 +210,9 @@ gf_memdup(const void *src, size_t size)
     void *dup_mem = NULL;
 
     dup_mem = GF_MALLOC(size, gf_common_mt_memdup);
-    if (!dup_mem)
-        goto out;
+    if (caa_likely(dup_mem))
+        memcpy(dup_mem, src, size);
 
-    memcpy(dup_mem, src, size);
-
-out:
     return dup_mem;
 }
 

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -176,7 +176,7 @@ __gf_calloc(size_t nmemb, size_t size, uint32_t type, const char *typestr)
 
     ptr = calloc(1, tot_size);
 
-    if (!ptr) {
+    if (caa_unlikely(!ptr)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -199,7 +199,7 @@ __gf_malloc(size_t size, uint32_t type, const char *typestr)
     tot_size = __gf_total_alloc_size(size);
 
     ptr = malloc(tot_size);
-    if (!ptr) {
+    if (caa_unlikely(!ptr)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -223,7 +223,7 @@ __gf_realloc(void *ptr, size_t size)
 
     tot_size = __gf_total_alloc_size(size);
     header = realloc(header, tot_size);
-    if (!header) {
+    if (caa_unlikely(!header)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -336,7 +336,7 @@ __gf_free(void *free_ptr)
     struct mem_header *header = NULL;
     uint64_t num_allocs = 0;
 
-    if (!free_ptr)
+    if (caa_unlikely(!free_ptr))
         return;
 
     if (!gf_mem_acct_enabled()) {


### PR DESCRIPTION
While it would have been better to remove redundant validations,
a start would be to decorate them with caa_likely/unlikely as a hint
to the compiler (and the reader) about the probabilit of an 'if' statement.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

