### PR TITLE
afr-common.c: add missing UNLOCK() to _afr_cleanup_fd_ctx()

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4058,7 +4058,7 @@ out:
     return 0;
 }
 
-void
+static void
 _afr_cleanup_fd_ctx(xlator_t *this, afr_fd_ctx_t *fd_ctx)
 {
     afr_private_t *priv = this->private;
@@ -4068,6 +4068,7 @@ _afr_cleanup_fd_ctx(xlator_t *this, afr_fd_ctx_t *fd_ctx)
         {
             list_del(&fd_ctx->lk_heal_info->pos);
         }
+        UNLOCK(&priv->lock);
         afr_lk_heal_info_cleanup(fd_ctx->lk_heal_info);
         fd_ctx->lk_heal_info = NULL;
     }


### PR DESCRIPTION
Fixes: #2881
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

