### PR TITLE
libglusterfs, rpc, fuse: drop xlator from async framework

### DIFF
--- a/libglusterfs/src/async.c
+++ b/libglusterfs/src/async.c
@@ -386,9 +386,7 @@ gf_async_run(struct cds_wfcq_node *node)
 
     /* We've just got work from the queue. Process it. */
     async = caa_container_of(node, gf_async_t, queue);
-    /* TODO: remove dependency from THIS and xl. */
-    THIS = async->xl;
-    async->cbk(async->xl, async);
+    async->cbk(async);
 }
 
 static void
@@ -469,17 +467,17 @@ gf_async_stop_check(gf_async_worker_t *worker)
 }
 
 static void
-gf_async_stop_all(xlator_t *xl, gf_async_t *async)
+gf_async_stop_all(gf_async_t *async)
 {
     if (gf_async_stop_check(gf_async_current_worker) > 0) {
         /* There are more workers running. We propagate the stop request to
          * them. */
-        gf_async(async, xl, gf_async_stop_all);
+        gf_async(async, gf_async_stop_all);
     }
 }
 
 static void
-gf_async_join(xlator_t *xl, gf_async_t *async)
+gf_async_join(gf_async_t *async)
 {
     gf_async_worker_t *worker;
 
@@ -505,7 +503,7 @@ gf_async_terminate(gf_async_worker_t *worker)
         gf_async_sync_now();
     } else {
         /* Force someone else to join this thread to release resources. */
-        gf_async(&worker->async, THIS, gf_async_join);
+        gf_async(&worker->async, gf_async_join);
     }
 }
 
@@ -575,7 +573,7 @@ gf_async_fini(void)
         /* Send the stop request to the thread pool. This will cause the
          * execution of gf_async_stop_all() by one of the worker threads which,
          * eventually, will terminate all worker threads. */
-        gf_async(&async, THIS, gf_async_stop_all);
+        gf_async(&async, gf_async_stop_all);
 
         /* We synchronize here with the last thread. */
         gf_async_sync_now();

--- a/libglusterfs/src/glusterfs/async.h
+++ b/libglusterfs/src/glusterfs/async.h
@@ -34,7 +34,6 @@
 
 #endif /* URCU_OLD */
 
-#include "glusterfs/xlator.h"
 #include "glusterfs/common-utils.h"
 #include "glusterfs/list.h"
 #include "glusterfs/libglusterfs-messages.h"
@@ -93,11 +92,9 @@ typedef struct _gf_async_queue gf_async_queue_t;
 struct _gf_async_control;
 typedef struct _gf_async_control gf_async_control_t;
 
-typedef void (*gf_async_callback_f)(xlator_t *xl, gf_async_t *async);
+typedef void (*gf_async_callback_f)(gf_async_t *async);
 
 struct _gf_async {
-    /* TODO: remove dependency on xl/THIS. */
-    xlator_t *xl;
     gf_async_callback_f cbk;
     struct cds_wfcq_node queue;
 };
@@ -185,14 +182,13 @@ void
 gf_async_adjust_threads(int32_t threads);
 
 static inline void
-gf_async(gf_async_t *async, xlator_t *xl, gf_async_callback_f cbk)
+gf_async(gf_async_t *async, gf_async_callback_f cbk)
 {
     if (!gf_async_ctrl.enabled) {
-        cbk(xl, async);
+        cbk(async);
         return;
     }
 
-    async->xl = xl;
     async->cbk = cbk;
     cds_wfcq_node_init(&async->queue);
     if (caa_unlikely(!cds_wfcq_enqueue(&gf_async_ctrl.queue.head,

--- a/rpc/rpc-lib/src/rpcsvc-common.h
+++ b/rpc/rpc-lib/src/rpcsvc-common.h
@@ -12,6 +12,7 @@
 #define _RPCSVC_COMMON_H
 
 #include <pthread.h>
+#include <glusterfs/xlator.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/dict.h>
 

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -2495,7 +2495,7 @@ socket_proto_state_machine(rpc_transport_t *this,
 }
 
 static void
-socket_event_poll_in_async(xlator_t *xl, gf_async_t *async)
+socket_event_poll_in_async(gf_async_t *async)
 {
     rpc_transport_pollin_t *pollin;
     rpc_transport_t *this;
@@ -2546,7 +2546,7 @@ socket_event_poll_in(rpc_transport_t *this, gf_boolean_t notify_handled)
 
     if (pollin) {
         rpc_transport_ref(this);
-        gf_async(&pollin->async, THIS, socket_event_poll_in_async);
+        gf_async(&pollin->async, socket_event_poll_in_async);
     }
 
     return ret;


### PR DESCRIPTION
Fix async framework to avoid explicit dependency from xlator
etc. code. Clients dealing with xlators should use them in
their private data structures, like it's done in FUSE bridge.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

