### PR TITLE
rpc: drop RPC request unused field

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -254,10 +254,6 @@ glusterfs_submit_reply(rpcsvc_request_t *req, void *arg, struct iovec *payload,
 
     ret = rpcsvc_submit_generic(req, &rsp, 1, payload, payloadcount, iobref);
 
-    /* Now that we've done our job of handing the message to the RPC layer
-     * we can safely unref the iob in the hope that RPC layer must have
-     * ref'ed the iob on receiving into the txlist.
-     */
     if (ret == -1) {
         gf_log(THIS->name, GF_LOG_ERROR, "Reply submission failed");
         goto out;

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -464,7 +464,6 @@ rpcsvc_request_init(rpcsvc_t *svc, rpc_transport_t *trans,
     req->svc = svc;
     req->trans_private = msg->private;
 
-    INIT_LIST_HEAD(&req->txlist);
     INIT_LIST_HEAD(&req->request_list);
     req->payloadsize = 0;
 

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -187,15 +187,6 @@ struct rpcsvc_request {
 
     struct iobref *iobref;
 
-    /* There can be cases of RPC requests where the reply needs to
-     * be built from multiple sources. E.g. where even the NFS reply
-     * can contain a payload, as in the NFSv3 read reply. Here the RPC header
-     * ,NFS header and the read data are brought together separately from
-     * different buffers, so we need to stage the buffers temporarily here
-     * before all of them get added to the connection's transmission list.
-     */
-    struct list_head txlist;
-
     /* While the reply record is being built, this variable keeps track
      * of how many bytes have been added to the record.
      */

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -698,10 +698,6 @@ glusterd_submit_reply(rpcsvc_request_t *req, void *arg, struct iovec *payload,
 
     ret = rpcsvc_submit_generic(req, &rsp, 1, payload, payloadcount, iobref);
 
-    /* Now that we've done our job of handing the message to the RPC layer
-     * we can safely unref the iob in the hope that RPC layer must have
-     * ref'ed the iob on receiving into the txlist.
-     */
     if (ret == -1) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REPLY_SUBMIT_FAIL,
                "Reply submission failed");

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -686,10 +686,6 @@ nfs3svc_submit_reply(rpcsvc_request_t *req, void *arg, nfs3_serializer sfunc)
 
     ret = 0;
 ret:
-    /* Now that we've done our job of handing the message to the RPC layer
-     * we can safely unref the iob in the hope that RPC layer must have
-     * ref'ed the iob on receiving into the txlist.
-     */
     if (NULL != iob)
         iobuf_unref(iob);
     if (NULL != iobref)
@@ -745,10 +741,6 @@ nfs3svc_submit_vector_reply(rpcsvc_request_t *req, void *arg,
 
     ret = 0;
 ret:
-    /* Now that we've done our job of handing the message to the RPC layer
-     * we can safely unref the iob in the hope that RPC layer must have
-     * ref'ed the iob on receiving into the txlist.
-     */
     if (NULL != iob)
         iobuf_unref(iob);
     if (new_iobref)

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -122,10 +122,6 @@ server_submit_reply(call_frame_t *frame, rpcsvc_request_t *req, void *arg,
     /* ret = rpcsvc_callback_submit (req->svc, req->trans, req->prog,
        GF_CBK_NULL, &rsp, 1);
     */
-    /* Now that we've done our job of handing the message to the RPC layer
-     * we can safely unref the iob in the hope that RPC layer must have
-     * ref'ed the iob on receiving into the txlist.
-     */
     iobuf_unref(iob);
     if (ret == -1) {
         gf_msg_callingfn("", GF_LOG_ERROR, 0, PS_MSG_REPLY_SUBMIT_FAILED,


### PR DESCRIPTION
Drop unused `txlist` of `struct rpcsvc_request` as well
as comments on functionality which is not really exists.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

