### PR TITLE
fuse: handle pid 0

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4833,7 +4833,7 @@ fuse_setlk_interrupt_handler(xlator_t *this, fuse_interrupt_record_t *fir)
         goto err;
     }
 
-    frame = get_call_frame_for_req(state);
+    frame = get_call_frame_for_req(state, GF_FOP_GETXATTR);
     if (!frame) {
         goto err;
     }

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -292,7 +292,7 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
             break;                                                             \
         }                                                                      \
                                                                                \
-        frame = get_call_frame_for_req(state);                                 \
+        frame = get_call_frame_for_req(state, op_num);                         \
         if (!frame) {                                                          \
             /* This is not completely clean, as some                           \
              * earlier allocations might remain unfreed                        \
@@ -516,7 +516,7 @@ GF_MUST_CHECK int32_t
 fuse_loc_fill(loc_t *loc, fuse_state_t *state, ino_t ino, ino_t par,
               const char *name);
 call_frame_t *
-get_call_frame_for_req(fuse_state_t *state);
+get_call_frame_for_req(fuse_state_t *state, int op_num);
 fuse_state_t *
 get_fuse_state(xlator_t *this, fuse_in_header_t *finh);
 void


### PR DESCRIPTION
* There was no clue on which operation caused the pid to be '0' - Added relevant op in log.
* When the error happened without setting ngroups, it crashed the process.
* Looks like in container usecases, when namespace pid is different, there are chances of
  fuse not getting proper pid, hence would have it as 0. Handled the crash, and treated it
  as 'root' user.

Fixes: #2467
Change-Id: Ic3a4561f73947c4acfeef40028c3a6cf3975392e
Signed-off-by: Amar Tumballi <amar@kadalu.io>
(cherry picked from commit 387fcb01e2a47a848462ae6835ab8b04b60d9c73)
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>

