### PR TITLE
libglusterfs, xlators: simplify circular buffer API

### DIFF
--- a/libglusterfs/src/circ-buff.c
+++ b/libglusterfs/src/circ-buff.c
@@ -97,7 +97,7 @@ cb_buffer_show(buffer_t *buffer)
 
 void
 cb_buffer_dump(buffer_t *buffer, void *data,
-               int(fn)(circular_buffer_t *buffer, void *data))
+               void (*dumper)(circular_buffer_t *buffer, void *data))
 {
     int index = 0;
     circular_buffer_t *entry = NULL;
@@ -118,7 +118,7 @@ cb_buffer_dump(buffer_t *buffer, void *data,
             for (entries = 0; entries < buffer->used_len; entries++) {
                 entry = buffer->cb[index];
                 if (entry)
-                    fn(entry, data);
+                    dumper(entry, data);
                 else
                     gf_msg_callingfn("circ-buff", GF_LOG_WARNING, 0,
                                      LG_MSG_NULL_PTR,
@@ -133,7 +133,7 @@ cb_buffer_dump(buffer_t *buffer, void *data,
         } else {
             for (i = 0; i < buffer->used_len; i++) {
                 entry = buffer->cb[i];
-                fn(entry, data);
+                dumper(entry, data);
             }
         }
     }

--- a/libglusterfs/src/event-history.c
+++ b/libglusterfs/src/event-history.c
@@ -39,17 +39,12 @@ out:
 
 void
 eh_dump(eh_t *history, void *data,
-        int(dump_fn)(circular_buffer_t *buffer, void *data))
+        void (*dumper)(circular_buffer_t *buffer, void *data))
 {
-    if (!history) {
+    if (history)
+        cb_buffer_dump(history->buffer, data, dumper);
+    else
         gf_msg_debug("event-history", 0, "history is NULL");
-        goto out;
-    }
-
-    cb_buffer_dump(history->buffer, data, dump_fn);
-
-out:
-    return;
 }
 
 int

--- a/libglusterfs/src/glusterfs/circ-buff.h
+++ b/libglusterfs/src/glusterfs/circ-buff.h
@@ -56,6 +56,6 @@ cb_buffer_destroy(buffer_t *buffer);
 
 void
 cb_buffer_dump(buffer_t *buffer, void *data,
-               int(fn)(circular_buffer_t *buffer, void *data));
+               void (*dumper)(circular_buffer_t *buffer, void *data));
 
 #endif /* _CB_H */

--- a/libglusterfs/src/glusterfs/event-history.h
+++ b/libglusterfs/src/glusterfs/event-history.h
@@ -25,7 +25,7 @@ typedef struct event_hist eh_t;
 
 void
 eh_dump(eh_t *event, void *data,
-        int(fn)(circular_buffer_t *buffer, void *data));
+        void (*dumper)(circular_buffer_t *buffer, void *data));
 
 eh_t *
 eh_new(size_t buffer_size, gf_boolean_t use_buffer_once,

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -1319,7 +1319,7 @@ out:
     return ret;
 }
 
-int
+static void
 afr_add_crawl_event(circular_buffer_t *cb, void *data)
 {
     dict_t *output = NULL;
@@ -1333,12 +1333,8 @@ afr_add_crawl_event(circular_buffer_t *cb, void *data)
     shd = &priv->shd;
     crawl_event = cb->data;
 
-    if (!shd->index_healers[crawl_event->child].local)
-        return 0;
-
-    afr_shd_dict_add_crawl_event(this, output, crawl_event);
-
-    return 0;
+    if (shd->index_healers[crawl_event->child].local)
+        afr_shd_dict_add_crawl_event(this, output, crawl_event);
 }
 
 int

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -61,7 +61,7 @@ trace_stat_to_str(struct iatt *buf, char *str, size_t len)
              buf->ia_ctime_nsec);
 }
 
-int
+static void
 dump_history_trace(circular_buffer_t *cb, void *data)
 {
     char timestr[GF_TIMESTR_SIZE] = {
@@ -73,11 +73,9 @@ dump_history_trace(circular_buffer_t *cb, void *data)
        at which the entry was added to the buffer */
 
     gf_time_fmt_tv(timestr, sizeof timestr, &cb->tv, gf_timefmt_Ymd_T);
+
     gf_proc_dump_write("TIME", "%s", timestr);
-
     gf_proc_dump_write("FOP", "%s\n", (char *)cb->data);
-
-    return 0;
 }
 
 int

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6369,6 +6369,19 @@ fuse_priv_dump(xlator_t *this)
     return 0;
 }
 
+static void
+dump_history_fuse(circular_buffer_t *cb, void *data)
+{
+    char timestr[GF_TIMESTR_SIZE] = {
+        0,
+    };
+
+    gf_time_fmt_tv(timestr, sizeof timestr, &cb->tv, gf_timefmt_F_HMS);
+
+    gf_proc_dump_write("TIME", "%s", timestr);
+    gf_proc_dump_write("message", "%s\n", (char *)cb->data);
+}
+
 int
 fuse_history_dump(xlator_t *this)
 {
@@ -6392,22 +6405,6 @@ fuse_history_dump(xlator_t *this)
     ret = 0;
 out:
     return ret;
-}
-
-int
-dump_history_fuse(circular_buffer_t *cb, void *data)
-{
-    char timestr[GF_TIMESTR_SIZE] = {
-        0,
-    };
-
-    gf_time_fmt_tv(timestr, sizeof timestr, &cb->tv, gf_timefmt_F_HMS);
-
-    gf_proc_dump_write("TIME", "%s", timestr);
-
-    gf_proc_dump_write("message", "%s\n", (char *)cb->data);
-
-    return 0;
 }
 
 int

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -529,7 +529,5 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key);
 void
 fuse_fop_resume(fuse_state_t *state);
 int
-dump_history_fuse(circular_buffer_t *cb, void *data);
-int
 fuse_check_selinux_cap_xattr(fuse_private_t *priv, char *name);
 #endif /* _GF_FUSE_BRIDGE_H_ */


### PR DESCRIPTION
Since there are no actual users of the value returned
from circular buffer (and so event history) data dumping
function, convert it to void and adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

