### PR TITLE
libglusterfs, rpc, xlators: use generic lists for dictionaries

### DIFF
--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -81,8 +81,6 @@ typedef struct _data_pair data_pair_t;
                                                                                \
     } while (0)
 
-#define dict_foreach_inline(d, c) for (c = d->members_list; c; c = c->next)
-
 #define DICT_KEY_VALUE_MAX_SIZE 1048576
 #define DICT_MAX_FLAGS 256
 #define DICT_FLAG_SET 1
@@ -101,8 +99,7 @@ struct _data {
 
 struct _data_pair {
     struct _data_pair *hash_next;
-    struct _data_pair *prev;
-    struct _data_pair *next;
+    struct list_head list;
     data_t *value;
     char *key;
     uint32_t key_hash;
@@ -114,7 +111,7 @@ struct _dict {
     int32_t count;
     gf_atomic_t refcount;
     data_pair_t **members;
-    data_pair_t *members_list;
+    struct list_head members_list;
     char *extra_stdfree;
     gf_lock_t lock;
     data_pair_t *members_internal;
@@ -324,9 +321,9 @@ dict_set_uint64(dict_t *this, char *key, uint64_t val);
 #define dict_get_time(dict, key, val) dict_get_int64((dict), (key), (val))
 #define dict_set_time(dict, key, val) dict_set_int64((dict), (key), (val))
 #elif __WORDSIZE == 32
-#define dict_get_time(dict, key, val)                   \
+#define dict_get_time(dict, key, val)                                          \
     dict_get_int32((dict), (key), ((int32_t *)(val)))
-#define dict_set_time(dict, key, val)                   \
+#define dict_set_time(dict, key, val)                                          \
     dict_set_int32((dict), (key), ((int32_t)(val)))
 #else
 #error "unknown word size"

--- a/rpc/xdr/src/glusterfs3.h
+++ b/rpc/xdr/src/glusterfs3.h
@@ -683,7 +683,6 @@ static inline int
 dict_to_xdr(dict_t *this, gfx_dict *dict)
 {
     int ret = -1;
-    int i = 0;
     int index = 0;
     data_pair_t *dpair = NULL;
     gfx_dict_pair *xpair = NULL;
@@ -713,8 +712,8 @@ dict_to_xdr(dict_t *this, gfx_dict *dict)
     if (!dict->pairs.pairs_val)
         goto out;
 
-    dpair = this->members_list;
-    for (i = 0; i < this->count; i++) {
+    list_for_each_entry(dpair, &this->members_list, list)
+    {
         xpair = &dict->pairs.pairs_val[index];
 
         xpair->key.key_val = dpair->key;
@@ -787,7 +786,6 @@ dict_to_xdr(dict_t *this, gfx_dict *dict)
                        "key '%s' is not sent on wire", dpair->key);
                 break;
         }
-        dpair = dpair->next;
     }
 
     dict->pairs.pairs_len = index;

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -927,7 +927,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
          */
         data_pair_t *curr = NULL;
 
-        dict_foreach_inline(xattr, curr)
+        list_for_each_entry(curr, &xattr->members_list, list)
         {
             ios_log(this, logfp, "\"%s.%s.%s.queue_size\": %d,", key_prefix,
                     str_prefix, curr->key, data_to_int32(curr->value));

--- a/xlators/mgmt/glusterd/src/glusterd-statedump.c
+++ b/xlators/mgmt/glusterd/src/glusterd-statedump.c
@@ -140,7 +140,8 @@ glusterd_dict_mgmt_v3_lock_statedump(dict_t *dict)
                          "dict NULL");
         goto out;
     }
-    for (trav = dict->members_list; trav; trav = trav->next) {
+    list_for_each_entry(trav, &dict->members_list, list)
+    {
         if (strstr(trav->key, "debug.last-success-bt") != NULL) {
             ret = snprintf(&dump[dumplen], sizeof(dump) - dumplen, "\n\t%s:%s",
                            trav->key, trav->value->data);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3518,16 +3518,8 @@ glusterd_dict_searialize(dict_t *dict_arr[], int count, int totcount, char *buf)
     for (i = 0; i < count; i++) {
         if (dict_arr[i]) {
             dict_count = dict_arr[i]->count;
-            pair = dict_arr[i]->members_list;
-            while (dict_count) {
-                if (!pair) {
-                    gf_msg("glusterd", GF_LOG_ERROR, 0,
-                           LG_MSG_PAIRS_LESS_THAN_COUNT,
-                           "less than count data pairs found!");
-                    ret = -1;
-                    goto out;
-                }
-
+            list_for_each_entry(pair, &dict_arr[i]->members_list, list)
+            {
                 if (!pair->key) {
                     gf_msg("glusterd", GF_LOG_ERROR, 0, LG_MSG_NULL_PTR,
                            "pair->key is null!");
@@ -3558,9 +3550,14 @@ glusterd_dict_searialize(dict_t *dict_arr[], int count, int totcount, char *buf)
                     memcpy(buf, pair->value->data, pair->value->len);
                     buf += pair->value->len;
                 }
-
-                pair = pair->next;
                 dict_count--;
+            }
+            if (dict_count > 0) {
+                gf_msg("glusterd", GF_LOG_ERROR, 0,
+                       LG_MSG_PAIRS_LESS_THAN_COUNT,
+                       "less than count data pairs found!");
+                ret = -1;
+                goto out;
             }
         }
     }

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2788,7 +2788,7 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         0,
     };
     int8_t sync_backend_xattrs = _gf_false;
-    data_pair_t *custom_xattrs;
+    data_pair_t *custom_xattrs = NULL;
     data_t *keyval = NULL;
     char **xattrs_to_heal = get_xattrs_to_heal();
 
@@ -3018,9 +3018,8 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         }
 
         /* Set custom xattrs based on info provided by DHT */
-        custom_xattrs = dict->members_list;
-
-        while (custom_xattrs != NULL) {
+        list_for_each_entry(custom_xattrs, &dict->members_list, list)
+        {
             ret = sys_lsetxattr(real_path, custom_xattrs->key,
                                 custom_xattrs->value->data,
                                 custom_xattrs->value->len, flags);
@@ -3030,8 +3029,6 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                        custom_xattrs->key, ret);
                 goto out;
             }
-
-            custom_xattrs = custom_xattrs->next;
         }
     }
 


### PR DESCRIPTION
Convert `dict_t` objects to use generic double-linked lists,
adjust related code and drop unused `dict_foreach_inline()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
