### PR TITLE
glusterfs.spec.in: issues with libtcmalloc

### DIFF
--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -71,7 +71,11 @@
 # libtcmalloc
 # if you wish to compile an rpm without tcmalloc (i.e. use gluster mempool)
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without tcmalloc
-%{?_without_tcmalloc:%global _without_libtcmalloc --without-tcmalloc}
+%{?_without_tcmalloc:%global _without_tcmalloc --without-tcmalloc}
+
+%ifnarch x86_64
+%global _without_tcmalloc --without-tcmalloc
+%endif
 
 # Do not use libtirpc on EL6, it does not have xdr_uint64_t() and xdr_uint32_t
 # Do not use libtirpc on EL7, it does not have xdr_sizeof()
@@ -253,7 +257,7 @@ Requires(pre):    shadow-utils
 BuildRequires:    systemd
 %endif
 
-%if ( 0%{?_with_tcmalloc:1} )
+%if ( 0%{!?_without_tcmalloc:1} )
 Requires:         gperftools-libs%{?_isa}
 %endif
 
@@ -275,7 +279,7 @@ BuildRequires:    ncurses-devel readline-devel
 BuildRequires:    libxml2-devel openssl-devel
 BuildRequires:    libaio-devel libacl-devel
 BuildRequires:    python%{_pythonver}-devel
-%if ( 0%{?_with_tcmalloc:1} )
+%if ( 0%{!?_without_tcmalloc:1} )
 BuildRequires:    gperftools-devel
 %endif
 %if ( 0%{?rhel} && 0%{?rhel} < 8 )
@@ -1651,6 +1655,9 @@ exit 0
 %endif
 
 %changelog
+* Mon Nov 1 2021 Kaleb S. KEITHLEY <kkeithle [at] redhat.com>
+- tcmalloc issues
+
 * Fri Jan 29 2021 Ravishankar N <ravishankar@redhat.com>
 - add liburing-devel as a requirement.
 


### PR DESCRIPTION
1) tcmalloc can't be dlopen()ed successfully on non-x86_64 arches,
    or at least not on aarch64, s390x, and armv7hl; causing issues
    with qemu and/or libvirt on those platforms.
2) invoking rpmbuild with --without-tcmalloc creates the %global
    %_without_tcmalloc (=true), and AFAIK does not creat the
    %global  %_with_tcmalloc (=false). The later tests for
    %_with_tcmalloc: do not work correctly, they need to test for
    '!%_without_tcmalloc'.
3)  a %global %_without_libtcmalloc is created but never used.
    The %configure step uses %_without_tcmalloc.

Change-Id: Ibe2f35f48b1b5b99d106cd2e81827531fef33039
Fixes: #2913
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

