### PR TITLE
SELinux:  persist ganesha_use_fusefs over an upgrade

### DIFF
--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -1018,7 +1018,10 @@ exit 0
 %if ( 0%{!?_without_server:1} )
 %if ( 0%{?fedora} && 0%{?fedora} > 25 || ( 0%{?rhel} && 0%{?rhel} > 6 ) )
 %post ganesha
-semanage boolean -m ganesha_use_fusefs --on
+# first install
+if [ $1 -eq 1 ]; then
+  %selinux_set_booleans ganesha_use_fusefs=1
+fi
 exit 0
 %endif
 %endif
@@ -1026,7 +1029,9 @@ exit 0
 %if ( 0%{!?_without_georeplication:1} )
 %post geo-replication
 %if ( 0%{?rhel} && 0%{?rhel} >= 8 )
-%selinux_set_booleans %{selinuxbooleans}
+if [ $1 -eq 1 ]; then
+  %selinux_set_booleans %{selinuxbooleans}
+fi
 %endif
 if [ $1 -ge 1 ]; then
     %systemd_postun_with_restart glusterd
@@ -1198,7 +1203,20 @@ exit 0
 %if ( 0%{!?_without_server:1} )
 %if ( 0%{?fedora} && 0%{?fedora} > 25  || ( 0%{?rhel} && 0%{?rhel} > 6 ) )
 %postun ganesha
-semanage boolean -m ganesha_use_fusefs --off
+if [ $1 -eq 0 ]; then
+  # use the value of ganesha_use_fusefs from before glusterfs-ganesha was installed
+  %selinux_unset_booleans ganesha_use_fusefs=1
+fi
+exit 0
+%endif
+%endif
+
+%if ( 0%{!?_without_georeplication:1} )
+%postun geo-replication
+%if ( 0%{?rhel} && 0%{?rhel} >= 8 )
+if [ $1 -eq 0 ]; then
+  %selinux_unset_booleans %{selinuxbooleans}
+fi
 exit 0
 %endif
 %endif
@@ -1208,19 +1226,9 @@ exit 0
 ##
 %if ( 0%{!?_without_server:1} )
 %if ( 0%{?fedora} && 0%{?fedora} > 25  || ( 0%{?rhel} && 0%{?rhel} > 6 ) )
-%trigger ganesha -- selinux-policy-targeted
-semanage boolean -m ganesha_use_fusefs --on
-exit 0
-%endif
-%endif
-
-##-----------------------------------------------------------------------------
-## All %%triggerun should be placed here and keep them sorted
-##
-%if ( 0%{!?_without_server:1} )
-%if ( 0%{?fedora} && 0%{?fedora} > 25  || ( 0%{?rhel} && 0%{?rhel} > 6 ) )
-%triggerun ganesha -- selinux-policy-targeted
-semanage boolean -m ganesha_use_fusefs --off
+# ensure ganesha_use_fusefs is on in case of policy mode switch (eg. mls->targeted)
+%triggerin ganesha -- selinux-policy-targeted
+semanage boolean -m ganesha_use_fusefs --on -S targeted
 exit 0
 %endif
 %endif


### PR DESCRIPTION
* Remove %triggerun ganesha
This trigger shouldn't be needed to begin with since removing
selinux-policy-targeted means that the user is switching SELinux off, or
is is switching the policy (to "mls" or "minimum"). In either case the
current boolean setting is not going to be used any more. The last
option, removal of glusterfs-ganesha, is covered by '%postun ganesha'.
But more importantly, the trigger is called every time
selinux-policy-targeted is updated (which can be avoided).
%triggerun is executed after %triggerin -
https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering
So when selinux-policy-targeted is updated, the new version is installed
first triggering `semanage boolean -m ganesha_use_fusefs --on`,
and then the old version is uninstalled triggering
`semanage boolean -m ganesha_use_fusefs --off`.

* use selinux_[un]set_booleans instead of "semanage boolean"
The macro pair properly manages SELinux stores and doesn't disable the
boolean in case it was enabled before ${name}-ganesha was installed.

* Only change booleans when the package is first installed or uninstalled
Updating ${name}-ganesha would disable the boolean because %postun is
called after %post (same issue as with the triggers).

Change-Id: Ibb926ffbe00c9f000bd740708c0a4b3435ee7871
Fixes: #2832
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

Co-authored-by: Vit Mojzis <vmojzis@redhat.com>

