### PR TITLE
glusterd: Added a check for available ports in the port_range

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -98,20 +98,24 @@ pmap_port_alloc(xlator_t *this)
 {
     struct pmap_registry *pmap = NULL;
     int p = 0;
+    int i;
 
     GF_ASSERT(this);
 
     pmap = pmap_registry_get(this);
 
-    while (true) {
-        /* coverity[DC.WEAK_CRYPTO] */
-        p = (rand() % (pmap->max_port - pmap->base_port + 1)) + pmap->base_port;
+    /* coverity[DC.WEAK_CRYPTO] */
+    p = (rand() % (pmap->max_port - pmap->base_port + 1)) + pmap->base_port;
+    for (i = pmap->base_port; i <= pmap->max_port; i++) {
         if (pmap_port_isfree(p)) {
-            break;
+            return p;
+        }
+        if (p++ >= pmap->max_port) {
+            p = pmap->base_port;
         }
     }
 
-    return p;
+    return 0;
 }
 
 /* pmap_assign_port does a pmap_registry_remove followed by pmap_port_alloc,


### PR DESCRIPTION
**Issue:**
After the latest update to use randomized ports, if all ports
till the max-port value in the glusterd.vol is occupied then,
volume start doesn't fail with the error that "All ports are
exhausted", rather it hangs. The reason is there isn't any check
in the function `pmap_port_alloc` to check for the occupied ports
within the permissible range and the loop goes on infinitely.

**Fix:**
Added a check for the available ports within the max-port range
and fail with correct error msg (already implemented) if all ports
are occupied.

Fixes: #2910

Change-Id: I862822ce573c8b78cf0fb5dd2db95667aa4581d3
Signed-off-by: nik-redhat <nladha@redhat.com>

