### PR TITLE
Fixes:2912  Update the hostname in the gluster cluster by the command "gluster peer probe xxxx"

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -966,8 +966,8 @@ __glusterd_handle_stage_op(rpcsvc_request_t *req)
         gf_msg_debug(this->name, 0, "No transaction's opinfo set");
 
         state = GD_OP_STATE_LOCKED;
-        glusterd_txn_opinfo_init(&txn_op_info, state, &op_req.op,
-                                 req_ctx->dict, req);
+        glusterd_txn_opinfo_init(&txn_op_info, state, &op_req.op, req_ctx->dict,
+                                 req);
 
         if (req_ctx->op != GD_OP_GSYNC_SET)
             txn_op_info.skip_locking = _gf_true;
@@ -2653,7 +2653,7 @@ glusterd_peer_hostname_update(glusterd_peerinfo_t *peerinfo,
     GF_ASSERT(peerinfo);
     GF_ASSERT(hostname);
 
-    ret = gd_add_address_to_peer(peerinfo, hostname);
+    ret = gd_add_address_to_peer(peerinfo, hostname, _gf_true);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0,
                GD_MSG_HOSTNAME_ADD_TO_PEERLIST_FAIL,
@@ -2663,6 +2663,11 @@ glusterd_peer_hostname_update(glusterd_peerinfo_t *peerinfo,
 
     if (store_update)
         ret = glusterd_store_peerinfo(peerinfo);
+
+    if (peerinfo->hostname != NULL) {
+        GF_FREE(peerinfo->hostname);
+    }
+    peerinfo->hostname = gf_strdup(hostname);
 out:
     gf_msg_debug(THIS->name, 0, "Returning %d", ret);
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -363,7 +363,7 @@ glusterd_peerinfo_new(glusterd_friend_sm_state_t state, uuid_t *uuid,
 
     CDS_INIT_LIST_HEAD(&new_peer->hostnames);
     if (hostname) {
-        ret = gd_add_address_to_peer(new_peer, hostname);
+        ret = gd_add_address_to_peer(new_peer, hostname, _gf_true);
         if (ret)
             goto out;
         /* Also set it to peerinfo->hostname. Doing this as we use
@@ -604,7 +604,8 @@ out:
 }
 
 int
-gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address)
+gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address,
+                       gf_boolean_t add_head)
 {
     int ret = -1;
     glusterd_peer_hostname_t *hostname = NULL;
@@ -621,9 +622,14 @@ gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address)
     if (ret)
         goto out;
 
+    ret = 0;
+    if (add_head) {
+        cds_list_add_rcu(&hostname->hostname_list, &peerinfo->hostnames);
+        goto out;
+    }
+
     cds_list_add_tail_rcu(&hostname->hostname_list, &peerinfo->hostnames);
 
-    ret = 0;
 out:
     return ret;
 }
@@ -740,7 +746,7 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
                key);
         goto out;
     }
-    ret = gd_add_address_to_peer(peerinfo, hostname);
+    ret = gd_add_address_to_peer(peerinfo, hostname, _gf_true);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,
                "Could not add address to peer");
@@ -776,7 +782,7 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
                    key);
             goto out;
         }
-        ret = gd_add_address_to_peer(peerinfo, hostname);
+        ret = gd_add_address_to_peer(peerinfo, hostname, _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,
                    "Could not add address to peer");

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -58,7 +58,8 @@ gf_boolean_t
 gd_peer_has_address(glusterd_peerinfo_t *peerinfo, const char *address);
 
 int
-gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address);
+gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address,
+                       gf_boolean_t add_head);
 
 int
 gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -317,7 +317,7 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
             goto reply;
         }
 
-        ret = gd_add_address_to_peer(peerinfo, rsp.hostname);
+        ret = gd_add_address_to_peer(peerinfo, rsp.hostname, _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0,
                    GD_MSG_HOSTNAME_ADD_TO_PEERLIST_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -2799,7 +2799,8 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             cds_list_add_tail(&ta_brickinfo->brick_list, &volinfo->ta_bricks);
             ta_brick_count++;
             if (gf_store_iter_destroy(&iter)) {
-                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_STORE_ITER_DESTROY_FAIL,
+                gf_msg(this->name, GF_LOG_ERROR, 0,
+                       GD_MSG_STORE_ITER_DESTROY_FAIL,
                        "Failed to destroy store iter");
                 ret = -1;
                 goto out;
@@ -4563,7 +4564,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
                 peerinfo->state.state = atoi(value);
             } else if (!strncmp(GLUSTERD_STORE_KEY_PEER_HOSTNAME, key,
                                 SLEN(GLUSTERD_STORE_KEY_PEER_HOSTNAME))) {
-                ret = gd_add_address_to_peer(peerinfo, value);
+                ret = gd_add_address_to_peer(peerinfo, value, _gf_false);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0,
                            GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,


### PR DESCRIPTION
Change-Id: I2edd1210e99e0d9afed4ee32d9aff92838e49f83

When updating the domain name, the new domain name is always added to the tail of the hostname list, resulting in the glusterfs cluster unable to use the latest domain name.
This modification adds the newly added domain name to the header of the hostname list, and update it.





Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>

