### PR TITLE
glusterd/brick: Do not connect into the backup volfile server

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2654,6 +2654,23 @@ mgmt_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
                 }
             }
             server = ctx->cmd_args.curr_server;
+
+            if (ctx->cmd_args.brick_port && ctx->cmd_args.brick_name) {
+                /* This process requires a portmap signin with glusterd.
+                 * Currently the glusterd portmaps are local to each glusterd.
+                 * Hence connecting the process to a different volfile server
+                 * won't work well with such process, so don't try to connect
+                 * to backup volfile server here.
+                 */
+                if (!ctx->active) {
+                    need_term = 1;
+                }
+                emval = ENOTCONN;
+                GF_LOG_OCCASIONALLY(log_ctr2, "glusterfsd-mgmt", GF_LOG_INFO,
+                                    "Port-mapper is active, Giving up on the "
+                                    "backup volfile servers");
+                break;
+            }
             if (server->list.next == &ctx->cmd_args.volfile_servers) {
                 if (!ctx->active) {
                     need_term = 1;


### PR DESCRIPTION
A brick process requires portmap with it's local glusterd. Since
the portmapper is not a centralized one, the informations are stored
locally in each glusterd. When a glusterd goes down, connecting to
a backup volfile server will result in undefined behaviour especially
when the portmap signin and signout requests are send to a different
glusterd than it is intended. If that happens then there can be
undefined behaviour when there are bricks with the same path are present
in differnt nodes.

In this patch, we will prevent bricks connecting to a backup volfile
servers. Which means that the bricks won't be connected to any other
glusterd's to receive a management update if the glusterd on the local
node goes down.

THANKS TO PRANITH FOR THE RCA HERE
https://github.com/gluster/glusterfs/issues/2480

Fixes: #2480
>Change-Id: Iddd6f1d0f0da1cf0c90729043f23a293d478bf7c
>Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

Change-Id: I45d962994a1128b59a04ca9880404fe7357990c6
Signed-off-by: nik-redhat <nladha@redhat.com>

