### PR TITLE
glusterd: use the hostname lastest probed

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3468,6 +3468,7 @@ gf_get_hostname_from_ip(char *client_ip, char **hostname)
     }
 
     *hostname = gf_strdup((char *)client_hostname);
+    GF_ASSERT(*hostname);
 out:
     if (client_ip_copy)
         GF_FREE(client_ip_copy);

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -138,11 +138,14 @@ glusterd_handle_friend_req(rpcsvc_request_t *req, uuid_t uuid, char *hostname,
     }
 
     event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(event->peername);
     gf_uuid_copy(event->peerid, peerinfo->uuid);
 
     gf_uuid_copy(ctx->uuid, uuid);
-    if (hostname)
+    if (hostname) {
         ctx->hostname = gf_strdup(hostname);
+        GF_ASSERT(ctx->hostname);
+    }
     ctx->req = req;
 
     ret = dict_unserialize_specific_keys(
@@ -233,8 +236,10 @@ glusterd_handle_unfriend_req(rpcsvc_request_t *req, uuid_t uuid, char *hostname,
         goto out;
     }
 
-    if (hostname)
+    if (hostname) {
         event->peername = gf_strdup(hostname);
+        GF_ASSERT(event->peername);
+    }
 
     gf_uuid_copy(event->peerid, uuid);
 
@@ -247,8 +252,10 @@ glusterd_handle_unfriend_req(rpcsvc_request_t *req, uuid_t uuid, char *hostname,
     }
 
     gf_uuid_copy(ctx->uuid, uuid);
-    if (hostname)
+    if (hostname) {
         ctx->hostname = gf_strdup(hostname);
+        GF_ASSERT(ctx->hostname);
+    }
     ctx->req = req;
 
     event->ctx = ctx;
@@ -2665,6 +2672,7 @@ glusterd_peer_hostname_update(glusterd_peerinfo_t *peerinfo,
     if (peerinfo->hostname != NULL)
         GF_FREE(peerinfo->hostname);
     peerinfo->hostname = gf_strdup(hostname);
+    GF_ASSERT(peerinfo->hostname);
 
     if (store_update)
         ret = glusterd_store_peerinfo(peerinfo);
@@ -3465,6 +3473,7 @@ glusterd_friend_rpc_create(xlator_t *this, glusterd_peerinfo_t *peerinfo,
 
     gf_uuid_copy(peerctx->peerid, peerinfo->uuid);
     peerctx->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(peerctx->peername);
     peerctx->peerinfo_gen = peerinfo->generation; /* A peerinfos generation
                                                      number can be used to
                                                      uniquely identify a
@@ -3681,6 +3690,7 @@ glusterd_probe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
         ret = glusterd_friend_sm_new_event(GD_FRIEND_EVENT_NEW_NAME, &event);
         if (!ret) {
             event->peername = gf_strdup(peerinfo->hostname);
+            GF_ASSERT(event->peername);
             gf_uuid_copy(event->peerid, peerinfo->uuid);
 
             ret = glusterd_friend_sm_inject_event(event);
@@ -3751,6 +3761,7 @@ glusterd_deprobe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
     }
 
     ctx->hostname = gf_strdup(hoststr);
+    GF_ASSERT(ctx->hostname);
     ctx->port = port;
     ctx->req = req;
     ctx->dict = dict;
@@ -3758,6 +3769,7 @@ glusterd_deprobe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
     event->ctx = ctx;
 
     event->peername = gf_strdup(hoststr);
+    GF_ASSERT(event->peername);
     gf_uuid_copy(event->peerid, uuid);
 
     ret = glusterd_friend_sm_inject_event(event);
@@ -3816,6 +3828,7 @@ glusterd_xfer_friend_add_resp(rpcsvc_request_t *req, char *myhostname,
     rsp.op_ret = op_ret;
     rsp.op_errno = op_errno;
     rsp.hostname = gf_strdup(myhostname);
+    GF_ASSERT(rsp.hostname);
     rsp.port = port;
 
     ret = glusterd_submit_reply(req, &rsp, NULL, 0, NULL,
@@ -6193,6 +6206,7 @@ glusterd_friend_remove_notify(glusterd_peerctx_t *peerctx, int32_t op_errno)
                                      peerinfo->hostname, peerinfo->port, dict);
 
         new_event->peername = gf_strdup(peerinfo->hostname);
+        GF_ASSERT(new_event->peername);
         gf_uuid_copy(new_event->peerid, peerinfo->uuid);
         ret = glusterd_friend_sm_inject_event(new_event);
 

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -2653,13 +2653,18 @@ glusterd_peer_hostname_update(glusterd_peerinfo_t *peerinfo,
     GF_ASSERT(peerinfo);
     GF_ASSERT(hostname);
 
-    ret = gd_add_address_to_peer(peerinfo, hostname);
+    ret = gd_add_address_to_peer_head(peerinfo, hostname);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0,
                GD_MSG_HOSTNAME_ADD_TO_PEERLIST_FAIL,
                "Couldn't add address to the peer info");
         goto out;
     }
+
+    /* Also set peerinfo->hostname to the first address */
+    if (peerinfo->hostname != NULL)
+        GF_FREE(peerinfo->hostname);
+    peerinfo->hostname = gf_strdup(hostname);
 
     if (store_update)
         ret = glusterd_store_peerinfo(peerinfo);

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1909,11 +1909,13 @@ glusterd_event_connected_inject(glusterd_peerctx_t *peerctx)
         goto out;
     }
     ctx->hostname = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(ctx->hostname);
     ctx->port = peerinfo->port;
     ctx->req = peerctx->args.req;
     ctx->dict = peerctx->args.dict;
 
     event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(event->peername);
     gf_uuid_copy(event->peerid, peerinfo->uuid);
     event->ctx = ctx;
 

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -56,6 +56,7 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
         else
             peer_str = gf_strdup(uuid_utoa(uuid));
 
+        GF_ASSERT(peer_str);
         RCU_READ_UNLOCK;
 
         is_operrstr_blk = (op_errstr && strcmp(op_errstr, ""));

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -371,6 +371,7 @@ glusterd_peerinfo_new(glusterd_friend_sm_state_t state, uuid_t *uuid,
          * get everything right
          */
         new_peer->hostname = gf_strdup(hostname);
+        GF_ASSERT(new_peer->hostname);
     }
 
     if (uuid) {
@@ -445,6 +446,7 @@ glusterd_uuid_to_hostname(uuid_t uuid)
 
     if (!gf_uuid_compare(MY_UUID, uuid)) {
         hostname = gf_strdup("localhost");
+        GF_ASSERT(hostname);
         return hostname;
     }
     RCU_READ_LOCK;
@@ -453,6 +455,7 @@ glusterd_uuid_to_hostname(uuid_t uuid)
         {
             if (!gf_uuid_compare(entry->uuid, uuid)) {
                 hostname = gf_strdup(entry->hostname);
+                GF_ASSERT(hostname);
                 break;
             }
         }
@@ -525,6 +528,7 @@ glusterd_are_vol_all_peers_up(glusterd_volinfo_t *volinfo,
             if (!(peerinfo->connected) ||
                 (peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)) {
                 *down_peerstr = gf_strdup(peerinfo->hostname);
+                GF_ASSERT(*down_peerstr);
                 RCU_READ_UNLOCK;
                 gf_msg_debug(THIS->name, 0, "Peer %s is down. ", *down_peerstr);
                 goto out;
@@ -558,6 +562,7 @@ glusterd_peer_hostname_new(const char *hostname,
     }
 
     peer_hostname->hostname = gf_strdup(hostname);
+    GF_ASSERT(peer_hostname->hostname);
     CDS_INIT_LIST_HEAD(&peer_hostname->hostname_list);
 
     *name = peer_hostname;
@@ -775,6 +780,7 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
     if (peerinfo->hostname != NULL)
         GF_FREE(peerinfo->hostname);
     peerinfo->hostname = gf_strdup(hostname);
+    GF_ASSERT(peerinfo->hostname);
 
     if (conf->op_version < GD_OP_VERSION_3_6_0) {
         ret = 0;

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -604,6 +604,31 @@ out:
 }
 
 int
+gd_add_address_to_peer_head(glusterd_peerinfo_t *peerinfo, const char *address)
+{
+    int ret = -1;
+    glusterd_peer_hostname_t *hostname = NULL;
+
+    GF_VALIDATE_OR_GOTO("glusterd", (peerinfo != NULL), out);
+    GF_VALIDATE_OR_GOTO("glusterd", (address != NULL), out);
+
+    if (gd_peer_has_address(peerinfo, address)) {
+        ret = 0;
+        goto out;
+    }
+
+    ret = glusterd_peer_hostname_new(address, &hostname);
+    if (ret)
+        goto out;
+
+    cds_list_add_rcu(&hostname->hostname_list, &peerinfo->hostnames);
+
+    ret = 0;
+out:
+    return ret;
+}
+
+int
 gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address)
 {
     int ret = -1;
@@ -740,7 +765,7 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
                key);
         goto out;
     }
-    ret = gd_add_address_to_peer(peerinfo, hostname);
+    ret = gd_add_address_to_peer_head(peerinfo, hostname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,
                "Could not add address to peer");

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -58,6 +58,9 @@ gf_boolean_t
 gd_peer_has_address(glusterd_peerinfo_t *peerinfo, const char *address);
 
 int
+gd_add_address_to_peer_head(glusterd_peerinfo_t *peerinfo, const char *address);
+
+int
 gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address);
 
 int

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -329,6 +329,7 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
         ret = glusterd_friend_sm_new_event(GD_FRIEND_EVENT_NEW_NAME, &event);
         if (!ret) {
             event->peername = gf_strdup(peerinfo->hostname);
+            GF_ASSERT(event->peername);
             gf_uuid_copy(event->peerid, peerinfo->uuid);
 
             ret = glusterd_friend_sm_inject_event(event);
@@ -395,6 +396,7 @@ cont:
     }
 
     event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(event->peername);
     gf_uuid_copy(event->peerid, peerinfo->uuid);
 
     event->ctx = ((call_frame_t *)myframe)->local;
@@ -503,8 +505,9 @@ __glusterd_friend_add_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     gf_uuid_copy(ev_ctx->uuid, rsp.uuid);
     ev_ctx->hostname = gf_strdup(rsp.hostname);
-
+    GF_ASSERT(ev_ctx->hostname);
     event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(ev_ctx->hostname);
     gf_uuid_copy(event->peerid, peerinfo->uuid);
     event->ctx = ev_ctx;
     ret = glusterd_friend_sm_inject_event(event);
@@ -611,6 +614,7 @@ inject:
         goto unlock;
     }
     event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(event->peername);
     gf_uuid_copy(event->peerid, peerinfo->uuid);
 
     ret = glusterd_friend_sm_inject_event(event);
@@ -1476,6 +1480,7 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
 
     gf_uuid_copy(req.uuid, MY_UUID);
     req.hostname = gf_strdup(hostname);
+    GF_ASSERT(req.hostname);
     req.port = port;
 
     ret = glusterd_submit_request(
@@ -1524,6 +1529,7 @@ glusterd_rpc_friend_add(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     req.hostname = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(req.hostname);
     req.port = peerinfo->port;
 
     RCU_READ_UNLOCK;
@@ -1636,6 +1642,7 @@ glusterd_rpc_friend_remove(call_frame_t *frame, xlator_t *this, void *data)
 
     gf_uuid_copy(req.uuid, MY_UUID);
     req.hostname = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(req.hostname);
     req.port = peerinfo->port;
 
     ret = glusterd_submit_request(peerinfo->rpc, &req, frame, peerinfo->peer,

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -271,10 +271,12 @@ glusterd_ac_reverse_probe_begin(glusterd_friend_sm_event_t *event, void *ctx)
     }
 
     new_ev_ctx->hostname = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(new_ev_ctx->hostname);
     new_ev_ctx->port = peerinfo->port;
     new_ev_ctx->req = NULL;
 
     new_event->peername = gf_strdup(peerinfo->hostname);
+    GF_ASSERT(new_event->peername);
     gf_uuid_copy(new_event->peerid, peerinfo->uuid);
     new_event->ctx = new_ev_ctx;
 
@@ -864,6 +866,7 @@ glusterd_ac_handle_friend_remove_req(glusterd_friend_sm_event_t *event,
         }
 
         new_event->peername = gf_strdup(peerinfo->hostname);
+        GF_ASSERT(new_event->peername);
         gf_uuid_copy(new_event->peerid, peerinfo->uuid);
 
         ret = glusterd_friend_sm_inject_event(new_event);
@@ -1054,6 +1057,7 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
 
     gf_uuid_copy(new_ev_ctx->uuid, ev_ctx->uuid);
     new_ev_ctx->hostname = gf_strdup(ev_ctx->hostname);
+    GF_ASSERT(new_ev_ctx->hostname);
     new_ev_ctx->op = GD_FRIEND_UPDATE_ADD;
 
     new_event->ctx = new_ev_ctx;

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4598,6 +4598,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
         address = cds_list_entry(peerinfo->hostnames.next,
                                  glusterd_peer_hostname_t, hostname_list);
         peerinfo->hostname = gf_strdup(address->hostname);
+        GF_ASSERT(peerinfo->hostname);
 
         ret = glusterd_friend_add_from_peerinfo(peerinfo, 1, NULL);
         if (ret)

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -236,6 +236,7 @@ glusterd_hostname_new(xlator_t *this, const char *hostname,
     }
 
     hostname_obj->hostname = gf_strdup(hostname);
+    GF_ASSERT(hostname_obj->hostname);
     CDS_INIT_LIST_HEAD(&hostname_obj->hostname_list);
 
     *name = hostname_obj;


### PR DESCRIPTION
Do a new hostname probe for using another hostname. After probe the new
hostname, there are some problems.

This patch fix it. Place the hostname lasted probed to the first seat.

Fixes: #2932 #2912
Signed-off-by: Cheng Lin <cheng.lin130@zte.com.cn>
Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>
