### PR TITLE
cli: Fix wrong value of inodeSize in volume status xml output

### DIFF
--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -418,7 +418,7 @@ cli_xml_output_vol_status_detail(xmlTextWriterPtr writer, dict_t *dict,
     ret = dict_get_str(dict, key, &inode_size);
     if (!ret) {
         ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"inodeSize",
-                                              "%s", fs_name);
+                                              "%s", inode_size);
         XML_RET_CHECK_AND_GOTO(ret, out);
     }
     snprintf(key, sizeof(key), "brick%d.total_inodes", brick_index);


### PR DESCRIPTION
Fs type was added to inodeSize xml output. Now it is fixed
by adding the actual variable.

Fixes: #2936
Change-Id: Iaa285cb2a7dbf77d7a2cf1e2636e4285d2257124
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>

