### PR TITLE
build, libglusterfs: add timers that notify via file descriptors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -812,6 +812,27 @@ if test "x$enable_epoll" != "xno"; then
 fi
 # end EPOLL section
 
+# TIMERFD and timer selection section
+AC_ARG_ENABLE([timerfd],
+              AC_HELP_STRING([--disable-timerfd],
+                             [Do not use timerfd for timers.]))
+
+BUILD_TIMERFD=no
+if test "x$enable_timerfd" != "xno"; then
+   AC_CHECK_HEADERS([sys/timerfd.h],
+                    [BUILD_TIMERFD=yes],
+                    [BUILD_TIMERFD=no])
+fi
+
+if test "x$BUILD_EPOLL" = "xyes" -a "x$BUILD_TIMERFD" = "xyes"; then
+   AC_DEFINE(GF_TIMERFD_TIMERS, 1, [Use timerfd-based timers.])
+   TIMERTYPE=timerfd
+else
+   TIMERTYPE=generic
+fi
+
+# end TIMERFD and timers section
+
 # SYNCDAEMON section
 AC_ARG_ENABLE([georeplication],
               AC_HELP_STRING([--disable-georeplication],
@@ -1865,6 +1886,7 @@ echo "GlusterFS configure summary"
 echo "==========================="
 echo "FUSE client          : $BUILD_FUSE_CLIENT"
 echo "epoll IO multiplex   : $BUILD_EPOLL"
+echo "Timer implementation : $TIMERTYPE"
 echo "fusermount           : $BUILD_FUSERMOUNT"
 echo "readline             : $BUILD_READLINE"
 echo "georeplication       : $BUILD_SYNCDAEMON"

--- a/libglusterfs/src/glusterfs/timer.h
+++ b/libglusterfs/src/glusterfs/timer.h
@@ -14,9 +14,30 @@
 #include "glusterfs/glusterfs.h"
 #include "glusterfs/xlator.h"
 #include <sys/time.h>
+
+#if defined(GF_TIMERFD_TIMERS)
+#include <sys/timerfd.h>
+#else /* not GF_TIMERFD_TIMERS */
 #include <pthread.h>
+#endif /* GF_TIMERFD_TIMERS */
 
 typedef void (*gf_timer_cbk_t)(void *);
+
+#if defined(GF_TIMERFD_TIMERS)
+
+struct _gf_timer {
+    gf_timer_cbk_t callbk;
+    glusterfs_ctx_t *ctx;
+    gf_boolean_t fired;
+    xlator_t *xl;
+    void *data;
+    int idx;
+    int fd;
+};
+
+typedef struct _gf_timer gf_timer_t;
+
+#else /* not GF_TIMERFD_TIMERS */
 
 struct _gf_timer {
     union {
@@ -44,6 +65,8 @@ struct _gf_timer_registry {
 typedef struct _gf_timer gf_timer_t;
 typedef struct _gf_timer_registry gf_timer_registry_t;
 
+#endif /* GF_TIMERFD_TIMERS */
+
 gf_timer_t *
 gf_timer_call_after(glusterfs_ctx_t *ctx, struct timespec delta,
                     gf_timer_cbk_t cbk, void *data);
@@ -53,4 +76,5 @@ gf_timer_call_cancel(glusterfs_ctx_t *ctx, gf_timer_t *event);
 
 void
 gf_timer_registry_destroy(glusterfs_ctx_t *ctx);
+
 #endif /* _TIMER_H */


### PR DESCRIPTION
On Linux with `timerfd_create()` and `timerfd_settime()` system calls,
optionally hook timers into generic event processing infrastructure,
provide `--disable-timerfd` build option to fallback to generic code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

