### PR TITLE
tests: replace localhost and 127.0.01  with valid ip

### DIFF
--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -18,8 +18,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0
@@ -31,7 +30,7 @@ grp="ggroup"
 
 secondary_url=$usr@$secondary
 secondary_vol=$GSV0
-ssh_url=$usr@$SH0
+ssh_url=$usr@$H0
 
 #Cleanup stale keys
 sed -i '/^command=.*SSH_ORIGINAL_COMMAND#.*/d' /home/$usr/.ssh/authorized_keys

--- a/tests/00-geo-rep/00-georep-verify-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-setup.t
@@ -17,8 +17,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0
@@ -53,8 +52,8 @@ TEST glusterfs -s $H0 --volfile-id $GSV0 $M1
 ############################################################
 
 #Test invalid secondary url
-TEST ! $GEOREP_CLI $primary ${SH0}:${GSV0} create push-pem
-TEST ! $GEOREP_CLI $primary ${SH0}:::${GSV0} create push-pem
+TEST ! $GEOREP_CLI $primary ${H0}:${GSV0} create push-pem
+TEST ! $GEOREP_CLI $primary ${H0}:::${GSV0} create push-pem
 
 #Create geo-rep session
 TEST create_georep_session $primary $secondary

--- a/tests/00-geo-rep/01-georep-glusterd-tests.t
+++ b/tests/00-geo-rep/01-georep-glusterd-tests.t
@@ -16,9 +16,8 @@ TEST pidof glusterd
 #Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
-secondary1=root@${SH0}::${GSV1}
+secondary=${H0}::${GSV0}
+secondary1=root@${H0}::${GSV1}
 num_active=2
 num_passive=2
 primary_mnt=$M0
@@ -65,10 +64,10 @@ TEST glusterfs -s $H0 --volfile-id $GSV0 $M1
 ############################################################
 
 #Negative testcase: Test invalid primary
-TEST ! $GEOREP_CLI primary1 ${SH0}::${GSV0} create push-pem
+TEST ! $GEOREP_CLI primary1 ${H0}::${GSV0} create push-pem
 
 #Negatvie testcase: Test invalid secondary
-TEST ! $GEOREP_CLI $primary ${SH0}::secondary3 create push-pem
+TEST ! $GEOREP_CLI $primary ${H0}::secondary3 create push-pem
 
 ##------------------- Session 1 Creation Begin-----------------##
 #Create geo-rep session
@@ -117,7 +116,7 @@ TEST $GEOREP_CLI $primary $secondary1 start force
 #With root@ prefix
 TEST ! $GEOREP_CLI $primary $secondary1 create push-pem
 #Without root@ prefix
-TEST ! $GEOREP_CLI $primary ${SH0}::${GSV1} create push-pem
+TEST ! $GEOREP_CLI $primary ${H0}::${GSV1} create push-pem
 TEST $GEOREP_CLI $primary $secondary1 create push-pem force
 
 ##------------------- Fanout status testcases Begin --------------##

--- a/tests/00-geo-rep/bug-1600145.t
+++ b/tests/00-geo-rep/bug-1600145.t
@@ -16,8 +16,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0

--- a/tests/00-geo-rep/bug-1708603.t
+++ b/tests/00-geo-rep/bug-1708603.t
@@ -16,8 +16,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="gluster volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-basic-dr-rsync-arbiter.t
+++ b/tests/00-geo-rep/georep-basic-dr-rsync-arbiter.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=4
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-basic-dr-rsync.t
+++ b/tests/00-geo-rep/georep-basic-dr-rsync.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0
@@ -229,7 +228,7 @@ EXPECT_WITHIN $GEO_REP_TIMEOUT 0 verify_rename_with_existing_destination ${secon
 EXPECT_WITHIN $GEO_REP_TIMEOUT "x0" arequal_checksum ${primary_mnt} ${secondary_mnt}
 
 #Test config upgrade BUG: 1707731
-config_file=$GLUSTERD_WORKDIR/geo-replication/${GMV0}_${SH0}_${GSV0}/gsyncd.conf
+config_file=$GLUSTERD_WORKDIR/geo-replication/${GMV0}_${H0}_${GSV0}/gsyncd.conf
 cat >> $config_file<<EOL
 [peers ${GMV0} ${GSV0}]
 use_tarssh = true

--- a/tests/00-geo-rep/georep-basic-dr-tarssh-arbiter.t
+++ b/tests/00-geo-rep/georep-basic-dr-tarssh-arbiter.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=4
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-basic-dr-tarssh.t
+++ b/tests/00-geo-rep/georep-basic-dr-tarssh.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-basic-rsync-ec.t
+++ b/tests/00-geo-rep/georep-basic-rsync-ec.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=10
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-basic-tarssh-ec.t
+++ b/tests/00-geo-rep/georep-basic-tarssh-ec.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=10
 primary_mnt=$M0

--- a/tests/00-geo-rep/georep-config-upgrade.t
+++ b/tests/00-geo-rep/georep-config-upgrade.t
@@ -7,7 +7,6 @@
 
 SCRIPT_TIMEOUT=300
 OLD_CONFIG_PATH=$(dirname $0)/gsyncd.conf.old
-WORKING_DIR=/var/lib/glusterd/geo-replication/primary_127.0.0.1_secondary
 
 ##Cleanup and start glusterd
 cleanup;
@@ -17,13 +16,13 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0
 secondary_mnt=$M1
 
+WORKING_DIR=/var/lib/glusterd/geo-replication/primary_${H0}_secondary
 ############################################################
 #SETUP VOLUMES AND GEO-REPLICATION
 ############################################################

--- a/tests/00-geo-rep/georep-stderr-hang.t
+++ b/tests/00-geo-rep/georep-stderr-hang.t
@@ -24,8 +24,7 @@ TEST pidof glusterd
 ##Variables
 GEOREP_CLI="$CLI volume geo-replication"
 primary=$GMV0
-SH0="127.0.0.1"
-secondary=${SH0}::${GSV0}
+secondary=${H0}::${GSV0}
 num_active=2
 num_passive=2
 primary_mnt=$M0

--- a/tests/basic/ec/quota.t
+++ b/tests/basic/ec/quota.t
@@ -10,7 +10,7 @@ build_tester $(dirname $0)/../quota.c -o $QDD
 
 TEST glusterd
 TEST pidof glusterd
-TEST $CLI volume create $V0 disperse $H0:$B0/${V0}{0..2}
+TEST $CLI volume create $V0 disperse 3 $H0:$B0/${V0}{0..2}
 EXPECT 'Created' volinfo_field $V0 'Status'
 TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field $V0 'Status'

--- a/tests/basic/ec/quota.t
+++ b/tests/basic/ec/quota.t
@@ -10,7 +10,7 @@ build_tester $(dirname $0)/../quota.c -o $QDD
 
 TEST glusterd
 TEST pidof glusterd
-TEST $CLI volume create $V0 disperse 3 $H0:$B0/${V0}{0..2}
+TEST $CLI volume create $V0 disperse $H0:$B0/${V0}{0..2}
 EXPECT 'Created' volinfo_field $V0 'Status'
 TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field $V0 'Status'

--- a/tests/basic/user-xlator.t
+++ b/tests/basic/user-xlator.t
@@ -5,7 +5,7 @@
 
 #### patchy.dev.d-backends-patchy1.vol
 brick=${B0//\//-}
-SERVER_VOLFILE="/var/lib/glusterd/vols/${V0}/${V0}.${HOSTNAME}.${brick:1}-${V0}1.vol"
+SERVER_VOLFILE="/var/lib/glusterd/vols/${V0}/${V0}.${H0}.${brick:1}-${V0}1.vol"
 
 cleanup;
 

--- a/tests/bugs/glusterd/bug-824753.t
+++ b/tests/bugs/glusterd/bug-824753.t
@@ -32,7 +32,7 @@ touch $M0/file1;
 
 TEST $CC -g $(dirname $0)/bug-824753-file-locker.c -o $(dirname $0)/file-locker
 
-TEST $(dirname $0)/file-locker $V0 $H0 $B0 $M0 file1
+TEST $(dirname $0)/file-locker $V0 `hostname` $B0 $M0 file1
 
 ## Finish up
 TEST rm -f $(dirname $0)/file-locker

--- a/tests/bugs/posix/bug-765380.t
+++ b/tests/bugs/posix/bug-765380.t
@@ -6,7 +6,6 @@ cleanup;
 
 TEST glusterd
 TEST pidof glusterd
-
 REPLICA=2
 
 TEST $CLI volume create $V0 replica $REPLICA $H0:$B0/${V0}00 $H0:$B0/${V0}01 $H0:$B0/${V0}10 $H0:$B0/${V0}11
@@ -22,14 +21,13 @@ function count_hostname_or_uuid_from_pathinfo()
 }
 
 TEST touch $M0/f00f
-
-EXPECT $REPLICA count_hostname_or_uuid_from_pathinfo $H0
+EXPECT $REPLICA count_hostname_or_uuid_from_pathinfo `hostname`
 
 # turn on node-uuid-pathinfo option
 TEST $CLI volume set $V0 node-uuid-pathinfo on
 
 # do not expext hostname as part of the pathinfo string
-EXPECT 0 count_hostname_or_uuid_from_pathinfo $H0
+EXPECT 0 count_hostname_or_uuid_from_pathinfo `hostname`
 
 uuid=$(grep UUID $GLUSTERD_WORKDIR/glusterd.info | cut -f2 -d=)
 

--- a/tests/bugs/rpc/bug-921072.t
+++ b/tests/bugs/rpc/bug-921072.t
@@ -21,30 +21,30 @@ EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 # based on ip addresses (1-4)
 # case 1: allow only localhost ip
-TEST $CLI volume set $V0 nfs.rpc-auth-allow 127.0.0.1
+TEST $CLI volume set $V0 nfs.rpc-auth-allow $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 # case 2: allow only non-localhost ip
 TEST $CLI volume set $V0 nfs.rpc-auth-allow 192.168.1.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 #11
-TEST ! mount_nfs localhost:/$V0 $N0 nolock
+TEST ! mount_nfs $H0:/$V0 $N0 nolock
 TEST $CLI volume reset $V0 force
 TEST $CLI volume set $V0 nfs.disable off
 # case 3: reject only localhost ip
 TEST $CLI volume set $V0 nfs.rpc-auth-reject 127.0.0.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST ! mount_nfs localhost:/$V0 $N0 nolock
+TEST ! mount_nfs $H0:/$V0 $N0 nolock
 
 # case 4: reject only non-localhost ip
 TEST $CLI volume set $V0 nfs.rpc-auth-reject 192.168.1.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 
@@ -63,14 +63,14 @@ EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 TEST $CLI volume set $V0 nfs.rpc-auth-allow localhost
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 # case 6: allow only somehost
 TEST $CLI volume set $V0 nfs.rpc-auth-allow somehost
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST ! mount_nfs localhost:/$V0 $N0 nolock
+TEST ! mount_nfs $H0:/$V0 $N0 nolock
 
 # case 7: reject only localhost
 TEST $CLI volume reset $V0 force
@@ -79,13 +79,13 @@ TEST $CLI volume set $V0 nfs.addr-namelookup on
 TEST $CLI volume set $V0 nfs.rpc-auth-reject localhost
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 #30
-TEST ! mount_nfs localhost:/$V0 $N0 nolock
+TEST ! mount_nfs $H0:/$V0 $N0 nolock
 
 # case 8: reject only somehost
 TEST $CLI volume set $V0 nfs.rpc-auth-reject somehost
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 # based on ip addresses: repeat of cases 1-4
@@ -96,7 +96,7 @@ TEST $CLI volume set $V0 nfs.addr-namelookup on
 TEST $CLI volume set $V0 nfs.rpc-auth-allow 127.0.0.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 TEST mkdir -p $N0/subdir
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
@@ -113,17 +113,17 @@ TEST $CLI volume set $V0 nfs.addr-namelookup on
 TEST $CLI volume set $V0 nfs.rpc-auth-reject 127.0.0.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST ! mount_nfs localhost:/$V0 $N0 nolock
-TEST ! mount_nfs localhost:/$V0/subdir $N0 nolock
+TEST ! mount_nfs $H0:/$V0 $N0 nolock
+TEST ! mount_nfs $H0:/$V0/subdir $N0 nolock
 
 # case 12: reject only non-localhost ip
 TEST $CLI volume set $V0 nfs.rpc-auth-reject 192.168.1.1
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
-TEST mount_nfs localhost:/$V0 $N0 nolock
+TEST mount_nfs $H0:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
-TEST mount_nfs localhost:/$V0/subdir $N0 nolock
+TEST mount_nfs $H0:/$V0/subdir $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 TEST $CLI volume stop --mode=script $V0

--- a/tests/bugs/rpc/bug-921072.t
+++ b/tests/bugs/rpc/bug-921072.t
@@ -35,7 +35,7 @@ TEST ! mount_nfs $H0:/$V0 $N0 nolock
 TEST $CLI volume reset $V0 force
 TEST $CLI volume set $V0 nfs.disable off
 # case 3: reject only localhost ip
-TEST $CLI volume set $V0 nfs.rpc-auth-reject 127.0.0.1
+TEST $CLI volume set $V0 nfs.rpc-auth-reject $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
 TEST ! mount_nfs $H0:/$V0 $N0 nolock
@@ -93,7 +93,7 @@ EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 TEST $CLI volume reset $V0 force
 TEST $CLI volume set $V0 nfs.disable off
 TEST $CLI volume set $V0 nfs.addr-namelookup on
-TEST $CLI volume set $V0 nfs.rpc-auth-allow 127.0.0.1
+TEST $CLI volume set $V0 nfs.rpc-auth-allow $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
 TEST mount_nfs $H0:/$V0 $N0 nolock
@@ -110,7 +110,7 @@ TEST ! mount_nfs localhost:/$V0 $N0 nolock
 TEST $CLI volume reset $V0 force
 TEST $CLI volume set $V0 nfs.disable off
 TEST $CLI volume set $V0 nfs.addr-namelookup on
-TEST $CLI volume set $V0 nfs.rpc-auth-reject 127.0.0.1
+TEST $CLI volume set $V0 nfs.rpc-auth-reject $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
 TEST ! mount_nfs $H0:/$V0 $N0 nolock

--- a/tests/bugs/rpc/bug-921072.t
+++ b/tests/bugs/rpc/bug-921072.t
@@ -60,7 +60,7 @@ TEST mount_nfs localhost:/$V0 $N0 nolock
 EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $N0
 
 # case 5: allow only localhost
-TEST $CLI volume set $V0 nfs.rpc-auth-allow localhost
+TEST $CLI volume set $V0 nfs.rpc-auth-allow $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 
 TEST mount_nfs $H0:/$V0 $N0 nolock
@@ -76,7 +76,7 @@ TEST ! mount_nfs $H0:/$V0 $N0 nolock
 TEST $CLI volume reset $V0 force
 TEST $CLI volume set $V0 nfs.disable off
 TEST $CLI volume set $V0 nfs.addr-namelookup on
-TEST $CLI volume set $V0 nfs.rpc-auth-reject localhost
+TEST $CLI volume set $V0 nfs.rpc-auth-reject $H0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT 1 is_nfs_export_available
 #30
 TEST ! mount_nfs $H0:/$V0 $N0 nolock

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -50,7 +50,7 @@ if [ ! -f $ENV_RC ]; then
 fi
 . $ENV_RC
 
-H0=${H0:=`hostname`}; # hostname
+H0=${H0:=`ip -o -4 addr | grep -v "\<lo\>" | awk '{print $4}' | cut -d/ -f1 | head -n 1`}; # hostname
 MOUNT_TYPE_FUSE="fuse.glusterfs"
 GREP_MOUNT_OPT_RO="grep (ro"
 GREP_MOUNT_OPT_RW="grep (rw"


### PR DESCRIPTION
Problem:  From Fedora 34 it is mandatory to use valid ip
          instead of localhost, 127.0.0.1 or loopback address
          (0.0.0.0 to 0.255.255.255).

Solution: use $hostname -I | awk '{print $1}' instead

Fixes: #2944
Change-Id: I282a0a519c650c6848ffa668ade86a4f35f9de42
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

