### PR TITLE
rpc: cleanup rpc request data

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -1498,15 +1498,16 @@ rpcsvc_submit_generic(rpcsvc_request_t *req, struct iovec *proghdr,
     char new_iobref = 0;
     rpcsvc_drc_globals_t *drc = NULL;
     gf_latency_t *lat = NULL;
+    struct timespec end;
 
     if ((!req) || (!req->trans))
         return -1;
 
     if (req->prog && req->begin.tv_sec) {
         if ((req->procnum >= 0) && (req->procnum < req->prog->numactors)) {
-            timespec_now(&req->end);
+            timespec_now(&end);
             lat = &req->prog->latencies[req->procnum];
-            gf_latency_update(lat, &req->begin, &req->end);
+            gf_latency_update(lat, &req->begin, &end);
         }
     }
     trans = req->trans;

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -158,8 +158,6 @@ struct rpcsvc_request {
 
     int procnum;
 
-    int type;
-
     /* Uid and gid filled by the rpc-auth module during the authentication
      * phase.
      */
@@ -168,7 +166,6 @@ struct rpcsvc_request {
     pid_t pid;
 
     gf_lkowner_t lk_owner;
-    uint64_t gfs_id;
 
     /* Might want to move this to AUTH_UNIX specific state since this array
      * is not available for every authentication scheme.
@@ -201,10 +198,14 @@ struct rpcsvc_request {
      * sent to the client.
      */
     client_auth_data_t verf;
+
+#if defined(BUILD_GNFS)
     /* Container for a RPC program wanting to store a temp
-     * request-specific item.
+     * request-specific item. Currently this is used only
+     * by the legacy gnfs server xlator.
      */
     void *private;
+#endif /* BUILD_GNFS */
 
     /* Container for transport to store request-specific item */
     void *trans_private;
@@ -247,8 +248,11 @@ struct rpcsvc_request {
     gf_boolean_t ownthread;
 
     gf_boolean_t synctask;
-    struct timespec begin; /*req handling start time*/
-    struct timespec end;   /*req handling end time*/
+
+    /* If latency measurement is enabled, marks the request handling
+     * start time.
+     */
+    struct timespec begin;
 };
 
 #define rpcsvc_request_program(req) ((rpcsvc_program_t *)((req)->prog))


### PR DESCRIPTION
Drop unused `type` and `gfs_id` members from `struct rpcsvc_request`,
denote `private` as used only if `--enable-gnfs` is specified, move
`end` to `rpcsvc_submit_generic()` locals, adjust related comments.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000