### PR TITLE
ec: IO failure when shrinking dispersed volume during io running

### DIFF
--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -230,12 +230,12 @@ ec_manager_create(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_REPORT:
             cbk = fop->answer;
 
-            GF_ASSERT(cbk != NULL);
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.create != NULL) {
                 fop->cbks.create(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, cbk->xdata);
+                                 NULL, NULL, NULL, NULL, NULL,
+                                 cbk == NULL ? NULL : cbk->xdata);
             }
 
             return EC_STATE_LOCK_REUSE;

--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -228,11 +228,14 @@ ec_manager_create(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_DISPATCH:
         case -EC_STATE_PREPARE_ANSWER:
         case -EC_STATE_REPORT:
+            cbk = fop->answer;
+
+            GF_ASSERT(cbk != NULL);
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.create != NULL) {
                 fop->cbks.create(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                                 NULL, NULL, NULL, NULL, NULL, cbk->xdata);
             }
 
             return EC_STATE_LOCK_REUSE;


### PR DESCRIPTION
IO Failures are found when performing a shrink operation on a
distributed-dispersed volume, while IO is in progress.

RCA: During rebalance operation execution while layout has changed
     dht_creaete_cbk retry create operation under lock in 2nd attempt.
     It takes decision based on error set by posix_create in xdata
     in first attempt. ec(ec_manager_create) does not pass xdata to the
     upper xlator so dht_create is not able to take decision to
     reattempt fop creation in case if layout has changed and throw
     an EIO error.

Solution: Pass the xdata to the upper xlator to avoid an issue.
Fixes: #2947
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

