### PR TITLE
iobuf: use malloc in iobuf_get_from_stdalloc()

### DIFF
--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -34,7 +34,7 @@
 #define GF_ALIGN_BUF(ptr, bound)                                               \
     ((void *)((unsigned long)(ptr + bound - 1) & (unsigned long)(~(bound - 1))))
 
-#define GF_IOBUF_ALIGN_SIZE 512
+#define GF_IOBUF_ALIGN_SIZE 4096
 #define USE_IOBUF_POOL_IF_SIZE_GREATER_THAN 131072
 
 /* one allocatable unit for the consumers of the IOBUF API */

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -482,12 +482,12 @@ iobuf_get_from_stdalloc(struct iobuf_pool *iobuf_pool, const size_t page_size)
         break;
     }
 
-    iobuf = GF_CALLOC(1, sizeof(*iobuf), gf_common_mt_iobuf);
+    iobuf = GF_MALLOC(sizeof(*iobuf), gf_common_mt_iobuf);
     if (!iobuf)
         goto out;
 
     /* 4096 is the alignment */
-    iobuf->free_ptr = GF_CALLOC(1, ((page_size + GF_IOBUF_ALIGN_SIZE) - 1),
+    iobuf->free_ptr = GF_MALLOC(((page_size + GF_IOBUF_ALIGN_SIZE) - 1),
                                 gf_common_mt_char);
     if (!iobuf->free_ptr)
         goto out;


### PR DESCRIPTION
- use malloc instead of calloc in iobuf_get_from_stdalloc()
- iobuf_get_from_stdalloc() should align to 4K, not 512b

Fixes: #2041
Change-Id: I9e4f6349cbac0a89a4859eaea95d630a7fb569eb
Reported-by: Yaniv Kaul <ykaul@redhat.com>
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>

