### PR TITLE
Fixes:2912 Update the hostname in the gluster cluster by the command "gluster peer probe xxxx" and The communication between glusterd uses the latest domain name

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -58,7 +58,8 @@ gf_boolean_t
 gd_peer_has_address(glusterd_peerinfo_t *peerinfo, const char *address);
 
 int
-gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address);
+gd_add_address_to_peer(glusterd_peerinfo_t *peerinfo, const char *address,
+                       gf_boolean_t add_head);
 
 int
 gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -317,7 +317,7 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
             goto reply;
         }
 
-        ret = gd_add_address_to_peer(peerinfo, rsp.hostname);
+        ret = glusterd_peer_hostname_update(peerinfo, rsp.hostname, _gf_false);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0,
                    GD_MSG_HOSTNAME_ADD_TO_PEERLIST_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -2799,7 +2799,8 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             cds_list_add_tail(&ta_brickinfo->brick_list, &volinfo->ta_bricks);
             ta_brick_count++;
             if (gf_store_iter_destroy(&iter)) {
-                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_STORE_ITER_DESTROY_FAIL,
+                gf_msg(this->name, GF_LOG_ERROR, 0,
+                       GD_MSG_STORE_ITER_DESTROY_FAIL,
                        "Failed to destroy store iter");
                 ret = -1;
                 goto out;
@@ -4563,7 +4564,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
                 peerinfo->state.state = atoi(value);
             } else if (!strncmp(GLUSTERD_STORE_KEY_PEER_HOSTNAME, key,
                                 SLEN(GLUSTERD_STORE_KEY_PEER_HOSTNAME))) {
-                ret = gd_add_address_to_peer(peerinfo, value);
+                ret = gd_add_address_to_peer(peerinfo, value, _gf_false);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0,
                            GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -1352,4 +1352,8 @@ glusterd_add_peers_to_auth_list(char *volname);
 int
 glusterd_replace_old_auth_allow_list(char *volname);
 
+int
+glusterd_peer_hostname_update(glusterd_peerinfo_t *peerinfo,
+                              const char *hostname, gf_boolean_t store_update);
+
 #endif


### PR DESCRIPTION
Change-Id: Ie46320f80be8c61d1730e4d101827cc8fa054582

When updating the domain name, the new domain name is always added to the tail of the hostname list, resulting in the glusterfs cluster unable to use the latest domain name.
This modification adds the newly added domain name to the header of the hostname list, and update it. 
When the domain name is disconnected, it can be updated with the latest domain name and communicate with it by running the command "gluster peer probe latest_host_name"

Signed-off-by: JamesWSWu

