### PR TITLE
Coverity: Fix logically dead code

### DIFF
--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -98,10 +98,6 @@ __iot_dequeue(iot_conf_t *conf, int *pri)
 
         /* Get the first per-client queue for this priority. */
         ctx = list_first_entry(&fop_data->clients, iot_client_ctx_t, clients);
-        if (!ctx) {
-            continue;
-        }
-
         if (list_empty(&ctx->reqs)) {
             continue;
         }


### PR DESCRIPTION
While fetching the client ctx in __iot_dequeue() if the list
fop_data->clients is null, it would have been already caught by the
list_empty check at line 95 and the result of the pointer arithmatic
here will never be null.

CID: 1466053
Updates: #1060

Change-Id: I039cdbf8f10582da7ae7968e6af0fc54e42c1c7b
Signed-off-by: karthik-us <ksubrahm@redhat.com>

