### PR TITLE
glusterd: Update cutom log directory option

### DIFF
--- a/tests/cluster.rc
+++ b/tests/cluster.rc
@@ -50,7 +50,7 @@ function define_glusterds() {
         sopt="management.glusterd-sockfile=${!b}/glusterd/gd.sock"
         #Get the logdir
         logdir=`gluster --print-logdir`
-        clopt="management.cluster-test-mode=${logdir}/$i";
+        clopt="management.logging-directory=${logdir}/$i";
         #Fetch the testcases name and prefix the glusterd log with it
         logfile=`echo ${0##*/}`_glusterd$i.log
         lopt="--log-file=$logdir/$i/$logfile"

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1485,15 +1485,28 @@ init(xlator_t *this)
     if (len < 0 || len >= PATH_MAX)
         exit(2);
 
-    dir_data = dict_get(this->options, "cluster-test-mode");
+    dir_data = dict_get(this->options, "logging-directory");
     if (!dir_data) {
-        /* Use default working dir */
-        len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
-                       DEFAULT_LOG_FILE_DIRECTORY);
+        // Check for deprecated 'cluster-test-mode' option
+        dir_data = dict_get(this->options, "cluster-test-mode");
+        if (dir_data) {
+            len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
+                           dir_data->data);
+            gf_msg(
+                this->name, GF_LOG_WARNING, 0, GD_MSG_CLUSTER_RC_ENABLE,
+                "gluster log directory is set to %s. The option "
+                "'cluster-test-mode' is deprecated and will be removed soon. "
+                "Please use the new option 'logging-directory' instead.",
+                dir_data->data);
+        } else {
+            /* Use default working dir */
+            len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
+                           DEFAULT_LOG_FILE_DIRECTORY);
+        }
     } else {
         len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s", dir_data->data);
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_CLUSTER_RC_ENABLE,
-               "cluster-test-mode is enabled logdir is %s", dir_data->data);
+               "gluster log directory is set to %s", dir_data->data);
     }
     if (len < 0 || len >= PATH_MAX)
         exit(2);


### PR DESCRIPTION
**Description:**
Currently, option `cluster-test-mode` was used to set
a user-defined logging directory for gluster related logs which
doesn't seem to be an appropriate name for the option.

**Fix:**
Updated the option to be `logging-directory` keeping in mind the
naming convention of other options like `working-directory`,
`run-directory`.

**NOTE:**
This option doesn't update the path for cli and glusterd log file,
that still needs to be set manually via command line or through
sysconfig file.

Updates: #2939

Change-Id: I5fbbeff21ea1a89d439537311a81389b57e7acde
Signed-off-by: nik-redhat <nladha@redhat.com>

