### PR TITLE
Fix the log tar function when running the tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -93,7 +93,7 @@ function tar_logs()
                 tar -czf "${logdir}"/"${savetarname}".tar.gz -X "${logdir}"/.notar \
                         "${logdir}"/* 2> /dev/null \
                         && \
-                find "$logdir"/* -maxdepth 0 -name '*.tar.gz' -prune \
+                find "$logdir"/* -maxdepth 0 -name '*.tar.*' -prune \
                                         -o -exec rm -rf '{}' ';'
 
                 echo "Logs preserved in tarball ${savetarname}.tar.gz"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -93,7 +93,7 @@ function tar_logs()
                 tar -czf "${logdir}"/"${savetarname}".tar.gz -X "${logdir}"/.notar \
                         "${logdir}"/* 2> /dev/null \
                         && \
-                find "$logdir"/* -maxdepth 0 -name '*.tar' -prune \
+                find "$logdir"/* -maxdepth 0 -name '*.tar.gz' -prune \
                                         -o -exec rm -rf '{}' ';'
 
                 echo "Logs preserved in tarball ${savetarname}.tar.gz"


### PR DESCRIPTION
Logs are not stored on running the regression test suite. It should
fix the empty log directories when archived.

Fixes: #2664
Signed-off-by: Deepshikha Khandelwal <dkhandel@redhat.com>

