### PR TITLE
glusterd, libglusterfs: fix regexp usage

### DIFF
--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -85,7 +85,6 @@ enum gf_common_mem_types_ {
     gf_common_mt_txn_opinfo_obj_t,   /* used only in one location */
     gf_common_mt_strfd_t,            /* used only in one location */
     gf_common_mt_strfd_data_t,       /* used only in one location */
-    gf_common_mt_regex_t,            /* used only in one location */
     gf_common_mt_ereg,               /* used only in one location */
     gf_common_mt_dnscache,           /* used only in one location */
     gf_common_mt_dnscache_entry,     /* used only in one location */


### PR DESCRIPTION
Prefer stack allocation for `regex_t` variable, add missing
call to `regfree()`, drop memory type which is no longer used.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

