### PR TITLE
multiple files: remove the stub pool

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -119,11 +119,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
         goto err;
     }
 
-    ctx->stub_mem_pool = mem_pool_new(call_stub_t, 1024);
-    if (!ctx->stub_mem_pool) {
-        goto err;
-    }
-
     ctx->dict_pool = mem_pool_new(dict_t, GF_MEMPOOL_COUNT_OF_DICT_T);
     if (!ctx->dict_pool)
         goto err;
@@ -159,8 +154,6 @@ err:
     }
 
     if (ret && ctx) {
-        if (ctx->stub_mem_pool)
-            mem_pool_destroy(ctx->stub_mem_pool);
         if (ctx->dict_pool)
             mem_pool_destroy(ctx->dict_pool);
         if (ctx->dict_data_pool)
@@ -1179,8 +1172,6 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     }
 
     /* Free the memory pool */
-    if (ctx->stub_mem_pool)
-        mem_pool_destroy(ctx->stub_mem_pool);
     if (ctx->dict_pool)
         mem_pool_destroy(ctx->dict_pool);
     if (ctx->dict_data_pool)

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -140,12 +140,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
         goto out;
     }
 
-    ctx->stub_mem_pool = mem_pool_new(call_stub_t, 16);
-    if (!ctx->stub_mem_pool) {
-        gf_log("cli", GF_LOG_ERROR, "Failed to stub mem pool.");
-        goto out;
-    }
-
     ctx->dict_pool = mem_pool_new(dict_t, 32);
     if (!ctx->dict_pool) {
         gf_log("cli", GF_LOG_ERROR, "Failed to create dict pool.");
@@ -193,7 +187,6 @@ out:
         GF_FREE(pool);
         pool = NULL;
         GF_FREE(ctx->process_uuid);
-        mem_pool_destroy(ctx->stub_mem_pool);
         mem_pool_destroy(ctx->dict_pool);
         mem_pool_destroy(ctx->dict_pair_pool);
         mem_pool_destroy(ctx->dict_data_pool);

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1653,12 +1653,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
         goto out;
     }
 
-    ctx->stub_mem_pool = mem_pool_new(call_stub_t, 1024);
-    if (!ctx->stub_mem_pool) {
-        gf_smsg("", GF_LOG_CRITICAL, 0, glusterfsd_msg_14, "stub", NULL);
-        goto out;
-    }
-
     ctx->dict_pool = mem_pool_new(dict_t, GF_MEMPOOL_COUNT_OF_DICT_T);
     if (!ctx->dict_pool)
         goto out;
@@ -1735,7 +1729,6 @@ out:
             mem_pool_destroy(ctx->pool->stack_mem_pool);
         }
         GF_FREE(ctx->pool);
-        mem_pool_destroy(ctx->stub_mem_pool);
         mem_pool_destroy(ctx->dict_pool);
         mem_pool_destroy(ctx->dict_data_pool);
         mem_pool_destroy(ctx->dict_pair_pool);

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -664,7 +664,6 @@ struct _glusterfs_ctx {
     unsigned char measure_latency;
     pthread_t sigwaiter;
     char *cmdlinestr;
-    struct mem_pool *stub_mem_pool;
     unsigned char cleanup_started;
     int graph_id;        /* Incremented per graph, value should
                             indicate how many times the graph has

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -123,10 +123,6 @@ gf_changelog_ctx_defaults_init(glusterfs_ctx_t *ctx)
     if (!pool->stack_mem_pool)
         goto free_pool;
 
-    ctx->stub_mem_pool = mem_pool_new(call_stub_t, 16);
-    if (!ctx->stub_mem_pool)
-        goto free_pool;
-
     ctx->dict_pool = mem_pool_new(dict_t, 32);
     if (!ctx->dict_pool)
         goto free_pool;
@@ -167,8 +163,6 @@ free_pool:
 
         GF_FREE(pool);
     }
-
-    GF_FREE(ctx->stub_mem_pool);
 
     GF_FREE(ctx->dict_pool);
 

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -578,8 +578,6 @@ glusterfs_ctx_pool_destroy(glusterfs_ctx_t *ctx)
         return 0;
 
     /* Free the memory pool */
-    if (ctx->stub_mem_pool)
-        mem_pool_destroy(ctx->stub_mem_pool);
     if (ctx->dict_pool)
         mem_pool_destroy(ctx->dict_pool);
     if (ctx->dict_data_pool)


### PR DESCRIPTION
It's unused since I've removed its usage in commit 11b7266 - call-stub: remove unused fields (#2055)

Fixes: #2964
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

