### PR TITLE
qr_lookup()/qr_lookup_cbk() - remove unneeded dict_get()

### DIFF
--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -564,7 +564,7 @@ __qr_cache_is_fresh(xlator_t *this, qr_inode_t *qr_inode)
     return _gf_true;
 }
 
-int
+static int
 qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, inode_t *inode_ret, struct iatt *buf,
               dict_t *xdata, struct iatt *postparent)
@@ -582,12 +582,7 @@ qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         goto out;
     }
 
-    if (dict_get(xdata, GLUSTERFS_BAD_INODE)) {
-        qr_inode_prune(this, inode, local->incident_gen);
-        goto out;
-    }
-
-    if (dict_get(xdata, "sh-failed")) {
+    else if (dict_get_sizen(xdata, GLUSTERFS_BAD_INODE)) {
         qr_inode_prune(this, inode, local->incident_gen);
         goto out;
     }
@@ -619,18 +614,16 @@ out:
     return 0;
 }
 
-int
+static int
 qr_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
     qr_private_t *priv = NULL;
     qr_conf_t *conf = NULL;
     qr_inode_t *qr_inode = NULL;
-    int ret = -1;
+    int ret;
     dict_t *new_xdata = NULL;
     qr_local_t *local = NULL;
 
-    priv = this->private;
-    conf = &priv->conf;
     local = qr_local_get(this, loc->inode);
     local->inode = inode_ref(loc->inode);
     frame->local = local;
@@ -640,19 +633,22 @@ qr_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         /* cached. only validate in qr_lookup_cbk */
         goto wind;
 
-    if (!xdata)
+    if (!xdata) {
         xdata = new_xdata = dict_new();
+        if (!xdata)
+            goto wind;
+    }
 
-    if (!xdata)
-        goto wind;
-
-    ret = 0;
-    if (conf->max_file_size)
-        ret = dict_set(xdata, GF_CONTENT_KEY,
-                       data_from_uint64(conf->max_file_size));
-    if (ret)
-        gf_msg(this->name, GF_LOG_WARNING, 0, QUICK_READ_MSG_DICT_SET_FAILED,
-               "cannot set key in request dict (%s)", loc->path);
+    priv = this->private;
+    conf = &priv->conf;
+    if (conf->max_file_size) {
+        ret = dict_set_sizen(xdata, GF_CONTENT_KEY,
+                             data_from_uint64(conf->max_file_size));
+        if (ret)
+            gf_msg(this->name, GF_LOG_WARNING, 0,
+                   QUICK_READ_MSG_DICT_SET_FAILED,
+                   "cannot set key in request dict (%s)", loc->path);
+    }
 wind:
     STACK_WIND(frame, qr_lookup_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->lookup, loc, xdata);


### PR DESCRIPTION
There was a relic from the past that tried to fetch a no longer relevant
'sh-failed' dict entry - removed it, and cleaned up the code a bit around.

TODO (in a different patch): store the result of
data_from_uint64(conf->max_file_size)
in the conf and fetch it, instead of re-doing it on every lookup.

Fixes: #2975
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

