### PR TITLE
libglusterfs, xlators: add library wrapper for setrlimit

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1090,6 +1090,9 @@ int
 gf_gfid_generate_from_xxh64(uuid_t gfid, char *key);
 
 int
+gf_set_nofile(int high, int low);
+
+int
 gf_set_timestamp(const char *src, const char *dest);
 
 static inline int

--- a/libglusterfs/src/glusterfs/libglusterfs-messages.h
+++ b/libglusterfs/src/glusterfs/libglusterfs-messages.h
@@ -126,7 +126,7 @@ GLFS_MSGID(
     LG_MSG_IO_URING_NOT_SUPPORTED, LG_MSG_IO_URING_INVALID,
     LG_MSG_IO_URING_MISSING_FEAT, LG_MSG_IO_URING_TOO_SMALL,
     LG_MSG_IO_URING_ENTER_FAILED, LG_MSG_IO_SYNC_TIMEOUT,
-    LG_MSG_IO_SYNC_ABORTED, LG_MSG_IO_SYNC_COMPLETED);
+    LG_MSG_IO_SYNC_ABORTED, LG_MSG_IO_SYNC_COMPLETED, LG_MSG_NOFILE_SET_FAILED);
 
 #define LG_MSG_EPOLL_FD_CREATE_FAILED_STR "epoll fd creation failed"
 #define LG_MSG_INVALID_POLL_IN_STR "invalid poll_in value"
@@ -234,6 +234,8 @@ GLFS_MSGID(
 #define LG_MSG_STRDUP_ERROR_STR "failed to create metrics dir"
 #define LG_MSG_FILENAME_NOT_SPECIFIED_STR "no filename specified"
 #define LG_MSG_UNDERSIZED_BUF_STR "data value is smaller than expected"
+#define LG_MSG_NOFILE_SET_FAILED_STR                                           \
+    "failed to set maximum allowed number of opened file descriptors"
 #define LG_MSG_DICT_SET_FAILED_STR "unable to set dict"
 #define LG_MSG_COUNT_LESS_THAN_ZERO_STR "count < 0!"
 #define LG_MSG_PAIRS_LESS_THAN_COUNT_STR "less than count data pairs found"

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -677,6 +677,7 @@ gf_rsync_md5_checksum
 gf_rsync_weak_checksum
 gf_set_log_file_path
 gf_set_log_ident
+gf_set_nofile
 gf_set_timestamp
 gf_set_volfile_server_common
 _gf_smsg

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1457,22 +1457,11 @@ init(xlator_t *this)
     vgtool = _gf_none;
 #endif
 
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
-        lim.rlim_cur = 65536;
-        lim.rlim_max = 65536;
-
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_SET_XATTR_FAIL,
-                    "Failed to set 'ulimit -n 65536'", NULL);
-        } else {
-            gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_FILE_DESC_LIMIT_SET,
-                   "Maximum allowed open file descriptors "
-                   "set to 65536");
-        }
-    }
-#endif
+    ret = gf_set_nofile(GLUSTERD_NOFILE, 0);
+    if (ret != -1)
+        gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_FILE_DESC_LIMIT_SET,
+               "set maximum allowed number of opened file descriptors to %d",
+               GLUSTERD_NOFILE);
 
     dir_data = dict_get(this->options, "run-directory");
 

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -44,6 +44,9 @@
 #define GLUSTERD_MIN_EVENT_THREADS 1
 #define GLUSTERD_MAX_EVENT_THREADS 32
 
+/* Opened file descriptors limit for glusterd. */
+#define GLUSTERD_NOFILE 65536
+
 #define GLUSTERD_TR_LOG_SIZE 50
 #define GLUSTERD_QUORUM_TYPE_KEY "cluster.server-quorum-type"
 #define GLUSTERD_QUORUM_RATIO_KEY "cluster.server-quorum-ratio"

--- a/xlators/protocol/server/src/server-messages.h
+++ b/xlators/protocol/server/src/server-messages.h
@@ -103,7 +103,6 @@ GLFS_MSGID(
 #define PS_MSG_RPCSVC_LISTENER_CREATE_FAILED_STR "creation of listener failed"
 #define PS_MSG_RPCSVC_NOTIFY_STR "registration of notify with rpcsvc failed"
 #define PS_MSG_PGM_REG_FAILED_STR "registration of program failed"
-#define PS_MSG_ULIMIT_SET_FAILED_STR "WARNING: Failed to set 'ulimit -n 1M'"
 #define PS_MSG_FD_NOT_FOUND_STR "Failed to set max open fd to 64k"
 #define PS_MSG_VOL_FILE_OPEN_FAILED_STR                                        \
     "volfile-id argument not given. This is mandatory argument, defaulting "   \

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1303,30 +1303,13 @@ server_init(xlator_t *this)
         goto err;
     }
 
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
+    ret = gf_set_nofile(SERVER_NOFILE_HIGH, SERVER_NOFILE_LOW);
+    if (ret != -1)
+        gf_msg_trace(this->name, 0,
+                     "set maximum allowed number"
+                     " of opened file descriptors to %d",
+                     ret);
 
-        lim.rlim_cur = 1048576;
-        lim.rlim_max = 1048576;
-
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_ULIMIT_SET_FAILED,
-                    "errno=%s", strerror(errno), NULL);
-            lim.rlim_cur = 65536;
-            lim.rlim_max = 65536;
-
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_FD_NOT_FOUND,
-                        "errno=%s", strerror(errno), NULL);
-            } else {
-                gf_msg_trace(this->name, 0,
-                             "max open fd set "
-                             "to 64k");
-            }
-        }
-    }
-#endif
     if (!this->ctx->cmd_args.volfile_id) {
         /* In some use cases this is a valid case, but
            document this to be annoying log in that case */

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -30,6 +30,10 @@
 #define SERVER_MIN_EVENT_THREADS 1
 #define SERVER_MAX_EVENT_THREADS 1024
 
+/* Opened file descriptor limits for the server. */
+#define SERVER_NOFILE_HIGH 1048576
+#define SERVER_NOFILE_LOW 65536
+
 #define DEFAULT_VOLUME_FILE_PATH CONFDIR "/glusterfs.vol"
 
 typedef enum {

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -995,32 +995,12 @@ posix_init(xlator_t *this)
                "Could not lock brick directory (%s)", strerror(op_errno));
         goto out;
     }
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
-        lim.rlim_cur = 1048576;
-        lim.rlim_max = 1048576;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_SET_ULIMIT_FAILED,
-                   "Failed to set 'ulimit -n "
-                   " 1048576'");
-            lim.rlim_cur = 65536;
-            lim.rlim_max = 65536;
+    ret = gf_set_nofile(POSIX_NOFILE_HIGH, POSIX_NOFILE_LOW);
+    if (ret != -1)
+        gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_MAX_FILE_OPEN,
+               "set maximum allowed open file descriptors to %d", ret);
 
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_msg(this->name, GF_LOG_WARNING, errno,
-                       P_MSG_SET_FILE_MAX_FAILED,
-                       "Failed to set maximum allowed open "
-                       "file descriptors to 64k");
-            } else {
-                gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_MAX_FILE_OPEN,
-                       "Maximum allowed "
-                       "open file descriptors set to 65536");
-            }
-        }
-    }
-#endif
     _private->shared_brick_count = 1;
     ret = dict_get_int32(this->options, "shared-brick-count",
                          &_private->shared_brick_count);

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -54,6 +54,10 @@
 
 #define DHT_LINKTO "trusted.glusterfs.dht.linkto"
 
+/* Opened file descriptors limits for the posix xlator. */
+#define POSIX_NOFILE_HIGH 1048576
+#define POSIX_NOFILE_LOW 65536
+
 #define POSIX_GFID_HANDLE_SIZE(base_path_len)                                  \
     (base_path_len + SLEN("/") + SLEN(GF_HIDDEN_PATH) + SLEN("/") +            \
      SLEN("00/") + SLEN("00/") + SLEN(UUID0_STR) + 1) /* '\0' */;


### PR DESCRIPTION
Add `gf_set_nofile()` library function to replace an ad-hoc
`setrlimit(RLIMIT_NOFILE, ...)` quirks, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

