### PR TITLE
call-stub.c: do not unconditionally set errno

### DIFF
--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -2375,7 +2375,6 @@ call_resume(call_stub_t *stub)
 {
     xlator_t *old_THIS = NULL;
 
-    errno = EINVAL;
     GF_VALIDATE_OR_GOTO("call-stub", stub, out);
 
     list_del_init(&stub->list);
@@ -2441,7 +2440,6 @@ call_resume_keep_stub(call_stub_t *stub)
 {
     xlator_t *old_THIS = NULL;
 
-    errno = EINVAL;
     GF_VALIDATE_OR_GOTO("call-stub", stub, out);
 
     list_del_init(&stub->list);


### PR DESCRIPTION
errno is a global variable, so there's an associated cost with setting it. However, there is no need or use in the code to set it unconditionally.

Fixes: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

