### PR TITLE
dht: fix dict leak

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4444,6 +4444,9 @@ out:
     if (migrate_data)
         dict_unref(migrate_data);
 
+    if (fix_layout)
+        dict_unref(fix_layout);
+
     if (statfs_frame) {
         STACK_DESTROY(statfs_frame->root);
     }


### PR DESCRIPTION
Add missing call to `dict_unref()` in `gf_defrag_start_crawl()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

