### PR TITLE
build: enforce library order required by the sanitizers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,11 +344,16 @@ AC_ARG_WITH([tcmalloc],
         [AC_HELP_STRING([--without-tcmalloc], [Use gluster based mempool])],
         [with_tcmalloc="no"], [with_tcmalloc="yes"])
 if test "x$with_tcmalloc" = "xyes"; then
+    # If sanitizer (e.g. ASan) is enabled, next AC_CHECK_LIB constructs
+    # 'gcc -o conftest -g -O2 conftest.c -ltcmalloc -lasan' which is not what
+    # we want because sanitizer library should come first in the library list.
+    # Zeroing LIBS do the trick (and we rely on GF_LDFLAGS and not LIBS anyway).
+    LIBS=""
     AC_CHECK_LIB([tcmalloc], [malloc], [],
                  [AC_MSG_ERROR([tcmalloc library needs to be present])])
     BUILD_TCMALLOC=yes
     GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
-    GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+    GF_LDFLAGS="${GF_LDFLAGS} -ltcmalloc"
     AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
     USE_MEMPOOL=no
 fi


### PR DESCRIPTION
If sanitizer (e.g. ASan) is enabled, using `AC_CHECK_LIB(...)` to
detect TCmalloc causes `configure` to construct compiler invocations
like `gcc -o conftest -g -O2 conftest.c -ltcmalloc -lasan`, which is
wrong because sanitizer library should come first in the library list.
Therefore all execution tests fails with the following error:
```
...
configure:13496: checking size of short
configure:13501: gcc -o conftest -g -O2 conftest.c -ltcmalloc -lasan >&5
configure:13501: $? = 0
configure:13501: ./conftest
==117080==ASan runtime does not come first in initial library list; you
should either link runtime to your application or manually preload it
with LD_PRELOAD.
configure:13501: $? = 1
configure: program exited with status 1
...
```
Zeroing `LIBS` before running `AC_CHECK_LIB([tcmalloc], ...)` and
appending (not prepending) `-ltcmalloc` to `GF_LDFLAGS` enforces
an expected order of the libraries.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000