### PR TITLE
posix-*.c: remove some string copies in posix_handle_pump() and relat…

### DIFF
--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -797,7 +797,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         op_ret = posix_istat(this, loc->inode, uuid_req, NULL, &stbuf);
         if ((op_ret == 0) && IA_ISDIR(stbuf.ia_type)) {
             gfid_path = alloca(PATH_MAX);
-            size = posix_handle_path(this, uuid_req, NULL, gfid_path, PATH_MAX);
+            size = posix_handle_path(this, uuid_req, NULL, gfid_path);
             if (size <= 0) {
                 op_errno = ESTALE;
                 op_ret = -1;

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1371,7 +1371,7 @@ del_stale_dir_handle(xlator_t *this, uuid_t gfid)
         goto out;
     }
 
-    size = posix_handle_path(this, gfid, NULL, newpath, sizeof(newpath));
+    size = posix_handle_path(this, gfid, NULL, newpath);
     if (size <= 0) {
         if (errno == ENOENT) {
             gf_msg_debug(this->name, ENOENT, "Failed for path: %s", newpath);

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -5704,7 +5704,7 @@ posix_readdirp_fill(xlator_t *this, fd_t *fd, gf_dirent_t *entries,
     itable = fd->inode->table;
 
     hpath = alloca(PATH_MAX);
-    len = posix_handle_path(this, fd->inode->gfid, NULL, hpath, PATH_MAX);
+    len = posix_handle_path(this, fd->inode->gfid, NULL, hpath);
     if (len <= 0) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLEPATH_FAILED,
                "Failed to create handle path, fd=%p, gfid=%s", fd,

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -44,9 +44,8 @@
 #define MAKE_HANDLE_PATH(var, this, gfid, base)                                \
     do {                                                                       \
         int __len = 0;                                                         \
-        int tot = PATH_MAX;                                                    \
-        var = alloca(tot);                                                     \
-        __len = posix_handle_path(this, gfid, base, var, tot);                 \
+        var = alloca(PATH_MAX);                                                \
+        __len = posix_handle_path(this, gfid, base, var);                      \
         if (__len <= 0) {                                                      \
             var = NULL;                                                        \
         }                                                                      \
@@ -98,8 +97,7 @@
 #define POSIX_ANCESTRY_DENTRY (1 << 1)
 
 int
-posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *buf,
-                  size_t len);
+posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *buf);
 
 int
 posix_make_ancestryfromgfid(xlator_t *this, char *path, int pathsize,


### PR DESCRIPTION
…ed functions

- Remove multipls strncpy() from posix_handle_pump(), as well as an strotoul() call.
- Remove redundant 'ret' variable
- posix_handle_path() always gets PATH_MAX path variables, no need to pass size to it.
- Make functions static, etc.

Fixes: #2987
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

