### PR TITLE
libglusterfs: annotate synctasks with AddressSanitizer API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,21 @@ if test "x$enable_asan" = "xyes"; then
         SANITIZER=asan
         AC_CHECK_LIB([asan], [__asan_init], ,
                 [AC_MSG_ERROR([--enable-asan requires libasan.so, exiting])])
+        if test "x$ac_cv_lib_asan___asan_init" = xyes; then
+                AC_MSG_CHECKING([whether asan API can be used])
+                saved_CFLAGS=${CFLAGS}
+                CFLAGS="${CFLAGS} -fsanitize=address"
+                AC_COMPILE_IFELSE(
+                [AC_LANG_PROGRAM([
+                   [#include <sanitizer/common_interface_defs.h>]],
+                   [[__sanitizer_finish_switch_fiber(0, 0, 0)]])],
+                   [ASAN_API=yes], [ASAN_API=no])
+                AC_MSG_RESULT([$ASAN_API])
+                if test x$ASAN_API = "xyes"; then
+                   AC_DEFINE(HAVE_ASAN_API, 1, [Define if asan API can be used.])
+                fi
+                CFLAGS=${saved_CFLAGS}
+        fi
         GF_CFLAGS="${GF_CFLAGS} -O2 -g -fsanitize=address -fno-omit-frame-pointer"
         GF_LDFLAGS="${GF_LDFLAGS} -lasan"
 fi

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -83,6 +83,10 @@ struct synctask {
     } tsan;
 #endif
 
+#ifdef HAVE_ASAN_API
+    void *fake_stack;
+#endif
+
 #ifdef HAVE_VALGRIND_API
     unsigned stackid;
 #endif
@@ -105,6 +109,10 @@ struct syncproc {
         void *fiber;
         char name[TSAN_THREAD_NAMELEN];
     } tsan;
+#endif
+
+#ifdef HAVE_ASAN_API
+    void *fake_stack;
 #endif
 
 #ifdef HAVE_VALGRIND_API

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -11,6 +11,10 @@
 #include "glusterfs/syncop.h"
 #include "glusterfs/libglusterfs-messages.h"
 
+#ifdef HAVE_ASAN_API
+#include <sanitizer/common_interface_defs.h>
+#endif
+
 #ifdef HAVE_TSAN_API
 #include <sanitizer/tsan_interface.h>
 #endif
@@ -275,10 +279,20 @@ synctask_yield(struct synctask *task, struct timespec *delta)
     __tsan_switch_to_fiber(task->proc->tsan.fiber, 0);
 #endif
 
+#ifdef HAVE_ASAN_API
+    __sanitizer_start_switch_fiber(&task->fake_stack,
+                                   task->proc->sched.uc_stack.ss_sp,
+                                   task->proc->sched.uc_stack.ss_size);
+#endif
+
     if (swapcontext(&task->ctx, &task->proc->sched) < 0) {
         gf_msg("syncop", GF_LOG_ERROR, errno, LG_MSG_SWAPCONTEXT_FAILED,
                "swapcontext failed");
     }
+
+#ifdef HAVE_ASAN_API
+    __sanitizer_finish_switch_fiber(task->proc->fake_stack, NULL, NULL);
+#endif
 
     THIS = oldTHIS;
 }
@@ -363,6 +377,11 @@ synctask_wrap(void)
        wrong and can lead to crashes. */
 
     task = synctask_get();
+
+#ifdef HAVE_ASAN_API
+    __sanitizer_finish_switch_fiber(task->fake_stack, NULL, NULL);
+#endif
+
     task->ret = task->syncfn(task->opaque);
     if (task->synccbk)
         task->synccbk(task->ret, task->frame, task->opaque);
@@ -694,10 +713,20 @@ synctask_switchto(struct synctask *task)
     __tsan_switch_to_fiber(task->tsan.fiber, 0);
 #endif
 
+#ifdef HAVE_ASAN_API
+    __sanitizer_start_switch_fiber(&task->proc->fake_stack,
+                                   task->ctx.uc_stack.ss_sp,
+                                   task->ctx.uc_stack.ss_size);
+#endif
+
     if (swapcontext(&task->proc->sched, &task->ctx) < 0) {
         gf_msg("syncop", GF_LOG_ERROR, errno, LG_MSG_SWAPCONTEXT_FAILED,
                "swapcontext failed");
     }
+
+#ifdef HAVE_ASAN_API
+    __sanitizer_finish_switch_fiber(task->fake_stack, NULL, NULL);
+#endif
 
     if (task->state == SYNCTASK_DONE) {
         synctask_done(task);


### PR DESCRIPTION
If `--enable-asan` is specified and API headers are detected,
annotate synctask context switch with AddressSanitizer API.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Fixes: #1400

