### PR TITLE
glusterd: fix dict data leak

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -880,7 +880,7 @@ err:
     }
     if (dict)
         dict_unref(dict);
-    if (ret && brick_req.dict.dict_val)
+    if (brick_req.dict.dict_val)
         GF_FREE(brick_req.dict.dict_val);
 
     GF_FREE(volfile_content);


### PR DESCRIPTION
Unconditionally free serialized dict data
in `__glusterd_send_svc_configure_req()`.

Found with AddressSanitizer:

==273334==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 89 byte(s) in 1 object(s) allocated from:
    #0 0x7fc2ce2a293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fc2cdff9c6c in __gf_malloc libglusterfs/src/mem-pool.c:201
    #2 0x7fc2cdff9c6c in __gf_malloc libglusterfs/src/mem-pool.c:188
    #3 0x7fc2cdf86bde in dict_allocate_and_serialize libglusterfs/src/dict.c:3285
    #4 0x7fc2b8398843 in __glusterd_send_svc_configure_req xlators/mgmt/glusterd/src/glusterd-svc-helper.c:830
    #5 0x7fc2b8399238 in glusterd_attach_svc xlators/mgmt/glusterd/src/glusterd-svc-helper.c:932
    #6 0x7fc2b83a60f1 in glusterd_shdsvc_start xlators/mgmt/glusterd/src/glusterd-shd-svc.c:509
    #7 0x7fc2b83a5124 in glusterd_shdsvc_manager xlators/mgmt/glusterd/src/glusterd-shd-svc.c:335
    #8 0x7fc2b8395364 in glusterd_svcs_manager xlators/mgmt/glusterd/src/glusterd-svc-helper.c:143
    #9 0x7fc2b82e3a6c in glusterd_op_start_volume xlators/mgmt/glusterd/src/glusterd-volume-ops.c:2412
    #10 0x7fc2b835ec5a in gd_mgmt_v3_commit_fn xlators/mgmt/glusterd/src/glusterd-mgmt.c:329
    #11 0x7fc2b8365497 in glusterd_mgmt_v3_commit xlators/mgmt/glusterd/src/glusterd-mgmt.c:1639
    #12 0x7fc2b836ad30 in glusterd_mgmt_v3_initiate_all_phases xlators/mgmt/glusterd/src/glusterd-mgmt.c:2651
    #13 0x7fc2b82d504b in __glusterd_handle_cli_start_volume xlators/mgmt/glusterd/src/glusterd-volume-ops.c:364
    #14 0x7fc2b817465c in glusterd_big_locked_handler xlators/mgmt/glusterd/src/glusterd-handler.c:79
    #15 0x7fc2ce020ff9 in synctask_wrap libglusterfs/src/syncop.c:385
    #16 0x7fc2cd69184f  (/lib64/libc.so.6+0x5784f)

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Fixes: #1000

