### PR TITLE
configure: Enable ltcmalloc_minimal instead of ltcmalloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,11 +344,11 @@ AC_ARG_WITH([tcmalloc],
         [AC_HELP_STRING([--without-tcmalloc], [Use gluster based mempool])],
         [with_tcmalloc="no"], [with_tcmalloc="yes"])
 if test "x$with_tcmalloc" = "xyes"; then
-    AC_CHECK_LIB([tcmalloc], [malloc], [],
+    AC_CHECK_LIB([tcmalloc_minimal], [malloc], [],
                  [AC_MSG_ERROR([tcmalloc library needs to be present])])
     BUILD_TCMALLOC=yes
     GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
-    GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+    GF_LDFLAGS="-ltcmalloc_minimal ${GF_LDFLAGS}"
     AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
     USE_MEMPOOL=no
 fi


### PR DESCRIPTION
The gluster process is getting crashed while ltcmalloc library
init/fini related functions are called in two different
threads during a library loaded/unloaded.The process is getting
crashed during access of tls variables in heap profiler
api. Though the issue is already fixed(gperftools/gperftools#786)
in gperftool-9 but the rpm has not been build for rhel-(7|8).
The heap profile api is access by an application while application is linked with libtcamlloc.

Solution: To avoid a crash linked library with ltcmalloc_minimal

> Fixes: #2971
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Cherry picked from upstream https://github.com/gluster/glusterfs/pull/2994)

Fixes: #2971
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

