### PR TITLE
HA status is in FAILOVER when configuring NFS ganesha with pacemaker 2.1

### DIFF
--- a/extras/ganesha/scripts/ganesha-ha.sh
+++ b/extras/ganesha/scripts/ganesha-ha.sh
@@ -35,6 +35,7 @@ VERSION_ID=""
 PCS9OR10_PCS_CNAME_OPTION=""
 PCS9OR10_PCS_CLONE_OPTION="clone"
 SECRET_PEM="/var/lib/glusterd/nfs/secret.pem"
+CRMADM_TIMEOUT_OPTION="5000"
 
 # UNBLOCK RA uses shared_storage which may become unavailable
 # during any of the nodes reboot. Hence increase timeout value.
@@ -235,9 +236,9 @@ setup_cluster()
     sleep 1
     # wait for the cluster to elect a DC before querying or writing
     # to the CIB. BZ 1334092
-    crmadmin --dc_lookup --timeout=5000 > /dev/null 2>&1
+    crmadmin --dc_lookup --timeout=${CRMADM_TIMEOUT_OPTION} > /dev/null 2>&1
     while [ $? -ne 0 ]; do
-        crmadmin --dc_lookup --timeout=5000 > /dev/null 2>&1
+        crmadmin --dc_lookup --timeout=${CRMADM_TIMEOUT_OPTION} > /dev/null 2>&1
     done
 
     unclean=$(pcs status | grep -u "UNCLEAN")
@@ -1072,6 +1073,12 @@ main()
                 PCS9OR10_PCS_CNAME_OPTION="--name"
                 PCS9OR10_PCS_CLONE_OPTION="--clone"
             fi
+        fi
+        # pacemaker 2.1.0 changed --timeout=value
+        echo ${crmadmin_vers}
+        crmadmin_vers=`crmadmin --version | grep -o "[12]\.[0-9]\.." | cut -c 1-3`
+        if [[ "${crmadmin_vers}" > "2.0" ]]; then
+            CRMADM_TIMEOUT_OPTION="5sec"
         fi
 
         if [[ "${HA_NUM_SERVERS}X" != "1X" ]]; then


### PR DESCRIPTION
pacemaker-2.1.x changed the --timeout=$timeout-in-millisecs to
--timeout=$timespec and when a bare number is used now, it is
interpretted as a timeout in seconds.
    
As a result, when waiting for a domain controller to be elected, the
crmadmin waits too long, gluster/glusterd times out and the HA setup is
left in an undefined state.
    
Fixes: #2997
Change-Id: Ida39a3ee5e6b4b0d3255bfef95601890afd80709
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

