### PR TITLE
rpc, libglusterfs: use `gf_time()` where seconds precision is enough

### DIFF
--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -133,15 +133,13 @@ dump_inode_stats(glusterfs_ctx_t *ctx, int fd)
 static void
 dump_global_metrics(glusterfs_ctx_t *ctx, int fd)
 {
-    struct timeval tv;
     time_t nowtime;
     struct tm *nowtm;
     char tmbuf[64] = {
         0,
     };
 
-    gettimeofday(&tv, NULL);
-    nowtime = tv.tv_sec;
+    nowtime = gf_time();
     nowtm = localtime(&nowtime);
     strftime(tmbuf, sizeof tmbuf, "%Y-%m-%d %H:%M:%S", nowtm);
 

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -107,9 +107,7 @@ rpc_clnt_ping_timer_expired(void *rpc_ptr)
     rpc_transport_t *trans = NULL;
     rpc_clnt_connection_t *conn = NULL;
     int disconnect = 0;
-    struct timespec current = {
-        0,
-    };
+    time_t current = 0;
     int unref = 0;
 
     rpc = (struct rpc_clnt *)rpc_ptr;
@@ -121,14 +119,13 @@ rpc_clnt_ping_timer_expired(void *rpc_ptr)
         goto out;
     }
 
-    timespec_now_realtime(&current);
+    current = gf_time();
     pthread_mutex_lock(&conn->lock);
     {
         unref = rpc_clnt_remove_ping_timer_locked(rpc);
 
-        if (((current.tv_sec - conn->last_received.tv_sec) <
-             conn->ping_timeout) ||
-            ((current.tv_sec - conn->last_sent.tv_sec) < conn->ping_timeout)) {
+        if (((current - conn->last_received) < conn->ping_timeout) ||
+            ((current - conn->last_sent) < conn->ping_timeout)) {
             gf_log(trans->name, GF_LOG_TRACE,
                    "ping timer expired but transport activity "
                    "detected - not bailing transport");

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -53,7 +53,7 @@ struct saved_frame {
     void *capital_this;
     void *frame;
     struct rpc_req *rpcreq;
-    struct timeval saved_at;
+    time_t saved_at;
     rpc_transport_rsp_t rsp;
 };
 
@@ -135,8 +135,8 @@ struct rpc_clnt_connection {
     gf_timer_t *ping_timer;
     struct rpc_clnt *rpc_clnt;
     struct saved_frames *saved_frames;
-    struct timespec last_sent;
-    struct timespec last_received;
+    time_t last_sent;
+    time_t last_received;
     uint64_t pingcnt;
     uint64_t msgcnt;
     uint64_t cleanup_gen;


### PR DESCRIPTION
Prefer `gf_time()` to `gettimeofday()` and `timespec_now_realtime()`
where seconds precision is enough, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

