### PR TITLE
client-*: adjust removal of 'this' from client functions

### DIFF
--- a/extras/ganesha/scripts/ganesha-ha.sh
+++ b/extras/ganesha/scripts/ganesha-ha.sh
@@ -35,6 +35,7 @@ VERSION_ID=""
 PCS9OR10_PCS_CNAME_OPTION=""
 PCS9OR10_PCS_CLONE_OPTION="clone"
 SECRET_PEM="/var/lib/glusterd/nfs/secret.pem"
+CRMADM_TIMEOUT_OPTION="5000"
 
 # UNBLOCK RA uses shared_storage which may become unavailable
 # during any of the nodes reboot. Hence increase timeout value.
@@ -235,9 +236,9 @@ setup_cluster()
     sleep 1
     # wait for the cluster to elect a DC before querying or writing
     # to the CIB. BZ 1334092
-    crmadmin --dc_lookup --timeout=5000 > /dev/null 2>&1
+    crmadmin --dc_lookup --timeout=${CRMADM_TIMEOUT_OPTION} > /dev/null 2>&1
     while [ $? -ne 0 ]; do
-        crmadmin --dc_lookup --timeout=5000 > /dev/null 2>&1
+        crmadmin --dc_lookup --timeout=${CRMADM_TIMEOUT_OPTION} > /dev/null 2>&1
     done
 
     unclean=$(pcs status | grep -u "UNCLEAN")
@@ -1072,6 +1073,12 @@ main()
                 PCS9OR10_PCS_CNAME_OPTION="--name"
                 PCS9OR10_PCS_CLONE_OPTION="--clone"
             fi
+        fi
+        # pacemaker 2.1.0 changed --timeout=value
+        echo ${crmadmin_vers}
+        crmadmin_vers=`crmadmin --version | grep -o "[12]\.[0-9]\.." | cut -c 1-3`
+        if [[ "${crmadmin_vers}" > "2.0" ]]; then
+            CRMADM_TIMEOUT_OPTION="5sec"
         fi
 
         if [[ "${HA_NUM_SERVERS}X" != "1X" ]]; then

--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -153,11 +153,11 @@ struct _call_stack {
 struct xlator_fops;
 
 static inline void
-FRAME_DESTROY(call_frame_t *frame)
+FRAME_DESTROY(call_frame_t *frame, const gf_boolean_t measure_latency)
 {
     void *local = NULL;
 
-    if (frame->root->ctx->measure_latency)
+    if (measure_latency)
         gf_frame_latency_update(frame);
 
     list_del_init(&frame->frames);
@@ -178,6 +178,7 @@ STACK_DESTROY(call_stack_t *stack)
 {
     call_frame_t *frame = NULL;
     call_frame_t *tmp = NULL;
+    gf_boolean_t measure_latency;
 
     LOCK(&stack->pool->lock);
     {
@@ -188,9 +189,10 @@ STACK_DESTROY(call_stack_t *stack)
 
     LOCK_DESTROY(&stack->stack_lock);
 
+    measure_latency = stack->ctx->measure_latency;
     list_for_each_entry_safe(frame, tmp, &stack->myframes, frames)
     {
-        FRAME_DESTROY(frame);
+        FRAME_DESTROY(frame, measure_latency);
     }
 
     GF_FREE(stack->groups_large);
@@ -205,6 +207,7 @@ STACK_RESET(call_stack_t *stack)
     call_frame_t *tmp = NULL;
     call_frame_t *last = NULL;
     struct list_head toreset = {0};
+    gf_boolean_t measure_latency;
 
     INIT_LIST_HEAD(&toreset);
 
@@ -221,9 +224,10 @@ STACK_RESET(call_stack_t *stack)
     }
     UNLOCK(&stack->pool->lock);
 
+    measure_latency = stack->ctx->measure_latency;
     list_for_each_entry_safe(frame, tmp, &toreset, frames)
     {
-        FRAME_DESTROY(frame);
+        FRAME_DESTROY(frame, measure_latency);
     }
 }
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -706,7 +706,7 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
 err:
     if (nframe) {
         rda_local_wipe(nframe->local);
-        FRAME_DESTROY(nframe);
+        FRAME_DESTROY(nframe, frame->root->ctx->measure_latency);
     }
 
     return -1;

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -2109,8 +2109,8 @@ out:
 /* New PRE and POST functions */
 
 int
-client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
-                        struct iatt *iatt, dict_t **xdata)
+client_post_common_iatt(gfx_common_iatt_rsp *rsp, struct iatt *iatt,
+                        dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->stat, iatt);
@@ -2120,8 +2120,8 @@ client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
 }
 
 int
-client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2, dict_t **xdata)
+client_post_common_2iatt(gfx_common_2iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->prestat, iatt);
@@ -2132,9 +2132,8 @@ client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
 }
 
 int
-client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2,
-                         struct iatt *iatt3, dict_t **xdata)
+client_post_common_3iatt(gfx_common_3iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, struct iatt *iatt3, dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->stat, iatt);
@@ -2146,13 +2145,12 @@ client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
 }
 
 int
-client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
-                        dict_t **xdata)
+client_post_common_dict(gfx_common_dict_rsp *rsp, dict_t **dict, dict_t **xdata)
 {
     int ret = 0;
     ret = xdr_to_dict(&rsp->dict, dict);
     if (ret)
-        gf_msg_debug(this->name, EINVAL,
+        gf_msg_debug(THIS->name, EINVAL,
                      "while decoding found empty dictionary");
     xdr_to_dict(&rsp->xdata, xdata);
 
@@ -2160,7 +2158,7 @@ client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
 }
 
 int
-client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
+client_post_readv_v2(gfx_read_rsp *rsp, struct iobref **iobref,
                      struct iobref *rsp_iobref, struct iatt *stat,
                      struct iovec *vector, struct iovec *rsp_vector,
                      int *rspcount, dict_t **xdata)
@@ -2186,7 +2184,7 @@ client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
 }
 
 int
-client_pre_stat_v2(xlator_t *this, gfx_stat_req *req, loc_t *loc, dict_t *xdata)
+client_pre_stat_v2(gfx_stat_req *req, loc_t *loc, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2209,8 +2207,8 @@ out:
 }
 
 int
-client_pre_readlink_v2(xlator_t *this, gfx_readlink_req *req, loc_t *loc,
-                       size_t size, dict_t *xdata)
+client_pre_readlink_v2(gfx_readlink_req *req, loc_t *loc, size_t size,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2232,8 +2230,8 @@ out:
 }
 
 int
-client_pre_mknod_v2(xlator_t *this, gfx_mknod_req *req, loc_t *loc, mode_t mode,
-                    dev_t rdev, mode_t umask, dict_t *xdata)
+client_pre_mknod_v2(gfx_mknod_req *req, loc_t *loc, mode_t mode, dev_t rdev,
+                    mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2260,8 +2258,8 @@ out:
 }
 
 int
-client_pre_mkdir_v2(xlator_t *this, gfx_mkdir_req *req, loc_t *loc, mode_t mode,
-                    mode_t umask, dict_t *xdata)
+client_pre_mkdir_v2(gfx_mkdir_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                    dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2288,8 +2286,8 @@ out:
 }
 
 int
-client_pre_unlink_v2(xlator_t *this, gfx_unlink_req *req, loc_t *loc,
-                     int32_t flags, dict_t *xdata)
+client_pre_unlink_v2(gfx_unlink_req *req, loc_t *loc, int32_t flags,
+                     dict_t *xdata)
 {
     int op_errno = 0;
 
@@ -2314,8 +2312,8 @@ out:
 }
 
 int
-client_pre_rmdir_v2(xlator_t *this, gfx_rmdir_req *req, loc_t *loc,
-                    int32_t flags, dict_t *xdata)
+client_pre_rmdir_v2(gfx_rmdir_req *req, loc_t *loc, int32_t flags,
+                    dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2340,8 +2338,8 @@ out:
 }
 
 int
-client_pre_symlink_v2(xlator_t *this, gfx_symlink_req *req, loc_t *loc,
-                      const char *linkname, mode_t umask, dict_t *xdata)
+client_pre_symlink_v2(gfx_symlink_req *req, loc_t *loc, const char *linkname,
+                      mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2366,8 +2364,8 @@ out:
 }
 
 int
-client_pre_rename_v2(xlator_t *this, gfx_rename_req *req, loc_t *oldloc,
-                     loc_t *newloc, dict_t *xdata)
+client_pre_rename_v2(gfx_rename_req *req, loc_t *oldloc, loc_t *newloc,
+                     dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2399,8 +2397,8 @@ out:
 }
 
 int
-client_pre_link_v2(xlator_t *this, gfx_link_req *req, loc_t *oldloc,
-                   loc_t *newloc, dict_t *xdata)
+client_pre_link_v2(gfx_link_req *req, loc_t *oldloc, loc_t *newloc,
+                   dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2431,8 +2429,8 @@ out:
 }
 
 int
-client_pre_truncate_v2(xlator_t *this, gfx_truncate_req *req, loc_t *loc,
-                       off_t offset, dict_t *xdata)
+client_pre_truncate_v2(gfx_truncate_req *req, loc_t *loc, off_t offset,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2455,8 +2453,8 @@ out:
 }
 
 int
-client_pre_open_v2(xlator_t *this, gfx_open_req *req, loc_t *loc, fd_t *fd,
-                   int32_t flags, dict_t *xdata)
+client_pre_open_v2(gfx_open_req *req, loc_t *loc, fd_t *fd, int32_t flags,
+                   dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2568,8 +2566,7 @@ out:
 }
 
 int
-client_pre_statfs_v2(xlator_t *this, gfx_statfs_req *req, loc_t *loc,
-                     dict_t *xdata)
+client_pre_statfs_v2(gfx_statfs_req *req, loc_t *loc, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2636,8 +2633,8 @@ out:
 }
 
 int
-client_pre_setxattr_v2(xlator_t *this, gfx_setxattr_req *req, loc_t *loc,
-                       dict_t *xattr, int32_t flags, dict_t *xdata)
+client_pre_setxattr_v2(gfx_setxattr_req *req, loc_t *loc, dict_t *xattr,
+                       int32_t flags, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2665,8 +2662,8 @@ out:
 }
 
 int
-client_pre_getxattr_v2(xlator_t *this, gfx_getxattr_req *req, loc_t *loc,
-                       const char *name, dict_t *xdata)
+client_pre_getxattr_v2(gfx_getxattr_req *req, loc_t *loc, const char *name,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2698,7 +2695,7 @@ out:
 }
 
 int
-client_pre_removexattr_v2(xlator_t *this, gfx_removexattr_req *req, loc_t *loc,
+client_pre_removexattr_v2(gfx_removexattr_req *req, loc_t *loc,
                           const char *name, dict_t *xdata)
 {
     int op_errno = ESTALE;
@@ -2723,8 +2720,7 @@ out:
 }
 
 int
-client_pre_opendir_v2(xlator_t *this, gfx_opendir_req *req, loc_t *loc,
-                      fd_t *fd, dict_t *xdata)
+client_pre_opendir_v2(gfx_opendir_req *req, loc_t *loc, fd_t *fd, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2768,8 +2764,8 @@ out:
 }
 
 int
-client_pre_access_v2(xlator_t *this, gfx_access_req *req, loc_t *loc,
-                     int32_t mask, dict_t *xdata)
+client_pre_access_v2(gfx_access_req *req, loc_t *loc, int32_t mask,
+                     dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2792,8 +2788,8 @@ out:
 }
 
 int
-client_pre_create_v2(xlator_t *this, gfx_create_req *req, loc_t *loc, fd_t *fd,
-                     mode_t mode, int32_t flags, mode_t umask, dict_t *xdata)
+client_pre_create_v2(gfx_create_req *req, loc_t *loc, fd_t *fd, mode_t mode,
+                     int32_t flags, mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -2960,7 +2956,7 @@ out:
 }
 
 int
-client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
+client_pre_inodelk_v2(gfx_inodelk_req *req, loc_t *loc, int cmd,
                       struct gf_flock *flock, const char *volume, dict_t *xdata)
 {
     int op_errno = ESTALE;
@@ -2984,7 +2980,7 @@ client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
     else if (cmd == F_SETLKW || cmd == F_SETLKW64)
         gf_cmd = GF_LK_SETLKW;
     else {
-        gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,
+        gf_smsg(THIS->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,
                 "gf_cmd=%d", gf_cmd, NULL);
         op_errno = EINVAL;
         goto out;
@@ -3065,9 +3061,9 @@ out:
 }
 
 int
-client_pre_entrylk_v2(xlator_t *this, gfx_entrylk_req *req, loc_t *loc,
-                      entrylk_cmd cmd_entrylk, entrylk_type type,
-                      const char *volume, const char *basename, dict_t *xdata)
+client_pre_entrylk_v2(gfx_entrylk_req *req, loc_t *loc, entrylk_cmd cmd_entrylk,
+                      entrylk_type type, const char *volume,
+                      const char *basename, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -3127,8 +3123,8 @@ out:
 }
 
 int
-client_pre_xattrop_v2(xlator_t *this, gfx_xattrop_req *req, loc_t *loc,
-                      dict_t *xattr, int32_t flags, dict_t *xdata)
+client_pre_xattrop_v2(gfx_xattrop_req *req, loc_t *loc, dict_t *xattr,
+                      int32_t flags, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -3249,8 +3245,8 @@ out:
 }
 
 int
-client_pre_setattr_v2(xlator_t *this, gfx_setattr_req *req, loc_t *loc,
-                      int32_t valid, struct iatt *stbuf, dict_t *xdata)
+client_pre_setattr_v2(gfx_setattr_req *req, loc_t *loc, int32_t valid,
+                      struct iatt *stbuf, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -3408,7 +3404,7 @@ out:
 }
 
 int
-client_pre_ipc_v2(xlator_t *this, gfx_ipc_req *req, int32_t cmd, dict_t *xdata)
+client_pre_ipc_v2(gfx_ipc_req *req, int32_t cmd, dict_t *xdata)
 {
     req->op = cmd;
 
@@ -3439,8 +3435,8 @@ out:
 }
 
 int
-client_pre_lease_v2(xlator_t *this, gfx_lease_req *req, loc_t *loc,
-                    struct gf_lease *lease, dict_t *xdata)
+client_pre_lease_v2(gfx_lease_req *req, loc_t *loc, struct gf_lease *lease,
+                    dict_t *xdata)
 {
     int op_errno = 0;
 
@@ -3463,9 +3459,9 @@ out:
 }
 
 int
-client_pre_put_v2(xlator_t *this, gfx_put_req *req, loc_t *loc, mode_t mode,
-                  mode_t umask, int32_t flags, size_t size, off_t offset,
-                  dict_t *xattr, dict_t *xdata)
+client_pre_put_v2(gfx_put_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                  int32_t flags, size_t size, off_t offset, dict_t *xattr,
+                  dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -3497,7 +3493,7 @@ out:
 }
 
 int
-client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
+client_post_create_v2(gfx_create_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preparent, struct iatt *postparent,
                       clnt_local_t *local, dict_t **xdata)
 {
@@ -3512,8 +3508,7 @@ client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
 }
 
 int
-client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
-                     dict_t **xdata)
+client_post_lease_v2(gfx_lease_rsp *rsp, struct gf_lease *lease, dict_t **xdata)
 {
     if (rsp->op_ret >= 0) {
         gf_proto_lease_to_lease(&rsp->lease, lease);
@@ -3523,8 +3518,7 @@ client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
 }
 
 int
-client_post_lk_v2(xlator_t *this, gfx_lk_rsp *rsp, struct gf_flock *lock,
-                  dict_t **xdata)
+client_post_lk_v2(gfx_lk_rsp *rsp, struct gf_flock *lock, dict_t **xdata)
 {
     if (rsp->op_ret >= 0) {
         gf_proto_flock_to_flock(&rsp->flock, lock);
@@ -3553,7 +3547,7 @@ client_post_readdirp_v2(xlator_t *this, gfx_readdirp_rsp *rsp, fd_t *fd,
 }
 
 int
-client_post_rename_v2(xlator_t *this, gfx_rename_rsp *rsp, struct iatt *stbuf,
+client_post_rename_v2(gfx_rename_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t **xdata)

--- a/xlators/protocol/client/src/client-common.h
+++ b/xlators/protocol/client/src/client-common.h
@@ -386,64 +386,63 @@ client_post_lease(xlator_t *this, gfs3_lease_rsp *rsp, struct gf_lease *lease,
 
 /* New functions for version 4 */
 int
-client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
+client_post_common_dict(gfx_common_dict_rsp *rsp, dict_t **dict,
                         dict_t **xdata);
 int
-client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2,
-                         struct iatt *iatt3, dict_t **xdata);
+client_post_common_3iatt(gfx_common_3iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, struct iatt *iatt3,
+                         dict_t **xdata);
 int
-client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2, dict_t **xdata);
+client_post_common_2iatt(gfx_common_2iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, dict_t **xdata);
 int
-client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
-                        struct iatt *iatt, dict_t **xdata);
+client_post_common_iatt(gfx_common_iatt_rsp *rsp, struct iatt *iatt,
+                        dict_t **xdata);
 int
 client_post_common_rsp(xlator_t *this, gfx_common_rsp *rsp, dict_t **xdata);
 
 int
-client_pre_stat_v2(xlator_t *this, gfx_stat_req *req, loc_t *loc,
-                   dict_t *xdata);
+client_pre_stat_v2(gfx_stat_req *req, loc_t *loc, dict_t *xdata);
 
 int
-client_pre_readlink_v2(xlator_t *this, gfx_readlink_req *req, loc_t *loc,
-                       size_t size, dict_t *xdata);
+client_pre_readlink_v2(gfx_readlink_req *req, loc_t *loc, size_t size,
+                       dict_t *xdata);
 
 int
-client_pre_mknod_v2(xlator_t *this, gfx_mknod_req *req, loc_t *loc, mode_t mode,
-                    dev_t rdev, mode_t umask, dict_t *xdata);
-
-int
-client_pre_mkdir_v2(xlator_t *this, gfx_mkdir_req *req, loc_t *loc, mode_t mode,
+client_pre_mknod_v2(gfx_mknod_req *req, loc_t *loc, mode_t mode, dev_t rdev,
                     mode_t umask, dict_t *xdata);
 
 int
-client_pre_unlink_v2(xlator_t *this, gfx_unlink_req *req, loc_t *loc,
-                     int32_t flags, dict_t *xdata);
+client_pre_mkdir_v2(gfx_mkdir_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                    dict_t *xdata);
 
 int
-client_pre_rmdir_v2(xlator_t *this, gfx_rmdir_req *req, loc_t *loc,
-                    int32_t flags, dict_t *xdata);
+client_pre_unlink_v2(gfx_unlink_req *req, loc_t *loc, int32_t flags,
+                     dict_t *xdata);
 
 int
-client_pre_symlink_v2(xlator_t *this, gfx_symlink_req *req, loc_t *loc,
-                      const char *linkname, mode_t umask, dict_t *xdata);
+client_pre_rmdir_v2(gfx_rmdir_req *req, loc_t *loc, int32_t flags,
+                    dict_t *xdata);
 
 int
-client_pre_rename_v2(xlator_t *this, gfx_rename_req *req, loc_t *oldloc,
-                     loc_t *newloc, dict_t *xdata);
+client_pre_symlink_v2(gfx_symlink_req *req, loc_t *loc, const char *linkname,
+                      mode_t umask, dict_t *xdata);
 
 int
-client_pre_link_v2(xlator_t *this, gfx_link_req *req, loc_t *oldloc,
-                   loc_t *newloc, dict_t *xdata);
+client_pre_rename_v2(gfx_rename_req *req, loc_t *oldloc, loc_t *newloc,
+                     dict_t *xdata);
 
 int
-client_pre_truncate_v2(xlator_t *this, gfx_truncate_req *req, loc_t *loc,
-                       off_t offset, dict_t *xdata);
+client_pre_link_v2(gfx_link_req *req, loc_t *oldloc, loc_t *newloc,
+                   dict_t *xdata);
 
 int
-client_pre_open_v2(xlator_t *this, gfx_open_req *req, loc_t *loc, fd_t *fd,
-                   int32_t flags, dict_t *xdata);
+client_pre_truncate_v2(gfx_truncate_req *req, loc_t *loc, off_t offset,
+                       dict_t *xdata);
+
+int
+client_pre_open_v2(gfx_open_req *req, loc_t *loc, fd_t *fd, int32_t flags,
+                   dict_t *xdata);
 
 int
 client_pre_readv_v2(xlator_t *this, gfx_read_req *req, fd_t *fd, size_t size,
@@ -454,8 +453,7 @@ client_pre_writev_v2(xlator_t *this, gfx_write_req *req, fd_t *fd, size_t size,
                      off_t offset, int32_t flags, dict_t **xdata);
 
 int
-client_pre_statfs_v2(xlator_t *this, gfx_statfs_req *req, loc_t *loc,
-                     dict_t *xdata);
+client_pre_statfs_v2(gfx_statfs_req *req, loc_t *loc, dict_t *xdata);
 
 int
 client_pre_flush_v2(xlator_t *this, gfx_flush_req *req, fd_t *fd,
@@ -466,32 +464,32 @@ client_pre_fsync_v2(xlator_t *this, gfx_fsync_req *req, fd_t *fd, int32_t flags,
                     dict_t *xdata);
 
 int
-client_pre_setxattr_v2(xlator_t *this, gfx_setxattr_req *req, loc_t *loc,
-                       dict_t *xattr, int32_t flags, dict_t *xdata);
+client_pre_setxattr_v2(gfx_setxattr_req *req, loc_t *loc, dict_t *xattr,
+                       int32_t flags, dict_t *xdata);
 
 int
-client_pre_getxattr_v2(xlator_t *this, gfx_getxattr_req *req, loc_t *loc,
-                       const char *name, dict_t *xdata);
+client_pre_getxattr_v2(gfx_getxattr_req *req, loc_t *loc, const char *name,
+                       dict_t *xdata);
 
 int
-client_pre_removexattr_v2(xlator_t *this, gfx_removexattr_req *req, loc_t *loc,
+client_pre_removexattr_v2(gfx_removexattr_req *req, loc_t *loc,
                           const char *name, dict_t *xdata);
 
 int
-client_pre_opendir_v2(xlator_t *this, gfx_opendir_req *req, loc_t *loc,
-                      fd_t *fd, dict_t *xdata);
+client_pre_opendir_v2(gfx_opendir_req *req, loc_t *loc, fd_t *fd,
+                      dict_t *xdata);
 
 int
 client_pre_fsyncdir_v2(xlator_t *this, gfx_fsyncdir_req *req, fd_t *fd,
                        int32_t flags, dict_t *xdata);
 
 int
-client_pre_access_v2(xlator_t *this, gfx_access_req *req, loc_t *loc,
-                     int32_t mask, dict_t *xdata);
+client_pre_access_v2(gfx_access_req *req, loc_t *loc, int32_t mask,
+                     dict_t *xdata);
 
 int
-client_pre_create_v2(xlator_t *this, gfx_create_req *req, loc_t *loc, fd_t *fd,
-                     mode_t mode, int32_t flags, mode_t umask, dict_t *xdata);
+client_pre_create_v2(gfx_create_req *req, loc_t *loc, fd_t *fd, mode_t mode,
+                     int32_t flags, mode_t umask, dict_t *xdata);
 
 int
 client_pre_ftruncate_v2(xlator_t *this, gfx_ftruncate_req *req, fd_t *fd,
@@ -514,7 +512,7 @@ client_pre_readdir_v2(xlator_t *this, gfx_readdir_req *req, fd_t *fd,
                       size_t size, off_t offset, dict_t *xdata);
 
 int
-client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
+client_pre_inodelk_v2(gfx_inodelk_req *req, loc_t *loc, int cmd,
                       struct gf_flock *flock, const char *volume,
                       dict_t *xdata);
 
@@ -524,9 +522,9 @@ client_pre_finodelk_v2(xlator_t *this, gfx_finodelk_req *req, fd_t *fd, int cmd,
                        dict_t *xdata);
 
 int
-client_pre_entrylk_v2(xlator_t *this, gfx_entrylk_req *req, loc_t *loc,
-                      entrylk_cmd cmd_entrylk, entrylk_type type,
-                      const char *volume, const char *basename, dict_t *xdata);
+client_pre_entrylk_v2(gfx_entrylk_req *req, loc_t *loc, entrylk_cmd cmd_entrylk,
+                      entrylk_type type, const char *volume,
+                      const char *basename, dict_t *xdata);
 
 int
 client_pre_fentrylk_v2(xlator_t *this, gfx_fentrylk_req *req, fd_t *fd,
@@ -534,8 +532,8 @@ client_pre_fentrylk_v2(xlator_t *this, gfx_fentrylk_req *req, fd_t *fd,
                        const char *volume, const char *basename, dict_t *xdata);
 
 int
-client_pre_xattrop_v2(xlator_t *this, gfx_xattrop_req *req, loc_t *loc,
-                      dict_t *xattr, int32_t flags, dict_t *xdata);
+client_pre_xattrop_v2(gfx_xattrop_req *req, loc_t *loc, dict_t *xattr,
+                      int32_t flags, dict_t *xdata);
 
 int
 client_pre_fxattrop_v2(xlator_t *this, gfx_fxattrop_req *req, fd_t *fd,
@@ -557,8 +555,8 @@ client_pre_rchecksum_v2(xlator_t *this, gfx_rchecksum_req *req, fd_t *fd,
                         int32_t len, off_t offset, dict_t *xdata);
 
 int
-client_pre_setattr_v2(xlator_t *this, gfx_setattr_req *req, loc_t *loc,
-                      int32_t valid, struct iatt *stbuf, dict_t *xdata);
+client_pre_setattr_v2(gfx_setattr_req *req, loc_t *loc, int32_t valid,
+                      struct iatt *stbuf, dict_t *xdata);
 int
 client_pre_fsetattr_v2(xlator_t *this, gfx_fsetattr_req *req, fd_t *fd,
                        int32_t valid, struct iatt *stbuf, dict_t *xdata);
@@ -582,33 +580,32 @@ int
 client_pre_zerofill_v2(xlator_t *this, gfx_zerofill_req *req, fd_t *fd,
                        off_t offset, size_t size, dict_t *xdata);
 int
-client_pre_ipc_v2(xlator_t *this, gfx_ipc_req *req, int32_t cmd, dict_t *xdata);
+client_pre_ipc_v2(gfx_ipc_req *req, int32_t cmd, dict_t *xdata);
 
 int
-client_pre_lease_v2(xlator_t *this, gfx_lease_req *req, loc_t *loc,
-                    struct gf_lease *lease, dict_t *xdata);
+client_pre_lease_v2(gfx_lease_req *req, loc_t *loc, struct gf_lease *lease,
+                    dict_t *xdata);
 
 int
-client_pre_put_v2(xlator_t *this, gfx_put_req *req, loc_t *loc, mode_t mode,
-                  mode_t umask, int32_t flags, size_t size, off_t offset,
-                  dict_t *xattr, dict_t *xdata);
+client_pre_put_v2(gfx_put_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                  int32_t flags, size_t size, off_t offset, dict_t *xattr,
+                  dict_t *xdata);
 
 int
-client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
+client_post_readv_v2(gfx_read_rsp *rsp, struct iobref **iobref,
                      struct iobref *rsp_iobref, struct iatt *stat,
                      struct iovec *vector, struct iovec *rsp_vector,
                      int *rspcount, dict_t **xdata);
 
 int
-client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
+client_post_create_v2(gfx_create_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preparent, struct iatt *postparent,
                       clnt_local_t *local, dict_t **xdata);
 int
-client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
+client_post_lease_v2(gfx_lease_rsp *rsp, struct gf_lease *lease,
                      dict_t **xdata);
 int
-client_post_lk_v2(xlator_t *this, gfx_lk_rsp *rsp, struct gf_flock *lock,
-                  dict_t **xdata);
+client_post_lk_v2(gfx_lk_rsp *rsp, struct gf_flock *lock, dict_t **xdata);
 int
 client_post_readdir_v2(xlator_t *this, gfx_readdir_rsp *rsp,
                        gf_dirent_t *entries, dict_t **xdata);
@@ -616,7 +613,7 @@ int
 client_post_readdirp_v2(xlator_t *this, gfx_readdirp_rsp *rsp, fd_t *fd,
                         gf_dirent_t *entries, dict_t **xdata);
 int
-client_post_rename_v2(xlator_t *this, gfx_rename_rsp *rsp, struct iatt *stbuf,
+client_post_rename_v2(gfx_rename_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t **xdata);

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -578,26 +578,20 @@ out:
     return ret;
 }
 int
-clnt_unserialize_rsp_locklist_v2(xlator_t *this,
-                                 struct gfx_getactivelk_rsp *rsp,
+clnt_unserialize_rsp_locklist_v2(struct gfx_getactivelk_rsp *rsp,
                                  lock_migration_info_t *lmi)
 {
     struct gfs3_locklist *trav = NULL;
     lock_migration_info_t *temp = NULL;
     int ret = -1;
-    clnt_conf_t *conf = NULL;
 
     trav = rsp->reply;
-
-    conf = this->private;
-    if (!conf)
-        goto out;
 
     while (trav) {
         /* TODO: move to GF_MALLOC() */
         temp = GF_CALLOC(1, sizeof(*lmi), gf_common_mt_lock_mig);
         if (temp == NULL) {
-            gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_NO_MEM, NULL);
+            gf_smsg(THIS->name, GF_LOG_ERROR, 0, PC_MSG_NO_MEM, NULL);
             goto out;
         }
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -66,7 +66,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -136,7 +136,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -202,7 +202,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -321,7 +321,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_iatt(this, &rsp, &iatt, &xdata);
+    ret = client_post_common_iatt(&rsp, &iatt, &xdata);
 out:
     if (rsp.op_ret == -1) {
         /* stale filehandles are possible during normal operations, no
@@ -440,7 +440,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &preparent, &postparent, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -499,7 +499,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &preparent, &postparent, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -554,7 +554,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -661,7 +661,7 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 out:
@@ -775,7 +775,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 
@@ -881,7 +881,7 @@ client4_0_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = gf_error_to_errno(rsp.op_errno);
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -954,7 +954,7 @@ client4_0_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = gf_error_to_errno(rsp.op_errno);
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -1219,7 +1219,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1269,7 +1269,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_iatt(this, &rsp, &stat, &xdata);
+    ret = client_post_common_iatt(&rsp, &stat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1510,7 +1510,7 @@ client4_0_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = rsp.op_errno;
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -1576,7 +1576,7 @@ client4_0_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
     op_errno = rsp.op_errno;
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         rsp.op_ret = -1;
         op_errno = -ret;
@@ -1697,7 +1697,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 
@@ -1752,7 +1752,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1804,7 +1804,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 out:
     if (rsp.op_ret == -1) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
@@ -1947,7 +1947,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2001,7 +2001,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2064,8 +2064,8 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_create_v2(this, &rsp, &stbuf, &preparent, &postparent,
-                                local, &xdata);
+    ret = client_post_create_v2(&rsp, &stbuf, &preparent, &postparent, local,
+                                &xdata);
     if (ret < 0)
         goto out;
 
@@ -2131,7 +2131,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_lease_v2(this, &rsp, &lease, &xdata);
+    ret = client_post_lease_v2(&rsp, &lease, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2185,7 +2185,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (rsp.op_ret >= 0) {
-        ret = client_post_lk_v2(this, &rsp, &lock, &xdata);
+        ret = client_post_lk_v2(&rsp, &lock, &xdata);
         if (ret < 0)
             goto out;
 
@@ -2387,7 +2387,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    client_post_rename_v2(this, &rsp, &stbuf, &preoldparent, &postoldparent,
+    client_post_rename_v2(&rsp, &stbuf, &preoldparent, &postoldparent,
                           &prenewparent, &postnewparent, &xdata);
 out:
     if (rsp.op_ret == -1) {
@@ -2449,7 +2449,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 out:
     if (rsp.op_ret == -1) {
@@ -2581,7 +2581,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     /* Preserve the op_errno received from the server */
     op_errno = gf_error_to_errno(rsp.op_errno);
 
-    ret = client_post_common_2iatt(this, &rsp, &stbuf, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &stbuf, &postparent, &xdata);
     if (ret < 0) {
         /* Don't change the op_errno if the fop failed on server */
         if (rsp.op_ret == 0)
@@ -2675,8 +2675,8 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     memset(vector, 0, sizeof(vector));
 
-    ret = client_post_readv_v2(this, &rsp, &iobref, req->rsp_iobref, &stat,
-                               vector, &req->rsp[1], &rspcount, &xdata);
+    ret = client_post_readv_v2(&rsp, &iobref, req->rsp_iobref, &stat, vector,
+                               &req->rsp[1], &rspcount, &xdata);
 out:
     if (rsp.op_ret == -1) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
@@ -2861,8 +2861,7 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &prestat, &poststat,
-                                   &xdata);
+    ret = client_post_common_3iatt(&rsp, &stbuf, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 out:
@@ -3093,7 +3092,7 @@ client4_0_stat(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_stat_v2(this, &req, args->loc, args->xdata);
+    ret = client_pre_stat_v2(&req, args->loc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3135,8 +3134,7 @@ client4_0_truncate(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_truncate_v2(this, &req, args->loc, args->offset,
-                                 args->xdata);
+    ret = client_pre_truncate_v2(&req, args->loc, args->offset, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3221,7 +3219,7 @@ client4_0_access(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_access_v2(this, &req, args->loc, args->mask, args->xdata);
+    ret = client_pre_access_v2(&req, args->loc, args->mask, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3272,8 +3270,7 @@ client4_0_readlink(call_frame_t *frame, xlator_t *this, void *data)
 
     frame->local = local;
 
-    ret = client_pre_readlink_v2(this, &req, args->loc, args->size,
-                                 args->xdata);
+    ret = client_pre_readlink_v2(&req, args->loc, args->size, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3316,7 +3313,7 @@ client4_0_unlink(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_unlink_v2(this, &req, args->loc, args->flags, args->xdata);
+    ret = client_pre_unlink_v2(&req, args->loc, args->flags, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3357,7 +3354,7 @@ client4_0_rmdir(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_rmdir_v2(this, &req, args->loc, args->flags, args->xdata);
+    ret = client_pre_rmdir_v2(&req, args->loc, args->flags, args->xdata);
 
     if (ret) {
         op_errno = -ret;
@@ -3415,8 +3412,8 @@ client4_0_symlink(call_frame_t *frame, xlator_t *this, void *data)
 
     local->loc2.path = gf_strdup(args->linkname);
 
-    ret = client_pre_symlink_v2(this, &req, args->loc, args->linkname,
-                                args->umask, args->xdata);
+    ret = client_pre_symlink_v2(&req, args->loc, args->linkname, args->umask,
+                                args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3460,8 +3457,7 @@ client4_0_rename(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_rename_v2(this, &req, args->oldloc, args->newloc,
-                               args->xdata);
+    ret = client_pre_rename_v2(&req, args->oldloc, args->newloc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3513,8 +3509,7 @@ client4_0_link(call_frame_t *frame, xlator_t *this, void *data)
 
     frame->local = local;
 
-    ret = client_pre_link_v2(this, &req, args->oldloc, args->newloc,
-                             args->xdata);
+    ret = client_pre_link_v2(&req, args->oldloc, args->newloc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3573,7 +3568,7 @@ client4_0_mknod(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_mknod_v2(this, &req, args->loc, args->mode, args->rdev,
+    ret = client_pre_mknod_v2(&req, args->loc, args->mode, args->rdev,
                               args->umask, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3639,7 +3634,7 @@ client4_0_mkdir(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_mkdir_v2(this, &req, args->loc, args->mode, args->umask,
+    ret = client_pre_mkdir_v2(&req, args->loc, args->mode, args->umask,
                               args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3696,7 +3691,7 @@ client4_0_create(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_create_v2(this, &req, args->loc, args->fd, args->mode,
+    ret = client_pre_create_v2(&req, args->loc, args->fd, args->mode,
                                args->flags, args->umask, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3755,7 +3750,7 @@ client4_0_open(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_open_v2(this, &req, args->loc, args->fd, args->flags,
+    ret = client_pre_open_v2(&req, args->loc, args->fd, args->flags,
                              args->xdata);
 
     if (ret) {
@@ -4112,7 +4107,7 @@ client4_0_opendir(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_opendir_v2(this, &req, args->loc, args->fd, args->xdata);
+    ret = client_pre_opendir_v2(&req, args->loc, args->fd, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4199,7 +4194,7 @@ client4_0_statfs(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_statfs_v2(this, &req, args->loc, args->xdata);
+    ret = client_pre_statfs_v2(&req, args->loc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4241,8 +4236,8 @@ client4_0_setxattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_setxattr_v2(this, &req, args->loc, args->xattr,
-                                 args->flags, args->xdata);
+    ret = client_pre_setxattr_v2(&req, args->loc, args->xattr, args->flags,
+                                 args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4424,8 +4419,7 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
         }
     }
 
-    ret = client_pre_getxattr_v2(this, &req, args->loc, args->name,
-                                 args->xdata);
+    ret = client_pre_getxattr_v2(&req, args->loc, args->name, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4485,7 +4479,7 @@ client4_0_xattrop(call_frame_t *frame, xlator_t *this, void *data)
     loc_path(&local->loc, NULL);
     conf = this->private;
 
-    ret = client_pre_xattrop_v2(this, &req, args->loc, args->xattr, args->flags,
+    ret = client_pre_xattrop_v2(&req, args->loc, args->xattr, args->flags,
                                 args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4581,8 +4575,7 @@ client4_0_removexattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_removexattr_v2(this, &req, args->loc, args->name,
-                                    args->xdata);
+    ret = client_pre_removexattr_v2(&req, args->loc, args->name, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4667,7 +4660,7 @@ client4_0_lease(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_lease_v2(this, &req, args->loc, args->lease, args->xdata);
+    ret = client_pre_lease_v2(&req, args->loc, args->lease, args->xdata);
     if (ret < 0) {
         op_errno = -ret;
         goto unwind;
@@ -4792,7 +4785,7 @@ client4_0_inodelk(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_inodelk_v2(this, &req, args->loc, args->cmd, args->flock,
+    ret = client_pre_inodelk_v2(&req, args->loc, args->cmd, args->flock,
                                 args->volume, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4883,9 +4876,8 @@ client4_0_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_entrylk_v2(this, &req, args->loc, args->cmd_entrylk,
-                                args->type, args->volume, args->basename,
-                                args->xdata);
+    ret = client_pre_entrylk_v2(&req, args->loc, args->cmd_entrylk, args->type,
+                                args->volume, args->basename, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -5179,7 +5171,7 @@ client4_0_setattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_setattr_v2(this, &req, args->loc, args->valid, args->stbuf,
+    ret = client_pre_setattr_v2(&req, args->loc, args->valid, args->stbuf,
                                 args->xdata);
 
     if (ret) {
@@ -5346,7 +5338,7 @@ client4_0_ipc(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_ipc_v2(this, &req, args->cmd, args->xdata);
+    ret = client_pre_ipc_v2(&req, args->cmd, args->xdata);
 
     if (ret) {
         op_errno = -ret;
@@ -5714,8 +5706,8 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (-1 != rsp.op_ret) {
-        ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent,
-                                       &postparent, &xdata);
+        ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
+                                       &xdata);
         if (ret < 0)
             goto out;
     }
@@ -5863,7 +5855,7 @@ client4_0_put(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_put_v2(this, &req, args->loc, args->mode, args->umask,
+    ret = client_pre_put_v2(&req, args->loc, args->mode, args->umask,
                             args->flags, args->size, args->offset, args->xattr,
                             args->xdata);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -19,8 +19,6 @@
 
 extern int32_t
 client3_getspec(call_frame_t *frame, xlator_t *this, void *data);
-extern int32_t
-client3_3_getxattr(call_frame_t *frame, xlator_t *this, void *data);
 
 int
 client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
@@ -42,10 +40,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -59,7 +54,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -75,7 +70,7 @@ out:
             /* no need to print the gfid, because it will be null,
              * since symlink operation failed.
              */
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "source=%s", local->loc.path,
                     "target=%s", local->loc2.path, NULL);
         }
@@ -111,10 +106,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -129,7 +121,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -142,7 +134,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1 &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_MKNOD, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, NULL);
@@ -178,10 +170,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -195,7 +184,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -208,7 +197,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1 &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_MKDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, NULL);
@@ -235,10 +224,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_open_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -252,7 +238,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -272,7 +258,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_OPEN, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, "gfid=%s",
@@ -300,10 +286,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -314,7 +297,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -327,10 +310,10 @@ out:
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -356,10 +339,7 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -370,7 +350,7 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readlink_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -382,10 +362,10 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -419,10 +399,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -433,7 +410,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -445,10 +422,10 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -478,10 +455,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -492,7 +466,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -504,7 +478,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -533,10 +507,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -547,7 +518,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -558,7 +529,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
@@ -583,10 +554,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -597,7 +565,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_statfs_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -610,7 +578,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
@@ -637,11 +605,8 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -654,7 +619,7 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -666,11 +631,11 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
         if (local->attempt_reopen)
-            client_attempt_reopen(local->fd, this);
+            client_attempt_reopen(local->fd, THIS);
     }
     CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
@@ -688,7 +653,6 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
 {
     call_frame_t *frame = NULL;
     clnt_local_t *local = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     gfx_common_rsp rsp = {
         0,
@@ -696,7 +660,6 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
 
     frame = myframe;
-    this = THIS;
     local = frame->local;
 
     if (-1 == req->rpc_status) {
@@ -706,7 +669,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -717,7 +680,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
         !fd_is_anonymous(local->fd)) {
         /* Delete all saved locks of the owner issuing flush */
         ret = delete_granted_locks_owner(local->fd, &local->owner);
-        gf_msg_trace(this->name, 0, "deleting locks of owner (%s) returned %d",
+        gf_msg_trace(THIS->name, 0, "deleting locks of owner (%s) returned %d",
                      lkowner_utoa(&local->owner), ret);
     }
 
@@ -725,7 +688,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -753,10 +716,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -768,7 +728,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -781,7 +741,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
@@ -802,11 +762,8 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     int op_errno = EINVAL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -818,7 +775,7 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -830,9 +787,9 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, op_errno, "remote operation failed");
+            gf_msg_debug(THIS->name, op_errno, "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -996,11 +953,8 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     gf_loglevel_t loglevel = GF_LOG_NONE;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1012,7 +966,7 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1032,7 +986,7 @@ out:
         else
             loglevel = GF_LOG_WARNING;
 
-        gf_smsg(this->name, loglevel, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, loglevel, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -1054,10 +1008,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1069,7 +1020,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1079,7 +1030,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
@@ -1100,10 +1051,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1114,7 +1062,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1125,7 +1073,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
@@ -1146,10 +1094,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1160,7 +1105,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1171,7 +1116,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
@@ -1198,10 +1143,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1212,7 +1154,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1223,7 +1165,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
@@ -1248,10 +1190,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1262,7 +1201,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1273,7 +1212,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
@@ -1294,10 +1233,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1308,7 +1244,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1318,7 +1254,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1390,10 +1326,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1404,7 +1337,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1414,7 +1347,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_ENTRYLK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1437,10 +1370,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1451,7 +1381,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1462,7 +1392,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -1618,11 +1548,8 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     int op_errno = EINVAL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1633,7 +1560,7 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1646,9 +1573,9 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, op_errno, "remote operation failed");
+            gf_msg_debug(THIS->name, op_errno, "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -1676,10 +1603,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1690,7 +1614,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1703,7 +1627,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
@@ -1731,10 +1655,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1745,7 +1666,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1756,7 +1677,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
@@ -1783,10 +1704,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1797,7 +1715,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1807,7 +1725,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
@@ -1829,10 +1747,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1843,7 +1758,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1853,7 +1768,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
@@ -1874,10 +1789,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1888,7 +1800,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_seek_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1898,7 +1810,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
@@ -1925,10 +1837,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1940,7 +1849,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1951,7 +1860,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
@@ -1979,10 +1888,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1994,7 +1900,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2005,7 +1911,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
@@ -2039,10 +1945,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_create_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2057,7 +1960,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_create_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2081,7 +1984,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path, NULL);
     }
 
@@ -2107,15 +2010,12 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
     if (-1 == req->rpc_status) {
-        gf_smsg(this->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_REMOTE_OP_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_REMOTE_OP_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
@@ -2124,7 +2024,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lease_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2135,7 +2035,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2164,8 +2064,6 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
 
@@ -2177,7 +2075,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lk_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2203,6 +2101,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (local->check_reopen) {
+        this = THIS;
         if (lock.l_type == F_WRLCK)
             set_fd_reopen_status(this, xdata, FD_REOPEN_NOT_ALLOWED);
         else
@@ -2211,7 +2110,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2365,10 +2264,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2380,7 +2276,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rename_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2391,7 +2287,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
                           &prenewparent, &postnewparent, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
@@ -2424,10 +2320,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2442,7 +2335,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2454,7 +2347,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "source=%s", local->loc.path,
                     "target=%s", local->loc2.path, NULL);
         }
@@ -2481,10 +2374,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_open_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2501,7 +2391,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
        but separated by fop number only */
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2521,7 +2411,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_OPENDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, "gfid=%s",
@@ -2555,9 +2445,6 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int op_errno = EINVAL;
     dict_t *xdata = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2571,7 +2458,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         op_errno = EINVAL;
@@ -2615,11 +2502,11 @@ out:
         /* any error other than ENOENT */
         if (!(local->loc.name && rsp.op_errno == ENOENT) &&
             !(rsp.op_errno == ESTALE))
-            gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path,
                     "gfid=%s", loc_gfid_utoa(&local->loc), NULL);
         else
-            gf_msg_trace(this->name, 0,
+            gf_msg_trace(THIS->name, 0,
                          "not found on remote "
                          "node");
     }
@@ -2650,10 +2537,7 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = 0, rspcount = 0;
     clnt_local_t *local = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2666,7 +2550,7 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_read_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2679,11 +2563,11 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                &req->rsp[1], &rspcount, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
         if (local->attempt_reopen)
-            client_attempt_reopen(local->fd, this);
+            client_attempt_reopen(local->fd, THIS);
     }
     CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), vector, rspcount,
@@ -2726,10 +2610,7 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int32_t ret = 0;
     lock_migration_info_t locklist;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2741,7 +2622,7 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_getactivelk_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2751,14 +2632,14 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     INIT_LIST_HEAD(&locklist.list);
 
     if (rsp.op_ret > 0) {
-        clnt_unserialize_rsp_locklist_v2(this, &rsp, &locklist);
+        clnt_unserialize_rsp_locklist_v2(&rsp, &locklist);
     }
 
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2781,10 +2662,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int32_t ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2796,7 +2674,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2806,7 +2684,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2841,8 +2719,6 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
 
@@ -2854,7 +2730,7 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2866,9 +2742,10 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
+        this = THIS;
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
         if (local->attempt_reopen_out)
@@ -5522,10 +5399,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -5537,7 +5411,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rchecksum_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -5547,7 +5421,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -5670,7 +5544,6 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     call_frame_t *frame = NULL;
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
     struct iatt stbuf = {
@@ -5684,8 +5557,6 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     inode_t *inode = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
     inode = local->loc.inode;
@@ -5698,7 +5569,7 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -5713,7 +5584,7 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -376,8 +376,7 @@ serialize_req_locklist_v2(lock_migration_info_t *locklist,
                           gfx_setactivelk_req *req);
 
 int
-clnt_unserialize_rsp_locklist_v2(xlator_t *this,
-                                 struct gfx_getactivelk_rsp *rsp,
+clnt_unserialize_rsp_locklist_v2(struct gfx_getactivelk_rsp *rsp,
                                  lock_migration_info_t *lmi);
 
 int


### PR DESCRIPTION
    After the removal of 'this' GF_ASSERT_AND_GOTO_WITH_ERROR,
    asjusted for that removal in relevant functions.
    
    Updates: #2989
    Signed-off-by: Yaniv Kaul <ykaul@redhat.com>
