### PR TITLE
multiple files: improve gf_dirent_for_name() functionality

### DIFF
--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -1056,17 +1056,9 @@ args_readdirp_cbk_store(default_args_cbk_t *args, int32_t op_ret,
     if (op_ret > 0) {
         list_for_each_entry(entry, &entries->list, list)
         {
-            stub_entry = gf_dirent_for_name(entry->d_name);
+            stub_entry = entry_copy(entry);
             if (!stub_entry)
                 goto out;
-            stub_entry->d_off = entry->d_off;
-            stub_entry->d_ino = entry->d_ino;
-            stub_entry->d_stat = entry->d_stat;
-            stub_entry->d_type = entry->d_type;
-            if (entry->inode)
-                stub_entry->inode = inode_ref(entry->inode);
-            if (entry->dict)
-                stub_entry->dict = dict_ref(entry->dict);
             list_add_tail(&stub_entry->list, &args->entries.list);
         }
     }
@@ -1100,12 +1092,11 @@ args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
     if (op_ret > 0) {
         list_for_each_entry(entry, &entries->list, list)
         {
-            stub_entry = gf_dirent_for_name(entry->d_name);
+            stub_entry = gf_dirent_for_name2(entry->d_name, entry->d_len,
+                                             entry->d_ino, entry->d_off,
+                                             entry->d_type);
             if (!stub_entry)
                 goto out;
-            stub_entry->d_off = entry->d_off;
-            stub_entry->d_ino = entry->d_ino;
-            stub_entry->d_type = entry->d_type;
             list_add_tail(&stub_entry->list, &args->entries.list);
         }
     }

--- a/libglusterfs/src/gf-dirent.c
+++ b/libglusterfs/src/gf-dirent.c
@@ -147,7 +147,7 @@ gf_dirent_for_name2(const char *name, const size_t name_len,
 {
     gf_dirent_t *gf_dirent = NULL;
 
-    gf_dirent = GF_CALLOC(gf_dirent_len(name_len), 1, gf_common_mt_gf_dirent_t);
+    gf_dirent = GF_MALLOC(gf_dirent_len(name_len), gf_common_mt_gf_dirent_t);
     if (!gf_dirent)
         return NULL;
 
@@ -157,6 +157,10 @@ gf_dirent_for_name2(const char *name, const size_t name_len,
     gf_dirent->d_off = d_off;
     gf_dirent->d_len = name_len;
     gf_dirent->d_type = d_type;
+
+    memset(&gf_dirent->d_stat, 0, sizeof(struct iatt));
+    gf_dirent->dict = NULL;
+    gf_dirent->inode = NULL;
 
     memcpy(gf_dirent->d_name, name, name_len + 1);
 

--- a/libglusterfs/src/gf-dirent.c
+++ b/libglusterfs/src/gf-dirent.c
@@ -141,24 +141,32 @@ out:
 }
 
 gf_dirent_t *
-gf_dirent_for_name(const char *name)
+gf_dirent_for_name2(const char *name, const size_t name_len,
+                    const uint64_t d_ino, const uint64_t d_off,
+                    const uint32_t d_type)
 {
     gf_dirent_t *gf_dirent = NULL;
 
-    /* TODO: use mem-pool */
-    gf_dirent = GF_CALLOC(gf_dirent_size(name), 1, gf_common_mt_gf_dirent_t);
+    gf_dirent = GF_CALLOC(gf_dirent_len(name_len), 1, gf_common_mt_gf_dirent_t);
     if (!gf_dirent)
         return NULL;
 
     INIT_LIST_HEAD(&gf_dirent->list);
-    strcpy(gf_dirent->d_name, name);
 
-    gf_dirent->d_off = 0;
-    gf_dirent->d_ino = -1;
-    gf_dirent->d_type = 0;
-    gf_dirent->d_len = strlen(name);
+    gf_dirent->d_ino = d_ino;
+    gf_dirent->d_off = d_off;
+    gf_dirent->d_len = name_len;
+    gf_dirent->d_type = d_type;
+
+    memcpy(gf_dirent->d_name, name, name_len + 1);
 
     return gf_dirent;
+}
+
+gf_dirent_t *
+gf_dirent_for_name(const char *name)
+{
+    return gf_dirent_for_name2(name, strlen(name), -1, 0, 0);
 }
 
 void
@@ -199,15 +207,12 @@ entry_copy(gf_dirent_t *source)
 {
     gf_dirent_t *sink = NULL;
 
-    sink = gf_dirent_for_name(source->d_name);
+    sink = gf_dirent_for_name2(source->d_name, source->d_len, source->d_ino,
+                               source->d_off, source->d_type);
     if (!sink)
         return NULL;
 
-    sink->d_off = source->d_off;
-    sink->d_ino = source->d_ino;
-    sink->d_type = source->d_type;
     sink->d_stat = source->d_stat;
-    sink->d_len = source->d_len;
 
     if (source->inode)
         sink->inode = inode_ref(source->inode);

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -14,8 +14,8 @@
 #include "glusterfs/iatt.h"
 #include "glusterfs/inode.h"
 
-#define gf_dirent_size(name) (sizeof(gf_dirent_t) + strlen(name) + 1)
 #define gf_dirent_len(_len) (sizeof(gf_dirent_t) + _len + 1)
+#define gf_dirent_size(name) gf_dirent_len(strlen(name))
 
 int
 gf_deitransform(xlator_t *this, uint64_t y);

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -15,6 +15,7 @@
 #include "glusterfs/inode.h"
 
 #define gf_dirent_size(name) (sizeof(gf_dirent_t) + strlen(name) + 1)
+#define gf_dirent_len(_len) (sizeof(gf_dirent_t) + _len + 1)
 
 int
 gf_deitransform(xlator_t *this, uint64_t y);
@@ -54,6 +55,10 @@ struct _gf_dirent {
 
 gf_dirent_t *
 gf_dirent_for_name(const char *name);
+gf_dirent_t *
+gf_dirent_for_name2(const char *name, const size_t name_len,
+                    const uint64_t d_ino, const uint64_t d_off,
+                    const uint32_t d_type);
 gf_dirent_t *
 entry_copy(gf_dirent_t *source);
 void

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -572,6 +572,7 @@ gf_cmd_log_init
 gf_deitransform
 gf_dirent_entry_free
 gf_dirent_for_name
+gf_dirent_for_name2
 gf_dirent_free
 gf_dirent_orig_offset
 gf_dm_hashfn

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -6840,7 +6840,9 @@ dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         }
 
     list:
-        entry = gf_dirent_for_name(orig_entry->d_name);
+        entry = gf_dirent_for_name2(orig_entry->d_name, orig_entry->d_len,
+                                    orig_entry->d_ino, orig_entry->d_off,
+                                    orig_entry->d_type);
         if (!entry) {
             goto unwind;
         }
@@ -6855,11 +6857,7 @@ dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             }
         }
 
-        entry->d_off = orig_entry->d_off;
         entry->d_stat = orig_entry->d_stat;
-        entry->d_ino = orig_entry->d_ino;
-        entry->d_type = orig_entry->d_type;
-        entry->d_len = orig_entry->d_len;
 
         if (orig_entry->dict)
             entry->dict = dict_ref(orig_entry->dict);
@@ -7088,17 +7086,14 @@ dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
         if (add) {
             add = _gf_false;
-            entry = gf_dirent_for_name(orig_entry->d_name);
+            entry = gf_dirent_for_name2(orig_entry->d_name, orig_entry->d_len,
+                                        orig_entry->d_ino, orig_entry->d_off,
+                                        orig_entry->d_type);
             if (!entry) {
                 gf_msg(this->name, GF_LOG_ERROR, ENOMEM, DHT_MSG_NO_MEMORY,
                        "Memory allocation failed ");
                 goto unwind;
             }
-
-            entry->d_off = orig_entry->d_off;
-            entry->d_ino = orig_entry->d_ino;
-            entry->d_type = orig_entry->d_type;
-            entry->d_len = orig_entry->d_len;
 
             gf_msg_debug(this->name, 0, "%s: Adding = entry %s", prev->name,
                          entry->d_name);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3204,7 +3204,9 @@ gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
             ret = -1;
             goto out;
         }
-        tmp_container->df_entry = gf_dirent_for_name(df_entry->d_name);
+        tmp_container->df_entry = gf_dirent_for_name2(
+            df_entry->d_name, df_entry->d_len, df_entry->d_ino, 0,
+            df_entry->d_type);
         if (!tmp_container->df_entry) {
             gf_log(this->name, GF_LOG_ERROR,
                    "Failed to allocate "
@@ -3216,12 +3218,6 @@ gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
         tmp_container->local_subvol_index = i;
 
         tmp_container->df_entry->d_stat = df_entry->d_stat;
-
-        tmp_container->df_entry->d_ino = df_entry->d_ino;
-
-        tmp_container->df_entry->d_type = df_entry->d_type;
-
-        tmp_container->df_entry->d_len = df_entry->d_len;
 
         tmp_container->parent_loc = GF_CALLOC(1, sizeof(*loc), gf_dht_mt_loc_t);
         if (!tmp_container->parent_loc) {

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -479,6 +479,7 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
     int32_t this_size = -1;
     gf_dirent_t *this_entry = NULL;
     xlator_t *this = NULL;
+    size_t entry_dname_len;
 
     this = THIS;
     if (!off) {
@@ -532,8 +533,9 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
             continue;
         }
 
+        entry_dname_len = strlen(entry->d_name);
         this_size = max(sizeof(gf_dirent_t), sizeof(gfx_dirplist)) +
-                    strlen(entry->d_name) + 1;
+                    entry_dname_len + 1;
 
         if (this_size + filled > size) {
             seekdir(dir, in_case);
@@ -553,14 +555,6 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
             break;
         }
 
-        this_entry = gf_dirent_for_name(entry->d_name);
-
-        if (!this_entry) {
-            gf_msg(THIS->name, GF_LOG_ERROR, errno,
-                   INDEX_MSG_INDEX_READDIR_FAILED,
-                   "could not create gf_dirent for entry %s", entry->d_name);
-            goto out;
-        }
         /*
          * we store the offset of next entry here, which is
          * probably not intended, but code using syncop_readdir()
@@ -568,8 +562,16 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
          * for directory read resumption.
          */
         last_off = (u_long)telldir(dir);
-        this_entry->d_off = last_off;
-        this_entry->d_ino = entry->d_ino;
+
+        this_entry = gf_dirent_for_name2(entry->d_name, entry_dname_len,
+                                         entry->d_ino, last_off, 0);
+
+        if (!this_entry) {
+            gf_msg(THIS->name, GF_LOG_ERROR, errno,
+                   INDEX_MSG_INDEX_READDIR_FAILED,
+                   "could not create gf_dirent for entry %s", entry->d_name);
+            goto out;
+        }
 
         list_add_tail(&this_entry->list, &entries->list);
 

--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -621,7 +621,7 @@ upcall_client_cache_invalidate(xlator_t *this, uuid_t gfid,
             __upcall_cleanup_client_entry(up_client_entry);
 
     } else {
-        gf_log(THIS->name, GF_LOG_TRACE,
+        gf_log(this->name, GF_LOG_TRACE,
                "Cache invalidation notification NOT sent to %s",
                up_client_entry->client_uid);
 

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -388,6 +388,7 @@ meta_default_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     struct meta_dirent *dirents = NULL;
     struct meta_dirent *end = NULL;
     struct meta_ops *ops = NULL;
+    size_t dirents_name_len;
 
     INIT_LIST_HEAD(&head.list);
 
@@ -417,42 +418,16 @@ meta_default_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         }
 
         while (dirents < end) {
-            this_size = sizeof(gf_dirent_t) + strlen(dirents->name) + 1;
+            dirents_name_len = strlen(dirents->name);
+            this_size = gf_dirent_len(dirents_name_len);
             if (this_size + filled_size > size)
                 goto unwind;
 
-            list = gf_dirent_for_name(dirents->name);
+            list = gf_dirent_for_name2(dirents->name, dirents_name_len, i + 42,
+                                       i + 1,
+                                       gf_d_type_from_ia_type(dirents->type));
             if (!list)
                 break;
-
-            list->d_off = i + 1;
-            list->d_ino = i + 42;
-            switch (dirents->type) {
-                case IA_IFDIR:
-                    list->d_type = DT_DIR;
-                    break;
-                case IA_IFCHR:
-                    list->d_type = DT_CHR;
-                    break;
-                case IA_IFBLK:
-                    list->d_type = DT_BLK;
-                    break;
-                case IA_IFIFO:
-                    list->d_type = DT_FIFO;
-                    break;
-                case IA_IFLNK:
-                    list->d_type = DT_LNK;
-                    break;
-                case IA_IFREG:
-                    list->d_type = DT_REG;
-                    break;
-                case IA_IFSOCK:
-                    list->d_type = DT_SOCK;
-                    break;
-                case IA_INVAL:
-                    list->d_type = DT_UNKNOWN;
-                    break;
-            }
 
             list_add_tail(&list->list, &head.list);
             ret++;

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -579,7 +579,7 @@ gf_fuse_fill_dirent(gf_dirent_t *entry, struct fuse_dirent *fde,
 
     fde->off = entry->d_off;
     fde->type = entry->d_type;
-    fde->namelen = strlen(entry->d_name);
+    fde->namelen = entry->d_len;
     (void)memcpy(fde->name, entry->d_name, fde->namelen);
 }
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -82,7 +82,7 @@ out:
 static rda_inode_ctx_t *
 __rda_inode_ctx_get(inode_t *inode, xlator_t *this)
 {
-    int ret = -1;
+    int ret;
     uint64_t ctx_uint = 0;
     rda_inode_ctx_t *ctx_p = NULL;
 
@@ -288,7 +288,7 @@ rda_inode_ctx_get_iatt(inode_t *inode, xlator_t *this, struct iatt *attr)
     }
     UNLOCK(&inode->lock);
 
-    if (ctx_p == NULL)
+    if (ctx_p == NULL) // if we did not find one, return a zero'ed iatt struct.
         memset(attr, 0, sizeof(struct iatt));
 }
 
@@ -304,22 +304,18 @@ __rda_fill_readdirp(xlator_t *this, gf_dirent_t *entries, size_t request_size,
     size_t dirent_size, size = 0;
     int32_t count = 0;
     struct rda_priv *priv = NULL;
-    struct iatt tmp_stat = {
-        0,
-    };
 
     priv = this->private;
 
     list_for_each_entry_safe(dirent, tmp, &ctx->entries.list, list)
     {
-        dirent_size = gf_dirent_size(dirent->d_name);
+        dirent_size = gf_dirent_len(dirent->d_len);
         if (size + dirent_size > request_size)
             break;
 
         if (dirent->inode && (!((strcmp(dirent->d_name, ".") == 0) ||
                                 (strcmp(dirent->d_name, "..") == 0)))) {
-            rda_inode_ctx_get_iatt(dirent->inode, this, &tmp_stat);
-            dirent->d_stat = tmp_stat;
+            rda_inode_ctx_get_iatt(dirent->inode, this, &dirent->d_stat);
         }
 
         size += dirent_size;

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -283,7 +283,7 @@ rda_inode_ctx_get_iatt(inode_t *inode, xlator_t *this, struct iatt *attr)
     {
         ctx_p = __rda_inode_ctx_get(inode, this);
         if (ctx_p) {
-            *attr = ctx_p->statbuf;
+            memcpy(attr, &ctx_p->statbuf, sizeof(struct iatt));
         }
     }
     UNLOCK(&inode->lock);

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -288,7 +288,7 @@ rda_inode_ctx_get_iatt(inode_t *inode, xlator_t *this, struct iatt *attr)
     }
     UNLOCK(&inode->lock);
 
-    if (ctx_p == NULL) // if we did not find one, return a zero'ed iatt struct.
+    if (ctx_p == NULL)  // if we did not find one, return a zero'ed iatt struct.
         memset(attr, 0, sizeof(struct iatt));
 }
 

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -141,7 +141,6 @@ unserialize_rsp_dirent_v2(xlator_t *this, struct gfx_readdir_rsp *rsp,
 {
     struct gfx_dirlist *trav = NULL;
     gf_dirent_t *entry = NULL;
-    int entry_len = 0;
     int ret = -1;
     clnt_conf_t *conf = NULL;
 
@@ -149,17 +148,12 @@ unserialize_rsp_dirent_v2(xlator_t *this, struct gfx_readdir_rsp *rsp,
 
     trav = rsp->reply;
     while (trav) {
-        entry_len = gf_dirent_size(trav->name);
-        entry = GF_CALLOC(1, entry_len, gf_common_mt_gf_dirent_t);
+        entry = gf_dirent_for_name2(trav->name, trav->d_len, trav->d_ino, 0,
+                                    trav->d_type);
         if (!entry)
             goto out;
 
-        entry->d_ino = trav->d_ino;
         gf_itransform(this, trav->d_off, &entry->d_off, conf->client_id);
-        entry->d_len = trav->d_len;
-        entry->d_type = trav->d_type;
-
-        strcpy(entry->d_name, trav->name);
 
         list_add_tail(&entry->list, &entries->list);
 
@@ -178,7 +172,6 @@ unserialize_rsp_direntp_v2(xlator_t *this, fd_t *fd,
     struct gfx_dirplist *trav = NULL;
     gf_dirent_t *entry = NULL;
     inode_table_t *itable = NULL;
-    int entry_len = 0;
     int ret = -1;
     clnt_conf_t *conf = NULL;
 
@@ -192,19 +185,14 @@ unserialize_rsp_direntp_v2(xlator_t *this, fd_t *fd,
         goto out;
 
     while (trav) {
-        entry_len = gf_dirent_size(trav->name);
-        entry = GF_CALLOC(1, entry_len, gf_common_mt_gf_dirent_t);
+        entry = gf_dirent_for_name2(trav->name, trav->d_len, trav->d_ino, 0,
+                                    trav->d_type);
         if (!entry)
             goto out;
 
-        entry->d_ino = trav->d_ino;
         gf_itransform(this, trav->d_off, &entry->d_off, conf->client_id);
-        entry->d_len = trav->d_len;
-        entry->d_type = trav->d_type;
 
         gfx_stat_to_iattx(&trav->stat, &entry->d_stat);
-
-        strcpy(entry->d_name, trav->name);
 
         xdr_to_dict(&trav->dict, &entry->dict);
 

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -97,8 +97,9 @@ posix_make_ancestral_node(const char *priv_base_path, char *path, int pathsize,
         0,
     };
     int ret = -1;
+    const size_t dir_name_len = strlen(dir_name);
 
-    len = strlen(path) + strlen(dir_name) + 1;
+    len = strlen(path) + dir_name_len + 1;
     if (len > pathsize) {
         goto out;
     }
@@ -108,7 +109,7 @@ posix_make_ancestral_node(const char *priv_base_path, char *path, int pathsize,
         strcat(path, "/");
 
     if (type & POSIX_ANCESTRY_DENTRY) {
-        entry = gf_dirent_for_name(dir_name);
+        entry = gf_dirent_for_name2(dir_name, dir_name_len, -1, 0, 0);
         if (!entry)
             goto out;
 


### PR DESCRIPTION
- Introduced gf_dirent_for_name2(), which populates most of the fields
with real content and replaced gf_dirent_for_name() in several cases.
- Reduced the no. of calls for strlen() across the code, re-used existing
length fields where applicable.
- Removed dead code

Updates: #3005
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

