### PR TITLE
client-*: adjust removal of 'this' from client functions

### DIFF
--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -43,8 +43,8 @@ client_cmd_to_gf_cmd(int32_t cmd, int32_t *gf_cmd)
 /* New PRE and POST functions */
 
 int
-client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
-                        struct iatt *iatt, dict_t **xdata)
+client_post_common_iatt(gfx_common_iatt_rsp *rsp, struct iatt *iatt,
+                        dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->stat, iatt);
@@ -54,8 +54,8 @@ client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
 }
 
 int
-client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2, dict_t **xdata)
+client_post_common_2iatt(gfx_common_2iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->prestat, iatt);
@@ -66,9 +66,8 @@ client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
 }
 
 int
-client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2,
-                         struct iatt *iatt3, dict_t **xdata)
+client_post_common_3iatt(gfx_common_3iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, struct iatt *iatt3, dict_t **xdata)
 {
     if (-1 != rsp->op_ret) {
         gfx_stat_to_iattx(&rsp->stat, iatt);
@@ -80,13 +79,12 @@ client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
 }
 
 int
-client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
-                        dict_t **xdata)
+client_post_common_dict(gfx_common_dict_rsp *rsp, dict_t **dict, dict_t **xdata)
 {
     int ret = 0;
     ret = xdr_to_dict(&rsp->dict, dict);
     if (ret)
-        gf_msg_debug(this->name, EINVAL,
+        gf_msg_debug(THIS->name, EINVAL,
                      "while decoding found empty dictionary");
     xdr_to_dict(&rsp->xdata, xdata);
 
@@ -94,7 +92,7 @@ client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
 }
 
 int
-client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
+client_post_readv_v2(gfx_read_rsp *rsp, struct iobref **iobref,
                      struct iobref *rsp_iobref, struct iatt *stat,
                      struct iovec *vector, struct iovec *rsp_vector,
                      int *rspcount, dict_t **xdata)
@@ -120,7 +118,7 @@ client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
 }
 
 int
-client_pre_stat_v2(xlator_t *this, gfx_stat_req *req, loc_t *loc, dict_t *xdata)
+client_pre_stat_v2(gfx_stat_req *req, loc_t *loc, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -143,8 +141,8 @@ out:
 }
 
 int
-client_pre_readlink_v2(xlator_t *this, gfx_readlink_req *req, loc_t *loc,
-                       size_t size, dict_t *xdata)
+client_pre_readlink_v2(gfx_readlink_req *req, loc_t *loc, size_t size,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -166,8 +164,8 @@ out:
 }
 
 int
-client_pre_mknod_v2(xlator_t *this, gfx_mknod_req *req, loc_t *loc, mode_t mode,
-                    dev_t rdev, mode_t umask, dict_t *xdata)
+client_pre_mknod_v2(gfx_mknod_req *req, loc_t *loc, mode_t mode, dev_t rdev,
+                    mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -194,8 +192,8 @@ out:
 }
 
 int
-client_pre_mkdir_v2(xlator_t *this, gfx_mkdir_req *req, loc_t *loc, mode_t mode,
-                    mode_t umask, dict_t *xdata)
+client_pre_mkdir_v2(gfx_mkdir_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                    dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -222,8 +220,8 @@ out:
 }
 
 int
-client_pre_unlink_v2(xlator_t *this, gfx_unlink_req *req, loc_t *loc,
-                     int32_t flags, dict_t *xdata)
+client_pre_unlink_v2(gfx_unlink_req *req, loc_t *loc, int32_t flags,
+                     dict_t *xdata)
 {
     int op_errno = 0;
 
@@ -248,8 +246,8 @@ out:
 }
 
 int
-client_pre_rmdir_v2(xlator_t *this, gfx_rmdir_req *req, loc_t *loc,
-                    int32_t flags, dict_t *xdata)
+client_pre_rmdir_v2(gfx_rmdir_req *req, loc_t *loc, int32_t flags,
+                    dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -274,8 +272,8 @@ out:
 }
 
 int
-client_pre_symlink_v2(xlator_t *this, gfx_symlink_req *req, loc_t *loc,
-                      const char *linkname, mode_t umask, dict_t *xdata)
+client_pre_symlink_v2(gfx_symlink_req *req, loc_t *loc, const char *linkname,
+                      mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -300,8 +298,8 @@ out:
 }
 
 int
-client_pre_rename_v2(xlator_t *this, gfx_rename_req *req, loc_t *oldloc,
-                     loc_t *newloc, dict_t *xdata)
+client_pre_rename_v2(gfx_rename_req *req, loc_t *oldloc, loc_t *newloc,
+                     dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -333,8 +331,8 @@ out:
 }
 
 int
-client_pre_link_v2(xlator_t *this, gfx_link_req *req, loc_t *oldloc,
-                   loc_t *newloc, dict_t *xdata)
+client_pre_link_v2(gfx_link_req *req, loc_t *oldloc, loc_t *newloc,
+                   dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -365,8 +363,8 @@ out:
 }
 
 int
-client_pre_truncate_v2(xlator_t *this, gfx_truncate_req *req, loc_t *loc,
-                       off_t offset, dict_t *xdata)
+client_pre_truncate_v2(gfx_truncate_req *req, loc_t *loc, off_t offset,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -389,8 +387,8 @@ out:
 }
 
 int
-client_pre_open_v2(xlator_t *this, gfx_open_req *req, loc_t *loc, fd_t *fd,
-                   int32_t flags, dict_t *xdata)
+client_pre_open_v2(gfx_open_req *req, loc_t *loc, fd_t *fd, int32_t flags,
+                   dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -502,8 +500,7 @@ out:
 }
 
 int
-client_pre_statfs_v2(xlator_t *this, gfx_statfs_req *req, loc_t *loc,
-                     dict_t *xdata)
+client_pre_statfs_v2(gfx_statfs_req *req, loc_t *loc, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -570,8 +567,8 @@ out:
 }
 
 int
-client_pre_setxattr_v2(xlator_t *this, gfx_setxattr_req *req, loc_t *loc,
-                       dict_t *xattr, int32_t flags, dict_t *xdata)
+client_pre_setxattr_v2(gfx_setxattr_req *req, loc_t *loc, dict_t *xattr,
+                       int32_t flags, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -599,8 +596,8 @@ out:
 }
 
 int
-client_pre_getxattr_v2(xlator_t *this, gfx_getxattr_req *req, loc_t *loc,
-                       const char *name, dict_t *xdata)
+client_pre_getxattr_v2(gfx_getxattr_req *req, loc_t *loc, const char *name,
+                       dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -632,7 +629,7 @@ out:
 }
 
 int
-client_pre_removexattr_v2(xlator_t *this, gfx_removexattr_req *req, loc_t *loc,
+client_pre_removexattr_v2(gfx_removexattr_req *req, loc_t *loc,
                           const char *name, dict_t *xdata)
 {
     int op_errno = ESTALE;
@@ -657,8 +654,7 @@ out:
 }
 
 int
-client_pre_opendir_v2(xlator_t *this, gfx_opendir_req *req, loc_t *loc,
-                      fd_t *fd, dict_t *xdata)
+client_pre_opendir_v2(gfx_opendir_req *req, loc_t *loc, fd_t *fd, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -702,8 +698,8 @@ out:
 }
 
 int
-client_pre_access_v2(xlator_t *this, gfx_access_req *req, loc_t *loc,
-                     int32_t mask, dict_t *xdata)
+client_pre_access_v2(gfx_access_req *req, loc_t *loc, int32_t mask,
+                     dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -726,8 +722,8 @@ out:
 }
 
 int
-client_pre_create_v2(xlator_t *this, gfx_create_req *req, loc_t *loc, fd_t *fd,
-                     mode_t mode, int32_t flags, mode_t umask, dict_t *xdata)
+client_pre_create_v2(gfx_create_req *req, loc_t *loc, fd_t *fd, mode_t mode,
+                     int32_t flags, mode_t umask, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -894,7 +890,7 @@ out:
 }
 
 int
-client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
+client_pre_inodelk_v2(gfx_inodelk_req *req, loc_t *loc, int cmd,
                       struct gf_flock *flock, const char *volume, dict_t *xdata)
 {
     int op_errno = ESTALE;
@@ -918,7 +914,7 @@ client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
     else if (cmd == F_SETLKW || cmd == F_SETLKW64)
         gf_cmd = GF_LK_SETLKW;
     else {
-        gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,
+        gf_smsg(THIS->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,
                 "gf_cmd=%d", gf_cmd, NULL);
         op_errno = EINVAL;
         goto out;
@@ -999,9 +995,9 @@ out:
 }
 
 int
-client_pre_entrylk_v2(xlator_t *this, gfx_entrylk_req *req, loc_t *loc,
-                      entrylk_cmd cmd_entrylk, entrylk_type type,
-                      const char *volume, const char *basename, dict_t *xdata)
+client_pre_entrylk_v2(gfx_entrylk_req *req, loc_t *loc, entrylk_cmd cmd_entrylk,
+                      entrylk_type type, const char *volume,
+                      const char *basename, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -1061,8 +1057,8 @@ out:
 }
 
 int
-client_pre_xattrop_v2(xlator_t *this, gfx_xattrop_req *req, loc_t *loc,
-                      dict_t *xattr, int32_t flags, dict_t *xdata)
+client_pre_xattrop_v2(gfx_xattrop_req *req, loc_t *loc, dict_t *xattr,
+                      int32_t flags, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -1183,8 +1179,8 @@ out:
 }
 
 int
-client_pre_setattr_v2(xlator_t *this, gfx_setattr_req *req, loc_t *loc,
-                      int32_t valid, struct iatt *stbuf, dict_t *xdata)
+client_pre_setattr_v2(gfx_setattr_req *req, loc_t *loc, int32_t valid,
+                      struct iatt *stbuf, dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -1342,7 +1338,7 @@ out:
 }
 
 int
-client_pre_ipc_v2(xlator_t *this, gfx_ipc_req *req, int32_t cmd, dict_t *xdata)
+client_pre_ipc_v2(gfx_ipc_req *req, int32_t cmd, dict_t *xdata)
 {
     req->op = cmd;
 
@@ -1373,8 +1369,8 @@ out:
 }
 
 int
-client_pre_lease_v2(xlator_t *this, gfx_lease_req *req, loc_t *loc,
-                    struct gf_lease *lease, dict_t *xdata)
+client_pre_lease_v2(gfx_lease_req *req, loc_t *loc, struct gf_lease *lease,
+                    dict_t *xdata)
 {
     int op_errno = 0;
 
@@ -1397,9 +1393,9 @@ out:
 }
 
 int
-client_pre_put_v2(xlator_t *this, gfx_put_req *req, loc_t *loc, mode_t mode,
-                  mode_t umask, int32_t flags, size_t size, off_t offset,
-                  dict_t *xattr, dict_t *xdata)
+client_pre_put_v2(gfx_put_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                  int32_t flags, size_t size, off_t offset, dict_t *xattr,
+                  dict_t *xdata)
 {
     int op_errno = ESTALE;
 
@@ -1431,7 +1427,7 @@ out:
 }
 
 int
-client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
+client_post_create_v2(gfx_create_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preparent, struct iatt *postparent,
                       clnt_local_t *local, dict_t **xdata)
 {
@@ -1446,8 +1442,7 @@ client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
 }
 
 int
-client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
-                     dict_t **xdata)
+client_post_lease_v2(gfx_lease_rsp *rsp, struct gf_lease *lease, dict_t **xdata)
 {
     if (rsp->op_ret >= 0) {
         gf_proto_lease_to_lease(&rsp->lease, lease);
@@ -1457,8 +1452,7 @@ client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
 }
 
 int
-client_post_lk_v2(xlator_t *this, gfx_lk_rsp *rsp, struct gf_flock *lock,
-                  dict_t **xdata)
+client_post_lk_v2(gfx_lk_rsp *rsp, struct gf_flock *lock, dict_t **xdata)
 {
     if (rsp->op_ret >= 0) {
         gf_proto_flock_to_flock(&rsp->flock, lock);
@@ -1487,7 +1481,7 @@ client_post_readdirp_v2(xlator_t *this, gfx_readdirp_rsp *rsp, fd_t *fd,
 }
 
 int
-client_post_rename_v2(xlator_t *this, gfx_rename_rsp *rsp, struct iatt *stbuf,
+client_post_rename_v2(gfx_rename_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t **xdata)

--- a/xlators/protocol/client/src/client-common.h
+++ b/xlators/protocol/client/src/client-common.h
@@ -21,64 +21,63 @@
 
 /* New functions for version 4 */
 int
-client_post_common_dict(xlator_t *this, gfx_common_dict_rsp *rsp, dict_t **dict,
+client_post_common_dict(gfx_common_dict_rsp *rsp, dict_t **dict,
                         dict_t **xdata);
 int
-client_post_common_3iatt(xlator_t *this, gfx_common_3iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2,
-                         struct iatt *iatt3, dict_t **xdata);
+client_post_common_3iatt(gfx_common_3iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, struct iatt *iatt3,
+                         dict_t **xdata);
 int
-client_post_common_2iatt(xlator_t *this, gfx_common_2iatt_rsp *rsp,
-                         struct iatt *iatt, struct iatt *iatt2, dict_t **xdata);
+client_post_common_2iatt(gfx_common_2iatt_rsp *rsp, struct iatt *iatt,
+                         struct iatt *iatt2, dict_t **xdata);
 int
-client_post_common_iatt(xlator_t *this, gfx_common_iatt_rsp *rsp,
-                        struct iatt *iatt, dict_t **xdata);
+client_post_common_iatt(gfx_common_iatt_rsp *rsp, struct iatt *iatt,
+                        dict_t **xdata);
 int
 client_post_common_rsp(xlator_t *this, gfx_common_rsp *rsp, dict_t **xdata);
 
 int
-client_pre_stat_v2(xlator_t *this, gfx_stat_req *req, loc_t *loc,
-                   dict_t *xdata);
+client_pre_stat_v2(gfx_stat_req *req, loc_t *loc, dict_t *xdata);
 
 int
-client_pre_readlink_v2(xlator_t *this, gfx_readlink_req *req, loc_t *loc,
-                       size_t size, dict_t *xdata);
+client_pre_readlink_v2(gfx_readlink_req *req, loc_t *loc, size_t size,
+                       dict_t *xdata);
 
 int
-client_pre_mknod_v2(xlator_t *this, gfx_mknod_req *req, loc_t *loc, mode_t mode,
-                    dev_t rdev, mode_t umask, dict_t *xdata);
-
-int
-client_pre_mkdir_v2(xlator_t *this, gfx_mkdir_req *req, loc_t *loc, mode_t mode,
+client_pre_mknod_v2(gfx_mknod_req *req, loc_t *loc, mode_t mode, dev_t rdev,
                     mode_t umask, dict_t *xdata);
 
 int
-client_pre_unlink_v2(xlator_t *this, gfx_unlink_req *req, loc_t *loc,
-                     int32_t flags, dict_t *xdata);
+client_pre_mkdir_v2(gfx_mkdir_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                    dict_t *xdata);
 
 int
-client_pre_rmdir_v2(xlator_t *this, gfx_rmdir_req *req, loc_t *loc,
-                    int32_t flags, dict_t *xdata);
+client_pre_unlink_v2(gfx_unlink_req *req, loc_t *loc, int32_t flags,
+                     dict_t *xdata);
 
 int
-client_pre_symlink_v2(xlator_t *this, gfx_symlink_req *req, loc_t *loc,
-                      const char *linkname, mode_t umask, dict_t *xdata);
+client_pre_rmdir_v2(gfx_rmdir_req *req, loc_t *loc, int32_t flags,
+                    dict_t *xdata);
 
 int
-client_pre_rename_v2(xlator_t *this, gfx_rename_req *req, loc_t *oldloc,
-                     loc_t *newloc, dict_t *xdata);
+client_pre_symlink_v2(gfx_symlink_req *req, loc_t *loc, const char *linkname,
+                      mode_t umask, dict_t *xdata);
 
 int
-client_pre_link_v2(xlator_t *this, gfx_link_req *req, loc_t *oldloc,
-                   loc_t *newloc, dict_t *xdata);
+client_pre_rename_v2(gfx_rename_req *req, loc_t *oldloc, loc_t *newloc,
+                     dict_t *xdata);
 
 int
-client_pre_truncate_v2(xlator_t *this, gfx_truncate_req *req, loc_t *loc,
-                       off_t offset, dict_t *xdata);
+client_pre_link_v2(gfx_link_req *req, loc_t *oldloc, loc_t *newloc,
+                   dict_t *xdata);
 
 int
-client_pre_open_v2(xlator_t *this, gfx_open_req *req, loc_t *loc, fd_t *fd,
-                   int32_t flags, dict_t *xdata);
+client_pre_truncate_v2(gfx_truncate_req *req, loc_t *loc, off_t offset,
+                       dict_t *xdata);
+
+int
+client_pre_open_v2(gfx_open_req *req, loc_t *loc, fd_t *fd, int32_t flags,
+                   dict_t *xdata);
 
 int
 client_pre_readv_v2(xlator_t *this, gfx_read_req *req, fd_t *fd, size_t size,
@@ -89,8 +88,7 @@ client_pre_writev_v2(xlator_t *this, gfx_write_req *req, fd_t *fd, size_t size,
                      off_t offset, int32_t flags, dict_t **xdata);
 
 int
-client_pre_statfs_v2(xlator_t *this, gfx_statfs_req *req, loc_t *loc,
-                     dict_t *xdata);
+client_pre_statfs_v2(gfx_statfs_req *req, loc_t *loc, dict_t *xdata);
 
 int
 client_pre_flush_v2(xlator_t *this, gfx_flush_req *req, fd_t *fd,
@@ -101,32 +99,32 @@ client_pre_fsync_v2(xlator_t *this, gfx_fsync_req *req, fd_t *fd, int32_t flags,
                     dict_t *xdata);
 
 int
-client_pre_setxattr_v2(xlator_t *this, gfx_setxattr_req *req, loc_t *loc,
-                       dict_t *xattr, int32_t flags, dict_t *xdata);
+client_pre_setxattr_v2(gfx_setxattr_req *req, loc_t *loc, dict_t *xattr,
+                       int32_t flags, dict_t *xdata);
 
 int
-client_pre_getxattr_v2(xlator_t *this, gfx_getxattr_req *req, loc_t *loc,
-                       const char *name, dict_t *xdata);
+client_pre_getxattr_v2(gfx_getxattr_req *req, loc_t *loc, const char *name,
+                       dict_t *xdata);
 
 int
-client_pre_removexattr_v2(xlator_t *this, gfx_removexattr_req *req, loc_t *loc,
+client_pre_removexattr_v2(gfx_removexattr_req *req, loc_t *loc,
                           const char *name, dict_t *xdata);
 
 int
-client_pre_opendir_v2(xlator_t *this, gfx_opendir_req *req, loc_t *loc,
-                      fd_t *fd, dict_t *xdata);
+client_pre_opendir_v2(gfx_opendir_req *req, loc_t *loc, fd_t *fd,
+                      dict_t *xdata);
 
 int
 client_pre_fsyncdir_v2(xlator_t *this, gfx_fsyncdir_req *req, fd_t *fd,
                        int32_t flags, dict_t *xdata);
 
 int
-client_pre_access_v2(xlator_t *this, gfx_access_req *req, loc_t *loc,
-                     int32_t mask, dict_t *xdata);
+client_pre_access_v2(gfx_access_req *req, loc_t *loc, int32_t mask,
+                     dict_t *xdata);
 
 int
-client_pre_create_v2(xlator_t *this, gfx_create_req *req, loc_t *loc, fd_t *fd,
-                     mode_t mode, int32_t flags, mode_t umask, dict_t *xdata);
+client_pre_create_v2(gfx_create_req *req, loc_t *loc, fd_t *fd, mode_t mode,
+                     int32_t flags, mode_t umask, dict_t *xdata);
 
 int
 client_pre_ftruncate_v2(xlator_t *this, gfx_ftruncate_req *req, fd_t *fd,
@@ -149,7 +147,7 @@ client_pre_readdir_v2(xlator_t *this, gfx_readdir_req *req, fd_t *fd,
                       size_t size, off_t offset, dict_t *xdata);
 
 int
-client_pre_inodelk_v2(xlator_t *this, gfx_inodelk_req *req, loc_t *loc, int cmd,
+client_pre_inodelk_v2(gfx_inodelk_req *req, loc_t *loc, int cmd,
                       struct gf_flock *flock, const char *volume,
                       dict_t *xdata);
 
@@ -159,9 +157,9 @@ client_pre_finodelk_v2(xlator_t *this, gfx_finodelk_req *req, fd_t *fd, int cmd,
                        dict_t *xdata);
 
 int
-client_pre_entrylk_v2(xlator_t *this, gfx_entrylk_req *req, loc_t *loc,
-                      entrylk_cmd cmd_entrylk, entrylk_type type,
-                      const char *volume, const char *basename, dict_t *xdata);
+client_pre_entrylk_v2(gfx_entrylk_req *req, loc_t *loc, entrylk_cmd cmd_entrylk,
+                      entrylk_type type, const char *volume,
+                      const char *basename, dict_t *xdata);
 
 int
 client_pre_fentrylk_v2(xlator_t *this, gfx_fentrylk_req *req, fd_t *fd,
@@ -169,8 +167,8 @@ client_pre_fentrylk_v2(xlator_t *this, gfx_fentrylk_req *req, fd_t *fd,
                        const char *volume, const char *basename, dict_t *xdata);
 
 int
-client_pre_xattrop_v2(xlator_t *this, gfx_xattrop_req *req, loc_t *loc,
-                      dict_t *xattr, int32_t flags, dict_t *xdata);
+client_pre_xattrop_v2(gfx_xattrop_req *req, loc_t *loc, dict_t *xattr,
+                      int32_t flags, dict_t *xdata);
 
 int
 client_pre_fxattrop_v2(xlator_t *this, gfx_fxattrop_req *req, fd_t *fd,
@@ -192,8 +190,8 @@ client_pre_rchecksum_v2(xlator_t *this, gfx_rchecksum_req *req, fd_t *fd,
                         int32_t len, off_t offset, dict_t *xdata);
 
 int
-client_pre_setattr_v2(xlator_t *this, gfx_setattr_req *req, loc_t *loc,
-                      int32_t valid, struct iatt *stbuf, dict_t *xdata);
+client_pre_setattr_v2(gfx_setattr_req *req, loc_t *loc, int32_t valid,
+                      struct iatt *stbuf, dict_t *xdata);
 int
 client_pre_fsetattr_v2(xlator_t *this, gfx_fsetattr_req *req, fd_t *fd,
                        int32_t valid, struct iatt *stbuf, dict_t *xdata);
@@ -217,33 +215,32 @@ int
 client_pre_zerofill_v2(xlator_t *this, gfx_zerofill_req *req, fd_t *fd,
                        off_t offset, size_t size, dict_t *xdata);
 int
-client_pre_ipc_v2(xlator_t *this, gfx_ipc_req *req, int32_t cmd, dict_t *xdata);
+client_pre_ipc_v2(gfx_ipc_req *req, int32_t cmd, dict_t *xdata);
 
 int
-client_pre_lease_v2(xlator_t *this, gfx_lease_req *req, loc_t *loc,
-                    struct gf_lease *lease, dict_t *xdata);
+client_pre_lease_v2(gfx_lease_req *req, loc_t *loc, struct gf_lease *lease,
+                    dict_t *xdata);
 
 int
-client_pre_put_v2(xlator_t *this, gfx_put_req *req, loc_t *loc, mode_t mode,
-                  mode_t umask, int32_t flags, size_t size, off_t offset,
-                  dict_t *xattr, dict_t *xdata);
+client_pre_put_v2(gfx_put_req *req, loc_t *loc, mode_t mode, mode_t umask,
+                  int32_t flags, size_t size, off_t offset, dict_t *xattr,
+                  dict_t *xdata);
 
 int
-client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
+client_post_readv_v2(gfx_read_rsp *rsp, struct iobref **iobref,
                      struct iobref *rsp_iobref, struct iatt *stat,
                      struct iovec *vector, struct iovec *rsp_vector,
                      int *rspcount, dict_t **xdata);
 
 int
-client_post_create_v2(xlator_t *this, gfx_create_rsp *rsp, struct iatt *stbuf,
+client_post_create_v2(gfx_create_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preparent, struct iatt *postparent,
                       clnt_local_t *local, dict_t **xdata);
 int
-client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
+client_post_lease_v2(gfx_lease_rsp *rsp, struct gf_lease *lease,
                      dict_t **xdata);
 int
-client_post_lk_v2(xlator_t *this, gfx_lk_rsp *rsp, struct gf_flock *lock,
-                  dict_t **xdata);
+client_post_lk_v2(gfx_lk_rsp *rsp, struct gf_flock *lock, dict_t **xdata);
 int
 client_post_readdir_v2(xlator_t *this, gfx_readdir_rsp *rsp,
                        gf_dirent_t *entries, dict_t **xdata);
@@ -251,7 +248,7 @@ int
 client_post_readdirp_v2(xlator_t *this, gfx_readdirp_rsp *rsp, fd_t *fd,
                         gf_dirent_t *entries, dict_t **xdata);
 int
-client_post_rename_v2(xlator_t *this, gfx_rename_rsp *rsp, struct iatt *stbuf,
+client_post_rename_v2(gfx_rename_rsp *rsp, struct iatt *stbuf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t **xdata);

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -374,26 +374,20 @@ clnt_getactivelk_rsp_cleanup_v2(gfx_getactivelk_rsp *rsp)
     }
 }
 int
-clnt_unserialize_rsp_locklist_v2(xlator_t *this,
-                                 struct gfx_getactivelk_rsp *rsp,
+clnt_unserialize_rsp_locklist_v2(struct gfx_getactivelk_rsp *rsp,
                                  lock_migration_info_t *lmi)
 {
     struct gfs3_locklist *trav = NULL;
     lock_migration_info_t *temp = NULL;
     int ret = -1;
-    clnt_conf_t *conf = NULL;
 
     trav = rsp->reply;
-
-    conf = this->private;
-    if (!conf)
-        goto out;
 
     while (trav) {
         /* TODO: move to GF_MALLOC() */
         temp = GF_CALLOC(1, sizeof(*lmi), gf_common_mt_lock_mig);
         if (temp == NULL) {
-            gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_NO_MEM, NULL);
+            gf_smsg(THIS->name, GF_LOG_ERROR, 0, PC_MSG_NO_MEM, NULL);
             goto out;
         }
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -145,7 +145,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -215,7 +215,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -281,7 +281,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 
 out:
@@ -400,7 +400,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_iatt(this, &rsp, &iatt, &xdata);
+    ret = client_post_common_iatt(&rsp, &iatt, &xdata);
 out:
     if (rsp.op_ret == -1) {
         /* stale filehandles are possible during normal operations, no
@@ -519,7 +519,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &preparent, &postparent, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -578,7 +578,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &preparent, &postparent, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -633,7 +633,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -740,7 +740,7 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 out:
@@ -844,7 +844,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 
@@ -950,7 +950,7 @@ client4_0_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = gf_error_to_errno(rsp.op_errno);
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -1023,7 +1023,7 @@ client4_0_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = gf_error_to_errno(rsp.op_errno);
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -1288,7 +1288,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1338,7 +1338,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_iatt(this, &rsp, &stat, &xdata);
+    ret = client_post_common_iatt(&rsp, &stat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1579,7 +1579,7 @@ client4_0_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     op_errno = rsp.op_errno;
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         op_errno = -ret;
         goto out;
@@ -1645,7 +1645,7 @@ client4_0_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
     op_errno = rsp.op_errno;
-    ret = client_post_common_dict(this, &rsp, &dict, &xdata);
+    ret = client_post_common_dict(&rsp, &dict, &xdata);
     if (ret) {
         rsp.op_ret = -1;
         op_errno = -ret;
@@ -1766,7 +1766,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 
@@ -1821,7 +1821,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -1873,7 +1873,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 out:
     if (rsp.op_ret == -1) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
@@ -2016,7 +2016,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2070,7 +2070,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
+    ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2133,8 +2133,8 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_create_v2(this, &rsp, &stbuf, &preparent, &postparent,
-                                local, &xdata);
+    ret = client_post_create_v2(&rsp, &stbuf, &preparent, &postparent, local,
+                                &xdata);
     if (ret < 0)
         goto out;
 
@@ -2200,7 +2200,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_lease_v2(this, &rsp, &lease, &xdata);
+    ret = client_post_lease_v2(&rsp, &lease, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
@@ -2254,7 +2254,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (rsp.op_ret >= 0) {
-        ret = client_post_lk_v2(this, &rsp, &lock, &xdata);
+        ret = client_post_lk_v2(&rsp, &lock, &xdata);
         if (ret < 0)
             goto out;
     }
@@ -2444,7 +2444,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    client_post_rename_v2(this, &rsp, &stbuf, &preoldparent, &postoldparent,
+    client_post_rename_v2(&rsp, &stbuf, &preoldparent, &postoldparent,
                           &prenewparent, &postnewparent, &xdata);
 out:
     if (rsp.op_ret == -1) {
@@ -2506,7 +2506,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
+    ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 out:
     if (rsp.op_ret == -1) {
@@ -2638,7 +2638,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     /* Preserve the op_errno received from the server */
     op_errno = gf_error_to_errno(rsp.op_errno);
 
-    ret = client_post_common_2iatt(this, &rsp, &stbuf, &postparent, &xdata);
+    ret = client_post_common_2iatt(&rsp, &stbuf, &postparent, &xdata);
     if (ret < 0) {
         /* Don't change the op_errno if the fop failed on server */
         if (rsp.op_ret == 0)
@@ -2732,8 +2732,8 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     memset(vector, 0, sizeof(vector));
 
-    ret = client_post_readv_v2(this, &rsp, &iobref, req->rsp_iobref, &stat,
-                               vector, &req->rsp[1], &rspcount, &xdata);
+    ret = client_post_readv_v2(&rsp, &iobref, req->rsp_iobref, &stat, vector,
+                               &req->rsp[1], &rspcount, &xdata);
 out:
     if (rsp.op_ret == -1) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
@@ -2918,8 +2918,7 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = client_post_common_3iatt(this, &rsp, &stbuf, &prestat, &poststat,
-                                   &xdata);
+    ret = client_post_common_3iatt(&rsp, &stbuf, &prestat, &poststat, &xdata);
     if (ret < 0)
         goto out;
 out:
@@ -3150,7 +3149,7 @@ client4_0_stat(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_stat_v2(this, &req, args->loc, args->xdata);
+    ret = client_pre_stat_v2(&req, args->loc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3192,8 +3191,7 @@ client4_0_truncate(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_truncate_v2(this, &req, args->loc, args->offset,
-                                 args->xdata);
+    ret = client_pre_truncate_v2(&req, args->loc, args->offset, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3278,7 +3276,7 @@ client4_0_access(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_access_v2(this, &req, args->loc, args->mask, args->xdata);
+    ret = client_pre_access_v2(&req, args->loc, args->mask, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3329,8 +3327,7 @@ client4_0_readlink(call_frame_t *frame, xlator_t *this, void *data)
 
     frame->local = local;
 
-    ret = client_pre_readlink_v2(this, &req, args->loc, args->size,
-                                 args->xdata);
+    ret = client_pre_readlink_v2(&req, args->loc, args->size, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3373,7 +3370,7 @@ client4_0_unlink(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_unlink_v2(this, &req, args->loc, args->flags, args->xdata);
+    ret = client_pre_unlink_v2(&req, args->loc, args->flags, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3414,7 +3411,7 @@ client4_0_rmdir(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_rmdir_v2(this, &req, args->loc, args->flags, args->xdata);
+    ret = client_pre_rmdir_v2(&req, args->loc, args->flags, args->xdata);
 
     if (ret) {
         op_errno = -ret;
@@ -3472,8 +3469,8 @@ client4_0_symlink(call_frame_t *frame, xlator_t *this, void *data)
 
     local->loc2.path = gf_strdup(args->linkname);
 
-    ret = client_pre_symlink_v2(this, &req, args->loc, args->linkname,
-                                args->umask, args->xdata);
+    ret = client_pre_symlink_v2(&req, args->loc, args->linkname, args->umask,
+                                args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3517,8 +3514,7 @@ client4_0_rename(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_rename_v2(this, &req, args->oldloc, args->newloc,
-                               args->xdata);
+    ret = client_pre_rename_v2(&req, args->oldloc, args->newloc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3570,8 +3566,7 @@ client4_0_link(call_frame_t *frame, xlator_t *this, void *data)
 
     frame->local = local;
 
-    ret = client_pre_link_v2(this, &req, args->oldloc, args->newloc,
-                             args->xdata);
+    ret = client_pre_link_v2(&req, args->oldloc, args->newloc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -3630,7 +3625,7 @@ client4_0_mknod(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_mknod_v2(this, &req, args->loc, args->mode, args->rdev,
+    ret = client_pre_mknod_v2(&req, args->loc, args->mode, args->rdev,
                               args->umask, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3696,7 +3691,7 @@ client4_0_mkdir(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_mkdir_v2(this, &req, args->loc, args->mode, args->umask,
+    ret = client_pre_mkdir_v2(&req, args->loc, args->mode, args->umask,
                               args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3753,7 +3748,7 @@ client4_0_create(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_create_v2(this, &req, args->loc, args->fd, args->mode,
+    ret = client_pre_create_v2(&req, args->loc, args->fd, args->mode,
                                args->flags, args->umask, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -3812,7 +3807,7 @@ client4_0_open(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_open_v2(this, &req, args->loc, args->fd, args->flags,
+    ret = client_pre_open_v2(&req, args->loc, args->fd, args->flags,
                              args->xdata);
 
     if (ret) {
@@ -4162,7 +4157,7 @@ client4_0_opendir(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_opendir_v2(this, &req, args->loc, args->fd, args->xdata);
+    ret = client_pre_opendir_v2(&req, args->loc, args->fd, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4249,7 +4244,7 @@ client4_0_statfs(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_statfs_v2(this, &req, args->loc, args->xdata);
+    ret = client_pre_statfs_v2(&req, args->loc, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4291,8 +4286,8 @@ client4_0_setxattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_setxattr_v2(this, &req, args->loc, args->xattr,
-                                 args->flags, args->xdata);
+    ret = client_pre_setxattr_v2(&req, args->loc, args->xattr, args->flags,
+                                 args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4449,7 +4444,7 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_getxattr_v2(this, &req, args->loc, args->name,
+    ret = client_pre_getxattr_v2(&req, args->loc, args->name,
                                  args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4506,7 +4501,7 @@ client4_0_xattrop(call_frame_t *frame, xlator_t *this, void *data)
     loc_path(&local->loc, NULL);
     conf = this->private;
 
-    ret = client_pre_xattrop_v2(this, &req, args->loc, args->xattr, args->flags,
+    ret = client_pre_xattrop_v2(&req, args->loc, args->xattr, args->flags,
                                 args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4602,8 +4597,7 @@ client4_0_removexattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_removexattr_v2(this, &req, args->loc, args->name,
-                                    args->xdata);
+    ret = client_pre_removexattr_v2(&req, args->loc, args->name, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -4688,7 +4682,7 @@ client4_0_lease(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_lease_v2(this, &req, args->loc, args->lease, args->xdata);
+    ret = client_pre_lease_v2(&req, args->loc, args->lease, args->xdata);
     if (ret < 0) {
         op_errno = -ret;
         goto unwind;
@@ -4812,7 +4806,7 @@ client4_0_inodelk(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_inodelk_v2(this, &req, args->loc, args->cmd, args->flock,
+    ret = client_pre_inodelk_v2(&req, args->loc, args->cmd, args->flock,
                                 args->volume, args->xdata);
     if (ret) {
         op_errno = -ret;
@@ -4903,9 +4897,8 @@ client4_0_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     conf = this->private;
 
-    ret = client_pre_entrylk_v2(this, &req, args->loc, args->cmd_entrylk,
-                                args->type, args->volume, args->basename,
-                                args->xdata);
+    ret = client_pre_entrylk_v2(&req, args->loc, args->cmd_entrylk, args->type,
+                                args->volume, args->basename, args->xdata);
     if (ret) {
         op_errno = -ret;
         goto unwind;
@@ -5199,7 +5192,7 @@ client4_0_setattr(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_setattr_v2(this, &req, args->loc, args->valid, args->stbuf,
+    ret = client_pre_setattr_v2(&req, args->loc, args->valid, args->stbuf,
                                 args->xdata);
 
     if (ret) {
@@ -5366,7 +5359,7 @@ client4_0_ipc(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    ret = client_pre_ipc_v2(this, &req, args->cmd, args->xdata);
+    ret = client_pre_ipc_v2(&req, args->cmd, args->xdata);
 
     if (ret) {
         op_errno = -ret;
@@ -5734,8 +5727,8 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (-1 != rsp.op_ret) {
-        ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent,
-                                       &postparent, &xdata);
+        ret = client_post_common_3iatt(&rsp, &stbuf, &preparent, &postparent,
+                                       &xdata);
         if (ret < 0)
             goto out;
     }
@@ -5883,7 +5876,7 @@ client4_0_put(call_frame_t *frame, xlator_t *this, void *data)
     loc_copy(&local->loc, args->loc);
     loc_path(&local->loc, NULL);
 
-    ret = client_pre_put_v2(this, &req, args->loc, args->mode, args->umask,
+    ret = client_pre_put_v2(&req, args->loc, args->mode, args->umask,
                             args->flags, args->size, args->offset, args->xattr,
                             args->xdata);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -121,10 +121,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -138,7 +135,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -154,7 +151,7 @@ out:
             /* no need to print the gfid, because it will be null,
              * since symlink operation failed.
              */
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "source=%s", local->loc.path,
                     "target=%s", local->loc2.path, NULL);
         }
@@ -190,10 +187,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -208,7 +202,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -221,7 +215,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1 &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_MKNOD, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, NULL);
@@ -257,10 +251,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -274,7 +265,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -287,7 +278,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1 &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_MKDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, NULL);
@@ -314,10 +305,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_open_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -331,7 +319,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -351,7 +339,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_OPEN, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, "gfid=%s",
@@ -379,10 +367,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -393,7 +378,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -406,10 +391,10 @@ out:
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -435,10 +420,7 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -449,7 +431,7 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readlink_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -461,10 +443,10 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -498,10 +480,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -512,7 +491,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -524,10 +503,10 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
-            gf_msg_debug(this->name, gf_error_to_errno(rsp.op_errno),
+            gf_msg_debug(THIS->name, gf_error_to_errno(rsp.op_errno),
                          "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -557,10 +536,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -571,7 +547,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -583,7 +559,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -612,10 +588,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -626,7 +599,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -637,7 +610,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
@@ -662,10 +635,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -676,7 +646,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_statfs_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -689,7 +659,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
@@ -716,11 +686,8 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -733,7 +700,7 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -745,11 +712,11 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
         if (local->attempt_reopen)
-            client_attempt_reopen(local->fd, this);
+            client_attempt_reopen(local->fd, THIS);
     }
     CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
@@ -761,12 +728,11 @@ out:
     return 0;
 }
 
-int
+static int
 client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
                     void *myframe)
 {
     call_frame_t *frame = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     gfx_common_rsp rsp = {
         0,
@@ -774,7 +740,6 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
 
     frame = myframe;
-    this = THIS;
 
     if (-1 == req->rpc_status) {
         rsp.op_ret = -1;
@@ -783,7 +748,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -794,7 +759,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -822,10 +787,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -837,7 +799,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -850,7 +812,7 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
@@ -871,11 +833,8 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     int op_errno = EINVAL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -887,7 +846,7 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -899,9 +858,9 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, op_errno, "remote operation failed");
+            gf_msg_debug(THIS->name, op_errno, "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -1065,11 +1024,8 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     gf_loglevel_t loglevel = GF_LOG_NONE;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1081,7 +1037,7 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1101,7 +1057,7 @@ out:
         else
             loglevel = GF_LOG_WARNING;
 
-        gf_smsg(this->name, loglevel, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, loglevel, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -1123,10 +1079,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1138,7 +1091,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1148,7 +1101,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
@@ -1169,10 +1122,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1183,7 +1133,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1194,7 +1144,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
@@ -1215,10 +1165,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1229,7 +1176,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1240,7 +1187,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
@@ -1267,10 +1214,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1281,7 +1225,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1292,7 +1236,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
@@ -1317,10 +1261,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1331,7 +1272,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1342,7 +1283,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
@@ -1363,10 +1304,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1377,7 +1315,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1387,7 +1325,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1459,10 +1397,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1473,7 +1408,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1483,7 +1418,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_ENTRYLK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1506,10 +1441,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1520,7 +1452,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1531,7 +1463,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -1687,11 +1619,8 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     int op_errno = EINVAL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1702,7 +1631,7 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1715,9 +1644,9 @@ out:
     op_errno = gf_error_to_errno(rsp.op_errno);
     if (rsp.op_ret == -1) {
         if (op_errno == ENOTSUP) {
-            gf_msg_debug(this->name, op_errno, "remote operation failed");
+            gf_msg_debug(THIS->name, op_errno, "remote operation failed");
         } else {
-            gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
@@ -1745,10 +1674,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1759,7 +1685,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1772,7 +1698,7 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
@@ -1800,10 +1726,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1814,7 +1737,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1825,7 +1748,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
@@ -1852,10 +1775,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1866,7 +1786,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1876,7 +1796,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(&rsp, &prestat, &poststat, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
@@ -1898,10 +1818,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1912,7 +1829,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1922,7 +1839,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
@@ -1943,10 +1860,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -1957,7 +1871,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_seek_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -1967,7 +1881,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
@@ -1994,10 +1908,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2009,7 +1920,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2020,7 +1931,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
@@ -2048,10 +1959,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2063,7 +1971,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2074,7 +1982,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
@@ -2108,10 +2016,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_create_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2126,7 +2031,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_create_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2150,7 +2055,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path, NULL);
     }
 
@@ -2176,15 +2081,12 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
     if (-1 == req->rpc_status) {
-        gf_smsg(this->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_REMOTE_OP_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_REMOTE_OP_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
@@ -2193,7 +2095,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lease_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2204,7 +2106,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2233,8 +2135,6 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
 
@@ -2246,7 +2146,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lk_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2260,6 +2160,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (local->check_reopen) {
+        this = THIS;
         if (lock.l_type == F_WRLCK)
             set_fd_reopen_status(this, xdata, FD_REOPEN_NOT_ALLOWED);
         else
@@ -2268,7 +2169,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2422,10 +2323,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2437,7 +2335,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rename_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2448,7 +2346,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
                           &prenewparent, &postnewparent, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
@@ -2481,10 +2379,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int ret = 0;
     clnt_local_t *local = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2499,7 +2394,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2511,7 +2406,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     if (rsp.op_ret == -1) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
-            gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+            gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "source=%s", local->loc.path,
                     "target=%s", local->loc2.path, NULL);
         }
@@ -2538,10 +2433,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     gfx_open_rsp rsp = {
         0,
     };
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2558,7 +2450,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
        but separated by fop number only */
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2578,7 +2470,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name,
+        gf_smsg(THIS->name,
                 fop_log_level(GF_FOP_OPENDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "path=%s", local->loc.path, "gfid=%s",
@@ -2612,9 +2504,6 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     int op_errno = EINVAL;
     dict_t *xdata = NULL;
     inode_t *inode = NULL;
-    xlator_t *this = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2628,7 +2517,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         op_errno = EINVAL;
@@ -2672,11 +2561,11 @@ out:
         /* any error other than ENOENT */
         if (!(local->loc.name && rsp.op_errno == ENOENT) &&
             !(rsp.op_errno == ESTALE))
-            gf_smsg(this->name, GF_LOG_WARNING, rsp.op_errno,
+            gf_smsg(THIS->name, GF_LOG_WARNING, rsp.op_errno,
                     PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path,
                     "gfid=%s", loc_gfid_utoa(&local->loc), NULL);
         else
-            gf_msg_trace(this->name, 0,
+            gf_msg_trace(THIS->name, 0,
                          "not found on remote "
                          "node");
     }
@@ -2707,10 +2596,7 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int ret = 0, rspcount = 0;
     clnt_local_t *local = NULL;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
     local = frame->local;
@@ -2723,7 +2609,7 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_read_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2736,11 +2622,11 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                &req->rsp[1], &rspcount, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
         if (local->attempt_reopen)
-            client_attempt_reopen(local->fd, this);
+            client_attempt_reopen(local->fd, THIS);
     }
     CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), vector, rspcount,
@@ -2783,10 +2669,7 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     int32_t ret = 0;
     lock_migration_info_t locklist;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2798,7 +2681,7 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_getactivelk_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2808,14 +2691,14 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     INIT_LIST_HEAD(&locklist.list);
 
     if (rsp.op_ret > 0) {
-        clnt_unserialize_rsp_locklist_v2(this, &rsp, &locklist);
+        clnt_unserialize_rsp_locklist_v2(&rsp, &locklist);
     }
 
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2838,10 +2721,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int32_t ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -2853,7 +2733,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2863,7 +2743,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -2898,8 +2778,6 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
 
@@ -2911,7 +2789,7 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2923,9 +2801,10 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
+        this = THIS;
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
         if (local->attempt_reopen_out)
@@ -5543,10 +5422,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
-
-    this = THIS;
 
     frame = myframe;
 
@@ -5558,7 +5434,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rchecksum_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -5568,7 +5444,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
@@ -5691,7 +5567,6 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     call_frame_t *frame = NULL;
     int ret = 0;
-    xlator_t *this = NULL;
     dict_t *xdata = NULL;
     clnt_local_t *local = NULL;
     struct iatt stbuf = {
@@ -5705,8 +5580,6 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     inode_t *inode = NULL;
 
-    this = THIS;
-
     frame = myframe;
     local = frame->local;
     inode = local->loc.inode;
@@ -5719,7 +5592,7 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
     if (ret < 0) {
-        gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
+        gf_smsg(THIS->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -5734,7 +5607,7 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 out:
     if (rsp.op_ret == -1) {
-        gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
+        gf_smsg(THIS->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -309,8 +309,7 @@ serialize_req_locklist_v2(lock_migration_info_t *locklist,
                           gfx_setactivelk_req *req);
 
 int
-clnt_unserialize_rsp_locklist_v2(xlator_t *this,
-                                 struct gfx_getactivelk_rsp *rsp,
+clnt_unserialize_rsp_locklist_v2(struct gfx_getactivelk_rsp *rsp,
                                  lock_migration_info_t *lmi);
 
 int


### PR DESCRIPTION
    After the removal of 'this' GF_ASSERT_AND_GOTO_WITH_ERROR,
    adjusted for that removal in relevant functions.
