### PR TITLE
Multiple files: reduce the work needed to format the time in a log line

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -6011,7 +6011,7 @@ gf_cli_top_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 ret = dict_get_int32n(dict, key, keylen, (int32_t *)&time_usec);
                 if (ret)
                     goto out;
-                gf_time_fmt(timestr, sizeof timestr, time_sec, gf_timefmt_FT);
+                gf_time_fmt_FT(timestr, sizeof timestr, time_sec);
                 snprintf(timestr + strlen(timestr),
                          sizeof timestr - strlen(timestr), ".%ld", time_usec);
                 if (strlen(filename) < VOL_TOP_PERF_FILENAME_DEF_WIDTH)

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -1701,7 +1701,7 @@ cli_xml_output_vol_top_rw_perf(xmlTextWriterPtr writer, dict_t *dict,
     if (ret)
         goto out;
 
-    gf_time_fmt_tv(timestr, sizeof timestr, &tv, gf_timefmt_FT);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, NULL);
     ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"time", "%s",
                                           timestr);
     XML_RET_CHECK_AND_GOTO(ret, out);

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -2107,7 +2107,7 @@ parse_cmdline(int argc, char *argv[], glusterfs_ctx_t *ctx)
              (S_ISREG(stbuf.st_mode) || S_ISLNK(stbuf.st_mode))) ||
             (ret == -1)) {
             /* Have separate logfile per run. */
-            gf_time_fmt(timestr, sizeof timestr, gf_time(), gf_timefmt_FT);
+            gf_time_fmt_FT(timestr, sizeof timestr, gf_time());
             sprintf(tmp_logfile, "%s.%s.%d", cmd_args->log_file, timestr,
                     getpid());
 

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -945,7 +945,7 @@ gf_print_trace(int32_t signum, glusterfs_ctx_t *ctx)
     {
         /* Dump the timestamp of the crash too, so the previous logs
            can be related */
-        gf_time_fmt(timestr, sizeof timestr, gf_time(), gf_timefmt_FT);
+        gf_time_fmt_FT(timestr, sizeof timestr, gf_time());
         gf_msg_plain_nomem(GF_LOG_ALERT, "time of crash: ");
         gf_msg_plain_nomem(GF_LOG_ALERT, timestr);
     }
@@ -3214,22 +3214,6 @@ out:
     return ret;
 }
 
-static const char *__gf_timefmts[] = {
-    "%F %T", "%Y/%m/%d-%T", "%b %d %T", "%F %H%M%S", "%Y-%m-%d-%T", "%s",
-};
-
-static const char *__gf_zerotimes[] = {
-    "0000-00-00 00:00:00", "0000/00/00-00:00:00", "xxx 00 00:00:00",
-    "0000-00-00 000000",   "0000-00-00-00:00:00", "0",
-};
-
-void
-_gf_timestuff(const char ***fmts, const char ***zeros)
-{
-    *fmts = __gf_timefmts;
-    *zeros = __gf_zerotimes;
-}
-
 char *
 generate_glusterfs_ctx_id(void)
 {
@@ -5460,7 +5444,7 @@ gf_pipe(int fd[2], int flags)
     int ret = 0;
 #if defined(HAVE_PIPE2)
     ret = pipe2(fd, flags);
-#else /* not HAVE_PIPE2 */
+#else  /* not HAVE_PIPE2 */
     ret = pipe(fd);
     if (ret < 0)
         return ret;

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -725,7 +725,6 @@ gf_thread_set_vname
 gf_timer_call_after
 gf_timer_call_cancel
 gf_timer_registry_destroy
-_gf_timestuff
 gf_trim
 gf_tw_add_timer
 gf_tw_del_timer

--- a/libglusterfs/src/stack.c
+++ b/libglusterfs/src/stack.c
@@ -114,9 +114,7 @@ gf_proc_dump_call_frame(call_frame_t *call_frame, const char *key_buf, ...)
     UNLOCK(&call_frame->lock);
 
     if (my_frame.root->ctx->measure_latency) {
-        gf_time_fmt(timestr, sizeof(timestr), my_frame.begin.tv_sec,
-                    gf_timefmt_FT);
-        len = strlen(timestr);
+        len = gf_time_fmt_FT(timestr, sizeof(timestr), my_frame.begin.tv_sec);
         snprintf(timestr + len, sizeof(timestr) - len, ".%" GF_PRI_SNSECONDS,
                  my_frame.begin.tv_nsec);
         gf_proc_dump_write("frame-creation-time", "%s", timestr);
@@ -161,9 +159,7 @@ gf_proc_dump_call_stack(call_stack_t *call_stack, const char *key_buf, ...)
     va_list ap;
     call_frame_t *trav;
     int32_t i = 1, cnt = 0;
-    char timestr[GF_TIMESTR_SIZE] = {
-        0,
-    };
+    char timestr[GF_TIMESTR_SIZE];
     int len;
 
     if (!call_stack)
@@ -176,7 +172,7 @@ gf_proc_dump_call_stack(call_stack_t *call_stack, const char *key_buf, ...)
     va_end(ap);
 
     cnt = call_frames_count(call_stack);
-    gf_time_fmt(timestr, sizeof(timestr), call_stack->tv.tv_sec, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), call_stack->tv.tv_sec);
     len = strlen(timestr);
     snprintf(timestr + len, sizeof(timestr) - len, ".%" GF_PRI_SNSECONDS,
              call_stack->tv.tv_nsec);

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -907,7 +907,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
     // continue even though gettimeofday() has failed
     ret = gettimeofday(&tv, NULL);
     if (0 == ret) {
-        gf_time_fmt_tv(timestr, sizeof timestr, &tv, gf_timefmt_FT);
+        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
     }
 
     len = snprintf(sign_string, sizeof(sign_string), "DUMP-START-TIME: %s\n",
@@ -956,7 +956,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
 
     ret = gettimeofday(&tv, NULL);
     if (0 == ret) {
-        gf_time_fmt_tv(timestr, sizeof timestr, &tv, gf_timefmt_FT);
+        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
     }
 
     len = snprintf(sign_string, sizeof(sign_string), "\nDUMP-END-TIME: %s",

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -162,8 +162,7 @@ call_bail(void *data)
 
     list_for_each_entry_safe(trav, tmp, &list, list)
     {
-        gf_time_fmt(frame_sent, sizeof frame_sent, trav->saved_at,
-                    gf_timefmt_FT);
+        gf_time_fmt_tv_FT(frame_sent, sizeof frame_sent, &trav->saved_at, NULL);
 
         gf_log(conn->name, GF_LOG_ERROR,
                "bailing out frame type(%s), op(%s(%d)), xid = 0x%x, "
@@ -308,7 +307,7 @@ out:
     return saved_frame;
 }
 
-void
+static void
 saved_frames_unwind(struct saved_frames *saved_frames)
 {
     struct saved_frame *trav = NULL;
@@ -324,8 +323,7 @@ saved_frames_unwind(struct saved_frames *saved_frames)
         if (!trav->rpcreq || !trav->rpcreq->prog)
             continue;
 
-        gf_time_fmt(timestr, sizeof timestr, trav->saved_at, gf_timefmt_FT);
-
+        gf_time_fmt_tv_FT(timestr, sizeof timestr, &trav->saved_at, NULL);
         gf_log_callingfn(
             trav->rpcreq->conn->name, GF_LOG_ERROR,
             "forced unwinding frame type(%s) op(%s(%d)) "

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -162,7 +162,7 @@ call_bail(void *data)
 
     list_for_each_entry_safe(trav, tmp, &list, list)
     {
-        gf_time_fmt_tv_FT(frame_sent, sizeof frame_sent, &trav->saved_at, NULL);
+        gf_time_fmt_FT(frame_sent, sizeof frame_sent, trav->saved_at);
 
         gf_log(conn->name, GF_LOG_ERROR,
                "bailing out frame type(%s), op(%s(%d)), xid = 0x%x, "
@@ -323,7 +323,7 @@ saved_frames_unwind(struct saved_frames *saved_frames)
         if (!trav->rpcreq || !trav->rpcreq->prog)
             continue;
 
-        gf_time_fmt_tv_FT(timestr, sizeof timestr, &trav->saved_at, NULL);
+        gf_time_fmt_FT(timestr, sizeof timestr, trav->saved_at);
         gf_log_callingfn(
             trav->rpcreq->conn->name, GF_LOG_ERROR,
             "forced unwinding frame type(%s) op(%s(%d)) "

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -677,14 +677,14 @@ ios_dump_throughput_stats(struct ios_stat_head *list_head, xlator_t *this,
     char timestr[GF_TIMESTR_SIZE] = {
         0,
     };
+    glusterfs_ctx_t *ctx = this->ctx;
 
     LOCK(&list_head->lock);
     {
         list_for_each_entry(entry, &list_head->iosstats->list, list)
         {
-            gf_time_fmt_tv(timestr, sizeof timestr,
-                           &entry->iosstat->thru_counters[type].time,
-                           gf_timefmt_FT);
+            gf_time_fmt_tv_FT(timestr, sizeof timestr,
+                              &entry->iosstat->thru_counters[type].time, ctx);
 
             ios_log(this, logfp, "%s \t %-10.2f  \t  %s", timestr, entry->value,
                     entry->iosstat->filename);
@@ -1308,8 +1308,8 @@ io_stats_dump_global_to_logfp(xlator_t *this, struct ios_global_stats *stats,
     if (interval == -1) {
         LOCK(&conf->lock);
         {
-            gf_time_fmt_tv(timestr, sizeof timestr,
-                           &conf->cumulative.max_openfd_time, gf_timefmt_FT);
+            gf_time_fmt_tv_FT(timestr, sizeof timestr,
+                              &conf->cumulative.max_openfd_time, this->ctx);
             ios_log(this, logfp,
                     "Current open fd's: %" PRId64 " Max open fd's: %" PRId64
                     " time %s",
@@ -1795,9 +1795,8 @@ io_stats_dump_stats_to_dict(xlator_t *this, dict_t *resp,
                 ret = dict_set_uint64(resp, "max-open",
                                       conf->cumulative.max_nr_opens);
 
-                gf_time_fmt_tv(timestr, sizeof timestr,
-                               &conf->cumulative.max_openfd_time,
-                               gf_timefmt_FT);
+                gf_time_fmt_tv_FT(timestr, sizeof timestr,
+                                  &conf->cumulative.max_openfd_time, this->ctx);
 
                 dict_timestr = gf_strdup(timestr);
                 if (!dict_timestr)

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -610,7 +610,7 @@ br_scrubber_log_time(xlator_t *this, const char *sfx)
     now = gf_time();
     priv = this->private;
 
-    gf_time_fmt(timestr, sizeof(timestr), now, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), now);
 
     if (strcasecmp(sfx, "started") == 0) {
         br_update_scrub_start_time(&priv->scrub_stat, now);
@@ -632,7 +632,7 @@ br_fsscanner_log_time(xlator_t *this, br_child_t *child, const char *sfx)
     time_t now = 0;
 
     now = gf_time();
-    gf_time_fmt(timestr, sizeof(timestr), now, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), now);
 
     if (strcasecmp(sfx, "started") == 0) {
         gf_msg_debug(this->name, 0, "Scrubbing \"%s\" %s at %s",
@@ -950,8 +950,7 @@ br_fsscan_schedule(xlator_t *this)
     gf_tw_add_timer(priv->timer_wheel, timer);
     _br_monitor_set_scrub_state(scrub_monitor, BR_SCRUB_STATE_PENDING);
 
-    gf_time_fmt(timestr, sizeof(timestr), (scrub_monitor->boot + timo),
-                gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), (scrub_monitor->boot + timo));
     gf_msg(this->name, GF_LOG_INFO, 0, BRB_MSG_SCRUB_INFO,
            "Scrubbing is "
            "scheduled to run at %s",
@@ -993,7 +992,7 @@ br_fsscan_activate(xlator_t *this)
     }
     pthread_mutex_unlock(&scrub_monitor->donelock);
 
-    gf_time_fmt(timestr, sizeof(timestr), now + timo, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), now + timo);
     (void)gf_tw_mod_timer(priv->timer_wheel, scrub_monitor->timer, timo);
 
     _br_monitor_set_scrub_state(scrub_monitor, BR_SCRUB_STATE_PENDING);
@@ -1033,7 +1032,7 @@ br_fsscan_reschedule(xlator_t *this)
         return -1;
     }
 
-    gf_time_fmt(timestr, sizeof(timestr), now + timo, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), now + timo);
 
     pthread_mutex_lock(&scrub_monitor->donelock);
     {
@@ -1073,7 +1072,7 @@ br_fsscan_ondemand(xlator_t *this)
 
     now = gf_time();
     timo = BR_SCRUB_ONDEMAND;
-    gf_time_fmt(timestr, sizeof(timestr), now + timo, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof(timestr), now + timo);
 
     pthread_mutex_lock(&scrub_monitor->donelock);
     {

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -3535,9 +3535,9 @@ pl_dump_lock(char *str, int size, struct gf_flock *flock, gf_lkowner_t *owner,
     };
 
     if (granted_time)
-        gf_time_fmt(granted, sizeof(granted), *granted_time, gf_timefmt_FT);
+        gf_time_fmt_FT(granted, sizeof(granted), *granted_time);
     if (blkd_time)
-        gf_time_fmt(blocked, sizeof(blocked), *blkd_time, gf_timefmt_FT);
+        gf_time_fmt_FT(blocked, sizeof(blocked), *blkd_time);
     switch (flock->l_type) {
         case F_RDLCK:
             type_str = "READ";
@@ -3604,8 +3604,7 @@ __dump_entrylks(pl_inode_t *pl_inode)
 
         list_for_each_entry(lock, &dom->entrylk_list, domain_list)
         {
-            gf_time_fmt(granted, sizeof(granted), lock->granted_time,
-                        gf_timefmt_FT);
+            gf_time_fmt_FT(granted, sizeof(granted), lock->granted_time);
             gf_proc_dump_build_key(key, k, "entrylk[%d](ACTIVE)", count);
             if (lock->blkd_time == 0) {
                 snprintf(tmp, sizeof(tmp), ENTRY_GRNTD_FMT,
@@ -3615,8 +3614,7 @@ __dump_entrylks(pl_inode_t *pl_inode)
                          lkowner_utoa(&lock->owner), lock->client,
                          lock->connection_id, granted);
             } else {
-                gf_time_fmt(blocked, sizeof(blocked), lock->blkd_time,
-                            gf_timefmt_FT);
+                gf_time_fmt_FT(blocked, sizeof(blocked), lock->blkd_time);
                 snprintf(tmp, sizeof(tmp), ENTRY_BLKD_GRNTD_FMT,
                          lock->type == ENTRYLK_RDLCK ? "ENTRYLK_RDLCK"
                                                      : "ENTRYLK_WRLCK",
@@ -3632,8 +3630,7 @@ __dump_entrylks(pl_inode_t *pl_inode)
 
         list_for_each_entry(lock, &dom->blocked_entrylks, blocked_locks)
         {
-            gf_time_fmt(blocked, sizeof(blocked), lock->blkd_time,
-                        gf_timefmt_FT);
+            gf_time_fmt_FT(blocked, sizeof(blocked), lock->blkd_time);
 
             gf_proc_dump_build_key(key, k, "entrylk[%d](BLOCKED)", count);
             snprintf(

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5209,8 +5209,7 @@ glusterd_print_snapinfo_by_vol(FILE *fp, glusterd_volinfo_t *volinfo,
 
             goto out;
         }
-        gf_time_fmt(timestr, sizeof timestr, snapinfo->time_stamp,
-                    gf_timefmt_FT);
+        gf_time_fmt_FT(timestr, sizeof timestr, snapinfo->time_stamp);
 
         fprintf(fp, "Volume%d.snapshot%d.name: %s\n", volcount, snapcount,
                 snapinfo->snapname);

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -3011,7 +3011,7 @@ glusterd_snapshot_get_snap_detail(dict_t *dict, glusterd_snap_t *snap,
     }
     value = NULL;
 
-    gf_time_fmt(timestr, sizeof timestr, snap->time_stamp, gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof timestr, snap->time_stamp);
     value = gf_strdup(timestr);
 
     if (NULL == value) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -8449,8 +8449,7 @@ glusterd_sm_tr_log_transition_add_to_dict(dict_t *dict,
         goto out;
 
     snprintf(key, sizeof(key), "log%d-time", count);
-    gf_time_fmt(timestr, sizeof timestr, log->transitions[i].time,
-                gf_timefmt_FT);
+    gf_time_fmt_FT(timestr, sizeof timestr, log->transitions[i].time);
     ret = dict_set_dynstr_with_alloc(dict, key, timestr);
     if (ret)
         goto out;

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1942,8 +1942,8 @@ __ioc_cache_dump(ioc_inode_t *ioc_inode, char *prefix)
     table = ioc_inode->table;
 
     if (ioc_inode->cache.last_revalidate) {
-        gf_time_fmt(timestr, sizeof timestr, ioc_inode->cache.last_revalidate,
-                    gf_timefmt_FT);
+        gf_time_fmt_FT(timestr, sizeof timestr,
+                       ioc_inode->cache.last_revalidate);
 
         gf_proc_dump_write("last-cache-validation-time", "%s", timestr);
     }

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -1033,7 +1033,7 @@ qr_inodectx_dump(xlator_t *this, inode_t *inode)
                        qr_inode->data ? "yes" : "no");
 
     if (qr_inode->last_refresh) {
-        gf_time_fmt(buf, sizeof buf, qr_inode->last_refresh, gf_timefmt_FT);
+        gf_time_fmt_FT(buf, sizeof buf, qr_inode->last_refresh);
         gf_proc_dump_write("last-cache-validation-time", "%s", buf);
     }
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1992,8 +1992,7 @@ posix_fs_health_check(xlator_t *this, char *file_path)
     }
 
     time_sec = gf_time();
-    gf_time_fmt(timestamp, sizeof timestamp, time_sec, gf_timefmt_FT);
-    timelen = strlen(timestamp);
+    timelen = gf_time_fmt_FT(timestamp, sizeof timestamp, time_sec);
 
     memset(&aiocb, 0, sizeof(struct aiocb));
     aiocb.aio_fildes = fd;


### PR DESCRIPTION
Many inovcations use the same format - gf_timefmt_FT.
Co-locate the functions in the same file, to make them static, reduce
the unneeded calls and create a specific function for this use case.

Convert some gf_time_fmt() to gf_time_fmt_FT() and gf_time_fmt_tv()
to gf_time_fmt_tv_FT().

In the cases where we have the ctx variable, use it and skip the
call to gf_log_get_localtime() which calls 'THIS'.

Fixes: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

