### PR TITLE
glusterd: Updated the log level to DEBUG for redundant logs (#2887)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -97,7 +97,6 @@ glusterd_validate_quorum(xlator_t *this, glusterd_op_t op, dict_t *dict,
 
     ret = glusterd_volinfo_find(volname, &volinfo);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_VOLINFO_GET_FAIL, NULL);
         ret = 0;
         goto out;
     }
@@ -254,7 +253,7 @@ glusterd_is_volume_in_server_quorum(glusterd_volinfo_t *volinfo)
 
     ret = dict_get_str(volinfo->dict, GLUSTERD_QUORUM_TYPE_KEY, &quorum_type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_QUORUM_TYPE_KEY, NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5297,7 +5297,7 @@ glusterd_get_global_server_quorum_ratio(dict_t *opts, double *quorum)
     ret = dict_get_strn(opts, GLUSTERD_QUORUM_RATIO_KEY,
                         SLEN(GLUSTERD_QUORUM_RATIO_KEY), &quorum_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_QUORUM_RATIO_KEY, NULL);
     } else {
         ret = gf_string2percent(quorum_str, quorum);


### PR DESCRIPTION
*Description:*
The `dict get failed` log msgs of the options
`cluster.server-quorum-type` and `cluster.server-quorum-ratio`
where redundant considering the fact that these options are only
availbale in the volume info when they are manually set by the user
for a volume.

Updates: #2846

> Fixes: #2846

> Change-Id: If5c7690b5e6605c154ac962cbfff9b4321388989
> Signed-off-by: nik-redhat <nladha@redhat.com>

Change-Id: I91ebba939b1c59589a73c89e4e04a64fe16baf92
Signed-off-by: nik-redhat <nladha@redhat.com>

