### PR TITLE
gluster: Removed the deprecated log commands from gluster man page

### DIFF
--- a/doc/gluster.8
+++ b/doc/gluster.8
@@ -101,13 +101,7 @@ Stop rebalancing the specified volume.
 Display the rebalance status of the specified volume.
 .SS "Log Commands"
 .TP
-\fB\ volume log filename <VOLNAME> [BRICK] <DIRECTORY> \fB
-Set the log directory for the corresponding volume/brick.
-.TP
-\fB\ volume log locate <VOLNAME> [BRICK] \fB
-Locate the log file for corresponding volume/brick.
-.TP
-\fB\ volume log rotate <VOLNAME> [BRICK] \fB
+\fB\ volume log <VOLNAME> rotate [BRICK] \fB
 Rotate the log file for corresponding volume/brick.
 .TP
 \fB\ volume profile <VOLNAME> {start|info [peek|incremental [peek]|cumulative|clear]|stop} [nfs] \fR


### PR DESCRIPTION
Description:
The log commands in the gluster man page still has
the `volume log locate` and `volume log filename` commands
which are deprecated and not available anymore.

Fix:
Removed those deprecated commands and fixed the `volume log rotate`
command.

Updates: #2939

> Fixes: #2939

> Change-Id: Ica55aa3f532fbfbb7bda8adbbfe20443f4f8464b
> Signed-off-by: nik-redhat <nladha@redhat.com>

Change-Id: I8fbf6424820bbc3a02d7d661f1f5f09795d352f6
Signed-off-by: nik-redhat <nladha@redhat.com>

