### PR TITLE
test: bug-1319374-THIS-crash.t is getting crashed

### DIFF
--- a/api/src/Makefile.am
+++ b/api/src/Makefile.am
@@ -9,7 +9,7 @@ libgfapi_la_SOURCES = glfs.c glfs-mgmt.c glfs-fops.c glfs-resolve.c \
 	glfs-handleops.c
 libgfapi_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la \
 	$(top_builddir)/rpc/rpc-lib/src/libgfrpc.la \
-	$(top_builddir)/rpc/xdr/src/libgfxdr.la
+	$(top_builddir)/rpc/xdr/src/libgfxdr.la -lssl -lcrypto
 
 libgfapi_la_LDFLAGS = -version-info $(GFAPI_LT_VERSION) $(GF_LDFLAGS) \
 	$(GFAPI_EXTRA_LDFLAGS) $(ACL_LIBS)

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -53,6 +53,8 @@
 #include <sys/statvfs.h>
 #include <stdint.h>
 #include <sys/time.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 /*
  * For off64_t to be defined, we need both

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -105,6 +105,7 @@ trap(void);
 #define GF_SERVER_PROCESS 0
 #define GF_CLIENT_PROCESS 1
 #define GF_GLUSTERD_PROCESS 2
+#define GF_CLIENT_GFAPI_PROCESS 3
 
 /* Defining this here as it is needed by glusterd for setting
  * nfs port in volume status.


### PR DESCRIPTION
The test case (./tests/bugs/gfapi/bug-1319374-THIS-crash.t) is
continuously getting crashed on the pull request (#2940).
The test case is crashed because openssl does not allow
to call SSL_library_init multiple times in the
multi-threading programs and the test program is trying to
call SSL_library_init more than once so it is crashing.

Solution: Call SSL_Library_init by gfapi library instead of
          calling by socket.so to avoid a crash.

Fixes: #3026
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

