### PR TITLE
Multiple files: read errno when needed and in the right order

### DIFF
--- a/tools/gfind_missing_files/gcrawler.c
+++ b/tools/gfind_missing_files/gcrawler.c
@@ -355,8 +355,8 @@ xworker_do_crawl(struct xwork *xwork, struct dirjob *job)
         entry = sys_readdir(dirp, scratch);
         if (!entry || errno != 0) {
             if (errno != 0) {
-                err("readdir(%s): %s\n", job->dirname, strerror(errno));
                 ret = errno;
+                err("readdir(%s): %s\n", job->dirname, strerror(errno));
                 goto out;
             }
             break;

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -371,10 +371,10 @@ br_stub_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = sys_lstat(priv->stub_basepath, &lstatbuf);
     if (ret) {
+        op_errno = errno;
         gf_msg_debug(this->name, errno,
                      "Stat failed on stub bad "
                      "object dir");
-        op_errno = errno;
         goto done;
     } else if (!S_ISDIR(lstatbuf.st_mode)) {
         gf_msg_debug(this->name, errno,

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1639,8 +1639,8 @@ index_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
     ret = sys_lstat(path, &lstatbuf);
     if (ret) {
-        gf_msg_debug(this->name, errno, "Stat failed on %s dir ", path);
         op_errno = errno;
+        gf_msg_debug(this->name, errno, "Stat failed on %s dir ", path);
         goto done;
     } else if (!S_ISDIR(lstatbuf.st_mode) && is_dir) {
         op_errno = ENOTDIR;

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -363,24 +363,24 @@ svs_lookup_entry(xlator_t *this, loc_t *loc, struct iatt *buf,
 
     object = glfs_h_lookupat(fs, parent_object, loc->name, &statbuf, 0);
     if (!object) {
+        *op_errno = errno;
         /* should this be in WARNING or ERROR mode? */
         gf_msg_debug(this->name, 0,
                      "failed to do lookup and "
                      "get the handle for entry %s (path: %s)",
                      loc->name, loc->path);
         op_ret = -1;
-        *op_errno = errno;
         goto out;
     }
 
     if (gf_uuid_is_null(object->gfid)) {
+        *op_errno = errno;
         /* should this be in WARNING or ERROR mode? */
         gf_msg_debug(this->name, 0,
                      "gfid from glfs handle is "
                      "NULL for entry %s (path: %s)",
                      loc->name, loc->path);
         op_ret = -1;
-        *op_errno = errno;
         goto out;
     }
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -820,16 +820,14 @@ posix_pstat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *path,
 
     ret = sys_lstat(path, &lstatbuf);
     if (ret == -1) {
+        op_errno = errno;
         if (errno != ENOENT) {
-            op_errno = errno;
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_LSTAT_FAILED,
                    "lstat failed on %s", path);
-            errno = op_errno; /*gf_msg could have changed errno*/
         } else {
-            op_errno = errno;
             gf_msg_debug(this->name, errno, "lstat failed on %s ", path);
-            errno = op_errno; /*gf_msg could have changed errno*/
         }
+        errno = op_errno; /*gf_msg could have changed errno*/
         goto out;
     }
 

--- a/xlators/storage/posix/src/posix-metadata.c
+++ b/xlators/storage/posix/src/posix-metadata.c
@@ -450,10 +450,10 @@ posix_set_mdata_xattr_legacy_files(xlator_t *this, inode_t *inode,
 
         ret = posix_store_mdata_xattr(this, realpath, -1, inode, mdata);
         if (ret) {
+            *op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_STOREMDATA_FAILED,
                    "gfid: %s key:%s ", uuid_utoa(inode->gfid),
                    GF_XATTR_MDATA_KEY);
-            *op_errno = errno;
             goto unlock;
         }
     }


### PR DESCRIPTION
In some cases, we fetched errno even though there was no error.
In others, we fetched it AFTER logging, which may have changed its value.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

