### PR TITLE
multiple files: remove unused this from gf_link_inode_from_dirent()

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -3743,7 +3743,7 @@ glfd_entry_refresh(struct glfs_fd *glfd, int plus)
                 }
             }
 
-            gf_link_inodes_from_dirent(THIS, fd->inode, &entries);
+            gf_link_inodes_from_dirent(fd->inode, &entries);
         }
 
         list_splice_init(&glfd->entries, &old.list);

--- a/libglusterfs/src/gf-dirent.c
+++ b/libglusterfs/src/gf-dirent.c
@@ -218,7 +218,7 @@ entry_copy(gf_dirent_t *source)
 }
 
 void
-gf_link_inode_from_dirent(xlator_t *this, inode_t *parent, gf_dirent_t *entry)
+gf_link_inode_from_dirent(inode_t *parent, gf_dirent_t *entry)
 {
     inode_t *link_inode = NULL;
     inode_t *tmp = NULL;
@@ -242,14 +242,13 @@ gf_link_inode_from_dirent(xlator_t *this, inode_t *parent, gf_dirent_t *entry)
    Need more thoughts before finalizing this function
 */
 int
-gf_link_inodes_from_dirent(xlator_t *this, inode_t *parent,
-                           gf_dirent_t *entries)
+gf_link_inodes_from_dirent(inode_t *parent, gf_dirent_t *entries)
 {
     gf_dirent_t *entry = NULL;
 
     list_for_each_entry(entry, &entries->list, list)
     {
-        gf_link_inode_from_dirent(this, parent, entry);
+        gf_link_inode_from_dirent(parent, entry);
     }
 
     return 0;

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -61,11 +61,10 @@ gf_dirent_entry_free(gf_dirent_t *entry);
 void
 gf_dirent_free(gf_dirent_t *entries);
 int
-gf_link_inodes_from_dirent(xlator_t *this, inode_t *parent,
-                           gf_dirent_t *entries);
+gf_link_inodes_from_dirent(inode_t *parent, gf_dirent_t *entries);
 int
 gf_fill_iatt_for_dirent(gf_dirent_t *entry, inode_t *parent, xlator_t *subvol);
 
 void
-gf_link_inode_from_dirent(xlator_t *this, inode_t *parent, gf_dirent_t *entry);
+gf_link_inode_from_dirent(inode_t *parent, gf_dirent_t *entry);
 #endif /* _GF_DIRENT_H */

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -120,7 +120,7 @@ syncop_ftw(xlator_t *subvol, loc_t *loc, int pid, void *data,
             if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
                 continue;
 
-            gf_link_inode_from_dirent(NULL, fd->inode, entry);
+            gf_link_inode_from_dirent(fd->inode, entry);
 
             ret = fn(subvol, entry, loc, data);
             if (ret)
@@ -208,7 +208,7 @@ syncop_ftw_throttle(xlator_t *subvol, loc_t *loc, int pid, void *data,
                 sleep(sleep_time);
             }
 
-            gf_link_inode_from_dirent(NULL, fd->inode, entry);
+            gf_link_inode_from_dirent(fd->inode, entry);
 
             ret = fn(subvol, entry, loc, data);
             if (ret)

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3655,7 +3655,7 @@ fuse_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     send_fuse_data(this, finh, buf, size);
 
     /* TODO: */
-    /* gf_link_inodes_from_dirent (this, state->fd->inode, entries); */
+    /* gf_link_inodes_from_dirent (state->fd->inode, entries); */
 
 out:
     free_fuse_state(state);

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -4188,7 +4188,7 @@ nfs3svc_readdir_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     stat = NFS3_OK;
 
     /* do inode linking here */
-    gf_link_inodes_from_dirent(this, cs->fd->inode, &cs->entries);
+    gf_link_inodes_from_dirent(cs->fd->inode, &cs->entries);
 
 nfs3err:
     if (cs->maxcount == 0) {

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -1995,7 +1995,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    gf_link_inodes_from_dirent(this, state->fd->inode, entries);
+    gf_link_inodes_from_dirent(state->fd->inode, entries);
 
 out:
     rsp.op_ret = op_ret;

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -1797,7 +1797,7 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    gf_link_inodes_from_dirent(this, state->fd->inode, entries);
+    gf_link_inodes_from_dirent(state->fd->inode, entries);
 
 out:
     rsp.op_ret = op_ret;


### PR DESCRIPTION
It's not needed, and there are some callers who used 'THIS' to populate it.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

