### PR TITLE
listxattr: filter internal virtual xattrs

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -4410,6 +4410,23 @@ invalid_fs:
     return ret;
 }
 
+
+/* filter out xattrs that need not be visible on the
+ * client application.
+ */
+static int
+gfapi_filter_xattr(char *key)
+{
+    int need_filter = 0;
+
+    /* If there are by chance any internal virtual xattrs (those starting with
+     * 'glusterfs.'), filter them */
+    if (strncmp("glusterfs.", key, 10) == 0)
+        need_filter = 1;
+
+    return need_filter;
+}
+
 int
 glfs_listxattr_process(void *value, size_t size, dict_t *xattr)
 {
@@ -4418,7 +4435,7 @@ glfs_listxattr_process(void *value, size_t size, dict_t *xattr)
     if (!xattr)
         goto out;
 
-    ret = dict_keys_join(NULL, 0, xattr, NULL);
+    ret = dict_keys_join(NULL, 0, xattr, gfapi_filter_xattr);
 
     if (!value || !size)
         goto out;
@@ -4427,7 +4444,7 @@ glfs_listxattr_process(void *value, size_t size, dict_t *xattr)
         ret = -1;
         errno = ERANGE;
     } else {
-        dict_keys_join(value, size, xattr, NULL);
+        dict_keys_join(value, size, xattr, gfapi_filter_xattr);
     }
 
 out:

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -4410,7 +4410,6 @@ invalid_fs:
     return ret;
 }
 
-
 /* filter out xattrs that need not be visible on the
  * client application.
  */
@@ -4421,7 +4420,7 @@ gfapi_filter_xattr(char *key)
 
     /* If there are by chance any internal virtual xattrs (those starting with
      * 'glusterfs.'), filter them */
-    if (strncmp("glusterfs.", key, 10) == 0)
+    if (strncmp("glusterfs.", key, SLEN("glusterfs.")) == 0)
         need_filter = 1;
 
     return need_filter;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4326,6 +4326,10 @@ fuse_filter_xattr(char *key)
         fnmatch("*.selinux*", key, FNM_PERIOD) == 0)
         need_filter = 1;
 
+    /* If there are by chance any internal virtual xattrs (those starting with
+     * 'glusterfs.'), filter them */
+    if (strncmp("glusterfs.", key, 10) == 0)
+        need_filter = 1;
     return need_filter;
 }
 

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4323,13 +4323,13 @@ fuse_filter_xattr(char *key)
     struct fuse_private *priv = THIS->private;
 
     if ((priv->client_pid == GF_CLIENT_PID_GSYNCD) &&
-        fnmatch("*.selinux*", key, FNM_PERIOD) == 0)
+        fnmatch("*.selinux*", key, FNM_PERIOD) == 0) {
         need_filter = 1;
-
-    /* If there are by chance any internal virtual xattrs (those starting with
-     * 'glusterfs.'), filter them */
-    if (strncmp("glusterfs.", key, SLEN("glusterfs.")) == 0)
+    } else if (strncmp("glusterfs.", key, SLEN("glusterfs.")) == 0) {
+        /* If there are by chance any internal virtual xattrs (those starting
+         * with 'glusterfs.'), filter them */
         need_filter = 1;
+    }
     return need_filter;
 }
 

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4328,7 +4328,7 @@ fuse_filter_xattr(char *key)
 
     /* If there are by chance any internal virtual xattrs (those starting with
      * 'glusterfs.'), filter them */
-    if (strncmp("glusterfs.", key, 10) == 0)
+    if (strncmp("glusterfs.", key, SLEN("glusterfs.")) == 0)
         need_filter = 1;
     return need_filter;
 }


### PR DESCRIPTION
In certain cases, there are some keys set in brick xlators which assume
a corresponding xlator on client side will handle the request and take
appropriate action. As many xlators are optional, and can be turned off,
there are cases where such xattrs will reach client application, causing
errors in application.

Resolve it by filtering out internal keys.

One example of such key is 'glusterfs.skip-cache'.

Updates: #1000
Change-Id: I65d5cbba32d7e8ec6926e7c00d90f780dd9a28b1
Signed-off-by: Amar Tumballi <amar@kadalu.io>

