### PR TITLE
multiple files: skip fetching ctime if not needed.

### DIFF
--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -134,7 +134,7 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;
@@ -291,7 +291,7 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;
@@ -358,7 +358,7 @@ posix_aio_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     iocb = &paiocb->iocb;
 
-    ret = posix_fdstat(this, fd->inode, _fd, &paiocb->prebuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &paiocb->prebuf, _gf_true);
     if (ret != 0) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
@@ -432,7 +432,7 @@ posix_aio_fsync_complete(struct posix_aio_cb *paiocb, int res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;
@@ -489,7 +489,7 @@ posix_aio_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 
     iocb = &paiocb->iocb;
 
-    ret = posix_fdstat(this, fd->inode, _fd, &paiocb->prebuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &paiocb->prebuf, _gf_false);
     if (ret != 0) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -52,7 +52,7 @@
 #include <glusterfs/compat-uuid.h>
 #include "timer-wheel.h"
 
-extern char *marker_xattrs[];
+// extern char *marker_xattrs[];
 #define ALIGN_SIZE 4096
 
 #undef HAVE_SET_FSID

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -55,7 +55,7 @@
 #include <glusterfs/compat-uuid.h>
 #include <glusterfs/syncop.h>
 
-extern char *marker_xattrs[];
+// extern char *marker_xattrs[];
 #define ALIGN_SIZE 4096
 
 #undef HAVE_SET_FSID
@@ -341,7 +341,7 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 parent:
     if (par_path) {
         op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path,
-                             &postparent, _gf_false);
+                             &postparent, _gf_false, _gf_true);
         if (op_ret == -1) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -519,7 +519,7 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -665,7 +665,8 @@ post_op:
         }
     }
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
+    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
+                         _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKNOD_FAILED,
@@ -676,7 +677,7 @@ post_op:
     posix_set_ctime(frame, this, real_path, -1, loc->inode, &stbuf);
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -788,7 +789,8 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gid = frame->root->gid;
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
+    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
+                         _gf_false);
 
     SET_FS_ID(frame->root->uid, gid);
 
@@ -805,7 +807,8 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     if (!gf_uuid_is_null(uuid_req)) {
-        op_ret = posix_istat(this, loc->inode, uuid_req, NULL, &stbuf);
+        op_ret = posix_istat(this, loc->inode, uuid_req, NULL, &stbuf,
+                             _gf_false);
         if ((op_ret == 0) && IA_ISDIR(stbuf.ia_type)) {
             gfid_path = alloca(PATH_MAX);
             size = posix_handle_path(this, uuid_req, NULL, gfid_path, PATH_MAX);
@@ -849,7 +852,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1018,7 +1021,8 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         gfid_set = _gf_true;
     }
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
+    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
+                         _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1029,7 +1033,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     posix_set_ctime(frame, this, real_path, -1, loc->inode, &stbuf);
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1163,7 +1167,8 @@ posix_unlink_gfid_handle_and_entry(call_frame_t *frame, xlator_t *this,
         /* Since this stat is to get link count and not for time
          * attributes, intentionally passing inode as NULL
          */
-        ret = posix_pstat(this, NULL, loc->gfid, real_path, &prebuf, _gf_true);
+        ret = posix_pstat(this, NULL, loc->gfid, real_path, &prebuf, _gf_true,
+                          _gf_false);
         if (ret) {
             UNLOCK(&loc->inode->lock);
             locked = _gf_false;
@@ -1220,7 +1225,8 @@ posix_unlink_stale_linkto(call_frame_t *frame, xlator_t *this,
     };
 
     /* get the stale file gfid and stat-info */
-    ret = posix_pstat(this, NULL, NULL, real_path, &stbuf, _gf_false);
+    ret = posix_pstat(this, NULL, NULL, real_path, &stbuf, _gf_false,
+                      _gf_false);
     if (ret) {
         if (errno == ENOENT) {
             ret = 0; /* retry creation if file doesn't exist */
@@ -1366,7 +1372,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1491,7 +1497,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 
     if (fdstat_requested) {
-        op_ret = posix_fdstat(this, loc->inode, fd, &postbuf);
+        op_ret = posix_fdstat(this, loc->inode, fd, &postbuf, _gf_true);
         if (op_ret == -1) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1509,7 +1515,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1606,7 +1612,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1659,7 +1665,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1729,7 +1735,7 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     SET_FS_ID(frame->root->uid, gid);
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1798,7 +1804,8 @@ ignore:
         gfid_set = _gf_true;
     }
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
+    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
+                         _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1807,7 +1814,7 @@ ignore:
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1851,7 +1858,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         0,
     };
     struct posix_private *priv = NULL;
-    char was_present = 1;
+    int was_present = 1;
     struct iatt preoldparent = {
         0,
     };
@@ -1911,7 +1918,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     op_ret = posix_pstat(this, oldloc->parent, oldloc->pargfid, par_oldpath,
-                         &preoldparent, _gf_false);
+                         &preoldparent, _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1920,7 +1927,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
-                         &prenewparent, _gf_false);
+                         &prenewparent, _gf_false, _gf_false);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1929,7 +1936,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
-                         _gf_false);
+                         _gf_false, _gf_false);
     if ((op_ret == -1) && (errno == ENOENT)) {
         was_present = 0;
     } else {
@@ -1937,25 +1944,25 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         if (IA_ISDIR(stbuf.ia_type))
             was_dir = 1;
         nlink = stbuf.ia_nlink;
-    }
-
-    if (was_present && IA_ISDIR(stbuf.ia_type) && !newloc->inode) {
-        gf_msg(this->name, GF_LOG_WARNING, EEXIST, P_MSG_DIR_FOUND,
-               "found directory at %s while expecting ENOENT", real_newpath);
-        op_ret = -1;
-        op_errno = EEXIST;
-        goto out;
-    }
-
-    if (was_present && IA_ISDIR(stbuf.ia_type) &&
-        gf_uuid_compare(newloc->inode->gfid, stbuf.ia_gfid)) {
-        gf_msg(this->name, GF_LOG_WARNING, EEXIST, P_MSG_DIR_FOUND,
-               "found directory %s at %s while renaming %s",
-               uuid_utoa_r(newloc->inode->gfid, olddirid), real_newpath,
-               uuid_utoa_r(stbuf.ia_gfid, newdirid));
-        op_ret = -1;
-        op_errno = EEXIST;
-        goto out;
+        if (IA_ISDIR(stbuf.ia_type)) {
+            if (!newloc->inode) {
+                gf_msg(this->name, GF_LOG_WARNING, EEXIST, P_MSG_DIR_FOUND,
+                       "found directory at %s while expecting ENOENT",
+                       real_newpath);
+                op_ret = -1;
+                op_errno = EEXIST;
+                goto out;
+            }
+            if (gf_uuid_compare(newloc->inode->gfid, stbuf.ia_gfid)) {
+                gf_msg(this->name, GF_LOG_WARNING, EEXIST, P_MSG_DIR_FOUND,
+                       "found directory %s at %s while renaming %s",
+                       uuid_utoa_r(newloc->inode->gfid, olddirid), real_newpath,
+                       uuid_utoa_r(stbuf.ia_gfid, newdirid));
+                op_ret = -1;
+                op_errno = EEXIST;
+                goto out;
+            }
+        }
     }
 
     op_ret = posix_inode_ctx_get_all(oldloc->inode, this, &ctx_old);
@@ -1992,7 +1999,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
             locked = _gf_true;
             get_link_count = _gf_true;
             op_ret = posix_pstat(this, newloc->inode, newloc->gfid,
-                                 real_newpath, &stbuf, _gf_false);
+                                 real_newpath, &stbuf, _gf_false, _gf_false);
             if ((op_ret == -1) && (errno != ENOENT)) {
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2078,7 +2085,7 @@ unlock:
     }
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2092,7 +2099,7 @@ unlock:
     posix_set_ctime(frame, this, real_newpath, -1, oldloc->inode, &stbuf);
 
     op_ret = posix_pstat(this, oldloc->parent, oldloc->pargfid, par_oldpath,
-                         &postoldparent, _gf_false);
+                         &postoldparent, _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2104,7 +2111,7 @@ unlock:
                            &postoldparent);
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
-                         &postnewparent, _gf_false);
+                         &postnewparent, _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2191,7 +2198,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
-                         &preparent, _gf_false);
+                         &preparent, _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2221,7 +2228,7 @@ real_op:
     entry_created = _gf_true;
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2232,7 +2239,7 @@ real_op:
     posix_set_ctime(frame, this, real_newpath, -1, newloc->inode, &stbuf);
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
-                         &postparent, _gf_false);
+                         &postparent, _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2318,7 +2325,7 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     };
     struct posix_fd *pfd = NULL;
     struct posix_private *priv = NULL;
-    char was_present = 1;
+    int was_present = 1;
 
     gid_t gid = 0;
     struct iatt preparent = {
@@ -2364,7 +2371,7 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2382,12 +2389,10 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         _flags = flags | O_CREAT;
     }
 
-    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
+    op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false,
+                         _gf_false);
     if ((op_ret == -1) && (errno == ENOENT)) {
         was_present = 0;
-    }
-
-    if (!was_present) {
         if (posix_is_layout_stale(xdata, par_path, this)) {
             op_ret = -1;
             op_errno = EIO;
@@ -2474,7 +2479,7 @@ fill_stat:
         gfid_set = _gf_true;
     }
 
-    op_ret = posix_fdstat(this, loc->inode, _fd, &stbuf);
+    op_ret = posix_fdstat(this, loc->inode, _fd, &stbuf, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -2485,7 +2490,7 @@ fill_stat:
     posix_set_ctime(frame, this, real_path, -1, loc->inode, &stbuf);
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2569,7 +2574,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret < 0) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2598,7 +2603,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret < 0) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -2632,7 +2637,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->inode, loc->gfid, real_path, &stbuf,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret < 0) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -34,7 +34,7 @@ posix_resolve(xlator_t *this, inode_table_t *itable, inode_t *parent,
     inode_t *inode = NULL;
     int ret = -1;
 
-    ret = posix_istat(this, NULL, parent->gfid, bname, iabuf);
+    ret = posix_istat(this, NULL, parent->gfid, bname, iabuf, _gf_false);
     if (ret < 0) {
         gf_log(this->name, GF_LOG_WARNING,
                "gfid: %s, bname: %s "
@@ -896,7 +896,7 @@ posix_handle_unset(xlator_t *this, uuid_t gfid, const char *basename)
     /* stat is being used only for gfid, so passing a NULL inode
      * doesn't fetch time attributes which is fine
      */
-    ret = posix_istat(this, NULL, gfid, basename, &stat);
+    ret = posix_istat(this, NULL, gfid, basename, &stat, _gf_false);
     if (ret == -1) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE, "%s",
                path);

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -172,12 +172,12 @@
             __parp = strdupa(entp);                                            \
             parp = dirname(__parp);                                            \
             op_ret = posix_pstat(this, loc->inode, NULL, entp, ent_p,          \
-                                 _gf_false);                                   \
+                                 _gf_false, _gf_true);                         \
             break;                                                             \
         }                                                                      \
         errno = 0;                                                             \
-        op_ret = posix_istat(this, loc->inode, loc->pargfid, loc->name,        \
-                             ent_p);                                           \
+        op_ret = posix_istat(this, loc->inode, loc->pargfid, loc->name, ent_p, \
+                             _gf_true);                                        \
         if (errno != ELOOP) {                                                  \
             MAKE_HANDLE_PATH(parp, this, loc->pargfid, NULL);                  \
             MAKE_HANDLE_PATH(entp, this, loc->pargfid, loc->name);             \

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -445,7 +445,7 @@ posix_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 
     op_ret = posix_pstat(this, loc->inode, loc->gfid, real_path, &statpost,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -616,7 +616,7 @@ posix_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         goto out;
     }
 
-    op_ret = posix_fdstat(this, fd->inode, pfd->fd, &statpre);
+    op_ret = posix_fdstat(this, fd->inode, pfd->fd, &statpre, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -678,7 +678,7 @@ posix_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         }
     }
 
-    op_ret = posix_fdstat(this, fd->inode, pfd->fd, &statpost);
+    op_ret = posix_fdstat(this, fd->inode, pfd->fd, &statpost, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -760,7 +760,7 @@ overwrite:
         pthread_mutex_lock(&ctx->write_atomic_lock);
     }
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, statpre);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, statpre, _gf_true);
     if (ret == -1) {
         ret = -errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -789,7 +789,7 @@ overwrite:
         goto unlock;
     }
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, statpost);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, statpost, _gf_true);
     if (ret == -1) {
         ret = -errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -990,7 +990,7 @@ posix_do_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         pthread_mutex_lock(&ctx->write_atomic_lock);
     }
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, statpre);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, statpre, _gf_true);
     if (ret == -1) {
         ret = -errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1047,7 +1047,7 @@ fsync:
         }
     }
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, statpost);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, statpost, _gf_true);
     if (ret == -1) {
         ret = -errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1260,7 +1260,7 @@ posix_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
                   dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
-        ret = posix_fdstat(this, fd->inode, pfd->fd, &preop);
+        ret = posix_fdstat(this, fd->inode, pfd->fd, &preop, _gf_false);
         if (ret == -1) {
             ret = -errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1531,7 +1531,7 @@ posix_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     }
 
     op_ret = posix_pstat(this, loc->inode, loc->gfid, real_path, &postbuf,
-                         _gf_false);
+                         _gf_false, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
@@ -1635,7 +1635,7 @@ posix_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
                   dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
-        op_ret = posix_fdstat(this, fd->inode, pfd->fd, &preop);
+        op_ret = posix_fdstat(this, fd->inode, pfd->fd, &preop, _gf_false);
         if (op_ret == -1) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
                    "pre-operation fstat failed on fd=%p", fd);
@@ -1733,7 +1733,7 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
                   dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
-        op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
+        op_ret = posix_fdstat(this, fd->inode, _fd, &preop, _gf_false);
         if (op_ret == -1) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -1777,7 +1777,7 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
      *  we read from
      */
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &stbuf);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &stbuf, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -2046,7 +2046,7 @@ overwrite:
         pthread_mutex_lock(&ctx->write_atomic_lock);
     }
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &preop, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -2092,7 +2092,7 @@ overwrite:
      * the file we wrote to
      */
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postop);
+    ret = posix_fdstat(this, fd->inode, _fd, &postop, _gf_true);
     if (ret == -1) {
         op_ret = -1;
         op_errno = errno;
@@ -2287,7 +2287,7 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
         }
     }
 
-    op_ret = posix_fdstat(this, fd_out->inode, _fd_out, &preop_dst);
+    op_ret = posix_fdstat(this, fd_out->inode, _fd_out, &preop_dst, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -2349,7 +2349,7 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
     /* copy_file_range successful, we also need to get the stat of
      * the file we wrote to (i.e. destination file or fd_out).
      */
-    ret = posix_fdstat(this, fd_out->inode, _fd_out, &postop_dst);
+    ret = posix_fdstat(this, fd_out->inode, _fd_out, &postop_dst, _gf_true);
     if (ret == -1) {
         op_ret = -1;
         op_errno = errno;
@@ -2363,7 +2363,7 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
      * allowing it to be done within the locked region if the request
      * is for atomic operation (and update) of copy_file_range.
      */
-    ret = posix_fdstat(this, fd_in->inode, _fd_in, &stbuf);
+    ret = posix_fdstat(this, fd_in->inode, _fd_in, &stbuf, _gf_true);
     if (ret == -1) {
         op_ret = -1;
         op_errno = errno;
@@ -2679,7 +2679,7 @@ posix_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 
     _fd = pfd->fd;
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &preop, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_FSTAT_FAILED,
@@ -2709,7 +2709,7 @@ posix_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
         }
     }
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &postop);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &postop, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_FSTAT_FAILED,
@@ -2824,7 +2824,8 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         goto out;
     }
 
-    posix_pstat(this, loc->inode, loc->gfid, real_path, &preop, _gf_false);
+    posix_pstat(this, loc->inode, loc->gfid, real_path, &preop, _gf_false,
+                _gf_true);
 
     op_ret = -1;
 
@@ -2849,7 +2850,7 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
             }
 
             ret = posix_pstat(this, loc->inode, loc->gfid, real_path,
-                              &tmp_stbuf, _gf_true);
+                              &tmp_stbuf, _gf_true, _gf_true);
             if (ret) {
                 op_errno = EINVAL;
                 goto unlock;
@@ -3044,7 +3045,7 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
      * Ignore errors for now
      */
     ret = posix_pstat(this, loc->inode, loc->gfid, real_path, &postop,
-                      _gf_false);
+                      _gf_false, _gf_true);
     if (ret)
         goto out;
 
@@ -4447,7 +4448,7 @@ posix_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     }
     _fd = pfd->fd;
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, &preop);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, &preop, _gf_true);
     if (ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
@@ -4488,7 +4489,7 @@ posix_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
         }
     }
 
-    ret = posix_fdstat(this, fd->inode, pfd->fd, &postop);
+    ret = posix_fdstat(this, fd->inode, pfd->fd, &postop, _gf_true);
     if (ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_XATTR_FAILED,
@@ -4620,13 +4621,14 @@ posix_common_removexattr(call_frame_t *frame, loc_t *loc, fd_t *fd,
     }
 
     if (loc) {
-        ret = posix_pstat(this, inode, loc->gfid, real_path, &preop, _gf_false);
+        ret = posix_pstat(this, inode, loc->gfid, real_path, &preop, _gf_false,
+                          _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PSTAT_FAILED,
                    "pstat operaton failed on %s", real_path);
         }
     } else {
-        ret = posix_fdstat(this, inode, _fd, &preop);
+        ret = posix_fdstat(this, inode, _fd, &preop, _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_FDSTAT_FAILED,
                    "fdstat operaton failed on %s", real_path ? real_path : "");
@@ -4685,15 +4687,15 @@ posix_common_removexattr(call_frame_t *frame, loc_t *loc, fd_t *fd,
 
     if (loc) {
         posix_set_ctime(frame, this, real_path, -1, inode, NULL);
-        ret = posix_pstat(this, inode, loc->gfid, real_path, &postop,
-                          _gf_false);
+        ret = posix_pstat(this, inode, loc->gfid, real_path, &postop, _gf_false,
+                          _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PSTAT_FAILED,
                    "pstat operaton failed on %s", real_path);
         }
     } else {
         posix_set_ctime(frame, this, NULL, _fd, inode, NULL);
-        ret = posix_fdstat(this, inode, _fd, &postop);
+        ret = posix_fdstat(this, inode, _fd, &postop, _gf_true);
         if (ret) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_FDSTAT_FAILED,
                    "fdstat operaton failed on %s", real_path);
@@ -4955,40 +4957,42 @@ _posix_handle_xattr_keyvalue_pair(dict_t *d, char *k, data_t *v, void *tmp)
         } else {
             size = sys_fgetxattr(filler->fdnum, k, (char *)array, count);
         }
+        if (size == -1) {
+            op_errno = errno;
+            if ((op_errno != ENODATA) && (op_errno != ENOATTR)) {
+                if (op_errno == ENOTSUP) {
+                    GF_LOG_OCCASIONALLY(gf_posix_xattr_enotsup_log, this->name,
+                                        GF_LOG_WARNING,
+                                        "Extended attributes not "
+                                        "supported by filesystem");
+                } else if (op_errno != ENOENT ||
+                           !posix_special_xattr(marker_xattrs, k)) {
+                    if (filler->real_path)
+                        gf_msg(this->name,
+                               fop_log_level(GF_FOP_XATTROP, op_errno),
+                               op_errno, P_MSG_XATTR_FAILED,
+                               "getxattr failed on %s while "
+                               "doing xattrop: Key:%s ",
+                               filler->real_path, k);
+                    else
+                        gf_msg(this->name, GF_LOG_ERROR, op_errno,
+                               P_MSG_XATTR_FAILED,
+                               "fgetxattr failed on gfid=%s "
+                               "while doing xattrop: "
+                               "Key:%s (%s)",
+                               uuid_utoa(filler->inode->gfid), k,
+                               strerror(op_errno));
+                }
 
-        op_errno = errno;
-        if ((size == -1) && (op_errno != ENODATA) && (op_errno != ENOATTR)) {
-            if (op_errno == ENOTSUP) {
-                GF_LOG_OCCASIONALLY(gf_posix_xattr_enotsup_log, this->name,
-                                    GF_LOG_WARNING,
-                                    "Extended attributes not "
-                                    "supported by filesystem");
-            } else if (op_errno != ENOENT ||
-                       !posix_special_xattr(marker_xattrs, k)) {
-                if (filler->real_path)
-                    gf_msg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno),
-                           op_errno, P_MSG_XATTR_FAILED,
-                           "getxattr failed on %s while "
-                           "doing xattrop: Key:%s ",
-                           filler->real_path, k);
-                else
-                    gf_msg(
-                        this->name, GF_LOG_ERROR, op_errno, P_MSG_XATTR_FAILED,
-                        "fgetxattr failed on gfid=%s "
-                        "while doing xattrop: "
-                        "Key:%s (%s)",
-                        uuid_utoa(filler->inode->gfid), k, strerror(op_errno));
+                op_ret = -1;
+                goto unlock;
             }
 
-            op_ret = -1;
-            goto unlock;
+            if (optype == GF_XATTROP_GET_AND_SET) {
+                GF_FREE(array);
+                array = NULL;
+            }
         }
-
-        if (size == -1 && optype == GF_XATTROP_GET_AND_SET) {
-            GF_FREE(array);
-            array = NULL;
-        }
-
         /* We only write back the xattr if it has been really modified
          * (i.e. v->data is not all 0's). Otherwise we return its value
          * but we don't update anything.
@@ -5041,7 +5045,8 @@ _posix_handle_xattr_keyvalue_pair(dict_t *d, char *k, data_t *v, void *tmp)
         } else {
             size = sys_fsetxattr(filler->fdnum, k, (char *)dst_data, count, 0);
         }
-        op_errno = errno;
+        if (size == -1)
+            op_errno = errno;
     }
 unlock:
     pthread_mutex_unlock(&ctx->xattrop_lock);
@@ -5173,10 +5178,10 @@ do_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
         goto out;
 
     if (fd) {
-        op_ret = posix_fdstat(this, inode, _fd, &stbuf);
+        op_ret = posix_fdstat(this, inode, _fd, &stbuf, _gf_false);
     } else {
         op_ret = posix_pstat(this, inode, inode->gfid, real_path, &stbuf,
-                             _gf_false);
+                             _gf_false, _gf_false);
     }
     if (op_ret < 0) {
         op_errno = errno;
@@ -5291,7 +5296,7 @@ posix_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     _fd = pfd->fd;
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &preop, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -5320,7 +5325,7 @@ posix_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         goto out;
     }
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &postop);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &postop, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -5377,7 +5382,7 @@ posix_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     _fd = pfd->fd;
 
-    op_ret = posix_fdstat(this, fd->inode, _fd, &buf);
+    op_ret = posix_fdstat(this, fd->inode, _fd, &buf, _gf_true);
     if (op_ret == -1) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
@@ -5724,7 +5729,8 @@ posix_readdirp_fill(xlator_t *this, fd_t *fd, gf_dirent_t *entries,
 
         strcpy(&hpath[len + 1], entry->d_name);
 
-        ret = posix_pstat(this, inode, gfid, hpath, &stbuf, _gf_false);
+        ret = posix_pstat(this, inode, gfid, hpath, &stbuf, _gf_false,
+                          _gf_true);
 
         if (ret == -1) {
             if (inode)
@@ -5932,7 +5938,7 @@ posix_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     if (xdata && (dict_get_sizen(xdata, GF_CS_OBJECT_STATUS) ||
                   dict_get_sizen(xdata, GF_CS_OBJECT_REPAIR))) {
-        op_ret = posix_fdstat(this, fd->inode, _fd, &preop);
+        op_ret = posix_fdstat(this, fd->inode, _fd, &preop, _gf_false);
         if (op_ret == -1) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -72,11 +72,12 @@
         if (LOC_IS_DIR(loc) && LOC_HAS_ABSPATH(loc)) {                         \
             MAKE_REAL_PATH(rpath, this, (loc)->path);                          \
             op_ret = posix_pstat(this, (loc)->inode, (loc)->gfid, rpath,       \
-                                 iatt_p, _gf_false);                           \
+                                 iatt_p, _gf_false, _gf_true);                 \
             break;                                                             \
         }                                                                      \
         errno = 0;                                                             \
-        op_ret = posix_istat(this, loc->inode, loc->gfid, NULL, iatt_p);       \
+        op_ret = posix_istat(this, loc->inode, loc->gfid, NULL, iatt_p,        \
+                             _gf_true);                                        \
         if (errno != ELOOP) {                                                  \
             MAKE_HANDLE_PATH(rpath, this, (loc)->gfid, NULL);                  \
             if (!rpath) {                                                      \

--- a/xlators/storage/posix/src/posix-io-uring.c
+++ b/xlators/storage/posix/src/posix-io-uring.c
@@ -104,7 +104,8 @@ posix_io_uring_ctx_init(call_frame_t *frame, xlator_t *this, fd_t *fd, int op,
 
     /* TODO: Explore filling up pre and post bufs using IOSQE_IO_LINK*/
     if ((op == GF_FOP_WRITE) || (op == GF_FOP_FSYNC)) {
-        if (posix_fdstat(this, fd->inode, pfd->fd, &ctx->prebuf) != 0) {
+        if (posix_fdstat(this, fd->inode, pfd->fd, &ctx->prebuf, _gf_true) !=
+            0) {
             *op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, *op_errno, P_MSG_FSTAT_FAILED,
                    "fstat failed on fd=%p", fd);
@@ -156,7 +157,7 @@ posix_io_uring_readv_complete(struct posix_uring_ctx *ctx, int32_t res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;
@@ -289,7 +290,7 @@ posix_io_uring_writev_complete(struct posix_uring_ctx *ctx, int32_t res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;
@@ -384,7 +385,7 @@ posix_io_uring_fsync_complete(struct posix_uring_ctx *ctx, int32_t res)
         goto out;
     }
 
-    ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
+    ret = posix_fdstat(this, fd->inode, _fd, &postbuf, _gf_true);
     if (ret != 0) {
         op_ret = -1;
         op_errno = errno;

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -364,13 +364,15 @@ int
 posix_gfid_set(xlator_t *this, const char *path, loc_t *loc, dict_t *xattr_req,
                pid_t pid, int *op_errno);
 int
-posix_fdstat(xlator_t *this, inode_t *inode, int fd, struct iatt *stbuf_p);
+posix_fdstat(xlator_t *this, inode_t *inode, int fd, struct iatt *stbuf_p,
+             gf_boolean_t fetch_time);
 int
 posix_istat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *basename,
-            struct iatt *iatt);
+            struct iatt *iatt, gf_boolean_t fetch_time);
 int
 posix_pstat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *real_path,
-            struct iatt *iatt, gf_boolean_t inode_locked);
+            struct iatt *iatt, gf_boolean_t inode_locked,
+            gf_boolean_t fetch_time);
 
 dict_t *
 posix_xattr_fill(xlator_t *this, const char *path, loc_t *loc, fd_t *fd,
@@ -393,8 +395,6 @@ posix_entry_create_xattr_set(xlator_t *this, loc_t *loc, const char *path,
 int
 posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd,
                  int *op_errno);
-void
-posix_fill_ino_from_gfid(xlator_t *this, struct iatt *buf);
 
 gf_boolean_t
 posix_special_xattr(char **pattern, char *key);


### PR DESCRIPTION
Modified posix_fdstat, posix_pstat, posix_istat with an additional
boolean that allows to skip fetching ctime data, as it won't be
needed later. Most of the time, we still fetch it.

However, we do skip ctime fetching in some cases:
posix_aio_fsync
posix_mkdir
posix_unlink_gfid_handle_and_entry
posix_unlink_stale_linkto
posix_rename
posix_create
posix_resolve
_posix_xattr_get_set
janitor_walker
posix_seek
posix_open
posix_fsync
posix_common_removexattr
do_xattrop
posix_readdirp_fill
posix_rchecksumposix_aio_fsync
posix_mkdir
posix_unlink_gfid_handle_and_entry
posix_unlink_stale_linkto
posix_rename
posix_create
posix_resolve
_posix_xattr_get_set
janitor_walker
posix_seek
posix_open
posix_fsync
posix_common_removexattr
do_xattrop
posix_readdirp_fill
posix_rchecksum

Updates: #1000
Signed-off-by: Yaniv Kaul

