### PR TITLE
Events: make structures more memory friendly

### DIFF
--- a/cli/src/cli-rl.c
+++ b/cli/src/cli-rl.c
@@ -104,7 +104,7 @@ cli_rl_process_line(char *line)
 
 void
 cli_rl_stdin(int fd, int idx, int gen, void *data, int poll_out, int poll_in,
-             int poll_err, char event_thread_died)
+             int poll_err, int event_thread_died)
 {
     struct cli_state *state = data;
 

--- a/libglusterfs/src/event-poll.c
+++ b/libglusterfs/src/event-poll.c
@@ -33,11 +33,11 @@ struct event_slot_poll {
 static int
 event_register_poll(struct event_pool *event_pool, int fd,
                     event_handler_t handler, void *data, int poll_in,
-                    int poll_out, char notify_poller_death);
+                    int poll_out, int notify_poller_death);
 
 static void
 __flush_fd(int fd, int idx, int gen, void *data, int poll_in, int poll_out,
-           int poll_err, char event_thread_died)
+           int poll_err, int event_thread_died)
 {
     char buf[64];
     int ret = -1;
@@ -148,7 +148,7 @@ event_pool_new_poll(int count, int eventthreadcount)
 static int
 event_register_poll(struct event_pool *event_pool, int fd,
                     event_handler_t handler, void *data, int poll_in,
-                    int poll_out, char notify_poller_death)
+                    int poll_out, int notify_poller_death)
 {
     int idx = -1;
 

--- a/libglusterfs/src/event.c
+++ b/libglusterfs/src/event.c
@@ -54,7 +54,7 @@ gf_event_pool_new(int count, int eventthreadcount)
 int
 gf_event_register(struct event_pool *event_pool, int fd,
                   event_handler_t handler, void *data, int poll_in,
-                  int poll_out, char notify_poller_death)
+                  int poll_out, int notify_poller_death)
 {
     int ret = -1;
 
@@ -159,9 +159,9 @@ out:
     return ret;
 }
 
-void
+static void
 poller_destroy_handler(int fd, int idx, int gen, void *data, int poll_out,
-                       int poll_in, int poll_err, char event_thread_exit)
+                       int poll_in, int poll_err, int event_thread_exit)
 {
     struct event_destroy_data *destroy = NULL;
     int readfd = -1;

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -195,12 +195,12 @@ struct rpc_transport {
                            * client */
     gf_atomic_t disconnect_progress;
     int bind_insecure;
+    int notify_poller_death;
     /* connect_failed: saves the connect() syscall status as socket_t
      * member holding connect() status can't be accessed by higher gfapi
      * layer or in client management notification handler functions
      */
     gf_boolean_t connect_failed;
-    char notify_poller_death;
     char poller_death_accept;
 };
 

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -2854,7 +2854,7 @@ socket_complete_connection(rpc_transport_t *this)
 /* reads rpc_requests during pollin */
 static void
 socket_event_handler(int fd, int idx, int gen, void *data, int poll_in,
-                     int poll_out, int poll_err, char event_thread_died)
+                     int poll_out, int poll_err, int event_thread_died)
 {
     rpc_transport_t *this = NULL;
     socket_private_t *priv = NULL;
@@ -2979,7 +2979,7 @@ out:
 
 static void
 socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
-                            int poll_out, int poll_err, char event_thread_died)
+                            int poll_out, int poll_err, int event_thread_died)
 {
     rpc_transport_t *this = NULL;
     socket_private_t *priv = NULL;


### PR DESCRIPTION
Move separate fields to the same structure, to make them accessible
together.

Some other minor cleanups, mainly removing work from under lock, etc.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

