### PR TITLE
socket.c: comment properly what the SSL version is

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -4068,7 +4068,7 @@ out:
     return ret;
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000f
+#if OPENSSL_VERSION_NUMBER < 0x1010000f  // 1.1.0
 static pthread_mutex_t *lock_array = NULL;
 
 static void
@@ -4081,7 +4081,7 @@ locking_func(int mode, int type, const char *file, int line)
     }
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000000f
+#if OPENSSL_VERSION_NUMBER >= 0x1000000f  // 1.0.0
 static void
 threadid_func(CRYPTO_THREADID *id)
 {
@@ -4123,7 +4123,7 @@ init_openssl_mt(void)
 
     initialized = _gf_true;
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000f
+#if OPENSSL_VERSION_NUMBER < 0x1010000f  // 1.1.0
     int num_locks = CRYPTO_num_locks();
     int i;
 
@@ -4133,7 +4133,7 @@ init_openssl_mt(void)
         for (i = 0; i < num_locks; ++i) {
             pthread_mutex_init(&lock_array[i], NULL);
         }
-#if OPENSSL_VERSION_NUMBER >= 0x1000000f
+#if OPENSSL_VERSION_NUMBER >= 0x1000000f  // 1.0.0
         CRYPTO_THREADID_set_callback(threadid_func);
 #else /* older openssl */
         CRYPTO_set_id_callback(legacy_threadid_func);
@@ -4145,7 +4145,7 @@ init_openssl_mt(void)
 
 static void __attribute__((destructor)) fini_openssl_mt(void)
 {
-#if OPENSSL_VERSION_NUMBER < 0x1010000f
+#if OPENSSL_VERSION_NUMBER < 0x1010000f  // 1.1.0
     int i;
 
     if (!lock_array) {
@@ -4153,7 +4153,7 @@ static void __attribute__((destructor)) fini_openssl_mt(void)
     }
 
     CRYPTO_set_locking_callback(NULL);
-#if OPENSSL_VERSION_NUMBER >= 0x1000000f
+#if OPENSSL_VERSION_NUMBER >= 0x1000000f  // 1.0.0
     CRYPTO_THREADID_set_callback(NULL);
 #else /* older openssl */
     CRYPTO_set_id_callback(NULL);

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -300,7 +300,7 @@ aws_b64_encode(const unsigned char *input, int length)
 char *
 aws_sign_request(char *const str, char *awssekey)
 {
-#if (OPENSSL_VERSION_NUMBER < 0x1010002f)
+#if (OPENSSL_VERSION_NUMBER < 0x1010002f)  // 1.0.1-beta2
     HMAC_CTX ctx;
 #endif
     HMAC_CTX *pctx = NULL;
@@ -310,7 +310,7 @@ aws_sign_request(char *const str, char *awssekey)
     unsigned len;
     char *base64 = NULL;
 
-#if (OPENSSL_VERSION_NUMBER < 0x1010002f)
+#if (OPENSSL_VERSION_NUMBER < 0x1010002f)  // 1.0.1-beta2
     HMAC_CTX_init(&ctx);
     pctx = &ctx;
 #else
@@ -320,7 +320,7 @@ aws_sign_request(char *const str, char *awssekey)
     HMAC_Update(pctx, (unsigned char *)str, strlen(str));
     HMAC_Final(pctx, (unsigned char *)md, &len);
 
-#if (OPENSSL_VERSION_NUMBER < 0x1010002f)
+#if (OPENSSL_VERSION_NUMBER < 0x1010002f)  // 1.0.1-beta2
     HMAC_CTX_cleanup(pctx);
 #else
     HMAC_CTX_free(pctx);


### PR DESCRIPTION
Instead of guessing what the hex version stands for, just add a comment.
Data taken from https://gist.github.com/GPHemsley/73b5b29d69a65d1c69e653b66de1e985

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

