### PR TITLE
posix-acl*: remove some calls to posix_acl_ctx_new() and cleanups

### DIFF
--- a/xlators/system/posix-acl/src/posix-acl-xattr.c
+++ b/xlators/system/posix-acl/src/posix-acl-xattr.c
@@ -35,14 +35,14 @@ posix_ace_cmp(const void *val1, const void *val2)
     return ret;
 }
 
-void
-posix_acl_normalize(xlator_t *this, struct posix_acl *acl)
+static void
+posix_acl_normalize(struct posix_acl *acl)
 {
     qsort(acl->entries, acl->count, sizeof(struct posix_ace *), posix_ace_cmp);
 }
 
 struct posix_acl *
-posix_acl_from_xattr(xlator_t *this, const char *xattr_buf, int xattr_size)
+posix_acl_from_xattr(const char *xattr_buf, int xattr_size)
 {
     struct posix_acl_xattr_header *header = NULL;
     struct posix_acl_xattr_entry *entry = NULL;
@@ -70,7 +70,7 @@ posix_acl_from_xattr(xlator_t *this, const char *xattr_buf, int xattr_size)
     if (header->version != htole32(POSIX_ACL_XATTR_VERSION))
         return NULL;
 
-    acl = posix_acl_new(this, count);
+    acl = posix_acl_new(count);
     if (!acl)
         return NULL;
 
@@ -101,17 +101,16 @@ posix_acl_from_xattr(xlator_t *this, const char *xattr_buf, int xattr_size)
         entry++;
     }
 
-    posix_acl_normalize(this, acl);
+    posix_acl_normalize(acl);
 
     return acl;
 err:
-    posix_acl_destroy(this, acl);
+    GF_FREE(acl);
     return NULL;
 }
 
 int
-posix_acl_to_xattr(xlator_t *this, struct posix_acl *acl, char *xattr_buf,
-                   int xattr_size)
+posix_acl_to_xattr(struct posix_acl *acl, char *xattr_buf, int xattr_size)
 {
     int size = 0;
     struct posix_acl_xattr_header *header = NULL;
@@ -119,7 +118,7 @@ posix_acl_to_xattr(xlator_t *this, struct posix_acl *acl, char *xattr_buf,
     struct posix_ace *ace = NULL;
     int i = 0;
 
-    size = sizeof(*header) + (acl->count * sizeof(*entry));
+    size = posix_acl_xattr_size(acl->count);
 
     if (xattr_size < size)
         return size;
@@ -152,13 +151,12 @@ posix_acl_to_xattr(xlator_t *this, struct posix_acl *acl, char *xattr_buf,
 }
 
 int
-posix_acl_matches_xattr(xlator_t *this, struct posix_acl *acl, const char *buf,
-                        int size)
+posix_acl_matches_xattr(struct posix_acl *acl, const char *buf, int size)
 {
     struct posix_acl *acl2 = NULL;
     int ret = 1;
 
-    acl2 = posix_acl_from_xattr(this, buf, size);
+    acl2 = posix_acl_from_xattr(buf, size);
     if (!acl2)
         return 0;
 
@@ -171,7 +169,7 @@ posix_acl_matches_xattr(xlator_t *this, struct posix_acl *acl, const char *buf,
                (acl->count * sizeof(struct posix_ace))))
         ret = 0;
 out:
-    posix_acl_destroy(this, acl2);
+    GF_FREE(acl2);
 
     return ret;
 }

--- a/xlators/system/posix-acl/src/posix-acl-xattr.h
+++ b/xlators/system/posix-acl/src/posix-acl-xattr.h
@@ -17,13 +17,12 @@
 #include <glusterfs/glusterfs-acl.h>
 
 struct posix_acl *
-posix_acl_from_xattr(xlator_t *this, const char *buf, int size);
+posix_acl_from_xattr(const char *buf, int size);
 
 int
-posix_acl_to_xattr(xlator_t *this, struct posix_acl *acl, char *buf, int size);
+posix_acl_to_xattr(struct posix_acl *acl, char *buf, int size);
 
 int
-posix_acl_matches_xattr(xlator_t *this, struct posix_acl *acl, const char *buf,
-                        int size);
+posix_acl_matches_xattr(struct posix_acl *acl, const char *buf, int size);
 
 #endif /* !_POSIX_ACL_XATTR_H */

--- a/xlators/system/posix-acl/src/posix-acl.h
+++ b/xlators/system/posix-acl/src/posix-acl.h
@@ -20,13 +20,5 @@ struct posix_acl *
 posix_acl_ref(xlator_t *this, struct posix_acl *acl);
 void
 posix_acl_unref(xlator_t *this, struct posix_acl *acl);
-struct posix_acl_ctx *
-posix_acl_ctx_get(inode_t *inode, xlator_t *this);
-int
-posix_acl_get(inode_t *inode, xlator_t *this, struct posix_acl **acl_access_p,
-              struct posix_acl **acl_default_p);
-int
-posix_acl_set(inode_t *inode, xlator_t *this, struct posix_acl *acl_access,
-              struct posix_acl *acl_default);
 
 #endif /* !_POSIX_ACL_H */

--- a/xlators/system/posix-acl/src/posix-acl.h
+++ b/xlators/system/posix-acl/src/posix-acl.h
@@ -15,13 +15,11 @@
 #include <glusterfs/glusterfs-acl.h>
 
 struct posix_acl *
-posix_acl_new(xlator_t *this, int entry_count);
+posix_acl_new(int entry_count);
 struct posix_acl *
 posix_acl_ref(xlator_t *this, struct posix_acl *acl);
 void
 posix_acl_unref(xlator_t *this, struct posix_acl *acl);
-void
-posix_acl_destroy(xlator_t *this, struct posix_acl *acl);
 struct posix_acl_ctx *
 posix_acl_ctx_get(inode_t *inode, xlator_t *this);
 int


### PR DESCRIPTION
1. Remove unused 'this' parameter from functions.
2. posix_acl_destroy() was actually just a call to GF_FREE(acl), so replaced.
3. Removed unneeded calls to posix_acl_to_xattr() which were just to get the size
of the structs with the right call - a call to posix_acl_xattr_size()
4. posix_acl_new() would used to take a lock to increment the ref count of the acl
object it just created - for no reason.
5. Both posix_acl_lookup_cbk() and posix_acl_readdirp_cbk() used to call posix_acl_ctx_new(),
but do nothing with the resulting ctx. The following function, posix_acl_get() did it anyway,
so removed the redundant call.

Updates: #XXXX
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

