### PR TITLE
store, glusterd-store: improve store read iteration code

### DIFF
--- a/libglusterfs/src/glusterfs/store.h
+++ b/libglusterfs/src/glusterfs/store.h
@@ -26,6 +26,7 @@ typedef struct gf_store_handle_ gf_store_handle_t;
 struct gf_store_iter_ {
     FILE *file;
     char filepath[PATH_MAX];
+    char buf[8192];
 };
 
 typedef struct gf_store_iter_ gf_store_iter_t;
@@ -83,10 +84,6 @@ gf_store_handle_destroy(gf_store_handle_t *handle);
 
 int32_t
 gf_store_iter_new(gf_store_handle_t *shandle, gf_store_iter_t **iter);
-
-int32_t
-gf_store_validate_key_value(char *storepath, char *key, char *val,
-                            gf_store_op_errno_t *op_errno);
 
 int32_t
 gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -551,7 +551,7 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     GF_ASSERT(value);
 
     ret = gf_store_read_and_tokenize(iter->file, &iter_key, &iter_val,
-                                     &store_errno, iter->buf, 8192);
+                                     &store_errno, iter->buf, sizeof(iter->buf));
     if (ret < 0) {
         goto out;
     }

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -199,6 +199,8 @@ gf_store_read_and_tokenize(FILE *file, char **iter_key, char **iter_val,
     GF_ASSERT(iter_val);
     GF_ASSERT(store_errno);
 
+    str[0] = '\0';
+
 retry:
     temp = fgets(str, buf_size, file);
     if (temp == NULL || feof(file)) {
@@ -273,8 +275,9 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
     } else {
         fseek(handle->read, 0, SEEK_SET);
     }
+
+    char buf[8192];
     do {
-        char buf[8192];
         ret = gf_store_read_and_tokenize(handle->read, &iter_key, &iter_val,
                                          &store_errno, buf, 8192);
         if (ret < 0) {
@@ -509,15 +512,15 @@ gf_store_iter_new(gf_store_handle_t *shandle, gf_store_iter_t **iter)
         goto out;
     }
 
-    tmp_iter = GF_CALLOC(1, sizeof(*tmp_iter), gf_common_mt_store_iter_t);
+    tmp_iter = GF_MALLOC(sizeof(*tmp_iter), gf_common_mt_store_iter_t);
     if (!tmp_iter)
         goto out;
 
+    tmp_iter->file = fp;
     if (snprintf(tmp_iter->filepath, sizeof(tmp_iter->filepath), "%s",
                  shandle->path) >= sizeof(tmp_iter->filepath))
         goto out;
-
-    tmp_iter->file = fp;
+    tmp_iter->buf[0] = '\0';
 
     *iter = tmp_iter;
     tmp_iter = NULL;
@@ -534,53 +537,12 @@ out:
 }
 
 int32_t
-gf_store_validate_key_value(char *storepath, char *key, char *val,
-                            gf_store_op_errno_t *op_errno)
-{
-    int ret = 0;
-
-    GF_ASSERT(op_errno);
-    GF_ASSERT(storepath);
-
-    if ((key == NULL) && (val == NULL)) {
-        ret = -1;
-        gf_msg("", GF_LOG_ERROR, 0, LG_MSG_INVALID_ENTRY,
-               "Glusterd "
-               "store may be corrupted, Invalid key and value (null)"
-               " in %s",
-               storepath);
-        *op_errno = GD_STORE_KEY_VALUE_NULL;
-    } else if (key == NULL) {
-        ret = -1;
-        gf_msg("", GF_LOG_ERROR, 0, LG_MSG_INVALID_ENTRY,
-               "Glusterd "
-               "store may be corrupted, Invalid key (null) in %s",
-               storepath);
-        *op_errno = GD_STORE_KEY_NULL;
-    } else if (val == NULL) {
-        ret = -1;
-        gf_msg("", GF_LOG_ERROR, 0, LG_MSG_INVALID_ENTRY,
-               "Glusterd "
-               "store may be corrupted, Invalid value (null) for key"
-               " %s in %s",
-               key, storepath);
-        *op_errno = GD_STORE_VALUE_NULL;
-    } else {
-        ret = 0;
-        *op_errno = GD_STORE_SUCCESS;
-    }
-
-    return ret;
-}
-
-int32_t
 gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
                        gf_store_op_errno_t *op_errno)
 {
     int32_t ret = -1;
     char *iter_key = NULL;
     char *iter_val = NULL;
-    char buf[8192];
 
     gf_store_op_errno_t store_errno = GD_STORE_SUCCESS;
 
@@ -589,15 +551,10 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
     GF_ASSERT(value);
 
     ret = gf_store_read_and_tokenize(iter->file, &iter_key, &iter_val,
-                                     &store_errno, buf, 8192);
+                                     &store_errno, iter->buf, 8192);
     if (ret < 0) {
         goto out;
     }
-
-    ret = gf_store_validate_key_value(iter->filepath, iter_key, iter_val,
-                                      &store_errno);
-    if (ret)
-        goto out;
 
     *key = gf_strdup(iter_key);
     if (!*key) {

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4015,8 +4015,8 @@ glusterd_store_retrieve_missed_snaps_list(xlator_t *this)
         goto out;
     }
 
+    char buf[8192];
     do {
-        char buf[8192];
         ret = gf_store_read_and_tokenize(fp, &missed_node_info, &value,
                                          &store_errno, buf, 8192);
         if (ret) {


### PR DESCRIPTION
- Removed gf_store_validate_key_value() - it wasn't needed, as gf_store_read_and_tokenize()
 already performed the validations for both key and value, ensuring neither is NULL.
- Added an 8K buffer to the iter struct and re-used across calls to gf_store_iter_get_next().
- Used MALLOC instead of CALLOC for the iter structure, as we initialized all its fields.
- Extracted the buffer definition from the loop, where applicable.

 Updates: #1000
 Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

