### PR TITLE
fuse-bridge.c: fix clang-scan warning on uninitialized use

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4805,9 +4805,11 @@ fuse_setlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = 0;
 
     ret = fuse_interrupt_finish_fop(frame, this, _gf_true, (void **)&state);
-    GF_FREE(state->name);
-    dict_unref(state->xdata);
-    GF_FREE(state);
+    if (state) {
+        GF_FREE(state->name);
+        dict_unref(state->xdata);
+        GF_FREE(state);
+    }
     if (ret) {
         return 0;
     }


### PR DESCRIPTION
Seems like state variable may by NULL.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>
Updates: #1000

