### PR TITLE
posix_check_internal_writes() - remove dict actions from lock

### DIFF
--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -214,7 +214,8 @@ posix_create_link_if_gfid_exists(xlator_t *this, uuid_t gfid, char *real_path,
                                  inode_table_t *itable);
 
 int
-posix_check_internal_writes(xlator_t *this, fd_t *fd, int sysfd, dict_t *xdata);
+posix_check_internal_writes(xlator_t *this, struct _inode *fd_inode, int sysfd,
+                            dict_t *xdata);
 
 void
 posix_disk_space_check(struct posix_private *priv);

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -214,7 +214,7 @@ posix_create_link_if_gfid_exists(xlator_t *this, uuid_t gfid, char *real_path,
                                  inode_table_t *itable);
 
 int
-posix_check_internal_writes(xlator_t *this, struct _inode *fd_inode, int sysfd,
+posix_check_internal_writes(xlator_t *this, inode_t *fd_inode, int sysfd,
                             dict_t *xdata);
 
 void

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2958,7 +2958,7 @@ posix_override_umask(mode_t mode, mode_t mode_bit)
 }
 
 int
-posix_check_internal_writes(xlator_t *this, struct _inode *fd_inode, int sysfd,
+posix_check_internal_writes(xlator_t *this, inode_t *fd_inode, int sysfd,
                             dict_t *xdata)
 {
     int ret = 0;

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2004,16 +2004,15 @@ overwrite:
 
     _fd = pfd->fd;
 
-    ret = posix_check_internal_writes(this, fd, _fd, xdata);
-    if (ret < 0) {
-        gf_msg(this->name, GF_LOG_ERROR, 0, 0,
-               "possible overwrite from internal client, fd=%p", fd);
-        op_ret = -1;
-        op_errno = EBUSY;
-        goto out;
-    }
-
     if (xdata) {
+        ret = posix_check_internal_writes(this, fd->inode, _fd, xdata);
+        if (ret < 0) {
+            gf_msg(this->name, GF_LOG_ERROR, 0, 0,
+                   "possible overwrite from internal client, fd=%p", fd);
+            op_ret = -1;
+            op_errno = EBUSY;
+            goto out;
+        }
         if (dict_get(xdata, GLUSTERFS_WRITE_IS_APPEND))
             write_append = _gf_true;
         if (dict_get(xdata, GLUSTERFS_WRITE_UPDATE_ATOMIC))
@@ -2243,16 +2242,17 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
      * this functon or fop does not require additional changes for
      * handling internal writes.
      */
-    ret = posix_check_internal_writes(this, fd_out, _fd_out, xdata);
-    if (ret < 0) {
-        gf_msg(this->name, GF_LOG_ERROR, 0, 0,
-               "possible overwrite from internal client, fd=%p", fd_out);
-        op_ret = -1;
-        op_errno = EBUSY;
-        goto out;
-    }
 
     if (xdata) {
+        ret = posix_check_internal_writes(this, fd_out->inode, _fd_out, xdata);
+        if (ret < 0) {
+            gf_msg(this->name, GF_LOG_ERROR, 0, 0,
+                   "possible overwrite from internal client, fd=%p", fd_out);
+            op_ret = -1;
+            op_errno = EBUSY;
+            goto out;
+        }
+
         if (dict_get(xdata, GLUSTERFS_WRITE_UPDATE_ATOMIC))
             update_atomic = _gf_true;
     }


### PR DESCRIPTION
We can (1) do those dict fetches outside the lock and (2) avoid
the lock altogether if none of the items are found in the lock.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

