### PR TITLE
libglusterfs: prefer mallinfo2() to mallinfo() if available

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -917,9 +917,9 @@ xml_output:
             type, brick_count, dist_count, stripe_count, replica_count,
             disperse_count, redundancy_count, arbiter_count);
 
-        cli_out("Transport-type: %s",
-                ((transport == 0) ? "tcp"
-                                  : (transport == 1) ? "rdma" : "tcp,rdma"));
+        cli_out("Transport-type: %s", ((transport == 0)   ? "tcp"
+                                       : (transport == 1) ? "rdma"
+                                                          : "tcp,rdma"));
         j = 1;
 
         GF_FREE(local->get_vol.volname);
@@ -6120,7 +6120,7 @@ cli_print_volume_status_mem(dict_t *dict, gf_boolean_t notbrick)
     int brick_index_max = -1;
     int other_count = 0;
     int index_max = 0;
-    int val = 0;
+    uint64_t val = 0;
     int i = 0;
 
     GF_ASSERT(dict);
@@ -6170,64 +6170,64 @@ cli_print_volume_status_mem(dict_t *dict, gf_boolean_t notbrick)
         cli_out("Mallinfo\n--------");
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.arena", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Arena", val);
+        cli_out("%-8s : %" PRIu64, "Arena", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.ordblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Ordblks", val);
+        cli_out("%-8s : %" PRIu64, "Ordblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.smblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Smblks", val);
+        cli_out("%-8s : %" PRIu64, "Smblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.hblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Hblks", val);
+        cli_out("%-8s : %" PRIu64, "Hblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.hblkhd", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Hblkhd", val);
+        cli_out("%-8s : %" PRIu64, "Hblkhd", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.usmblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Usmblks", val);
+        cli_out("%-8s : %" PRIu64, "Usmblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.fsmblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Fsmblks", val);
+        cli_out("%-8s : %" PRIu64, "Fsmblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.uordblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Uordblks", val);
+        cli_out("%-8s : %" PRIu64, "Uordblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.fordblks", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Fordblks", val);
+        cli_out("%-8s : %" PRIu64, "Fordblks", val);
 
         snprintf(key, sizeof(key), "brick%d.mallinfo.keepcost", i);
-        ret = dict_get_int32(dict, key, &val);
+        ret = dict_get_uint64(dict, key, &val);
         if (ret)
             goto out;
-        cli_out("%-8s : %d", "Keepcost", val);
+        cli_out("%-8s : %" PRIu64, "Keepcost", val);
 
         cli_out(" ");
         snprintf(key, sizeof(key), "brick%d", i);

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -560,16 +560,16 @@ cli_xml_output_vol_status_mem(xmlTextWriterPtr writer, dict_t *dict,
                               int brick_index)
 {
     int ret = -1;
-    int arena = 0;
-    int ordblks = 0;
-    int smblks = 0;
-    int hblks = 0;
-    int hblkhd = 0;
-    int usmblks = 0;
-    int fsmblks = 0;
-    int uordblks = 0;
-    int fordblks = 0;
-    int keepcost = 0;
+    uint64_t arena = 0;
+    uint64_t ordblks = 0;
+    uint64_t smblks = 0;
+    uint64_t hblks = 0;
+    uint64_t hblkhd = 0;
+    uint64_t usmblks = 0;
+    uint64_t fsmblks = 0;
+    uint64_t uordblks = 0;
+    uint64_t fordblks = 0;
+    uint64_t keepcost = 0;
     char key[1024] = {
         0,
     };
@@ -583,83 +583,83 @@ cli_xml_output_vol_status_mem(xmlTextWriterPtr writer, dict_t *dict,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.arena", brick_index);
-    ret = dict_get_int32(dict, key, &arena);
+    ret = dict_get_uint64(dict, key, &arena);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"arena", "%d",
-                                          arena);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"arena",
+                                          "%" PRIu64, arena);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.ordblks", brick_index);
-    ret = dict_get_int32(dict, key, &ordblks);
+    ret = dict_get_uint64(dict, key, &ordblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"ordblks", "%d",
-                                          ordblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"ordblks",
+                                          "%" PRIu64, ordblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.smblks", brick_index);
-    ret = dict_get_int32(dict, key, &smblks);
+    ret = dict_get_uint64(dict, key, &smblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"smblks", "%d",
-                                          smblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"smblks",
+                                          "%" PRIu64, smblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.hblks", brick_index);
-    ret = dict_get_int32(dict, key, &hblks);
+    ret = dict_get_uint64(dict, key, &hblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"hblks", "%d",
-                                          hblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"hblks",
+                                          "%" PRIu64, hblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.hblkhd", brick_index);
-    ret = dict_get_int32(dict, key, &hblkhd);
+    ret = dict_get_uint64(dict, key, &hblkhd);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"hblkhd", "%d",
-                                          hblkhd);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"hblkhd",
+                                          "%" PRIu64, hblkhd);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.usmblks", brick_index);
-    ret = dict_get_int32(dict, key, &usmblks);
+    ret = dict_get_uint64(dict, key, &usmblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"usmblks", "%d",
-                                          usmblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"usmblks",
+                                          "%" PRIu64, usmblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.fsmblks", brick_index);
-    ret = dict_get_int32(dict, key, &fsmblks);
+    ret = dict_get_uint64(dict, key, &fsmblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"fsmblks", "%d",
-                                          fsmblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"fsmblks",
+                                          "%" PRIu64, fsmblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.uordblks", brick_index);
-    ret = dict_get_int32(dict, key, &uordblks);
+    ret = dict_get_uint64(dict, key, &uordblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"uordblks", "%d",
-                                          uordblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"uordblks",
+                                          "%" PRIu64, uordblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.fordblks", brick_index);
-    ret = dict_get_int32(dict, key, &fordblks);
+    ret = dict_get_uint64(dict, key, &fordblks);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"fordblks", "%d",
-                                          fordblks);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"fordblks",
+                                          "%" PRIu64, fordblks);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "brick%d.mallinfo.keepcost", brick_index);
-    ret = dict_get_int32(dict, key, &keepcost);
+    ret = dict_get_uint64(dict, key, &keepcost);
     if (ret)
         goto out;
-    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"keepcost", "%d",
-                                          keepcost);
+    ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"keepcost",
+                                          "%" PRIu64, keepcost);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     /* </mallinfo> */

--- a/configure.ac
+++ b/configure.ac
@@ -1003,10 +1003,17 @@ AC_TRY_COMPILE([#include <math.h>], [double x=0.0; x=ceil(0.0);],
 fi
 
 dnl glusterfs prints memory usage to stderr by sending it SIGUSR1
-AC_CHECK_FUNC([mallinfo], [have_mallinfo=yes])
-if test "x${have_mallinfo}" = "xyes"; then
-   AC_DEFINE(HAVE_MALLINFO, 1, [define if found mallinfo])
+dnl try mallinfo2 first, fallback to mallinfo if not available
+AC_CHECK_FUNC([mallinfo2], [have_mallinfo2=yes])
+if test "x${have_mallinfo2}" = "xyes"; then
+   AC_DEFINE(HAVE_MALLINFO2, 1, [define if found mallinfo2])
+else
+   AC_CHECK_FUNC([mallinfo], [have_mallinfo=yes])
+   if test "x${have_mallinfo}" = "xyes"; then
+      AC_DEFINE(HAVE_MALLINFO, 1, [define if found mallinfo])
+   fi
 fi
+AC_SUBST(HAVE_MALLINFO2)
 AC_SUBST(HAVE_MALLINFO)
 
 dnl Linux, Solaris, Cygwin

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -300,28 +300,55 @@ gf_proc_dump_xlator_mem_info_only_in_use(xlator_t *xl)
     return;
 }
 
-/* Currently this dumps only mallinfo. More can be built on here */
+/* Currently this dumps only mallinfo. More can be built on here. */
+
+#if defined(HAVE_MALLINFO2)
+
+typedef struct mallinfo2 gf_mallinfo_t;
+
+static inline void
+gf_mallinfo(gf_mallinfo_t *info)
+{
+    memset(info, 0, sizeof(gf_mallinfo_t));
+    *info = mallinfo2();
+}
+
+#define M_FMT "%zd"
+
+#elif defined(HAVE_MALLINFO)
+
+typedef struct mallinfo gf_mallinfo_t;
+
+static inline void
+gf_mallinfo(gf_mallinfo_t *info)
+{
+    memset(info, 0, sizeof(gf_mallinfo_t));
+    *info = mallinfo();
+}
+
+#define M_FMT "%d"
+
+#endif /* HAVE_MALLINFO2 */
+
 void
 gf_proc_dump_mem_info()
 {
-#ifdef HAVE_MALLINFO
-    struct mallinfo info;
+#if defined(HAVE_MALLINFO2) || defined(HAVE_MALLINFO)
+    gf_mallinfo_t info;
 
-    memset(&info, 0, sizeof(struct mallinfo));
-    info = mallinfo();
-
+    gf_mallinfo(&info);
     gf_proc_dump_add_section("mallinfo");
-    gf_proc_dump_write("mallinfo_arena", "%d", info.arena);
-    gf_proc_dump_write("mallinfo_ordblks", "%d", info.ordblks);
-    gf_proc_dump_write("mallinfo_smblks", "%d", info.smblks);
-    gf_proc_dump_write("mallinfo_hblks", "%d", info.hblks);
-    gf_proc_dump_write("mallinfo_hblkhd", "%d", info.hblkhd);
-    gf_proc_dump_write("mallinfo_usmblks", "%d", info.usmblks);
-    gf_proc_dump_write("mallinfo_fsmblks", "%d", info.fsmblks);
-    gf_proc_dump_write("mallinfo_uordblks", "%d", info.uordblks);
-    gf_proc_dump_write("mallinfo_fordblks", "%d", info.fordblks);
-    gf_proc_dump_write("mallinfo_keepcost", "%d", info.keepcost);
-#endif
+    gf_proc_dump_write("mallinfo_arena", M_FMT, info.arena);
+    gf_proc_dump_write("mallinfo_ordblks", M_FMT, info.ordblks);
+    gf_proc_dump_write("mallinfo_smblks", M_FMT, info.smblks);
+    gf_proc_dump_write("mallinfo_hblks", M_FMT, info.hblks);
+    gf_proc_dump_write("mallinfo_hblkhd", M_FMT, info.hblkhd);
+    gf_proc_dump_write("mallinfo_usmblks", M_FMT, info.usmblks);
+    gf_proc_dump_write("mallinfo_fsmblks", M_FMT, info.fsmblks);
+    gf_proc_dump_write("mallinfo_uordblks", M_FMT, info.uordblks);
+    gf_proc_dump_write("mallinfo_fordblks", M_FMT, info.fordblks);
+    gf_proc_dump_write("mallinfo_keepcost", M_FMT, info.keepcost);
+#endif /* MALLINFO2 || MALLINFO */
     gf_proc_dump_xlator_mem_info(&global_xlator);
 }
 
@@ -330,54 +357,52 @@ gf_proc_dump_mem_info_to_dict(dict_t *dict)
 {
     if (!dict)
         return;
-#ifdef HAVE_MALLINFO
-    struct mallinfo info;
+#if defined(HAVE_MALLINFO2) || defined(HAVE_MALLINFO)
+    gf_mallinfo_t info;
     int ret = -1;
 
-    memset(&info, 0, sizeof(struct mallinfo));
-    info = mallinfo();
+    gf_mallinfo(&info);
 
-    ret = dict_set_int32(dict, "mallinfo.arena", info.arena);
+    ret = dict_set_uint64(dict, "mallinfo.arena", info.arena);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.ordblks", info.ordblks);
+    ret = dict_set_uint64(dict, "mallinfo.ordblks", info.ordblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.smblks", info.smblks);
+    ret = dict_set_uint64(dict, "mallinfo.smblks", info.smblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.hblks", info.hblks);
+    ret = dict_set_uint64(dict, "mallinfo.hblks", info.hblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.hblkhd", info.hblkhd);
+    ret = dict_set_uint64(dict, "mallinfo.hblkhd", info.hblkhd);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.usmblks", info.usmblks);
+    ret = dict_set_uint64(dict, "mallinfo.usmblks", info.usmblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.fsmblks", info.fsmblks);
+    ret = dict_set_uint64(dict, "mallinfo.fsmblks", info.fsmblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.uordblks", info.uordblks);
+    ret = dict_set_uint64(dict, "mallinfo.uordblks", info.uordblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.fordblks", info.fordblks);
+    ret = dict_set_uint64(dict, "mallinfo.fordblks", info.fordblks);
     if (ret)
         return;
 
-    ret = dict_set_int32(dict, "mallinfo.keepcost", info.keepcost);
+    ret = dict_set_uint64(dict, "mallinfo.keepcost", info.keepcost);
     if (ret)
         return;
-#endif
-    return;
+#endif /* HAVE_MALLINFO2 || HAVE_MALLINFO */
 }
 
 void


### PR DESCRIPTION
Since glibc 2.33, mallinfo() is marked obsolete due to the limited
range of 'int' type used in 'struct mallinfo', and new 'size_t'-based
counterpart 'struct mallinfo2' with corresponding function mallinfo2()
should be preferred instead. To avoid compatibility mess, it's also
reasonable to use 'uint64_t' values for storing and operating with
mallinfo data internally, as suggested by Xavi Hernandez.

Updates: #2414

> Fixes: #2414
> Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>

Change-Id: I3c8d22a6d05629af3e5700d9c699c9f39d7085b3
Signed-off-by: nik-redhat <nladha@redhat.com>

