### PR TITLE
Adapting glusterfs to be endian-independent code

### DIFF
--- a/libglusterfs/src/hashfn.c
+++ b/libglusterfs/src/hashfn.c
@@ -137,7 +137,7 @@ gf_dm_hashfn(const char *msg, int len)
 
     for (i = 0; i < full_quads; i++) {
         for (j = 0; j < 4; j++) {
-            word = *intmsg;
+        	word = le32toh(*intmsg);
             array[j] = word;
             intmsg++;
             full_words--;
@@ -148,7 +148,7 @@ gf_dm_hashfn(const char *msg, int len)
 
     for (j = 0; j < 4; j++) {
         if (full_words) {
-            word = *intmsg;
+        	word = le32toh(*intmsg);
             array[j] = word;
             intmsg++;
             full_words--;

--- a/libglusterfs/src/hashfn.c
+++ b/libglusterfs/src/hashfn.c
@@ -11,6 +11,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+
 #define get16bits(d) (*((const uint16_t *)(d)))
 
 #define DM_DELTA 0x9E3779B9
@@ -126,7 +132,7 @@ gf_dm_hashfn(const char *msg, int len)
     int full_words = 0;
     int full_bytes = 0;
     uint32_t *intmsg = NULL;
-    int word = 0;
+    uint32_t word = 0;
 
     intmsg = (uint32_t *)msg;
     pad = __pad(len);
@@ -137,7 +143,7 @@ gf_dm_hashfn(const char *msg, int len)
 
     for (i = 0; i < full_quads; i++) {
         for (j = 0; j < 4; j++) {
-        	word = le32toh(*intmsg);
+            word = le32toh(*intmsg);
             array[j] = word;
             intmsg++;
             full_words--;
@@ -148,7 +154,7 @@ gf_dm_hashfn(const char *msg, int len)
 
     for (j = 0; j < 4; j++) {
         if (full_words) {
-        	word = le32toh(*intmsg);
+            word = le32toh(*intmsg);
             array[j] = word;
             intmsg++;
             full_words--;

--- a/tests/basic/distribute/throttle-rebal.t
+++ b/tests/basic/distribute/throttle-rebal.t
@@ -17,7 +17,7 @@ function set_throttle {
 }
 
 #Determine number of cores
-cores=$(cat /proc/cpuinfo | grep processor | wc -l)
+cores=$(getconf _NPROCESSORS_ONLN)
 if [ "$cores" == "" ]; then
         echo "Could not get number of cores available"
 fi


### PR DESCRIPTION
Some regression tests fail on IBM 390x machine, the main RC seems to be
the different endianness: s390x is big-endian, x86 is little-endian.

Work scope:
Detect the cases where assignment returns a different value due architectures and
use the little-endian to host byte order (use thie convertion as the t tests are running fine on x86).

This commit covers the adaptation required for running DHT .t files on a big-endian arch:
- adapting the hash_func to be endian safe.
- use getconf to get #core.

Note:
- Dict serialize/deserialize code already implements network byte order (big-endian)

Updates: #2491

Change-Id: I2900f0f363ab00af8c68900b8aa2e30c574120e5
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

