### PR TITLE
Doc: Update the link to compiling rpms in test framework doc

### DIFF
--- a/doc/developer-guide/Using-Gluster-Test-Framework.md
+++ b/doc/developer-guide/Using-Gluster-Test-Framework.md
@@ -162,7 +162,7 @@ Either install an existing set of rpms:
 
 Or compile your own ones (fairly easy):
 
-	https://docs.gluster.org/en/latest/Developer-guide/compiling-rpms/
+	https://docs.gluster.org/Developer-guide/compiling-rpms/
 
 ​3. Clone the GlusterFS git repository
 


### PR DESCRIPTION
After the move to github pages for docs.gluster.org as part of fix to issue,
https://github.com/gluster/project-infrastructure/issues/141
the link to Compiling RPMS is again broken. Fixing it with this patch.

Fixes: #3054
Change-Id: Ib50f3512b4a502074737d02e16992d105f3ca991
Signed-off-by: karthik-us <ksubrahm@redhat.com>

