### PR TITLE
[glusterd] Fix Coverity Issue (CWE-120)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -4847,7 +4847,7 @@ glusterd_do_snap_vol(glusterd_volinfo_t *origin_vol, glusterd_snap_t *snap,
                    "snap_plugin");
             goto out;
         }
-        strcpy(snap_vol->snap_plugin, snap_plugin);
+        gf_strncpy(snap_vol->snap_plugin, snap_plugin, sizeof(snap_vol->snap_plugin));
     }
     /* To use generic functions from the plugin */
     glusterd_snapshot_plugin_by_name(snap_vol->snap_plugin, &snap_ops);


### PR DESCRIPTION
Copy the src string into dest safely. `gf_strncpy` takes care of NULL
termination and uses strncpy under the hood.
Updates: #1060
CID: 1382365

Change-Id: I2ef20d3f4859e6c5aba2b75f199db304baf7657f
Signed-off-by: black-dragon74 <niryadav@redhat.com>

