### PR TITLE
[glusterd] Fix coverity issue (CWE-562)

### DIFF
--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
@@ -955,9 +955,20 @@ glusterd_lvm_snap_clone_brick_path(char *snap_mount_dir,
 
     if ((len < 0) || (len >= sizeof(brick_path))) {
         ret = -1;
+        goto out;
     }
 
-    *snap_brick_path = brick_path;
+    *snap_brick_path = gf_strdup(brick_path);
+    if (!*snap_brick_path) {
+        ret = -1;
+        goto out;
+    }
+
+out:
+    if (ret && *snap_brick_path) {
+        GF_FREE(*snap_brick_path);
+        *snap_brick_path = NULL;
+    }
 
     return ret;
 }


### PR DESCRIPTION
Stack allocation has been replaced by the call to `gf_strdup` which
allocates memory on heap(`GF_MALLOC`) and hence fixes the possible invalid pointer
deref.

Updates: #1060
CID: 1467252

Change-Id: Ia11c694d663498aa46ebb5a8626540ed33848a5e
Signed-off-by: black-dragon74 <niryadav@redhat.com>

