### PR TITLE
[glusterd] Fix Coverity Issue (CWE-562)

### DIFF
--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -499,12 +499,23 @@ glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
 
     if ((len < 0) || (len >= sizeof(brick_path))) {
         ret = -1;
+        goto out;
     }
 
-    *snap_brick_path = brick_path;
+    *snap_brick_path = gf_strdup(brick_path);
+    if (!*snap_brick_path) {
+        ret = -1;
+        goto out;
+    }
 
+out:
     if (origin_brick)
         GF_FREE(origin_brick);
+
+    if (ret && *snap_brick_path) {
+        GF_FREE(*snap_brick_path);
+        *snap_brick_path = NULL;
+    }
 
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -480,6 +480,10 @@ glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
     char *origin_brick = NULL;
 
     origin_brick = gf_strdup(origin_brick_path);
+    if (!origin_brick) {
+        ret = -1;
+        goto out;
+    }
     origin_brick_mount = dirname(origin_brick);
 
     if (clone)


### PR DESCRIPTION
Stack allocation has been replaced by the call to gf_strdup which allocates memory on heap(GF_MALLOC) and hence fixes the possible invalid pointer deref.

Updates: #1060
CID: 1468104

Signed-off-by: black-dragon74 <niryadav@redhat.com>

