### PR TITLE
leases-internal.c: fix and improve __lease_ctx_set()

### DIFF
--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -127,18 +127,7 @@ static int
 __lease_ctx_set(inode_t *inode, xlator_t *this)
 {
     lease_inode_ctx_t *inode_ctx = NULL;
-    int ret = -1;
-    uint64_t ctx = 0;
-
-    GF_VALIDATE_OR_GOTO("leases", inode, out);
-    GF_VALIDATE_OR_GOTO("leases", this, out);
-
-    ret = __inode_ctx_get(inode, this, &ctx);
-    if (!ret) {
-        gf_msg(this->name, GF_LOG_ERROR, 0, LEASE_MSG_INVAL_INODE_CTX,
-               "inode_ctx_get failed");
-        goto out;
-    }
+    int ret;
 
     inode_ctx = GF_CALLOC(1, sizeof(*inode_ctx),
                           gf_leases_mt_lease_inode_ctx_t);
@@ -166,9 +155,6 @@ __lease_ctx_get(inode_t *inode, xlator_t *this)
     lease_inode_ctx_t *inode_ctx = NULL;
     uint64_t ctx = 0;
     int ret = 0;
-
-    GF_VALIDATE_OR_GOTO("leases", inode, out);
-    GF_VALIDATE_OR_GOTO("leases", this, out);
 
     ret = __inode_ctx_get(inode, this, &ctx);
     if (ret < 0) {


### PR DESCRIPTION
- it was not checking properly for a failure to get inode ctx, should have
used 'ret < 0' and not '!ret'
- it did not need to fetch the inode ctx - we know there's no such ctx,
as it was called immediately after a get failed, so cleaned up the code around it.

Updates: #3076
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

