### PR TITLE
Add dependency to mount gluster_shared_storage only after glusterd.service

### DIFF
--- a/extras/hook-scripts/set/post/S32gluster_enable_shared_storage.sh
+++ b/extras/hook-scripts/set/post/S32gluster_enable_shared_storage.sh
@@ -131,6 +131,14 @@ if [ "$option" == "enable" ]; then
     mkdir -p /run/gluster/shared_storage
     $mount_cmd
     cp /etc/fstab /run/gluster/fstab.tmp
-    echo "$local_node_hostname:/gluster_shared_storage /run/gluster/shared_storage/ glusterfs defaults        0 0" >> /run/gluster/fstab.tmp
+
+    # Check if systemd is our init
+    init_process=$(basename $(readlink -e /proc/1/exe) 2>/dev/null )
+    if [ "$init_process" == "systemd" ]
+    then
+         # Add dependency for glusterd.service, as we use $local_node_hostname
+         extra_mount_options=",x-systemd.requires=glusterd.service"
+    fi
+    echo "$local_node_hostname:/gluster_shared_storage /run/gluster/shared_storage/ glusterfs defaults$extra_mount_options        0 0" >> /run/gluster/fstab.tmp
     mv /run/gluster/fstab.tmp /etc/fstab
 fi


### PR DESCRIPTION
Sometimes gluster_shared_storage is not mounted due to the fact that systemd tries to mount it before glusterd has started completely (more often happens when 5+ volumes are present) on the $local_node_hostname .

This patch checks if systemd is our init and if it is, adds an extra mount option:
```x-systemd.requires=glusterd.service```