### PR TITLE
glusterd: Fix coverity issue (CWE-562) (PR #3079)

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -249,10 +249,8 @@ glusterd_snap_volinfo_restore(dict_t *dict, dict_t *rsp_dict,
             snap_ops->brick_path(snap_mount_dir, brickinfo->origin_path, 0,
                                  snap_volinfo->snapshot->snapname,
                                  snap_volinfo->volname, brickinfo->mount_dir,
-                                 brick_count - 1, &value, 1);
+                                 brick_count - 1, new_brickinfo, 1);
         }
-        if (!ret)
-            gf_strncpy(new_brickinfo->path, value, sizeof(new_brickinfo->path));
 
         snprintf(key, sizeof(key), "snap%d.brick%d.snap_status", volcount,
                  brick_count);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -120,7 +120,7 @@ struct glusterd_snap_ops {
                                 int clone, char *snap_clone_name,
                                 char *snap_clone_volume_id,
                                 char *snap_brick_dir, int brick_num,
-                                char **snap_brick_path, int restore);
+                                glusterd_brickinfo_t *brickinfo, int restore);
 };
 
 extern struct glusterd_snap_ops lvm_snap_ops;

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
@@ -939,25 +939,23 @@ glusterd_lvm_snap_clone_brick_path(char *snap_mount_dir,
                                    char *snap_clone_name,
                                    char *snap_clone_volume_id,
                                    char *snap_brick_dir, int brick_num,
-                                   char **snap_brick_path, int restore)
+                                   glusterd_brickinfo_t *brickinfo, int restore)
 {
     int32_t len = 0;
     int ret = 0;
-    char brick_path[PATH_MAX] = "";
 
     if (strcmp(snap_brick_dir, "/") == 0) {
         snap_brick_dir = "";
     }
 
-    len = snprintf(brick_path, sizeof(brick_path), "%s/%s/brick%d%s",
+    len = snprintf(brickinfo->path, sizeof(brickinfo->path), "%s/%s/brick%d%s",
                    snap_mount_dir, snap_clone_volume_id, brick_num + 1,
                    snap_brick_dir);
 
-    if ((len < 0) || (len >= sizeof(brick_path))) {
+    if ((len < 0) || (len >= sizeof(brickinfo->path))) {
+        brickinfo->path[0] = 0;
         ret = -1;
     }
-
-    *snap_brick_path = brick_path;
 
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -471,7 +471,7 @@ glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
                                    char *snap_clone_name,
                                    char *snap_clone_volume_id,
                                    char *snap_brick_dir, int brick_num,
-                                   char **snap_brick_path, int restore)
+                                   glusterd_brickinfo_t *brickinfo, int restore)
 {
     int32_t len = 0;
     int ret = 0;
@@ -483,25 +483,24 @@ glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
     origin_brick_mount = dirname(origin_brick);
 
     if (clone)
-        len = snprintf(brick_path, sizeof(brick_path), "%s/%s_%d/%s",
+        len = snprintf(brickinfo->path, sizeof(brickinfo->path), "%s/%s_%d/%s",
                        origin_brick_mount, snap_clone_volume_id, brick_num,
                        snap_brick_dir);
     else {
         if (restore)
-            len = snprintf(brick_path, sizeof(brick_path), "%s/%s/brick%d%s",
+            len = snprintf(brickinfo->path, sizeof(brickinfo->path), "%s/%s/brick%d%s",
                            snap_mount_dir, snap_clone_volume_id, brick_num,
                            snap_brick_dir);
         else
-            len = snprintf(brick_path, sizeof(brick_path),
+            len = snprintf(brickinfo->path, sizeof(brickinfo->path),
                            "%s/.zfs/snapshot/%s_%d/%s", origin_brick_mount,
                            snap_clone_volume_id, brick_num, snap_brick_dir);
     }
 
     if ((len < 0) || (len >= sizeof(brick_path))) {
+        brickinfo->path[0] = 0;
         ret = -1;
     }
-
-    *snap_brick_path = brick_path;
 
     if (origin_brick)
         GF_FREE(origin_brick);


### PR DESCRIPTION
The function glusterd_lvm_snap_clone_brick_path is
trying to populate brick path without allocating a
memory so ideally the glusterd can be crash during
code path hit.

Solution: Pass glusterd_brickinfo object to populate brick path.

Updates: #1060
CID: 1467252
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

