### PR TITLE
geo-rep: AttributeError: 'list' object has no attribute 'join'

### DIFF
--- a/geo-replication/syncdaemon/syncdutils.py
+++ b/geo-replication/syncdaemon/syncdutils.py
@@ -925,7 +925,7 @@ class Volinfo(object):
         vi = XET.fromstring(vix)
         if vi.find('opRet').text != '0':
             if prelude:
-                via = '(via %s) ' % prelude.join(' ')
+                via = '(via %s) ' % ' '.join(prelude)
             else:
                 via = ' '
             raise GsyncdError('getting volume info of %s%s '


### PR DESCRIPTION
Probelm:  prelude.join(' ') operation is performed to
          convert prelude(which of list data type) into a string.

          This is erraneous as we cannot perform join on a list:

          Traceback (most recent call last):
          File "/usr/libexec/glusterfs/python/syncdaemon/gsyncd.py", line 332, in main
          func(args)
          File "/usr/libexec/glusterfs/python/syncdaemon/subcmds.py", line 60, in subcmd_monitor
          return monitor.monitor(local, remote)
          File "/usr/libexec/glusterfs/python/syncdaemon/monitor.py", line 431, in monitor
          return Monitor().multiplex(*distribute(local, remote))
          File "/usr/libexec/glusterfs/python/syncdaemon/monitor.py", line 390, in distribute
          svol = Volinfo(slave.volume, "localhost", prelude, master=False)
          File "/usr/libexec/glusterfs/python/syncdaemon/syncdutils.py", line 921, in init
          via = '(via %s) ' % prelude.join(' ')
          AttributeError: 'list' object has no attribute 'join'

Solution: we should perform ' '.join(prelude).
          This will serve the purpose of converting prelude
          into a string, and continue to support the
          existing logic.

          Added code change to support the same.

>Fixes: #2903
>Change-Id: I29c8523ad78a31e68ef473df7c579950664c5184
>Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

Change-Id: I29c8523ad78a31e68ef473df7c579950664c5184
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

