### PR TITLE
snapview-server: fix a possible extra 'unref()' on snapshot root inode

### DIFF
--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -554,10 +554,11 @@ svs_revalidate(xlator_t *this, loc_t *loc, inode_t *parent,
             goto out;
         }
 
-        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE)
+        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
+            inode_ref(parent);
             op_ret = svs_lookup_snapshot(this, loc, buf, postparent, parent,
                                          parent_ctx, op_errno);
-        else
+        } else
             op_ret = svs_lookup_entry(this, loc, buf, postparent, parent,
                                       parent_ctx, op_errno);
 
@@ -716,10 +717,11 @@ svs_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     if (parent_ctx) {
-        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE)
+        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
+            inode_ref(parent);
             op_ret = svs_lookup_snapshot(this, loc, &buf, &postparent, parent,
                                          parent_ctx, &op_errno);
-        else
+        } else
             op_ret = svs_lookup_entry(this, loc, &buf, &postparent, parent,
                                       parent_ctx, &op_errno);
         goto out;
@@ -1604,7 +1606,6 @@ svs_readdirp_fill(xlator_t *this, inode_t *parent, svs_inode_t *parent_ctx,
     } else {
         if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
             inode = inode_new(parent->table);
-            entry->inode = inode;
 
             /* If inode context allocation fails, then do not send
              * the inode for that particular entry as part of
@@ -1618,11 +1619,11 @@ svs_readdirp_fill(xlator_t *this, inode_t *parent, svs_inode_t *parent_ctx,
                        "failed to allocate inode "
                        "context for %s",
                        entry->d_name);
-                inode_unref(entry->inode);
-                entry->inode = NULL;
+                inode_unref(inode);
                 goto out;
             }
 
+            entry->inode = inode;
             /* Generate virtual gfid for SNAPSHOT dir and
              * update the statbuf
              */
@@ -1936,10 +1937,11 @@ svs_get_handle(xlator_t *this, loc_t *loc, svs_inode_t *inode_ctx,
     }
 
     if (parent_ctx) {
-        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE)
+        if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
+            inode_ref(parent);
             ret = svs_lookup_snapshot(this, loc, &buf, &postparent, parent,
                                       parent_ctx, op_errno);
-        else
+        } else
             ret = svs_lookup_entry(this, loc, &buf, &postparent, parent,
                                    parent_ctx, op_errno);
     }


### PR DESCRIPTION
`table->root` inode is agnostic to ref/unref as per the current inode
table implementation, but when in case of `snapd` process, the root inode
of snapshot process is mapped to another directory inode in global inode
table. Hence we need some 'extra' protection for this 'root' inode from
the snapshot process. Add an extra ref to the inode which goes through
glfs object initialization. This would prevent a possible mismanagement
of root inode during de-activate of snapshot.

Updates: #3103
Change-Id: I12b9c85f677c2868ef112f36547eb69dc80d3b7b
Signed-off-by: Amar Tumballi <amar@kadalu.io>

