### PR TITLE
libglusterfs: Set errno on integer parse failure

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -1193,17 +1193,16 @@ _gf_string2long(const char *str, long *n, int base)
     old_errno = errno;
     errno = 0;
     value = strtol(str, &tail, base);
-    if (str == tail)
+    if ((str == tail) || (*tail != 0)) {
         errno = EINVAL;
+        return -1;
+    }
 
     if (errno == ERANGE || errno == EINVAL)
         return -1;
 
     if (errno == 0)
         errno = old_errno;
-
-    if (tail[0] != '\0')
-        return -1;
 
     *n = value;
 


### PR DESCRIPTION
The _gf_string2long() function didn't set the errno code correctly
when the parsed string started by a number but wasn't really a
number, like a numeric IP address for example.

This patch ensures the errno is properly set before returning an
error.

Fixes: #2962
Change-Id: I33e6f75201da8bfc5c76089d8b30f1e3c0214857
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

