### PR TITLE
geo-rep: ensure py2py3 compatibily

### DIFF
--- a/geo-replication/syncdaemon/syncdutils.py
+++ b/geo-replication/syncdaemon/syncdutils.py
@@ -850,7 +850,7 @@ class Popen(subprocess.Popen):
         def logerr(l):
             logging.error(self.args[0] + "> " + l)
         for l in self.elines:
-            ls = l.split('\n')
+            ls = l.split(b'\n')
             ls[0] = lp + ls[0]
             lp = ls.pop()
             for ll in ls:


### PR DESCRIPTION
Problem: decode() returns unicode value on python2 and class bytes value on python3.

               In python3, split returns:- TypeError: a bytes-like object is required, not 'str'
               when a str seperator '\n' is used, as python3 expects seperator also to be bytes
               literal line to be split is bytes literal

               Traceback observed is as follows:
         
               Traceback (most recent call last):
                   File "/usr/libexec/glusterfs/python/syncdaemon/gsyncd.py", line 317, in main
                   func(args)
                   File "/usr/libexec/glusterfs/python/syncdaemon/subcmds.py", line 60, in subcmd_monitor
                   return monitor.monitor(local, remote)
                   File "/usr/libexec/glusterfs/python/syncdaemon/monitor.py", line 360, in monitor
                   return Monitor().multiplex(*distribute(local, remote))
                   File "/usr/libexec/glusterfs/python/syncdaemon/monitor.py", line 319, in distribute
                   svol = Volinfo(slave.volume, "localhost", prelude, master=False)
                   File "/usr/libexec/glusterfs/python/syncdaemon/syncdutils.py", line 924, in __init__
                   po.terminate_geterr()
                   File "/usr/libexec/glusterfs/python/syncdaemon/syncdutils.py", line 894, in terminate_geterr
                   self.errfail()
                   File "/usr/libexec/glusterfs/python/syncdaemon/syncdutils.py", line 863, in errfail
                   self.errlog()
                   File "/usr/libexec/glusterfs/python/syncdaemon/syncdutils.py", line 853, in errlog
                   ls = l.split('\n')
                   TypeError: a bytes-like object is required, not 'str'

Solution: when the str seperator is converted to bytes literal, both python2 and python3
               codebase work seemlessly.

               Python2 also supports split, with bytes literal as a seperator and line to be
               split is unicode.

Fixes: #2469
Change-Id: I0b383ef320e75fb697870b105ad72265b837234f
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>