### PR TITLE
build, libglusterfs, tests: use system xxhash if installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,6 +632,22 @@ GF_CFLAGS="${GF_CFLAGS} ${UUID_CFLAGS}"
 dnl PKGCONFIG_UUID is used for the dependency in *.pc.in files
 AC_SUBST(PKGCONFIG_UUID)
 
+dnl Check for xxhash library.
+PKG_CHECK_MODULES([XXHASH], [libxxhash],
+  [have_libxxhash=yes
+   AC_DEFINE(HAVE_LIBXXHASH, 1, [Define to 1 if you have libxxhash.so.])],
+  [have_libxxhash=no])
+AM_CONDITIONAL([HAVE_LIBXXHASH], [test x$have_libxxhash = xyes])
+
+dnl Note xxhsum binary is required to run gfid2path tests.
+if test "x$have_libxxhash" = "xyes"; then
+    AC_CHECK_PROG([XXHSUM], [xxhsum], [yes], [no])
+    if test "x$XXHSUM" = "xno"; then
+        AC_MSG_WARN([install 'xxhsum' binary if you plan to run the tests.])
+    fi
+    GF_CFLAGS="${GF_CFLAGS} ${XXHASH_CFLAGS}"
+fi
+
 dnl NetBSD does not support POSIX ACLs :-(
 case $host_os in
      *netbsd* | darwin*)

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -9,8 +9,11 @@ libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
 	-DXXH_NAMESPACE=GF_ -D__USE_LARGEFILE64 \
 	-I$(CONTRIBDIR)/rbtree \
 	-I$(CONTRIBDIR)/libexecinfo ${ARGP_STANDALONE_CPPFLAGS} \
-	-DSBIN_DIR=\"$(sbindir)\" -I$(CONTRIBDIR)/timer-wheel \
-	-I$(CONTRIBDIR)/xxhash
+	-DSBIN_DIR=\"$(sbindir)\" -I$(CONTRIBDIR)/timer-wheel
+
+if !HAVE_LIBXXHASH
+libglusterfs_la_CPPFLAGS += -I$(CONTRIBDIR)/xxhash
+endif
 
 libglusterfs_la_LIBADD = $(ZLIB_LIBS) $(MATH_LIB) $(UUID_LIBS) $(LIB_DL) \
 	$(URCU_LIBS) $(URCU_CDS_LIBS)
@@ -36,8 +39,11 @@ libglusterfs_la_SOURCES = dict.c xlator.c logging.c \
 	$(CONTRIBDIR)/libexecinfo/execinfo.c quota-common-utils.c rot-buffs.c \
 	$(CONTRIBDIR)/timer-wheel/timer-wheel.c \
 	$(CONTRIBDIR)/timer-wheel/find_last_bit.c default-args.c \
-	$(CONTRIBDIR)/xxhash/xxhash.c \
 	throttle-tbf.c monitoring.c async.c gf-io.c gf-io-common.c gf-io-legacy.c
+
+if !HAVE_LIBXXHASH
+libglusterfs_la_SOURCES += $(CONTRIBDIR)/xxhash/xxhash.c
+endif
 
 nodist_libglusterfs_la_SOURCES = y.tab.c graph.lex.c defaults.c
 nodist_libglusterfs_la_HEADERS = y.tab.h
@@ -88,11 +94,14 @@ noinst_HEADERS = unittest/unittest.h \
 	$(CONTRIBDIR)/mount/mntent_compat.h \
 	$(CONTRIBDIR)/libexecinfo/execinfo_compat.h \
 	$(CONTRIBDIR)/timer-wheel/timer-wheel.h \
-	$(CONTRIBDIR)/xxhash/xxhash.h \
 	$(CONTRIBDIR)/userspace-rcu/wfcqueue.h \
 	$(CONTRIBDIR)/userspace-rcu/wfstack.h \
 	$(CONTRIBDIR)/userspace-rcu/static-wfcqueue.h \
 	$(CONTRIBDIR)/userspace-rcu/static-wfstack.h
+
+if !HAVE_LIBXXHASH
+noinst_HEADERS += $(CONTRIBDIR)/xxhash/xxhash.h
+endif
 
 eventtypes.h: $(top_srcdir)/events/eventskeygen.py
 	$(PYTHON) $(top_srcdir)/events/eventskeygen.py C_HEADER

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -59,6 +59,12 @@
 #undef BIT_SET
 #endif
 
+#if defined(HAVE_LIBXXHASH)
+#define XXH64_FMT PRIx64
+#else /* use from contrib */
+#define XXH64_FMT "llx"
+#endif /* HAVE_LIBXXHASH */
+
 #ifndef AI_ADDRCONFIG
 #define AI_ADDRCONFIG 0
 #endif /* AI_ADDRCONFIG */
@@ -272,8 +278,8 @@ gf_gfid_generate_from_xxh64(uuid_t gfid, char *key)
     if (gf_gfid_from_xxh64(this, gfid, hash_2, 0)) {
         gf_msg_callingfn(this->name, GF_LOG_WARNING, 0,
                          LG_MSG_XXH64_TO_GFID_FAILED,
-                         "failed to encode the hash %llx into the 1st"
-                         "half of gfid",
+                         "failed to encode the hash %" XXH64_FMT
+                         " into the 1st half of gfid",
                          hash_2);
         goto out;
     }
@@ -282,15 +288,15 @@ gf_gfid_generate_from_xxh64(uuid_t gfid, char *key)
     if (gf_gfid_from_xxh64(this, gfid, hash_1, 8)) {
         gf_msg_callingfn(this->name, GF_LOG_WARNING, 0,
                          LG_MSG_XXH64_TO_GFID_FAILED,
-                         "failed to encode the hash %llx into the 2nd"
-                         "half of gfid",
+                         "failed to encode the hash %" XXH64_FMT
+                         " into the 2nd half of gfid",
                          hash_1);
         goto out;
     }
 
     gf_msg_debug(this->name, 0,
-                 "gfid generated is %s (hash1: %llx) "
-                 "hash2: %llx, xxh64_1: %s xxh64_2: %s",
+                 "gfid generated is %s (hash1: %" XXH64_FMT ") "
+                 "hash2: %" XXH64_FMT ", xxh64_1: %s xxh64_2: %s",
                  uuid_utoa(gfid), hash_1, hash_2, xxh64_1, xxh64_2);
 
     ret = 0;

--- a/tests/gfid2path/gfid2path_fuse.t
+++ b/tests/gfid2path/gfid2path_fuse.t
@@ -7,13 +7,17 @@ CLI_SETGFID2PATH="gluster-setgfid2path";
 
 cleanup;
 
-XXHSUM_SOURCE="$(dirname $0)/../../contrib/xxhash/xxhsum.c $(dirname $0)/../../contrib/xxhash/xxhash.c"
-XXHSUM_EXEC=$(dirname $0)/xxhsum
+if test -z $(type -p xxhsum); then
+    # Build xxhsum from contrib.
+    XXHSUM_SOURCE="$(dirname $0)/../../contrib/xxhash/xxhsum.c $(dirname $0)/../../contrib/xxhash/xxhash.c"
+    XXHSUM_EXEC=$(dirname $0)/xxhsum
+    build_tester $XXHSUM_SOURCE -o $XXHSUM_EXEC -I$(dirname $0)/../../contrib/xxhash
+else
+    # Use xxhsum found in PATH.
+    XXHSUM_EXEC=$(type -p xxhsum)
+fi
 
-## Build xxhsum C source
-build_tester $XXHSUM_SOURCE -o $XXHSUM_EXEC -I$(dirname $0)/../../contrib/xxhash
-TEST [ -e $XXHSUM_EXEC ]
-
+TEST [ -x $XXHSUM_EXEC ]
 TEST glusterd
 TEST pidof glusterd
 

--- a/tests/gfid2path/gfid2path_nfs.t
+++ b/tests/gfid2path/gfid2path_nfs.t
@@ -8,13 +8,17 @@
 
 cleanup;
 
-XXHSUM_SOURCE="$(dirname $0)/../../contrib/xxhash/xxhsum.c $(dirname $0)/../../contrib/xxhash/xxhash.c"
-XXHSUM_EXEC=$(dirname $0)/xxhsum
+if test -z $(type -p xxhsum); then
+    # Build xxhsum from contrib.
+    XXHSUM_SOURCE="$(dirname $0)/../../contrib/xxhash/xxhsum.c $(dirname $0)/../../contrib/xxhash/xxhash.c"
+    XXHSUM_EXEC=$(dirname $0)/xxhsum
+    build_tester $XXHSUM_SOURCE -o $XXHSUM_EXEC -I$(dirname $0)/../../contrib/xxhash
+else
+    # Use xxhsum found in PATH.
+    XXHSUM_EXEC=$(type -p xxhsum)
+fi
 
-## Build xxhsum C source
-build_tester $XXHSUM_SOURCE -o $XXHSUM_EXEC -I$(dirname $0)/../../contrib/xxhash
-TEST [ -e $XXHSUM_EXEC ]
-
+TEST [ -x $XXHSUM_EXEC ]
 TEST glusterd
 TEST pidof glusterd
 


### PR DESCRIPTION
Use installed `xxhash` library and `xxhsum` binary if found,
fallback to use everything from `contrib/xxhash` otherwise,
adjust `gfid2path` FUSE and NFS tests accordingly.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

