### PR TITLE
build, libglusterfs: use libexecinfo conditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1024,6 +1024,7 @@ if test "x${have_backtrace}" = "xyes"; then
    AC_DEFINE(HAVE_BACKTRACE, 1, [define if found backtrace])
 fi
 AC_SUBST(HAVE_BACKTRACE)
+AM_CONDITIONAL([HAVE_BACKTRACE], [test x$have_backtrace = xyes])
 
 dnl Old (before C11) compiler can compile (but not link) this:
 dnl

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -7,12 +7,15 @@ libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
 	-DXLATORDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator\" \
 	-DXLATORPARENTDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)\" \
 	-DXXH_NAMESPACE=GF_ -D__USE_LARGEFILE64 \
-	-I$(CONTRIBDIR)/rbtree \
-	-I$(CONTRIBDIR)/libexecinfo ${ARGP_STANDALONE_CPPFLAGS} \
+	-I$(CONTRIBDIR)/rbtree ${ARGP_STANDALONE_CPPFLAGS} \
 	-DSBIN_DIR=\"$(sbindir)\" -I$(CONTRIBDIR)/timer-wheel
 
 if !HAVE_LIBXXHASH
 libglusterfs_la_CPPFLAGS += -I$(CONTRIBDIR)/xxhash
+endif
+
+if !HAVE_BACKTRACE
+libglusterfs_la_CPPFLAGS += -I$(CONTRIBDIR)/libexecinfo
 endif
 
 libglusterfs_la_LIBADD = $(ZLIB_LIBS) $(MATH_LIB) $(UUID_LIBS) $(LIB_DL) \
@@ -36,13 +39,17 @@ libglusterfs_la_SOURCES = dict.c xlator.c logging.c \
 	$(CONTRIBDIR)/libgen/basename_r.c \
 	$(CONTRIBDIR)/libgen/dirname_r.c \
 	strfd.c parse-utils.c $(CONTRIBDIR)/mount/mntent.c \
-	$(CONTRIBDIR)/libexecinfo/execinfo.c quota-common-utils.c rot-buffs.c \
+	quota-common-utils.c rot-buffs.c \
 	$(CONTRIBDIR)/timer-wheel/timer-wheel.c \
 	$(CONTRIBDIR)/timer-wheel/find_last_bit.c default-args.c \
 	throttle-tbf.c monitoring.c async.c gf-io.c gf-io-common.c gf-io-legacy.c
 
 if !HAVE_LIBXXHASH
 libglusterfs_la_SOURCES += $(CONTRIBDIR)/xxhash/xxhash.c
+endif
+
+if !HAVE_BACKTRACE
+libglusterfs_la_SOURCES += $(CONTRIBDIR)/libexecinfo/execinfo.c
 endif
 
 nodist_libglusterfs_la_SOURCES = y.tab.c graph.lex.c defaults.c
@@ -92,7 +99,6 @@ libglusterfs_ladir = $(includedir)/glusterfs
 noinst_HEADERS = unittest/unittest.h \
 	$(CONTRIBDIR)/rbtree/rb.h \
 	$(CONTRIBDIR)/mount/mntent_compat.h \
-	$(CONTRIBDIR)/libexecinfo/execinfo_compat.h \
 	$(CONTRIBDIR)/timer-wheel/timer-wheel.h \
 	$(CONTRIBDIR)/userspace-rcu/wfcqueue.h \
 	$(CONTRIBDIR)/userspace-rcu/wfstack.h \
@@ -101,6 +107,10 @@ noinst_HEADERS = unittest/unittest.h \
 
 if !HAVE_LIBXXHASH
 noinst_HEADERS += $(CONTRIBDIR)/xxhash/xxhash.h
+endif
+
+if !HAVE_BACKTRACE
+noinst_HEADERS += $(CONTRIBDIR)/libexecinfo/execinfo_compat.h
 endif
 
 eventtypes.h: $(top_srcdir)/events/eventskeygen.py


### PR DESCRIPTION
Do not actually include and compile anything from `contrib/libexecinfo`
if usable `execinfo.h` header file was detected.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000