### PR TITLE
xlators: use common GF_UUID_BUF_SIZE

### DIFF
--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -248,7 +248,7 @@ typedef struct _afr_private {
        important as we might have had a network split brain.
     */
     uint32_t event_generation;
-    char vol_uuid[UUID_SIZE + 1];
+    char vol_uuid[GF_UUID_BUF_SIZE];
 
     gf_boolean_t choose_local;
     gf_boolean_t did_discovery;
@@ -281,7 +281,7 @@ typedef struct _afr_private {
 
     /*For anon-inode handling */
     char anon_inode_name[NAME_MAX + 1];
-    char anon_gfid_str[UUID_SIZE + 1];
+    char anon_gfid_str[GF_UUID_BUF_SIZE];
 } afr_private_t;
 
 typedef enum {

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -588,7 +588,7 @@ struct dht_conf {
      */
     uint32_t vol_commit_hash;
 
-    char vol_uuid[UUID_SIZE + 1];
+    char vol_uuid[GF_UUID_BUF_SIZE];
 
     gf_boolean_t disk_unit_percent;
 

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -680,7 +680,7 @@ struct _ec {
     struct mem_pool *cbk_pool;
     struct mem_pool *lock_pool;
     ec_self_heald_t shd;
-    char vol_uuid[UUID_SIZE + 1];
+    char vol_uuid[GF_UUID_BUF_SIZE];
     dict_t *leaf_to_subvolid;
     ec_read_policy_t read_policy;
     ec_matrix_list_t matrix;

--- a/xlators/lib/src/libxlator.h
+++ b/xlators/lib/src/libxlator.h
@@ -23,7 +23,6 @@
 #define XTIME "xtime"
 #define VOLUME_MARK "volume-mark"
 #define GF_XATTR_MARKER_KEY MARKER_XATTR_PREFIX "." VOLUME_MARK
-#define UUID_SIZE 36
 #define MARKER_UUID_TYPE 1
 #define MARKER_XTIME_TYPE 2
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -1319,7 +1319,7 @@ glusterd_store_node_state_write(int fd, glusterd_volinfo_t *volinfo)
 {
     int ret = -1;
     char buf[PATH_MAX];
-    char uuid[UUID_SIZE + 1];
+    char uuid[GF_UUID_BUF_SIZE];
     uint total_len = 0;
     glusterd_volinfo_data_store_t *dict_data = NULL;
     gf_store_handle_t shandle;
@@ -4151,7 +4151,7 @@ out:
 int32_t
 glusterd_store_write_missed_snapinfo(int32_t fd)
 {
-    char key[(UUID_SIZE * 2) + 2];
+    char key[GF_UUID_BUF_SIZE * 2];
     char value[PATH_MAX];
     int32_t ret = -1;
     glusterd_conf_t *priv = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-store.h
+++ b/xlators/mgmt/glusterd/src/glusterd-store.h
@@ -27,7 +27,6 @@ typedef enum glusterd_store_ver_ac_ {
     GLUSTERD_VOLINFO_VER_AC_DECREMENT = 2,
 } glusterd_volinfo_ver_ac_t;
 
-#define UUID_SIZE 36
 #define VOLINFO_BUFFER_SIZE 4093
 #define GLUSTERD_STORE_UUID_KEY "UUID"
 

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -650,8 +650,6 @@ typedef enum {
 #define RB_DSTBRICK_PIDFILE "rb_dst_brick.pid"
 #define RB_DSTBRICKVOL_FILENAME "rb_dst_brick.vol"
 
-#define GLUSTERD_UUID_LEN 50
-
 typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
 
 #define GLUSTERD_GET_VOLUME_DIR(path, volinfo, priv)                           \


### PR DESCRIPTION
Drop unused `GLUSTERD_UUID_LEN` and duplicated `UUID_SIZE` macros
and prefer the convenient `GF_UUID_BUF_SIZE` where appropriate.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

