### PR TITLE
rpc, xlators, glusterd: simplify RPC connection status handling

### DIFF
--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -104,7 +104,7 @@ send_brick_req(xlator_t *this, struct rpc_clnt *rpc, char *path, int op)
     ts.tv_sec += CONNECT_TIMEOUT;
     pthread_mutex_lock(&rpc->conn.lock);
     {
-        while (!rpc->conn.connected)
+        while (rpc->conn.status != RPC_STATUS_CONNECTED)
             if (pthread_cond_timedwait(&rpc->conn.cond, &rpc->conn.lock, &ts) ==
                 ETIMEDOUT) {
                 fprintf(stderr, "timeout waiting for RPC connection\n");

--- a/rpc/rpc-lib/src/libgfrpc.sym
+++ b/rpc/rpc-lib/src/libgfrpc.sym
@@ -1,7 +1,7 @@
-is_rpc_clnt_disconnected
 rpcclnt_cbk_program_register
 rpc_clnt_cleanup_and_start
 rpc_clnt_connection_cleanup
+rpc_clnt_connection_status
 rpc_clnt_disable
 rpc_clnt_new
 rpc_clnt_reconfig

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -306,11 +306,15 @@ rpc_clnt_start_ping(void *rpc_ptr)
             frame_count = conn->saved_frames->count;
         }
 
-        if ((frame_count == 0) || !conn->connected) {
+        if ((frame_count == 0) || conn->status != RPC_STATUS_CONNECTED) {
             gf_log(THIS->name, GF_LOG_DEBUG,
-                   "returning as transport is already disconnected"
-                   " OR there are no frames (%d || %d)",
-                   !conn->connected, frame_count);
+                   "returning because transport is %s %s there are %s\n",
+                   ((conn->status == RPC_STATUS_CONNECTED) ? "connected"
+                                                           : "disconnected"),
+                   ((!frame_count && conn->status != RPC_STATUS_CONNECTED)
+                        ? "and"
+                        : "but"),
+                   (frame_count ? "some frames" : "no frames"));
 
             pthread_mutex_unlock(&conn->lock);
             if (unref)

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -25,6 +25,12 @@ typedef enum {
     RPC_CLNT_DESTROY
 } rpc_clnt_event_t;
 
+typedef enum {
+    RPC_STATUS_INITIALIZED,
+    RPC_STATUS_CONNECTED,
+    RPC_STATUS_DISCONNECTED
+} rpc_clnt_status_t;
+
 #define SFRAME_GET_PROGNUM(sframe) (sframe->rpcreq->prog->prognum)
 #define SFRAME_GET_PROGVER(sframe) (sframe->rpcreq->prog->progver)
 #define SFRAME_GET_PROCNUM(sframe) (sframe->rpcreq->procnum)
@@ -144,8 +150,7 @@ struct rpc_clnt_connection {
     int32_t ping_started;
     time_t frame_timeout;
     time_t ping_timeout;
-    gf_boolean_t disconnected;
-    char connected;
+    rpc_clnt_status_t status;
 };
 typedef struct rpc_clnt_connection rpc_clnt_connection_t;
 
@@ -235,8 +240,8 @@ int
 rpc_clnt_connection_cleanup(rpc_clnt_connection_t *conn);
 int
 rpc_clnt_reconnect_cleanup(rpc_clnt_connection_t *conn);
-gf_boolean_t
-is_rpc_clnt_disconnected(rpc_clnt_connection_t *conn);
+rpc_clnt_status_t
+rpc_clnt_connection_status(rpc_clnt_connection_t *conn);
 
 void
 rpc_clnt_reconnect(void *trans_ptr);

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -6321,7 +6321,8 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
             /* If DISCONNECT event is already processed, skip the further
              * ones
              */
-            if (is_rpc_clnt_disconnected(&rpc->conn))
+            if (rpc_clnt_connection_status(&rpc->conn) ==
+                RPC_STATUS_DISCONNECTED)
                 break;
 
             gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_PEER_DISCONNECTED,

--- a/xlators/mgmt/glusterd/src/glusterd-statedump.c
+++ b/xlators/mgmt/glusterd/src/glusterd-statedump.c
@@ -76,7 +76,7 @@ glusterd_dump_peer_rpcstat(glusterd_peerinfo_t *peerinfo, char *input_key,
             gf_proc_dump_write(key, "%s", rpcsvc_peername);
         }
         gf_proc_dump_build_key(key, subkey, "rpc.connected");
-        gf_proc_dump_write(key, "%d", conn->connected);
+        gf_proc_dump_write(key, "%d", (conn->status == RPC_STATUS_CONNECTED));
 
         gf_proc_dump_build_key(key, subkey, "rpc.total-bytes-read");
         gf_proc_dump_write(key, "%" PRIu64, conn->trans->total_bytes_read);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -761,7 +761,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     }
 
     conn = &rpc->conn;
-    if (!conn->connected || conn->disconnected) {
+    if (rpc_clnt_connection_status(conn) != RPC_STATUS_CONNECTED) {
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_CONNECT_RETURNED,
                "not connected yet");
         return -1;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -6099,7 +6099,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
     }
 
     conn = &rpc->conn;
-    if (!conn->connected || conn->disconnected) {
+    if (rpc_clnt_connection_status(conn) != RPC_STATUS_CONNECTED) {
         gf_log(this->name, GF_LOG_INFO, "not connected yet");
         return -1;
     }


### PR DESCRIPTION
Replace confusing `connected` and `disconnected` flags of
`rpc_clnt_connection` with `rpc_clnt_status_t` to describe
RPC client connection status, replace `is_rpc_clnt_disconnected()`
with `rpc_clnt_connection_status()`, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
