### PR TITLE
Multiple files: reduce the number of include statements

### DIFF
--- a/api/examples/glfsxmp.c
+++ b/api/examples/glfsxmp.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <glusterfs/api/glfs.h>
-#include <glusterfs/api/glfs-handles.h>
 #include <string.h>
 #include <time.h>
 

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -18,13 +18,11 @@
 
 #include "glfs-internal.h"
 #include "glfs-mem-types.h"
-#include <glusterfs/syncop.h>
 #include "glfs.h"
 #include "gfapi-messages.h"
 #include <glusterfs/compat-errno.h>
 #include <limits.h>
 #include "glusterfs3.h"
-#include <glusterfs/iatt.h>
 
 #ifdef NAME_MAX
 #define GF_NAME_MAX NAME_MAX

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -10,9 +10,7 @@
 
 #include "glfs-internal.h"
 #include "glfs-mem-types.h"
-#include <glusterfs/syncop.h>
 #include "glfs.h"
-#include "glfs-handles.h"
 #include "gfapi-messages.h"
 
 int

--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -11,8 +11,6 @@
 #ifndef _GLFS_INTERNAL_H
 #define _GLFS_INTERNAL_H
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/upcall-utils.h>
 #include "glfs-handles.h"
 #include <glusterfs/refcount.h>

--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -15,16 +15,10 @@
 #include <signal.h>
 #include <pthread.h>
 
-#include <glusterfs/glusterfs.h>
-#include "glfs.h"
 #include <glusterfs/dict.h>
 
 #include "rpc-clnt.h"
-#include "protocol-common.h"
-#include "xdr-generic.h"
 #include "rpc-common-xdr.h"
-
-#include <glusterfs/syncop.h>
 
 #include "glfs-internal.h"
 #include "gfapi-messages.h"

--- a/api/src/glfs-primary.c
+++ b/api/src/glfs-primary.c
@@ -10,8 +10,6 @@
 
 #include <stdio.h>
 
-#include <glusterfs/glusterfs.h>
-
 #include "glfs-internal.h"
 #include "glfs-mem-types.h"
 #include "gfapi-messages.h"

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -15,16 +15,11 @@
 #include <inttypes.h>
 #include <limits.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/stack.h>
 #include <glusterfs/gf-event.h>
 #include "glfs-mem-types.h"
-#include <glusterfs/common-utils.h>
-#include <glusterfs/syncop.h>
 #include <glusterfs/call-stub.h>
 #include "gfapi-messages.h"
-#include <glusterfs/inode.h>
 #include "glfs-internal.h"
 
 #define graphid_str(subvol)                                                    \

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -34,14 +34,10 @@
 #include <sys/prctl.h>
 #endif
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/stack.h>
 #include <glusterfs/gf-event.h>
 #include "glfs-mem-types.h"
-#include <glusterfs/common-utils.h>
-#include <glusterfs/syncop.h>
-#include <glusterfs/call-stub.h>
 #include <glusterfs/hashfn.h>
 #include "rpc-clnt.h"
 #include <glusterfs/statedump.h>

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -44,7 +44,6 @@
 #endif
 
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/uio.h>
 #include <unistd.h>

--- a/cli/src/cli-cmd-global.c
+++ b/cli/src/cli-cmd-global.c
@@ -22,10 +22,8 @@
 #include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "cli1-xdr.h"
 #include <glusterfs/run.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/common-utils.h>
 
 int
 cli_cmd_global_help_cbk(struct cli_state *state, struct cli_cmd_word *in_word,

--- a/cli/src/cli-cmd-global.c
+++ b/cli/src/cli-cmd-global.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include <sys/socket.h>
 #include <netdb.h>

--- a/cli/src/cli-cmd-misc.c
+++ b/cli/src/cli-cmd-misc.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include "cli.h"
 #include "cli-cmd.h"

--- a/cli/src/cli-cmd-misc.c
+++ b/cli/src/cli-cmd-misc.c
@@ -16,7 +16,6 @@
 #include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "protocol-common.h"
 
 extern struct cli_cmd volume_cmds[];
 extern struct cli_cmd bitrot_cmds[];

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -21,9 +21,6 @@
 #include <glusterfs/dict.h>
 #include <glusterfs/list.h>
 
-#include "protocol-common.h"
-#include "cli1-xdr.h"
-
 #define MAX_SNAP_DESCRIPTION_LEN 1024
 
 static struct snap_config_opt_vals_ snap_confopt_vals[] = {

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 #include <fnmatch.h>
 #include <time.h>
 

--- a/cli/src/cli-cmd-peer.c
+++ b/cli/src/cli-cmd-peer.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include "cli.h"
 #include "cli-cmd.h"

--- a/cli/src/cli-cmd-peer.c
+++ b/cli/src/cli-cmd-peer.c
@@ -16,8 +16,6 @@
 #include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "cli1-xdr.h"
-#include "protocol-common.h"
 #include <glusterfs/events.h>
 
 int

--- a/cli/src/cli-cmd-snapshot.c
+++ b/cli/src/cli-cmd-snapshot.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include "cli.h"
 #include "cli-cmd.h"

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -16,7 +16,6 @@
 #include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "protocol-common.h"
 
 int
 cli_cmd_system_help_cbk(struct cli_state *state, struct cli_cmd_word *in_word,

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include "cli.h"
 #include "cli-cmd.h"

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -22,10 +22,8 @@
 #include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "cli1-xdr.h"
 #include <glusterfs/run.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/events.h>
 
 extern rpc_clnt_prog_t cli_quotad_clnt;

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
 
 #include <sys/socket.h>
 #include <netdb.h>

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -13,10 +13,8 @@
 #include <stdint.h>
 #include <pthread.h>
 
-#include "cli.h"
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
-#include "protocol-common.h"
 
 #include <fnmatch.h>
 

--- a/cli/src/cli-cmd.h
+++ b/cli/src/cli-cmd.h
@@ -10,8 +10,6 @@
 #ifndef __CLI_CMD_H__
 #define __CLI_CMD_H__
 
-#include <netdb.h>
-
 #include "cli.h"
 #include <glusterfs/list.h>
 

--- a/cli/src/cli-quotad-client.h
+++ b/cli/src/cli-quotad-client.h
@@ -11,9 +11,6 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include "cli-cmd.h"
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "protocol-common.h"
 #include "cli-mem-types.h"
 
 struct rpc_clnt *

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -29,6 +29,7 @@
 #define REBAL_ESTIMATE_SEC_UPPER_LIMIT (60 * 24 * 3600)
 #define REBAL_ESTIMATE_START_TIME 600
 
+#include "gd-common-utils.h"
 #include "cli.h"
 #include <glusterfs/compat-errno.h>
 #include "cli-cmd.h"
@@ -38,7 +39,6 @@
 #include <glusterfs/compat.h>
 #include "cli-mem-types.h"
 #include <glusterfs/syscall.h>
-#include "glusterfs3.h"
 #include "portmap-xdr.h"
 
 #include <glusterfs/run.h>

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -13,7 +13,6 @@
 #include <glusterfs/run.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/upcall-utils.h>
 
 enum gf_task_types { GF_TASK_TYPE_REBALANCE, GF_TASK_TYPE_REMOVE_BRICK };
 

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -8,6 +8,7 @@
    cases as published by the Free Software Foundation.
 */
 #include <stdlib.h>
+#include "gd-common-utils.h"
 #include "cli.h"
 #include "cli1-xdr.h"
 #include <glusterfs/run.h>

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -22,7 +22,6 @@
 #include <sys/utsname.h>
 
 #include <stdint.h>
-#include <pthread.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -38,22 +38,15 @@
 #include "cli-cmd.h"
 #include "cli-mem-types.h"
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/list.h>
 #include <glusterfs/timer.h>
-#include <glusterfs/stack.h>
 #include <glusterfs/revision.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/gf-event.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/call-stub.h>
 #include <fnmatch.h>
-
-#include "xdr-generic.h"
 
 /* using argp for command line parsing */
 

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -11,9 +11,6 @@
 #define __CLI_H__
 
 #include "rpc-clnt.h"
-#include <glusterfs/glusterfs.h>
-#include "protocol-common.h"
-#include <glusterfs/logging.h>
 #include <glusterfs/quota-common-utils.h>
 
 #include "cli1-xdr.h"

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -14,7 +14,6 @@
 #include <glusterfs/quota-common-utils.h>
 
 #include "cli1-xdr.h"
-#include "gd-common-utils.h"
 
 #if (HAVE_LIB_XML)
 #include <libxml/encoding.h>

--- a/contrib/timer-wheel/timer-wheel.c
+++ b/contrib/timer-wheel/timer-wheel.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/select.h>
+#include <pthread.h>
 
 #include "timer-wheel.h"
 

--- a/contrib/timer-wheel/timer-wheel.h
+++ b/contrib/timer-wheel/timer-wheel.h
@@ -17,8 +17,6 @@
 #ifndef __TIMER_WHEEL_H
 #define __TIMER_WHEEL_H
 
-#include "glusterfs/locking.h"
-
 #include "glusterfs/list.h"
 
 #define TVR_BITS  8

--- a/extras/geo-rep/gsync-sync-gfid.c
+++ b/extras/geo-rep/gsync-sync-gfid.c
@@ -1,7 +1,6 @@
 
 #include <ctype.h>
 #include <errno.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/syscall.h>
 #include <libgen.h>
 #include <limits.h>

--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -26,11 +26,9 @@
 #ifdef USE_LIBGLUSTERFS
 #include <glusterfs/defaults.h>
 #include <glusterfs/globals.h>
-#include <glusterfs/glusterfs.h>
 #endif
 
 #include "procdiggy.h"
-#include <glusterfs/common-utils.h>
 #include <glusterfs/run.h>
 
 #define _GLUSTERD_CALLED_ "_GLUSTERD_CALLED_"

--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -12,12 +12,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <glusterfs/glusterfs.h>
+#include <glusterfs/logging.h>
 #include <glusterfs/syscall.h>
 #include "glfs-internal.h"
 #include "rpc-clnt.h"
-#include "protocol-common.h"
-#include "xdr-generic.h"
 #include "glusterd1-xdr.h"
 
 /* In seconds */

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -10,17 +10,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/monitoring.h>
-
+#include "glusterd1-xdr.h"
 #include "rpc-clnt.h"
 #include "glusterfsd-messages.h"
 #include "glusterfs3.h"
 #include "portmap-xdr.h"
 #include "glusterfsd.h"
-#include "rpcsvc.h"
 #include "cli1-xdr.h"
 #include "server.h"
 

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -32,8 +32,6 @@
 #include <malloc.h>
 #endif
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/logging.h>
 #include "glusterfsd-messages.h"
@@ -41,13 +39,11 @@
 #include <glusterfs/list.h>
 #include <glusterfs/timer.h>
 #include <glusterfs/revision.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/gf-event.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/latency.h>
 #include "glusterfsd-mem-types.h"
 #include <glusterfs/syscall.h>
-#include <glusterfs/call-stub.h>
 #include <glusterfs/syncop.h>
 #include <glusterfs/client_t.h>
 #include <glusterfs/monitoring.h>

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -10,9 +10,6 @@
 #ifndef __GLUSTERFSD_H__
 #define __GLUSTERFSD_H__
 
-#include "rpcsvc.h"
-#include "glusterd1-xdr.h"
-
 #define DEFAULT_GLUSTERD_VOLFILE CONFDIR "/glusterd.vol"
 #define DEFAULT_CLIENT_VOLFILE CONFDIR "/glusterfs.vol"
 #define DEFAULT_SERVER_VOLFILE CONFDIR "/glusterfsd.vol"

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -15,10 +15,8 @@
 #include "glfs-internal.h"
 #include "protocol-common.h"
 #include <glusterfs/syscall.h>
-#include <glusterfs/syncop.h>
 #include <glusterfs/syncop-utils.h>
 #include <string.h>
-#include <glusterfs/glusterfs.h>
 #include <libgen.h>
 
 #if (HAVE_LIB_XML)

--- a/libglusterd/src/gd-common-utils.h
+++ b/libglusterd/src/gd-common-utils.h
@@ -11,13 +11,7 @@
 #ifndef _GD_COMMON_UTILS_H
 #define _GD_COMMON_UTILS_H
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <limits.h>
-#include <stddef.h>
-
 #include "protocol-common.h"
-#include "rpcsvc.h"
 
 int
 get_vol_type(int type, int dist_count, int brick_count);

--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -8,7 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <openssl/md5.h>
 #include <inttypes.h>
 
 #include "glusterfs/call-stub.h"

--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -8,7 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/dict.h"
 #include "glusterfs/statedump.h"
 #include "glusterfs/client_t.h"

--- a/libglusterfs/src/cluster-syncop.c
+++ b/libglusterfs/src/cluster-syncop.c
@@ -15,7 +15,6 @@
  * responses are gathered if it is not executed as part of synctask. So it
  * shouldn't be invoked in epoll worker thread */
 #include "glusterfs/cluster-syncop.h"
-#include "glusterfs/defaults.h"
 
 #define FOP_ONLIST(subvols, on, numsubvols, replies, output, frame, fop,       \
                    args...)                                                    \

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -20,6 +20,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <netdb.h>
 #include <unistd.h>
 #include <time.h>
 #include <locale.h>

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -46,9 +46,7 @@
 #include "glusterfs/revision.h"
 #include "glusterfs/glusterfs.h"
 #include "glusterfs/stack.h"
-#include "glusterfs/lkowner.h"
 #include "glusterfs/syscall.h"
-#include "glusterfs/globals.h"
 #define XXH_INLINE_ALL
 #include "xxhash.h"
 #include <ifaddrs.h>
@@ -295,7 +293,8 @@ gf_gfid_generate_from_xxh64(uuid_t gfid, char *key)
     }
 
     gf_msg_debug(this->name, 0,
-                 "gfid generated is %s (hash1: %" XXH64_FMT ") "
+                 "gfid generated is %s (hash1: %" XXH64_FMT
+                 ") "
                  "hash2: %" XXH64_FMT ", xxh64_1: %s xxh64_2: %s",
                  uuid_utoa(gfid), hash_1, hash_2, xxh64_1, xxh64_2);
 
@@ -5466,7 +5465,7 @@ gf_pipe(int fd[2], int flags)
     int ret = 0;
 #if defined(HAVE_PIPE2)
     ret = pipe2(fd, flags);
-#else /* not HAVE_PIPE2 */
+#else  /* not HAVE_PIPE2 */
     ret = pipe(fd);
     if (ret < 0)
         return ret;

--- a/libglusterfs/src/ctx.c
+++ b/libglusterfs/src/ctx.c
@@ -11,7 +11,6 @@
 #include <pthread.h>
 
 #include "glusterfs/globals.h"
-#include "glusterfs/glusterfs.h"
 #include "timer-wheel.h"
 
 glusterfs_ctx_t *global_ctx = NULL;

--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -25,7 +25,6 @@
 #include "config.h"
 #endif
 
-#include "glusterfs/xlator.h"
 #include "glusterfs/defaults.h"
 
 #pragma generate

--- a/libglusterfs/src/event-poll.c
+++ b/libglusterfs/src/event-poll.c
@@ -19,7 +19,6 @@
 #include "glusterfs/logging.h"
 #include "glusterfs/gf-event.h"
 #include "glusterfs/mem-pool.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/syscall.h"
 #include "glusterfs/libglusterfs-messages.h"
 

--- a/libglusterfs/src/event.c
+++ b/libglusterfs/src/event.c
@@ -18,7 +18,6 @@
 
 #include "glusterfs/gf-event.h"
 #include "glusterfs/timespec.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/libglusterfs-messages.h"
 #include "glusterfs/syscall.h"
 

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -21,7 +21,6 @@
 
 #include "glusterfs/syscall.h"
 #include "glusterfs/mem-pool.h"
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/globals.h"
 #include "glusterfs/events.h"
 

--- a/libglusterfs/src/fd-lk.c
+++ b/libglusterfs/src/fd-lk.c
@@ -8,8 +8,8 @@
   cases as published by the Free Software Foundation.
 */
 
+#include "glusterfs/fd.h"
 #include "glusterfs/fd-lk.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/libglusterfs-messages.h"
 
 int32_t

--- a/libglusterfs/src/gf-io-common.c
+++ b/libglusterfs/src/gf-io-common.c
@@ -14,6 +14,7 @@
 
 #include <urcu/uatomic.h>
 
+#include <glusterfs/list.h>
 #include <glusterfs/gf-io-common.h>
 
 #define LG_MSG_IO_THREAD_BAD_PRIORITY_LVL(_res) GF_LOG_ERROR
@@ -497,8 +498,8 @@ gf_io_thread_join(pthread_t thread, struct timespec *timeout)
 {
 #ifdef GF_LINUX_HOST_OS
     if (timeout != NULL) {
-        gf_io_success(gf_io_call_ret(pthread_timedjoin_np, thread, NULL,
-                                     timeout));
+        gf_io_success(
+            gf_io_call_ret(pthread_timedjoin_np, thread, NULL, timeout));
 
         return;
     }

--- a/libglusterfs/src/glusterfs/async.h
+++ b/libglusterfs/src/glusterfs/async.h
@@ -36,7 +36,6 @@
 
 #include "glusterfs/common-utils.h"
 #include "glusterfs/list.h"
-#include "glusterfs/libglusterfs-messages.h"
 
 /* This is the name prefix that all worker threads will have. A number will
  * be added to differentiate them. */

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -11,10 +11,8 @@
 #ifndef _CALL_STUB_H_
 #define _CALL_STUB_H_
 
-#include "glusterfs/xlator.h"
 #include "glusterfs/defaults.h"
 #include "glusterfs/default-args.h"
-#include "glusterfs/stack.h"
 #include "glusterfs/list.h"
 
 typedef struct _call_stub {

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -11,7 +11,6 @@
 #ifndef _CLIENT_T_H
 #define _CLIENT_T_H
 
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/locking.h" /* for gf_lock_t, not included by glusterfs.h */
 #include "glusterfs/atomic.h"  /* for gf_atomic_t */
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -12,14 +12,11 @@
 #define _COMMON_UTILS_H
 
 #include <stdint.h>
-#include <sys/uio.h>
-#include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <pthread.h>
 #include <unistd.h>
-#include <openssl/md5.h>
 #ifndef GF_BSD_HOST_OS
 #include <alloca.h>
 #endif

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <assert.h>
 #include <pthread.h>
+#include <dirent.h>
 #include <unistd.h>
 #ifndef GF_BSD_HOST_OS
 #include <alloca.h>
@@ -24,6 +25,8 @@
 #include <fnmatch.h>
 #include <uuid/uuid.h>
 #include <urcu/compiler.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
 
 /* FreeBSD, etc. */
 #ifndef __BITS_PER_LONG

--- a/libglusterfs/src/glusterfs/default-args.h
+++ b/libglusterfs/src/glusterfs/default-args.h
@@ -15,8 +15,6 @@
 #ifndef _DEFAULT_ARGS_H
 #define _DEFAULT_ARGS_H
 
-#include "glusterfs/xlator.h"
-
 int
 args_lookup_cbk_store(default_args_cbk_t *args, int32_t op_ret,
                       int32_t op_errno, inode_t *inode, struct iatt *buf,

--- a/libglusterfs/src/glusterfs/defaults.h
+++ b/libglusterfs/src/glusterfs/defaults.h
@@ -18,7 +18,6 @@
 #include <glusterfs/dict.h>
 #include <glusterfs/iatt.h>
 #include <glusterfs/locking.h>
-#include <glusterfs/glusterfs-fops.h>
 #include <glusterfs/stack.h>
 
 typedef struct {

--- a/libglusterfs/src/glusterfs/defaults.h
+++ b/libglusterfs/src/glusterfs/defaults.h
@@ -15,7 +15,11 @@
 #ifndef _DEFAULTS_H
 #define _DEFAULTS_H
 
-#include "glusterfs/xlator.h"
+#include <glusterfs/dict.h>
+#include <glusterfs/iatt.h>
+#include <glusterfs/locking.h>
+#include <glusterfs/glusterfs-fops.h>
+#include <glusterfs/stack.h>
 
 typedef struct {
     int op_ret;

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -12,7 +12,6 @@
 #define _DICT_H
 
 #include <inttypes.h>
-#include <sys/uio.h>
 #include <pthread.h>
 
 #include "glusterfs/common-utils.h"

--- a/libglusterfs/src/glusterfs/events.h
+++ b/libglusterfs/src/glusterfs/events.h
@@ -11,9 +11,8 @@
 #ifndef __EVENTS_H__
 #define __EVENTS_H__
 
-#include "eventtypes.h"
-
 #ifdef USE_EVENTS
+#include "eventtypes.h"
 int
 _gf_event(eventtypes_t event, const char *fmt, ...)
     __attribute__((__format__(__printf__, 2, 3)));

--- a/libglusterfs/src/glusterfs/fd-lk.h
+++ b/libglusterfs/src/glusterfs/fd-lk.h
@@ -11,10 +11,8 @@
 #ifndef _FD_LK_H
 #define _FD_LK_H
 
-#include "glusterfs/fd.h"
 #include "glusterfs/locking.h"
 #include "glusterfs/list.h"
-#include "glusterfs/glusterfs.h"
 
 #define get_lk_type(type)                                                      \
     type == F_UNLCK ? "F_UNLCK" : (type == F_RDLCK ? "F_RDLCK" : "F_WRLCK")

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -15,7 +15,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "glusterfs/glusterfs.h"
-#include "glusterfs/locking.h"
 #include "glusterfs/fd-lk.h"
 
 #define GF_ANON_FD_NO -2

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -15,18 +15,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <netdb.h>
 #include <errno.h>
-#include <dirent.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <arpa/inet.h>
-#include <sys/poll.h>
 #include <pthread.h>
 #include <limits.h> /* For PATH_MAX */
 #include <openssl/sha.h>
@@ -37,7 +32,6 @@
 #include "glusterfs/lkowner.h"
 #include "glusterfs/compat-uuid.h"
 #include "glusterfs/refcount.h"
-#include "glusterfs/atomic.h"
 
 #define GF_YES 1
 #define GF_NO 0

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -33,7 +33,6 @@
 
 #include "glusterfs/glusterfs-fops.h"
 #include "glusterfs/list.h"
-#include "glusterfs/locking.h"
 #include "glusterfs/logging.h"
 #include "glusterfs/lkowner.h"
 #include "glusterfs/compat-uuid.h"

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -28,7 +28,6 @@ typedef struct _inode inode_t;
 struct _dentry;
 typedef struct _dentry dentry_t;
 
-#include "glusterfs/list.h"
 #include "glusterfs/iatt.h"
 #include "glusterfs/compat-uuid.h"
 #include "glusterfs/fd.h"

--- a/libglusterfs/src/glusterfs/lkowner.h
+++ b/libglusterfs/src/glusterfs/lkowner.h
@@ -11,8 +11,6 @@
 #ifndef _LK_OWNER_H
 #define _LK_OWNER_H
 
-#include "glusterfs/glusterfs-fops.h"
-
 /* LKOWNER to string functions */
 static inline void
 lkowner_unparse(gf_lkowner_t *lkowner, char *buf, int buf_len)

--- a/libglusterfs/src/glusterfs/rot-buffs.h
+++ b/libglusterfs/src/glusterfs/rot-buffs.h
@@ -13,7 +13,6 @@
 
 #include "glusterfs/list.h"
 #include "glusterfs/locking.h"
-#include "glusterfs/common-utils.h"
 
 typedef struct rbuf_iovec {
     struct iovec iov;

--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -28,8 +28,6 @@ typedef struct call_pool call_pool_t;
 #include "glusterfs/xlator.h"
 #include "glusterfs/dict.h"
 #include "glusterfs/list.h"
-#include "glusterfs/common-utils.h"
-#include "glusterfs/lkowner.h"
 #include "glusterfs/client_t.h"
 #include "glusterfs/libglusterfs-messages.h"
 #include "glusterfs/timespec.h"

--- a/libglusterfs/src/glusterfs/throttle-tbf.h
+++ b/libglusterfs/src/glusterfs/throttle-tbf.h
@@ -9,7 +9,6 @@
 */
 
 #include "glusterfs/list.h"
-#include "glusterfs/xlator.h"
 #include "glusterfs/locking.h"
 
 #ifndef THROTTLE_TBF_H__

--- a/libglusterfs/src/glusterfs/timer.h
+++ b/libglusterfs/src/glusterfs/timer.h
@@ -11,7 +11,6 @@
 #ifndef _TIMER_H
 #define _TIMER_H
 
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/xlator.h"
 #include <sys/time.h>
 #include <pthread.h>

--- a/libglusterfs/src/glusterfs/upcall-utils.h
+++ b/libglusterfs/src/glusterfs/upcall-utils.h
@@ -14,6 +14,7 @@
 #include "glusterfs/iatt.h"
 #include "glusterfs/compat-uuid.h"
 #include "glusterfs/compat.h"
+#include <glusterfs/dict.h>
 
 /* Flags sent for cache_invalidation */
 #define UP_NLINK 0x00000001 /* update nlink */

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -60,7 +60,6 @@ typedef int32_t (*event_notify_fn_t)(xlator_t *this, int32_t event, void *data,
 #include "glusterfs/stack.h"
 #include "glusterfs/iobuf.h"
 #include "glusterfs/globals.h"
-#include "glusterfs/iatt.h"
 #include "glusterfs/options.h"
 #include "glusterfs/client_t.h"
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -9,7 +9,6 @@
 */
 
 #include "glusterfs/inode.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/statedump.h"
 #include <pthread.h>
 #include <sys/types.h>

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -10,7 +10,6 @@
 
 #include "glusterfs/iobuf.h"
 #include "glusterfs/statedump.h"
-#include <stdio.h>
 #include "glusterfs/libglusterfs-messages.h"
 
 /*

--- a/libglusterfs/src/latency.c
+++ b/libglusterfs/src/latency.c
@@ -13,7 +13,7 @@
  * latencies of FOPs broken down by subvolumes.
  */
 
-#include "glusterfs/glusterfs.h"
+#include <glusterfs/logging.h>
 #include "glusterfs/statedump.h"
 
 gf_latency_t *

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -38,7 +38,6 @@
 #define GF_MAX_SLOG_PAIR_COUNT 100
 
 #include "glusterfs/logging.h"
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/timer.h"
 #include "glusterfs/libglusterfs-messages.h"
 

--- a/libglusterfs/src/options.c
+++ b/libglusterfs/src/options.c
@@ -10,7 +10,6 @@
 
 #include <fnmatch.h>
 
-#include "glusterfs/xlator.h"
 #include "glusterfs/defaults.h"
 #include "glusterfs/libglusterfs-messages.h"
 

--- a/libglusterfs/src/quota-common-utils.c
+++ b/libglusterfs/src/quota-common-utils.c
@@ -11,7 +11,6 @@
 #include "glusterfs/dict.h"
 #include "glusterfs/logging.h"
 #include "glusterfs/quota-common-utils.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/libglusterfs-messages.h"
 
 gf_boolean_t

--- a/libglusterfs/src/rbthash.c
+++ b/libglusterfs/src/rbthash.c
@@ -12,7 +12,6 @@
 #include "rb.h"
 #include "glusterfs/locking.h"
 #include "glusterfs/mem-pool.h"
-#include "glusterfs/logging.h"
 #include "glusterfs/libglusterfs-messages.h"
 
 #include <pthread.h>

--- a/libglusterfs/src/rot-buffs.c
+++ b/libglusterfs/src/rot-buffs.c
@@ -11,7 +11,7 @@
 #include <math.h>
 
 #include "glusterfs/mem-types.h"
-#include "glusterfs/mem-pool.h"
+#include "glusterfs/common-utils.h"
 
 #include "glusterfs/rot-buffs.h"
 

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -9,10 +9,8 @@
 */
 
 #include <stdarg.h>
-#include "glusterfs/glusterfs.h"
 #include "glusterfs/logging.h"
 #include "glusterfs/statedump.h"
-#include "glusterfs/stack.h"
 #include "glusterfs/syscall.h"
 
 #ifdef HAVE_MALLOC_H

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -11,7 +11,7 @@
 #include <inttypes.h>
 #include <libgen.h>
 
-#include "glusterfs/glusterfs.h"
+#include <glusterfs/logging.h>
 #include "glusterfs/store.h"
 #include "glusterfs/xlator.h"
 #include "glusterfs/syscall.h"

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -10,7 +10,6 @@
 
 #include "glusterfs/syncop.h"
 #include "glusterfs/syncop-utils.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/libglusterfs-messages.h"
 
 struct syncop_dir_scan_data {

--- a/libglusterfs/src/throttle-tbf.c
+++ b/libglusterfs/src/throttle-tbf.c
@@ -24,6 +24,7 @@
  */
 
 #include "glusterfs/mem-pool.h"
+#include <glusterfs/common-utils.h>
 #include "glusterfs/throttle-tbf.h"
 
 typedef struct tbf_throttle {

--- a/libglusterfs/src/timer.c
+++ b/libglusterfs/src/timer.c
@@ -10,7 +10,6 @@
 
 #include "glusterfs/timer.h"
 #include "glusterfs/logging.h"
-#include "glusterfs/common-utils.h"
 #include "glusterfs/globals.h"
 #include "glusterfs/timespec.h"
 #include "glusterfs/libglusterfs-messages.h"

--- a/rpc/rpc-lib/src/auth-glusterfs.c
+++ b/rpc/rpc-lib/src/auth-glusterfs.c
@@ -10,7 +10,6 @@
 
 #include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include "xdr-rpc.h"
 #include "xdr-common.h"
 #include "glusterfs4-xdr.h"
 

--- a/rpc/rpc-lib/src/auth-glusterfs.c
+++ b/rpc/rpc-lib/src/auth-glusterfs.c
@@ -12,7 +12,6 @@
 #include <glusterfs/dict.h>
 #include "xdr-rpc.h"
 #include "xdr-common.h"
-#include "rpc-common-xdr.h"
 #include "glusterfs4-xdr.h"
 
 /* V3 */

--- a/rpc/rpc-lib/src/mgmt-pmap.c
+++ b/rpc/rpc-lib/src/mgmt-pmap.c
@@ -9,9 +9,7 @@
 */
 
 #include "portmap-xdr.h"
-#include "protocol-common.h"
 #include "rpc-clnt.h"
-#include "xdr-generic.h"
 
 /* Defining a minimal RPC client program for portmap signout
  */

--- a/rpc/rpc-lib/src/protocol-common.h
+++ b/rpc/rpc-lib/src/protocol-common.h
@@ -11,6 +11,8 @@
 #ifndef _PROTOCOL_COMMON_H
 #define _PROTOCOL_COMMON_H
 
+#include <glusterfs/compat.h>
+
 enum gf_fop_procnum {
     GFS3_OP_NULL, /* 0 */
     GFS3_OP_STAT,

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -12,10 +12,8 @@
 #include "rpc-clnt-ping.h"
 #include "xdr-rpcclnt.h"
 #include "rpc-transport.h"
-#include "protocol-common.h"
 #include <glusterfs/mem-pool.h>
 #include "xdr-rpc.h"
-#include "rpc-common-xdr.h"
 #include <glusterfs/timespec.h>
 
 char *clnt_ping_procs[GF_DUMP_MAXVALUE] = {

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -13,7 +13,6 @@
 #include "rpc-clnt.h"
 #include "rpc-clnt-ping.h"
 #include "xdr-rpcclnt.h"
-#include "rpc-transport.h"
 #include <glusterfs/mem-pool.h>
 #include "xdr-rpc.h"
 

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -14,9 +14,9 @@
 #include "rpc-clnt-ping.h"
 #include "xdr-rpcclnt.h"
 #include "rpc-transport.h"
-#include "protocol-common.h"
 #include <glusterfs/mem-pool.h>
 #include "xdr-rpc.h"
+
 #include "rpc-common-xdr.h"
 
 void

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -11,7 +11,6 @@
 #ifndef __RPC_CLNT_H
 #define __RPC_CLNT_H
 
-#include <glusterfs/stack.h>
 #include "rpc-transport.h"
 #include <glusterfs/timer.h>
 #include "xdr-common.h"

--- a/rpc/rpc-lib/src/rpc-drc.h
+++ b/rpc/rpc-lib/src/rpc-drc.h
@@ -11,7 +11,6 @@
 #ifndef RPC_DRC_H
 #define RPC_DRC_H
 
-#include "rpcsvc-common.h"
 #include "rpcsvc.h"
 #include <glusterfs/locking.h>
 #include <glusterfs/dict.h>

--- a/rpc/rpc-lib/src/rpc-transport.c
+++ b/rpc/rpc-lib/src/rpc-transport.c
@@ -9,6 +9,7 @@
 */
 
 #include <dlfcn.h>
+#include <netdb.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/poll.h>

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -14,7 +14,6 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/statedump.h>
 #include "xdr-rpc.h"
-#include <glusterfs/iobuf.h>
 #include "xdr-common.h"
 #include "xdr-generic.h"
 #include "rpc-common-xdr.h"

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -20,7 +20,6 @@
 #include <pthread.h>
 #include <sys/uio.h>
 #include <inttypes.h>
-#include <rpc/rpc_msg.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/client_t.h>
 

--- a/rpc/rpc-lib/src/xdr-common.h
+++ b/rpc/rpc-lib/src/xdr-common.h
@@ -13,7 +13,6 @@
 
 #include <rpc/types.h>
 #include <sys/types.h>
-#include <rpc/xdr.h>
 #include <rpc/auth.h>
 #include <sys/uio.h>
 

--- a/rpc/rpc-lib/src/xdr-rpc.h
+++ b/rpc/rpc-lib/src/xdr-rpc.h
@@ -24,8 +24,6 @@
 #include <rpc/xdr.h>
 #include <sys/uio.h>
 
-#include "xdr-common.h"
-
 typedef enum {
     AUTH_GLUSTERFS = 5,
     AUTH_GLUSTERFS_v2 = 390039, /* using a number from  'unused' range,

--- a/rpc/rpc-lib/src/xdr-rpcclnt.c
+++ b/rpc/rpc-lib/src/xdr-rpcclnt.c
@@ -14,7 +14,6 @@
 #include <rpc/auth_unix.h>
 #include <errno.h>
 
-#include "xdr-rpc.h"
 #include "xdr-common.h"
 #include <glusterfs/common-utils.h>
 

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -21,7 +21,6 @@
 
 #include "rpc-transport.h"
 #include "socket.h"
-#include <glusterfs/common-utils.h>
 
 static void
 _assign_port(struct sockaddr *sockaddr, uint16_t port)

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -15,14 +15,10 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#include <glusterfs/glusterfs.h>
 #include "afr.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/hashfn.h>
 #include <glusterfs/list.h>
-#include <glusterfs/call-stub.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/statedump.h>

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -15,14 +15,10 @@
 #include <signal.h>
 #include <string.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/list.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
-
-#include "afr.h"
 #include "afr-transaction.h"
 
 int32_t

--- a/xlators/cluster/afr/src/afr-dir-write.c
+++ b/xlators/cluster/afr/src/afr-dir-write.c
@@ -14,17 +14,13 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#include <glusterfs/glusterfs.h>
 #include "afr.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/list.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 
-#include "afr.h"
 #include "afr-transaction.h"
 
 void

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -17,13 +17,10 @@
 
 #include <urcu/uatomic.h>
 
-#include <glusterfs/glusterfs.h>
-#include "afr.h"
+#include "libxlator.h"  // for gf_get_max_stime()
 #include <glusterfs/dict.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/list.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/quota-common-utils.h>

--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -13,12 +13,8 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#include <glusterfs/glusterfs.h>
-#include "afr.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include "protocol-common.h"

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -8,10 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/dict.h>
-#include <glusterfs/common-utils.h>
-
-#include "afr.h"
 #include "afr-transaction.h"
 #include "afr-messages.h"
 

--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -13,12 +13,8 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#include <glusterfs/glusterfs.h>
-#include "afr.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/statedump.h>

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -8,7 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include "afr.h"
 #include "afr-transaction.h"
 #include "afr-messages.h"
 

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -13,6 +13,7 @@
 #include "protocol-common.h"
 #include "afr-messages.h"
 #include <glusterfs/events.h>
+#include <openssl/md5.h>
 
 void
 afr_heal_synctask(xlator_t *this, afr_local_t *local);

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -13,6 +13,7 @@
 #include "protocol-common.h"
 #include "afr-messages.h"
 #include <glusterfs/events.h>
+#include <openssl/md5.h>
 
 #define HAS_HOLES(i) ((i->ia_blocks * 512) < (i->ia_size))
 static int

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -12,7 +12,6 @@
 #include "afr-self-heal.h"
 #include "afr-transaction.h"
 #include "afr-messages.h"
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/syncop-utils.h>
 #include <glusterfs/events.h>
 

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -9,10 +9,8 @@
 */
 
 #include <glusterfs/dict.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/timer.h>
 
-#include "afr.h"
 #include "afr-transaction.h"
 #include "afr-self-heal.h"
 #include "afr-messages.h"

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -15,8 +15,6 @@
 #include <glusterfs/compat-errno.h>
 #include "afr-mem-types.h"
 
-#include "libxlator.h"
-#include <glusterfs/timer.h>
 #include <glusterfs/syncop.h>
 
 #include "afr-self-heald.h"

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -16,7 +16,6 @@
 #include <glusterfs/quota-common-utils.h>
 #include <glusterfs/upcall-utils.h>
 #include "glusterfs/compat-errno.h"  // for ENODATA on BSD
-#include <glusterfs/common-utils.h>
 
 #include <sys/time.h>
 #include <libgen.h>

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -13,11 +13,8 @@
 #include "dht-mem-types.h"
 #include "dht-messages.h"
 #include <glusterfs/call-stub.h>
-#include "libxlator.h"
 #include <glusterfs/syncop.h>
 #include <glusterfs/refcount.h>
-#include <glusterfs/timer.h>
-#include "protocol-common.h"
 #include <glusterfs/glusterfs-acl.h>
 
 #ifndef _DHT_H

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -13,7 +13,6 @@
  */
 #include "dht-common.h"
 #include "dht-lock.h"
-#include <glusterfs/defaults.h>
 
 int
 dht_rename_unlock(call_frame_t *frame, xlator_t *this);

--- a/xlators/cluster/ec/src/ec-code.h
+++ b/xlators/cluster/ec/src/ec-code.h
@@ -11,7 +11,6 @@
 #ifndef __EC_CODE_H__
 #define __EC_CODE_H__
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/list.h>
 
 #include "ec-types.h"

--- a/xlators/cluster/ec/src/ec-fops.h
+++ b/xlators/cluster/ec/src/ec-fops.h
@@ -11,8 +11,6 @@
 #ifndef __EC_FOPS_H__
 #define __EC_FOPS_H__
 
-#include <glusterfs/xlator.h>
-
 #include "ec-types.h"
 #include "ec-common.h"
 

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -11,7 +11,6 @@
 #ifndef __EC_TYPES_H__
 #define __EC_TYPES_H__
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/timer.h>
 #include "libxlator.h"
 #include <glusterfs/atomic.h>

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -8,7 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/defaults.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/upcall-utils.h>

--- a/xlators/debug/delay-gen/src/delay-gen.c
+++ b/xlators/debug/delay-gen/src/delay-gen.c
@@ -8,6 +8,7 @@
  *  cases as published by the Free Software Foundation.
  */
 
+#include <glusterfs/defaults.h>
 #include "delay-gen.h"
 
 #define DELAY_GRANULARITY (1 << 20)

--- a/xlators/debug/delay-gen/src/delay-gen.h
+++ b/xlators/debug/delay-gen/src/delay-gen.h
@@ -13,9 +13,6 @@
 
 #include "delay-gen-mem-types.h"
 #include "delay-gen-messages.h"
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 
 typedef struct {
     uint32_t delay_ppm;

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -10,7 +10,6 @@
 #include <glusterfs/xlator.h>
 #include "error-gen.h"
 #include <glusterfs/statedump.h>
-#include <glusterfs/defaults.h>
 
 /*
  * The user can specify an error probability as a float percentage, but we

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -7,7 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/xlator.h>
 #include <glusterfs/syscall.h>
 
 /**
@@ -29,8 +28,6 @@
 
 #include <fnmatch.h>
 #include <errno.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include "io-stats-mem-types.h"
 #include <stdarg.h>
 #include <glusterfs/defaults.h>

--- a/xlators/debug/sink/src/sink.c
+++ b/xlators/debug/sink/src/sink.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 int32_t

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -8,6 +8,10 @@
   cases as published by the Free Software Foundation.
 */
 
+#include <glusterfs/event-history.h>
+#include <glusterfs/logging.h>
+#include <glusterfs/circ-buff.h>
+#include <glusterfs/statedump.h>
 #include "trace.h"
 #include "trace-mem-types.h"
 

--- a/xlators/debug/trace/src/trace.h
+++ b/xlators/debug/trace/src/trace.h
@@ -10,14 +10,6 @@
 
 #include <time.h>
 #include <errno.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/common-utils.h>
-#include <glusterfs/event-history.h>
-#include <glusterfs/logging.h>
-#include <glusterfs/circ-buff.h>
-#include <glusterfs/statedump.h>
-#include <glusterfs/options.h>
 
 #define TRACE_DEFAULT_HISTORY_SIZE 1024
 

--- a/xlators/features/arbiter/src/arbiter.c
+++ b/xlators/features/arbiter/src/arbiter.c
@@ -11,7 +11,8 @@
 #include "arbiter.h"
 #include "arbiter-mem-types.h"
 #include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
+#include <glusterfs/dict.h>
+#include <glusterfs/stack.h>
 #include <glusterfs/logging.h>
 
 static arbiter_inode_ctx_t *

--- a/xlators/features/arbiter/src/arbiter.h
+++ b/xlators/features/arbiter/src/arbiter.h
@@ -11,8 +11,7 @@
 #ifndef _ARBITER_H
 #define _ARBITER_H
 
-#include <glusterfs/locking.h>
-#include <glusterfs/common-utils.h>
+#include <glusterfs/iatt.h>
 
 typedef struct arbiter_inode_ctx_ {
     struct iatt iattbuf;

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -8,9 +8,9 @@
    cases as published by the Free Software Foundation.
 */
 
-#include "barrier.h"
-#include <glusterfs/defaults.h>
+#include <glusterfs/timer.h>
 #include <glusterfs/call-stub.h>
+#include "barrier.h"
 
 #include <glusterfs/statedump.h>
 

--- a/xlators/features/barrier/src/barrier.h
+++ b/xlators/features/barrier/src/barrier.h
@@ -12,9 +12,6 @@
 #define __BARRIER_H__
 
 #include "barrier-mem-types.h"
-#include <glusterfs/xlator.h>
-#include <glusterfs/timer.h>
-#include <glusterfs/call-stub.h>
 
 #define BARRIER_FOP_CBK(fop_name, label, frame, this, params...)               \
     do {                                                                       \

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub-status.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub-status.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include <glusterfs/common-utils.h>
 #include "bit-rot-scrub-status.h"
 
 void

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub-status.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub-status.h
@@ -15,8 +15,6 @@
 #include <sys/time.h>
 #include <pthread.h>
 
-#include <glusterfs/common-utils.h>
-
 struct br_scrub_stats {
     uint64_t scrubbed_files; /* Total number of scrubbed files. */
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -12,9 +12,7 @@
 #include <ctype.h>
 #include <sys/uio.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
 
 #include "bit-rot-scrub.h"
 #include <pthread.h>

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.h
@@ -11,7 +11,6 @@
 #ifndef __BIT_ROT_SCRUB_H__
 #define __BIT_ROT_SCRUB_H__
 
-#include <glusterfs/xlator.h>
 #include "bit-rot.h"
 
 void *

--- a/xlators/features/bit-rot/src/bitd/bit-rot-ssm.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-ssm.h
@@ -11,7 +11,7 @@
 #ifndef __BIT_ROT_SSM_H__
 #define __BIT_ROT_SSM_H__
 
-#include <glusterfs/xlator.h>
+#include <glusterfs/defaults.h>
 
 typedef enum br_scrub_state {
     BR_SCRUB_STATE_INACTIVE = 0,

--- a/xlators/features/bit-rot/src/bitd/bit-rot.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.h
@@ -11,11 +11,8 @@
 #ifndef __BIT_ROT_H__
 #define __BIT_ROT_H__
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/syncop.h>
 #include <glusterfs/syncop-utils.h>
 #include "changelog.h"

--- a/xlators/features/bit-rot/src/bitd/bit-rot.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.h
@@ -25,8 +25,6 @@
 #include "bit-rot-stub-mem-types.h"
 #include "bit-rot-scrub-status.h"
 
-#include <openssl/sha.h>
-
 typedef enum scrub_throttle {
     BR_SCRUB_THROTTLE_VOID = -1,
     BR_SCRUB_THROTTLE_LAZY = 0,

--- a/xlators/features/bit-rot/src/stub/bit-rot-common.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-common.h
@@ -11,7 +11,6 @@
 #ifndef __BIT_ROT_COMMON_H__
 #define __BIT_ROT_COMMON_H__
 
-#include <glusterfs/glusterfs.h>
 #include "bit-rot-object-version.h"
 
 #define BR_VXATTR_VERSION (1 << 0)

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -8,6 +8,8 @@
    cases as published by the Free Software Foundation.
 */
 
+#include <glusterfs/syncop.h>
+#include <glusterfs/syncop-utils.h>
 #include "bit-rot-stub.h"
 
 br_stub_fd_t *

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.h
@@ -10,20 +10,14 @@
 #ifndef __BIT_ROT_STUB_H__
 #define __BIT_ROT_STUB_H__
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/call-stub.h>
 #include "bit-rot-stub-mem-types.h"
 #include <glusterfs/syscall.h>
-#include <glusterfs/common-utils.h>
 #include "bit-rot-common.h"
 #include "bit-rot-stub-messages.h"
 #include "glusterfs4-xdr.h"
-#include <glusterfs/syncop.h>
-#include <glusterfs/syncop-utils.h>
 
 #define BAD_OBJECT_THREAD_STACK_SIZE ((size_t)(1024 * 1024))
 #define BR_STUB_DUMP_STR_SIZE 65536

--- a/xlators/features/changelog/lib/src/gf-changelog-helpers.h
+++ b/xlators/features/changelog/lib/src/gf-changelog-helpers.h
@@ -12,7 +12,6 @@
 #define _GF_CHANGELOG_HELPERS_H
 
 #include <unistd.h>
-#include <dirent.h>
 #include <limits.h>
 #include <glusterfs/locking.h>
 

--- a/xlators/features/changelog/lib/src/gf-changelog-journal.h
+++ b/xlators/features/changelog/lib/src/gf-changelog-journal.h
@@ -14,8 +14,6 @@
 #include <unistd.h>
 #include <pthread.h>
 
-#include "changelog.h"
-
 enum api_conn {
     JNL_API_CONNECTED,
     JNL_API_CONN_INPROGESS,

--- a/xlators/features/changelog/lib/src/gf-changelog-rpc.h
+++ b/xlators/features/changelog/lib/src/gf-changelog-rpc.h
@@ -11,8 +11,6 @@
 #ifndef __GF_CHANGELOG_RPC_H
 #define __GF_CHANGELOG_RPC_H
 
-#include <glusterfs/xlator.h>
-
 #include "gf-changelog-helpers.h"
 #include "changelog-rpc-common.h"
 

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -23,9 +23,7 @@
 #include <string.h>
 
 #include <glusterfs/globals.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/syncop.h>
 
 #include "gf-changelog-rpc.h"

--- a/xlators/features/changelog/src/changelog-encoders.h
+++ b/xlators/features/changelog/src/changelog-encoders.h
@@ -11,9 +11,6 @@
 #ifndef _CHANGELOG_ENCODERS_H
 #define _CHANGELOG_ENCODERS_H
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
-
 #include "changelog-helpers.h"
 
 #define CHANGELOG_STORE_ASCII(priv, buf, off, gfid, gfid_len, cld)             \

--- a/xlators/features/changelog/src/changelog-ev-handle.h
+++ b/xlators/features/changelog/src/changelog-ev-handle.h
@@ -12,7 +12,6 @@
 #define __CHANGELOG_EV_HANDLE_H
 
 #include <glusterfs/list.h>
-#include <glusterfs/xlator.h>
 #include "rpc-clnt.h"
 
 #include <glusterfs/rot-buffs.h>

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -8,10 +8,7 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/iobuf.h>
 #include <glusterfs/syscall.h>
 
 #include "changelog-helpers.h"

--- a/xlators/features/changelog/src/changelog-misc.h
+++ b/xlators/features/changelog/src/changelog-misc.h
@@ -11,9 +11,6 @@
 #ifndef _CHANGELOG_MISC_H
 #define _CHANGELOG_MISC_H
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/common-utils.h>
-
 #define CHANGELOG_MAX_TYPE 4
 #define CHANGELOG_FILE_NAME "CHANGELOG"
 #define HTIME_FILE_NAME "HTIME"

--- a/xlators/features/changelog/src/changelog-rpc-common.h
+++ b/xlators/features/changelog/src/changelog-rpc-common.h
@@ -17,8 +17,6 @@
 
 #include "changelog-xdr.h"
 
-#include "changelog.h"
-
 /**
  * Let's keep this non-configurable for now.
  */

--- a/xlators/features/changelog/src/changelog-rpc-common.h
+++ b/xlators/features/changelog/src/changelog-rpc-common.h
@@ -14,10 +14,8 @@
 #include "rpcsvc.h"
 #include "rpc-clnt.h"
 #include <glusterfs/gf-event.h>
-#include <glusterfs/call-stub.h>
 
 #include "changelog-xdr.h"
-#include "xdr-generic.h"
 
 #include "changelog.h"
 

--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -12,6 +12,7 @@
 #include "changelog-rpc.h"
 #include "changelog-mem-types.h"
 #include "changelog-ev-handle.h"
+#include "socket.h"
 
 static struct rpcsvc_program *changelog_programs[];
 

--- a/xlators/features/changelog/src/changelog-rpc.h
+++ b/xlators/features/changelog/src/changelog-rpc.h
@@ -11,11 +11,9 @@
 #ifndef __CHANGELOG_RPC_H
 #define __CHANGELOG_RPC_H
 
-#include <glusterfs/xlator.h>
 #include "changelog-helpers.h"
 
 /* one time */
-#include "socket.h"
 #include "changelog-rpc-common.h"
 
 #define CHANGELOG_RPC_PROGNAME "GlusterFS Changelog"

--- a/xlators/features/changelog/src/changelog-rt.c
+++ b/xlators/features/changelog/src/changelog-rt.c
@@ -8,8 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/logging.h>
 
 #include "changelog-rt.h"

--- a/xlators/features/changelog/src/changelog-rt.h
+++ b/xlators/features/changelog/src/changelog-rt.h
@@ -13,7 +13,6 @@
 
 #include <glusterfs/locking.h>
 #include <glusterfs/timer.h>
-#include "pthread.h"
 
 #include "changelog-helpers.h"
 

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -8,8 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/iobuf.h>

--- a/xlators/features/cloudsync/src/cloudsync-common.h
+++ b/xlators/features/cloudsync/src/cloudsync-common.h
@@ -10,9 +10,7 @@
 #ifndef _CLOUDSYNC_COMMON_H
 #define _CLOUDSYNC_COMMON_H
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/call-stub.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/syncop.h>
 #include <glusterfs/compat-errno.h>
 #include "cloudsync-mem-types.h"

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -15,8 +15,6 @@
 #include <openssl/buffer.h>
 #include <openssl/crypto.h>
 #include <curl/curl.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
 #include "libcloudsyncs3.h"
 #include "cloudsync-common.h"
 

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
@@ -10,10 +10,6 @@
 #ifndef _LIBAWS_H
 #define _LIBAWS_H
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/call-stub.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/syncop.h>
 #include <curl/curl.h>
 #include "cloudsync-common.h"
 #include "libcloudsyncs3-mem-types.h"

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
 #include "libcvlt.h"
 #include "cloudsync-common.h"
 #include "cvlt-messages.h"

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
@@ -11,10 +11,6 @@
 #define _LIBCVLT_H
 
 #include <semaphore.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/call-stub.h>
-#include <glusterfs/syncop.h>
 #include <glusterfs/compat-errno.h>
 #include "cloudsync-common.h"
 #include "libcvlt-mem-types.h"

--- a/xlators/features/cloudsync/src/cloudsync.c
+++ b/xlators/features/cloudsync/src/cloudsync.c
@@ -8,9 +8,6 @@
  *   cases as published by the Free Software Foundation.
  */
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include "cloudsync.h"
 #include "cloudsync-common.h"
 #include <glusterfs/call-stub.h>

--- a/xlators/features/cloudsync/src/cloudsync.h
+++ b/xlators/features/cloudsync/src/cloudsync.h
@@ -11,11 +11,6 @@
 #ifndef __CLOUDSYNC_H__
 #define __CLOUDSYNC_H__
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/syncop.h>
-#include <glusterfs/call-stub.h>
 #include "cloudsync-common.h"
 #include "cloudsync-autogen-fops.h"
 

--- a/xlators/features/compress/src/cdc.c
+++ b/xlators/features/compress/src/cdc.c
@@ -10,8 +10,6 @@
 
 #include <sys/uio.h>
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/logging.h>
 
 #include "cdc.h"

--- a/xlators/features/gfid-access/src/gfid-access.h
+++ b/xlators/features/gfid-access/src/gfid-access.h
@@ -10,10 +10,8 @@
 #ifndef __GFID_ACCESS_H__
 #define __GFID_ACCESS_H__
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 #include "gfid-access-mem-types.h"
 

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -13,7 +13,6 @@
 #include <glusterfs/syscall.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/syncop.h>
-#include <glusterfs/common-utils.h>
 #include "index-messages.h"
 #include <ftw.h>
 #include <libgen.h> /* for dirname() */

--- a/xlators/features/index/src/index.h
+++ b/xlators/features/index/src/index.h
@@ -11,10 +11,7 @@
 #ifndef __INDEX_H__
 #define __INDEX_H__
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include "index-mem-types.h"
 
 #define INDEX_THREAD_STACK_SIZE ((size_t)(1024 * 1024))

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -13,6 +13,7 @@
 #include "config.h"
 #endif
 
+#include <glusterfs/upcall-utils.h>
 #include "leases.h"
 
 /* Mutex locks used in this xlator and their order of acquisition:

--- a/xlators/features/leases/src/leases.h
+++ b/xlators/features/leases/src/leases.h
@@ -16,15 +16,9 @@
 #include "config.h"
 #endif
 
-#include <glusterfs/common-utils.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/client_t.h>
-#include <glusterfs/lkowner.h>
 #include <glusterfs/locking.h>
-#include <glusterfs/upcall-utils.h>
 #include "timer-wheel.h"
 #include "leases-mem-types.h"
 #include "leases-messages.h"

--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -12,11 +12,8 @@
 #include <limits.h>
 #include <pthread.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
 
 #include "locks.h"
 #include "common.h"

--- a/xlators/features/locks/src/clear.h
+++ b/xlators/features/locks/src/clear.h
@@ -11,8 +11,6 @@
 #define __CLEAR_H__
 
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/stack.h>
-#include <glusterfs/call-stub.h>
 #include "locks.h"
 
 typedef enum {

--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -7,11 +7,8 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/list.h>
 #include <glusterfs/upcall-utils.h>
 

--- a/xlators/features/locks/src/locks.h
+++ b/xlators/features/locks/src/locks.h
@@ -11,12 +11,8 @@
 #define __POSIX_LOCKS_H__
 
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/stack.h>
 #include <glusterfs/call-stub.h>
 #include "locks-mem-types.h"
-#include <glusterfs/client_t.h>
-
-#include <glusterfs/lkowner.h>
 
 typedef enum {
     MLK_NONE,

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -19,7 +19,6 @@
 #include "common.h"
 #include <glusterfs/statedump.h>
 #include "clear.h"
-#include <glusterfs/defaults.h>
 #include <glusterfs/syncop.h>
 
 #ifndef LLONG_MAX

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -7,11 +7,8 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/list.h>
 
 #include "locks.h"

--- a/xlators/features/marker/src/marker-common.h
+++ b/xlators/features/marker/src/marker-common.h
@@ -10,7 +10,6 @@
 #ifndef _MARKER_COMMON_H
 #define _MARKER_COMMON_H
 
-#include <glusterfs/xlator.h>
 #include "marker.h"
 
 int32_t

--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -8,10 +8,7 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
-#include "libxlator.h"
-#include <glusterfs/common-utils.h>
+#include <glusterfs/compat-errno.h>
 #include "marker-quota.h"
 #include "marker-quota-helper.h"
 #include <glusterfs/syncop.h>

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -7,8 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include "libxlator.h"
 #include "marker.h"
 #include "marker-mem-types.h"

--- a/xlators/features/marker/src/marker.h
+++ b/xlators/features/marker/src/marker.h
@@ -11,10 +11,7 @@
 #define _MARKER_H
 
 #include "marker-quota.h"
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/compat-uuid.h>
-#include <glusterfs/call-stub.h>
 
 #define MARKER_XATTR_PREFIX "trusted.glusterfs"
 #define XTIME "xtime"

--- a/xlators/features/metadisp/src/backend.c
+++ b/xlators/features/metadisp/src/backend.c
@@ -1,5 +1,3 @@
-#define GFID_STR_LEN 37
-
 #include "metadisp.h"
 
 /*
@@ -13,7 +11,7 @@ int32_t
 build_backend_loc(uuid_t gfid, loc_t *src_loc, loc_t *dst_loc)
 {
     static uuid_t root = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    char gfid_buf[GFID_STR_LEN + 1] = {
+    char gfid_buf[GF_UUID_BUF_SIZE + 1] = {
         0,
     };
     char *path = NULL;
@@ -28,12 +26,12 @@ build_backend_loc(uuid_t gfid, loc_t *src_loc, loc_t *dst_loc)
 
     uuid_utoa_r(gfid, gfid_buf);
 
-    path = GF_CALLOC(GFID_STR_LEN + 1, sizeof(char),
+    path = GF_CALLOC(GF_UUID_BUF_SIZE + 1, sizeof(char),
                      gf_common_mt_char);  // freed via loc_wipe
 
     path[0] = '/';
-    strncpy(path + 1, gfid_buf, GFID_STR_LEN);
-    path[GFID_STR_LEN] = 0;
+    strncpy(path + 1, gfid_buf, GF_UUID_BUF_SIZE);
+    path[GF_UUID_BUF_SIZE] = 0;
     dst_loc->path = path;
     if (src_loc->name)
         dst_loc->name = strrchr(dst_loc->path, '/');

--- a/xlators/features/metadisp/src/fops-tmpl.c
+++ b/xlators/features/metadisp/src/fops-tmpl.c
@@ -3,7 +3,6 @@
 #include "config.h"
 #endif
 
-#include <glusterfs/xlator.h>
 #include "metadisp.h"
 #include "metadisp-fops.h"
 

--- a/xlators/features/metadisp/src/metadisp-fops.h
+++ b/xlators/features/metadisp/src/metadisp-fops.h
@@ -1,7 +1,6 @@
 #ifndef GF_METADISP_FOPS_H_
 #define GF_METADISP_FOPS_H_
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/glusterfs.h>
 

--- a/xlators/features/metadisp/src/metadisp.h
+++ b/xlators/features/metadisp/src/metadisp.h
@@ -10,11 +10,8 @@
 #ifndef GF_METADISP_H_
 #define GF_METADISP_H_
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 
 #define METADATA_CHILD(_this) FIRST_CHILD(_this)
 #define DATA_CHILD(_this) SECOND_CHILD(_this)

--- a/xlators/features/namespace/src/namespace.c
+++ b/xlators/features/namespace/src/namespace.c
@@ -15,7 +15,6 @@
 
 #include <sys/types.h>
 
-#include <glusterfs/defaults.h>
 #include <glusterfs/hashfn.h>
 #include <glusterfs/logging.h>
 #include "namespace.h"

--- a/xlators/features/namespace/src/namespace.h
+++ b/xlators/features/namespace/src/namespace.h
@@ -6,7 +6,6 @@
 #include "config.h"
 #endif
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
 
 #define GF_NAMESPACE "namespace"

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 #include "quiesce.h"
-#include <glusterfs/defaults.h>
 #include <glusterfs/call-stub.h>
 
 /* TODO: */

--- a/xlators/features/quiesce/src/quiesce.h
+++ b/xlators/features/quiesce/src/quiesce.h
@@ -13,7 +13,6 @@
 
 #include "quiesce-mem-types.h"
 #include "quiesce-messages.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/timer.h>
 
 #define GF_FOPS_EXPECTED_IN_PARALLEL 512

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -12,7 +12,6 @@
 
 #include <glusterfs/call-stub.h>
 #include "quota-mem-types.h"
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
@@ -20,7 +19,6 @@
 #include "rpcsvc.h"
 #include "rpc-clnt.h"
 #include "glusterfs3.h"
-#include "xdr-generic.h"
 #include <glusterfs/compat-errno.h>
 #include "protocol-common.h"
 #include <glusterfs/quota-common-utils.h>

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -16,11 +16,9 @@
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/gf-event.h>
-#include "rpcsvc.h"
 #include "rpc-clnt.h"
 #include "glusterfs3.h"
 #include <glusterfs/compat-errno.h>
-#include "protocol-common.h"
 #include <glusterfs/quota-common-utils.h>
 #include "quota-messages.h"
 

--- a/xlators/features/quota/src/quotad-aggregator.h
+++ b/xlators/features/quota/src/quotad-aggregator.h
@@ -13,7 +13,6 @@
 
 #include "quota.h"
 #include <glusterfs/stack.h>
-#include <glusterfs/inode.h>
 
 typedef struct {
     void *pool;

--- a/xlators/features/quota/src/quotad-helpers.h
+++ b/xlators/features/quota/src/quotad-helpers.h
@@ -12,7 +12,6 @@
 #define QUOTAD_HELPERS_H
 
 #include "rpcsvc.h"
-#include "quota.h"
 #include "quotad-aggregator.h"
 
 void

--- a/xlators/features/read-only/src/read-only-common.h
+++ b/xlators/features/read-only/src/read-only-common.h
@@ -7,7 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 gf_boolean_t

--- a/xlators/features/read-only/src/worm-helper.c
+++ b/xlators/features/read-only/src/worm-helper.c
@@ -9,7 +9,6 @@
 */
 #include "read-only-mem-types.h"
 #include "read-only.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/syncop.h>
 #include "worm-helper.h"
 

--- a/xlators/features/read-only/src/worm.c
+++ b/xlators/features/read-only/src/worm.c
@@ -7,8 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include "read-only-common.h"
 #include "read-only-mem-types.h"
 #include "read-only.h"

--- a/xlators/features/sdfs/src/sdfs.h
+++ b/xlators/features/sdfs/src/sdfs.h
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
 #include "sdfs-messages.h"
 #include <glusterfs/atomic.h>

--- a/xlators/features/selinux/src/selinux.h
+++ b/xlators/features/selinux/src/selinux.h
@@ -10,8 +10,6 @@
 #ifndef __SELINUX_H__
 #define __SELINUX_H__
 
-#include <glusterfs/common-utils.h>
-
 #define SELINUX_XATTR "security.selinux"
 #define SELINUX_GLUSTER_XATTR "trusted.glusterfs.selinux"
 

--- a/xlators/features/snapview-client/src/snapview-client.h
+++ b/xlators/features/snapview-client/src/snapview-client.h
@@ -13,7 +13,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 #include "snapview-client-mem-types.h"
 #include "snapview-client-messages.h"

--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -10,9 +10,7 @@
 #include "snapview-server.h"
 #include "snapview-server-mem-types.h"
 
-#include <glusterfs/xlator.h>
 #include "rpc-clnt.h"
-#include "xdr-generic.h"
 #include "protocol-common.h"
 #include <pthread.h>
 

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -11,9 +11,7 @@
 #include "snapview-server-mem-types.h"
 #include <glusterfs/compat-errno.h>
 
-#include <glusterfs/xlator.h>
 #include "rpc-clnt.h"
-#include "xdr-generic.h"
 #include "protocol-common.h"
 #include <glusterfs/syscall.h>
 #include <pthread.h>

--- a/xlators/features/snapview-server/src/snapview-server.h
+++ b/xlators/features/snapview-server/src/snapview-server.h
@@ -17,19 +17,14 @@
 #include <glusterfs/iatt.h>
 #include <ctype.h>
 #include <sys/uio.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
-#include "glfs.h"
-#include "glfs-handles.h"
 #include "glfs-internal.h"
-#include "glusterfs4-xdr.h"
 #include <glusterfs/glusterfs-acl.h>
 #include <glusterfs/syncop.h>
 #include <glusterfs/list.h>
 #include <glusterfs/timer.h>
 #include "rpc-clnt.h"
 #include "protocol-common.h"
-#include "xdr-generic.h"
 #include "snapview-server-messages.h"
 
 #define DEFAULT_SVD_LOG_FILE_DIRECTORY DATADIR "/log/glusterfs"

--- a/xlators/features/thin-arbiter/src/thin-arbiter.c
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.c
@@ -12,9 +12,8 @@
 #include "thin-arbiter-messages.h"
 #include "thin-arbiter-mem-types.h"
 #include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
+#include <glusterfs/defaults.h>
 
 int
 ta_set_incoming_values(dict_t *dict, char *key, data_t *value, void *data)

--- a/xlators/features/thin-arbiter/src/thin-arbiter.h
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.h
@@ -12,10 +12,7 @@
 #define _THIN_ARBITER_H
 
 #include <glusterfs/locking.h>
-#include <glusterfs/common-utils.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/list.h>
 
 #define THIN_ARBITER_SOURCE_XATTR "trusted.ta.source"

--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -14,18 +14,13 @@
 
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/common-utils.h>
 
 #include <glusterfs/statedump.h>
 #include <glusterfs/syncop.h>
 
 #include "upcall.h"
 #include "upcall-mem-types.h"
-#include "glusterfs4-xdr.h"
-#include "protocol-common.h"
-#include <glusterfs/defaults.h>
 
 /*
  * Check if any of the upcall options are enabled:

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -15,7 +15,6 @@
 
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/common-utils.h>
 
@@ -23,9 +22,8 @@
 
 #include "upcall.h"
 #include "upcall-mem-types.h"
-#include "glusterfs4-xdr.h"
-#include "protocol-common.h"
 #include <glusterfs/defaults.h>
+#include "upcall-cache-invalidation.h"
 
 static int32_t
 up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -14,7 +14,6 @@
 #include "upcall-mem-types.h"
 #include <glusterfs/client_t.h>
 #include "upcall-messages.h"
-#include "upcall-cache-invalidation.h"
 #include <glusterfs/upcall-utils.h>
 
 #define EXIT_IF_UPCALL_OFF(this, label)                                        \

--- a/xlators/features/utime/src/utime-helpers.h
+++ b/xlators/features/utime/src/utime-helpers.h
@@ -12,7 +12,6 @@
 #define _UTIME_HELPERS_H
 
 #include <glusterfs/stack.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/timespec.h>
 #include <time.h>
 

--- a/xlators/features/utime/src/utime.h
+++ b/xlators/features/utime/src/utime.h
@@ -11,9 +11,6 @@
 #ifndef __UTIME_H__
 #define __UTIME_H__
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include "utime-autogen-fops.h"
 
 typedef struct utime_priv {

--- a/xlators/meta/src/active-link.c
+++ b/xlators/meta/src/active-link.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/cmdline-file.c
+++ b/xlators/meta/src/cmdline-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/frames-file.c
+++ b/xlators/meta/src/frames-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/graph-dir.c
+++ b/xlators/meta/src/graph-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/graphs-dir.c
+++ b/xlators/meta/src/graphs-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/history-file.c
+++ b/xlators/meta/src/history-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/logfile-link.c
+++ b/xlators/meta/src/logfile-link.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/logging-dir.c
+++ b/xlators/meta/src/logging-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/loglevel-file.c
+++ b/xlators/meta/src/loglevel-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/mallinfo-file.c
+++ b/xlators/meta/src/mallinfo-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/measure-file.c
+++ b/xlators/meta/src/measure-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/meminfo-file.c
+++ b/xlators/meta/src/meminfo-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/meta-hooks.h
+++ b/xlators/meta/src/meta-hooks.h
@@ -10,7 +10,6 @@
 
 #ifndef __META_HOOKS_H
 #define __META_HOOKS_H
-#include <glusterfs/xlator.h>
 
 #define DECLARE_HOOK(name)                                                     \
     int meta_##name##_hook(call_frame_t *frame, xlator_t *this, loc_t *loc,    \

--- a/xlators/meta/src/name-file.c
+++ b/xlators/meta/src/name-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/option-file.c
+++ b/xlators/meta/src/option-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/options-dir.c
+++ b/xlators/meta/src/options-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/private-file.c
+++ b/xlators/meta/src/private-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/process_uuid-file.c
+++ b/xlators/meta/src/process_uuid-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/profile-file.c
+++ b/xlators/meta/src/profile-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/root-dir.c
+++ b/xlators/meta/src/root-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/subvolume-link.c
+++ b/xlators/meta/src/subvolume-link.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/subvolumes-dir.c
+++ b/xlators/meta/src/subvolumes-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/top-link.c
+++ b/xlators/meta/src/top-link.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/type-file.c
+++ b/xlators/meta/src/type-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/version-file.c
+++ b/xlators/meta/src/version-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/view-dir.c
+++ b/xlators/meta/src/view-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/volfile-file.c
+++ b/xlators/meta/src/volfile-file.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/meta/src/xlator-dir.c
+++ b/xlators/meta/src/xlator-dir.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 
 #include "meta-mem-types.h"

--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
@@ -10,7 +10,6 @@
 
 #include <glusterfs/globals.h>
 #include <glusterfs/run.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-bitd-svc.h"

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -17,6 +17,7 @@
 #include <glusterfs/compat-errno.h>
 #include "glusterd-scrub-svc.h"
 #include "glusterd-messages.h"
+#include "glusterd-bitd-svc.h"
 
 #include <sys/wait.h>
 #include <dlfcn.h>

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -8,10 +8,6 @@
    cases as published by the Free Software Foundation.
  */
 
-#include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -7,10 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"
 #include "glusterd-store.h"

--- a/xlators/mgmt/glusterd/src/glusterd-conn-helper.h
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-helper.h
@@ -11,8 +11,6 @@
 #ifndef _GLUSTERD_CONN_HELPER_H_
 #define _GLUSTERD_CONN_HELPER_H_
 
-#include "rpc-clnt.h"
-
 #include "glusterd-conn-mgmt.h"
 
 glusterd_svc_t *

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include "rpc-clnt.h"
 #include "glusterd.h"
 #include "glusterd-conn-mgmt.h"

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -8,13 +8,12 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/common-utils.h>
-#include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-messages.h"
 #include <glusterfs/syscall.h>
+#include <glusterfs/run.h>
 
 #include <ctype.h>
 

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -9,7 +9,6 @@
 */
 
 #include <glusterfs/common-utils.h>
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -7,10 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"
 #include "glusterd-store.h"

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-gfproxyd-svc-helper.h"
 #include "glusterd-messages.h"

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -10,7 +10,6 @@
 
 #include <glusterfs/globals.h>
 #include <glusterfs/run.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-gfproxyd-svc.h"

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -17,10 +17,8 @@
 #include <glusterfs/timer.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/statedump.h>
 #include <glusterfs/run.h>
 #include "glusterd-mem-types.h"
-#include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"
 #include "glusterd-mgmt.h"
@@ -30,7 +28,6 @@
 #include "glusterd-snapshot-utils.h"
 #include "glusterd-geo-rep.h"
 
-#include "glusterd-volgen.h"
 #include "glusterd-mountbroker.h"
 #include "glusterd-messages.h"
 #include "glusterd-errno.h"
@@ -40,6 +37,8 @@
 
 #include "glusterd-syncop.h"
 #include "glusterd-messages.h"
+
+#include "gd-common-utils.h"
 
 extern glusterd_op_info_t opinfo;
 static int volcount;

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -12,18 +12,14 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/dict.h>
-#include "protocol-common.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/timer.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/run.h>
 #include "glusterd-mem-types.h"
-#include "glusterd.h"
 #include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"
@@ -34,10 +30,6 @@
 #include "glusterd-snapshot-utils.h"
 #include "glusterd-geo-rep.h"
 
-#include "glusterd1-xdr.h"
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "rpc-clnt.h"
 #include "glusterd-volgen.h"
 #include "glusterd-mountbroker.h"
 #include "glusterd-messages.h"
@@ -45,8 +37,6 @@
 
 #include <sys/resource.h>
 #include <inttypes.h>
-
-#include <glusterfs/common-utils.h>
 
 #include "glusterd-syncop.h"
 #include "glusterd-messages.h"

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -8,13 +8,12 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/compat-errno.h>
 
-#include "glusterd.h"
+#include "rpc-common-xdr.h"
+
 #include "glusterd-utils.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
@@ -27,7 +26,6 @@
 #include "glusterfs3.h"
 #include "protocol-common.h"
 #include "rpcsvc.h"
-#include "rpc-common-xdr.h"
 #include "glusterd-gfproxyd-svc-helper.h"
 #include "glusterd-shd-svc-helper.h"
 

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.c
@@ -8,16 +8,12 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/run.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
-#include "glusterd.h"
 #include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -7,10 +7,6 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-#include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-log-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-log-ops.c
@@ -8,9 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
@@ -7,14 +7,7 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
-/* rpc related syncops */
-#include "rpc-clnt.h"
-#include "protocol-common.h"
-#include "xdr-generic.h"
-#include "glusterd1-xdr.h"
-#include "glusterd-syncop.h"
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-locks.h"
 #include "glusterd-mgmt.h"

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -8,13 +8,8 @@
    cases as published by the Free Software Foundation.
 */
 /* rpc related syncops */
-#include "rpc-clnt.h"
-#include "protocol-common.h"
-#include "xdr-generic.h"
-#include "glusterd1-xdr.h"
 #include "glusterd-syncop.h"
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-locks.h"
 #include "glusterd-mgmt.h"

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -18,12 +18,10 @@
 #include <glusterfs/list.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/run.h>
 #include "glusterd-mem-types.h"
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include <glusterfs/common-utils.h>
 #include "glusterd-mountbroker.h"

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -17,13 +17,8 @@
 #include <glusterfs/compat-uuid.h>
 
 #include "fnmatch.h"
-#include <glusterfs/xlator.h>
-#include "protocol-common.h"
-#include "glusterd.h"
-#include <glusterfs/call-stub.h>
 #include <glusterfs/list.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/statedump.h>
 #include "glusterd-op-sm.h"
@@ -32,7 +27,6 @@
 #include "glusterd-locks.h"
 #include "glusterd-quota.h"
 #include <glusterfs/syscall.h>
-#include "cli1-xdr.h"
 #include "glusterd-snapshot-utils.h"
 #include "glusterd-svc-mgmt.h"
 #include "glusterd-svc-helper.h"
@@ -131,8 +125,8 @@ glusterd_txn_opinfo_dict_fini()
 
 void
 glusterd_txn_opinfo_init(glusterd_op_info_t *opinfo,
-                         glusterd_op_sm_state_t state, int *op,
-                         dict_t *op_ctx, rpcsvc_request_t *req)
+                         glusterd_op_sm_state_t state, int *op, dict_t *op_ctx,
+                         rpcsvc_request_t *req)
 {
     glusterd_conf_t *conf = NULL;
 
@@ -5826,9 +5820,9 @@ glusterd_op_sm_transition_state(glusterd_op_info_t *opinfo,
     conf = THIS->private;
     GF_ASSERT(conf);
 
-    (void)glusterd_sm_tr_log_transition_add(
-        &conf->op_sm_log, opinfo->state, state[event_type].next_state,
-        event_type);
+    (void)glusterd_sm_tr_log_transition_add(&conf->op_sm_log, opinfo->state,
+                                            state[event_type].next_state,
+                                            event_type);
 
     opinfo->state = state[event_type].next_state;
     return 0;

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -13,12 +13,9 @@
 #include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/call-stub.h>
 #include "glusterd.h"
-#include "protocol-common.h"
 #include "glusterd-hooks.h"
 
 #define GD_OP_PROTECTED (0x02)

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -10,7 +10,6 @@
 #ifndef _GLUSTERD_OP_SM_H_
 #define _GLUSTERD_OP_SM_H_
 
-#include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
 #include <glusterfs/xlator.h>

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -12,8 +12,9 @@
 #include "glusterd-store.h"
 #include "glusterd-server-quorum.h"
 #include "glusterd-messages.h"
-#include <glusterfs/common-utils.h>
 #include "glusterd-utils.h"
+
+#include <netdb.h>
 
 void
 glusterd_peerinfo_destroy(struct rcu_head *head)

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -8,17 +8,13 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/compat-errno.h>
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 
 #include "portmap-xdr.h"
-#include "xdr-generic.h"
-#include "protocol-common.h"
 #include "glusterd-messages.h"
 #include "rpcsvc.h"
 

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.h
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.h
@@ -10,10 +10,10 @@
 #ifndef _GLUSTERD_PMAP_H_
 #define _GLUSTERD_PMAP_H_
 
-#include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/logging.h>
+#include <urcu/list.h>
+#include <glusterfs/xlator.h>
 
 struct pmap_ports {
     struct cds_list_head port_list;

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.h
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.h
@@ -13,11 +13,7 @@
 #include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/call-stub.h>
-#include "rpcsvc.h"
 
 struct pmap_ports {
     struct cds_list_head port_list;

--- a/xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c
@@ -12,10 +12,8 @@
 #include <limits.h>
 #include <signal.h>
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include <glusterfs/common-utils.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include "glusterd-messages.h"
 #include "glusterd-proc-mgmt.h"

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -8,9 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-store.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-quotad-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quotad-svc.c
@@ -10,7 +10,6 @@
 
 #include <glusterfs/globals.h>
 #include <glusterfs/run.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-quotad-svc.h"

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -14,12 +14,9 @@
 #include <sys/statvfs.h>
 
 #include <glusterfs/compat.h>
-#include "protocol-common.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/timer.h>
 #include "glusterd-mem-types.h"
-#include "glusterd.h"
 #include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"
@@ -31,8 +28,6 @@
 #include "glusterd-messages.h"
 
 #include <glusterfs/syscall.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
 
 #define GLUSTERD_GET_DEFRAG_SOCK_FILE(path, volinfo)                           \
     do {                                                                       \

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -8,10 +8,7 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
 #include <glusterfs/glusterfs.h>
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"
 #include "glusterd-store.h"

--- a/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
@@ -8,10 +8,7 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/common-utils.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
 #include <glusterfs/glusterfs.h>
-#include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"
 #include "glusterd-store.h"

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -9,16 +9,10 @@
 */
 
 #include "rpc-clnt.h"
-#include "glusterd1-xdr.h"
-#include "cli1-xdr.h"
-
-#include "xdr-generic.h"
 
 #include <glusterfs/compat-errno.h>
 #include "glusterd-op-sm.h"
 #include "glusterd-sm.h"
-#include "glusterd.h"
-#include "protocol-common.h"
 #include "glusterd-utils.h"
 #include <glusterfs/common-utils.h>
 #include "glusterd-messages.h"

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
@@ -10,7 +10,6 @@
 
 #include <glusterfs/globals.h>
 #include <glusterfs/run.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-scrub-svc.h"

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 #include <glusterfs/common-utils.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-messages.h"
 #include "glusterd-server-quorum.h"

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-shd-svc-helper.h"
 #include "glusterd-messages.h"

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.h
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.h
@@ -11,7 +11,6 @@
 #ifndef _GLUSTERD_SHD_SVC_HELPER_H_
 #define _GLUSTERD_SHD_SVC_HELPER_H_
 
-#include "glusterd.h"
 #include "glusterd-svc-mgmt.h"
 
 void

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -10,7 +10,6 @@
 
 #include <glusterfs/globals.h>
 #include <glusterfs/run.h>
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-volgen.h"
 #include "glusterd-shd-svc.h"

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
@@ -12,7 +12,6 @@
 #define _GLUSTERD_SHD_SVC_H_
 
 #include "glusterd-svc-mgmt.h"
-#include "glusterd.h"
 
 typedef struct glusterd_shdsvc_ glusterd_shdsvc_t;
 struct glusterd_shdsvc_ {

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -16,17 +16,12 @@
 #include <glusterfs/compat-uuid.h>
 
 #include "fnmatch.h"
-#include <glusterfs/xlator.h>
-#include "protocol-common.h"
-#include "glusterd.h"
-#include <glusterfs/call-stub.h>
-#include <glusterfs/defaults.h>
+#include <glusterfs/compat.h>
 #include <glusterfs/list.h>
 #include "glusterd-messages.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/statedump.h>
 #include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -14,7 +14,6 @@
 #include <glusterfs/compat-uuid.h>
 
 #include "rpc-clnt.h"
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/call-stub.h>
 #include "rpcsvc.h"
 #include <glusterfs/store.h>

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc-helper.h
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc-helper.h
@@ -11,8 +11,6 @@
 #ifndef _GLUSTERD_SNAPD_SVC_HELPER_H_
 #define _GLUSTERD_SNAPD_SVC_HELPER_H_
 
-#include "glusterd.h"
-
 void
 glusterd_svc_build_snapd_rundir(glusterd_volinfo_t *volinfo, char *path,
                                 int path_len);

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -36,12 +36,9 @@
 #include <regex.h>
 
 #include <glusterfs/compat.h>
-#include "protocol-common.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/timer.h>
 #include "glusterd-mem-types.h"
-#include "glusterd.h"
 #include "glusterd-sm.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"
@@ -56,8 +53,6 @@
 #include "glusterfs3.h"
 
 #include <glusterfs/syscall.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
 
 #include <glusterfs/events.h>
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -8,18 +8,14 @@
    cases as published by the Free Software Foundation.
 */
 
-#include "glusterd-op-sm.h"
 #include <inttypes.h>
 
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/dict.h>
-#include "protocol-common.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/timer.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/statedump.h>

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -25,7 +25,6 @@
 #include "glusterd-op-sm.h"
 #include "glusterd-utils.h"
 #include "glusterd-hooks.h"
-#include <glusterfs/store.h>
 #include "glusterd-store.h"
 #include "glusterd-snapshot-utils.h"
 #include "glusterd-messages.h"

--- a/xlators/mgmt/glusterd/src/glusterd-store.h
+++ b/xlators/mgmt/glusterd/src/glusterd-store.h
@@ -10,10 +10,8 @@
 #ifndef _GLUSTERD_HA_H_
 #define _GLUSTERD_HA_H_
 
-#include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/run.h>
 #include <glusterfs/logging.h>
 #include "glusterd.h"
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.h
+++ b/xlators/mgmt/glusterd/src/glusterd-store.h
@@ -13,13 +13,9 @@
 #include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/run.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/call-stub.h>
 #include "glusterd.h"
-#include "rpcsvc.h"
 
 typedef enum glusterd_store_ver_ac_ {
     GLUSTERD_VOLINFO_VER_AC_NONE = 0,

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -8,10 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 /* rpc related syncops */
-#include "rpc-clnt.h"
-#include "protocol-common.h"
-#include "xdr-generic.h"
-#include "glusterd1-xdr.h"
 #include "glusterd-syncop.h"
 #include "glusterd-mgmt.h"
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -24,52 +24,35 @@
 #include <glusterfs/dict.h>
 #include <glusterfs/logging.h>
 #include "glusterd-messages.h"
-#include <glusterfs/timer.h>
 #include <glusterfs/compat.h>
-#include <glusterfs/syncop.h>
 #include <glusterfs/run.h>
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/statedump.h>
 #include <glusterfs/syscall.h>
-#include "glusterd-mem-types.h"
 #include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"
-#include "glusterd-sm.h"
 #include "glusterd-utils.h"
 #include "glusterd-store.h"
-#include "glusterd-volgen.h"
-#include "glusterd-pmap.h"
 #include <glusterfs/glusterfs-acl.h>
-#include "glusterd-syncop.h"
 #include "glusterd-mgmt.h"
-#include "glusterd-locks.h"
 #include "glusterd-messages.h"
-#include "glusterd-volgen.h"
 #include "glusterd-snapshot-utils.h"
-#include "glusterd-svc-mgmt.h"
 #include "glusterd-svc-helper.h"
-#include "glusterd-shd-svc.h"
-#include "glusterd-quotad-svc.h"
-#include "glusterd-snapd-svc.h"
-#include "glusterd-bitd-svc.h"
-#include "glusterd-gfproxyd-svc.h"
 #include "glusterd-server-quorum.h"
 #include <glusterfs/quota-common-utils.h>
-#include <glusterfs/common-utils.h>
 #include "glusterd-shd-svc-helper.h"
+#include "gd-common-utils.h"
 
 #include <sys/resource.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <sys/types.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <rpc/pmap_clnt.h>
 #include <unistd.h>
 #include <fnmatch.h>
 #include <sys/statvfs.h>
 #include <ifaddrs.h>
+#include <netdb.h>
 
 #ifdef GF_SOLARIS_HOST_OS
 #include <sys/sockio.h>
@@ -5625,6 +5608,7 @@ glusterd_unlink_file(char *sockfpath)
     return ret;
 }
 
+#ifdef BUILD_GNFS
 void
 glusterd_nfs_pmap_deregister()
 {
@@ -5670,6 +5654,8 @@ glusterd_nfs_pmap_deregister()
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_PMAP_UNSET_FAIL,
                "De-registration of ACL v3 failed");
 }
+
+#endif  /// #ifdef BUILD_GNFS
 
 int
 glusterd_add_node_to_dict(char *server, dict_t *dict, int count,

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -20,14 +20,11 @@
 #include <libxml/xmlwriter.h>
 #endif
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
 #include "glusterd-messages.h"
 #include <glusterfs/timer.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/syncop.h>
 #include <glusterfs/run.h>
@@ -62,7 +59,6 @@
 #include <glusterfs/common-utils.h>
 #include "glusterd-shd-svc-helper.h"
 
-#include "xdr-generic.h"
 #include <sys/resource.h>
 #include <inttypes.h>
 #include <signal.h>

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -10,7 +10,6 @@
 #ifndef _GLUSTERD_UTILS_H
 #define _GLUSTERD_UTILS_H
 
-#include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
 #include "glusterd-peer-utils.h"
@@ -779,8 +778,10 @@ glusterd_are_all_volumes_stopped();
 gf_boolean_t
 glusterd_all_shd_compatible_volumes_stopped();
 
+#ifdef BUILD_GNFS
 void
 glusterd_nfs_pmap_deregister();
+#endif
 
 gf_boolean_t
 glusterd_is_volume_started(glusterd_volinfo_t *volinfo);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -13,15 +13,6 @@
 #include <pthread.h>
 #include <glusterfs/compat-uuid.h>
 
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/logging.h>
-#include <glusterfs/call-stub.h>
-#include "glusterd.h"
-#include "rpc-clnt.h"
-#include "protocol-common.h"
-
-#include "glusterfs4-xdr.h"
 #include "glusterd-peer-utils.h"
 
 #define GLUSTERD_SOCK_DIR "/var/run/gluster"

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -13,9 +13,7 @@
 #include <dlfcn.h>
 #include <utime.h>
 
-#include <glusterfs/xlator.h>
 #include "glusterd.h"
-#include <glusterfs/defaults.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
@@ -25,7 +23,6 @@
 #include "glusterd-hooks.h"
 #include <glusterfs/trie.h>
 #include "glusterd-mem-types.h"
-#include "cli1-xdr.h"
 #include "glusterd-volgen.h"
 #include "glusterd-geo-rep.h"
 #include "glusterd-utils.h"

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.h
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.h
@@ -15,7 +15,6 @@
 #include <libxml/xmlwriter.h>
 #endif
 
-#include "glusterd.h"
 #include "glusterd-messages.h"
 
 /* volopt map key name definitions */

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -9,8 +9,6 @@
 */
 #include <glusterfs/common-utils.h>
 #include <glusterfs/syscall.h>
-#include "cli1-xdr.h"
-#include "xdr-generic.h"
 #include "glusterd.h"
 #include "glusterd-op-sm.h"
 #include "glusterd-geo-rep.h"

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -9,6 +9,7 @@ cases as published by the Free Software Foundation.
 */
 
 #include <glusterfs/syscall.h>
+#include "glusterd.h"
 #include "glusterd-volgen.h"
 #include "glusterd-utils.h"
 

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -16,12 +16,12 @@
 #include <libgen.h>
 #include <glusterfs/compat-uuid.h>
 
+#include "rpc-common-xdr.h"
+
 #include "glusterd.h"
 #include "rpcsvc.h"
 #include "fnmatch.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/list.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/options.h>
@@ -49,7 +49,6 @@
 #include "glusterd-geo-rep.h"
 #include <glusterfs/run.h>
 #include "rpc-clnt-ping.h"
-#include "rpc-common-xdr.h"
 
 #include <glusterfs/syncop.h>
 

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -11,7 +11,6 @@
 #define _GLUSTERD_H_
 
 #include <sys/types.h>
-#include <dirent.h>
 #include <pthread.h>
 #include <libgen.h>
 
@@ -22,17 +21,12 @@
 #include "glusterd-sm.h"
 #include "glusterd-snapd-svc.h"
 #include "glusterd-shd-svc.h"
-#include "glusterd-bitd-svc.h"
 #include "glusterd1-xdr.h"
 #include "glusterd-pmap.h"
 #include "cli1-xdr.h"
 #include <glusterfs/syncop.h>
-#include <glusterfs/store.h>
-#include "glusterd-rcu.h"
 #include <glusterfs/events.h>
 #include "glusterd-gfproxyd-svc.h"
-
-#include "gd-common-utils.h"
 
 /* Threading limits for glusterd event threads. */
 #define GLUSTERD_MIN_EVENT_THREADS 1

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -17,19 +17,13 @@
 
 #include <glusterfs/compat-uuid.h>
 
-#include "rpc-clnt.h"
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/call-stub.h>
 #include "glusterd-mem-types.h"
-#include "rpcsvc.h"
 #include "glusterd-sm.h"
 #include "glusterd-snapd-svc.h"
 #include "glusterd-shd-svc.h"
 #include "glusterd-bitd-svc.h"
 #include "glusterd1-xdr.h"
-#include "protocol-common.h"
 #include "glusterd-pmap.h"
 #include "cli1-xdr.h"
 #include <glusterfs/syncop.h>

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
@@ -13,9 +13,7 @@
 #include <unistd.h>
 
 #include "glusterd-messages.h"
-#include "glusterd-errno.h"
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-snapshot-utils.h"
 
@@ -558,7 +556,7 @@ glusterd_lvm_brick_details(dict_t *rsp_dict,
         if (!token) {
             ret = -1;
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_INVALID_ENTRY,
-                    "Invalid vg entry");
+                   "Invalid vg entry");
             goto end;
         }
         value = gf_strdup(token);
@@ -574,7 +572,7 @@ glusterd_lvm_brick_details(dict_t *rsp_dict,
         ret = dict_set_dynstr(rsp_dict, key, value);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
-                    "Could not save vgname ");
+                   "Could not save vgname ");
             goto end;
         }
 

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -13,9 +13,7 @@
 #include <unistd.h>
 
 #include "glusterd-messages.h"
-#include "glusterd-errno.h"
 
-#include "glusterd.h"
 #include "glusterd-utils.h"
 #include "glusterd-snapshot-utils.h"
 
@@ -488,9 +486,9 @@ glusterd_zfs_snap_clone_brick_path(char *snap_mount_dir,
                        snap_brick_dir);
     else {
         if (restore)
-            len = snprintf(brickinfo->path, sizeof(brickinfo->path), "%s/%s/brick%d%s",
-                           snap_mount_dir, snap_clone_volume_id, brick_num,
-                           snap_brick_dir);
+            len = snprintf(brickinfo->path, sizeof(brickinfo->path),
+                           "%s/%s/brick%d%s", snap_mount_dir,
+                           snap_clone_volume_id, brick_num, snap_brick_dir);
         else
             len = snprintf(brickinfo->path, sizeof(brickinfo->path),
                            "%s/.zfs/snapshot/%s_%d/%s", origin_brick_mount,

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -19,11 +19,7 @@
 #include <sys/time.h>
 #include <fnmatch.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/statedump.h>
 
 #ifdef GF_DARWIN_HOST_OS

--- a/xlators/nfs/server/src/acl3.c
+++ b/xlators/nfs/server/src/acl3.c
@@ -8,12 +8,8 @@
  * cases as published by the Free Software Foundation.
  */
 
-#include <glusterfs/defaults.h>
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "nfs.h"
-#include <glusterfs/mem-pool.h>
 #include <glusterfs/logging.h>
 #include "nfs-fops.h"
 #include "nfs3.h"

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -8,13 +8,10 @@
   cases as published by the Free Software Foundation.
 */
 
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "mount3.h"
 #include "xdr-nfs3.h"
 #include "msg-nfs3.h"
-#include <glusterfs/iobuf.h>
 #include "nfs-common.h"
 #include "nfs3-fh.h"
 #include "nfs-fops.h"
@@ -24,7 +21,6 @@
 #include <glusterfs/iatt.h>
 #include "nfs-mem-types.h"
 #include "nfs.h"
-#include <glusterfs/common-utils.h>
 #include <glusterfs/store.h>
 #include "glfs-internal.h"
 #include "glfs.h"
@@ -32,6 +28,7 @@
 #include <glusterfs/hashfn.h>
 #include "nfs-messages.h"
 
+#include <netdb.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/uio.h>

--- a/xlators/nfs/server/src/mount3.h
+++ b/xlators/nfs/server/src/mount3.h
@@ -14,7 +14,6 @@
 #include "rpcsvc.h"
 #include <glusterfs/dict.h>
 #include <glusterfs/xlator.h>
-#include <glusterfs/iobuf.h>
 #include "nfs.h"
 #include <glusterfs/list.h>
 #include "xdr-nfs3.h"
@@ -22,7 +21,6 @@
 #include "nfs3-fh.h"
 #include <glusterfs/compat-uuid.h>
 #include "exports.h"
-#include "mount3-auth.h"
 #include "auth-cache.h"
 
 /* Registered with portmap */

--- a/xlators/nfs/server/src/nfs-common.c
+++ b/xlators/nfs/server/src/nfs-common.c
@@ -17,7 +17,6 @@
 #include "nfs-common.h"
 #include "nfs-fops.h"
 #include "nfs-mem-types.h"
-#include "rpcsvc.h"
 #include <glusterfs/iatt.h>
 #include "nfs-messages.h"
 

--- a/xlators/nfs/server/src/nfs-common.h
+++ b/xlators/nfs/server/src/nfs-common.h
@@ -14,7 +14,6 @@
 #include <unistd.h>
 
 #include <glusterfs/xlator.h>
-#include "rpcsvc.h"
 #include <glusterfs/iatt.h>
 #include <glusterfs/compat-uuid.h>
 

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -12,8 +12,6 @@
 
 #include <glusterfs/dict.h>
 #include <glusterfs/xlator.h>
-#include <glusterfs/iobuf.h>
-#include <glusterfs/call-stub.h>
 #include "nfs.h"
 #include "nfs-fops.h"
 #include "nfs-common.h"

--- a/xlators/nfs/server/src/nfs-fops.h
+++ b/xlators/nfs/server/src/nfs-fops.h
@@ -12,7 +12,6 @@
 #define _NFS_FOPS_H_
 
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/iobuf.h>
 #include <glusterfs/call-stub.h>
 #include "nfs.h"

--- a/xlators/nfs/server/src/nfs-generics.c
+++ b/xlators/nfs/server/src/nfs-generics.c
@@ -14,7 +14,6 @@
 #include "nfs-fops.h"
 #include "nfs-inodes.h"
 #include "nfs-generics.h"
-#include <glusterfs/xlator.h>
 
 int
 nfs_fstat(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,

--- a/xlators/nfs/server/src/nfs-generics.h
+++ b/xlators/nfs/server/src/nfs-generics.h
@@ -12,7 +12,6 @@
 #define _NFS_GENERICS_H_
 
 #include "nfs.h"
-#include <glusterfs/xlator.h>
 #include "nfs-fops.h"
 #include "nfs-inodes.h"
 

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -13,7 +13,6 @@
 #include "nfs.h"
 #include "nfs-inodes.h"
 #include "nfs-fops.h"
-#include <glusterfs/xlator.h>
 #include "nfs-messages.h"
 
 #include <libgen.h>

--- a/xlators/nfs/server/src/nfs-inodes.h
+++ b/xlators/nfs/server/src/nfs-inodes.h
@@ -12,9 +12,7 @@
 #define _NFS_INODES_H_
 
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/iobuf.h>
-#include <glusterfs/call-stub.h>
 #include "nfs-fops.h"
 
 extern int

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -13,9 +13,7 @@
  */
 
 #include <glusterfs/defaults.h>
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "nfs.h"
 #include <glusterfs/mem-pool.h>
 #include <glusterfs/logging.h>
@@ -29,7 +27,6 @@
 #include "acl3.h"
 #include "rpc-drc.h"
 #include <glusterfs/syscall.h>
-#include "rpcsvc.h"
 #include "nfs-messages.h"
 #include "glusterfs/statedump.h"
 

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -13,7 +13,6 @@
 
 #include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/lkowner.h>
 #include <glusterfs/gidcache.h>
 

--- a/xlators/nfs/server/src/nfs3-fh.c
+++ b/xlators/nfs/server/src/nfs3-fh.c
@@ -8,12 +8,9 @@
   cases as published by the Free Software Foundation.
 */
 
-#include "rpcsvc.h"
-#include <glusterfs/dict.h>
 #include <glusterfs/xlator.h>
 #include "xdr-nfs3.h"
 #include "msg-nfs3.h"
-#include <glusterfs/iobuf.h>
 #include "nfs3-fh.h"
 #include "nfs-common.h"
 #include <glusterfs/iatt.h>

--- a/xlators/nfs/server/src/nfs3-fh.h
+++ b/xlators/nfs/server/src/nfs3-fh.h
@@ -11,7 +11,6 @@
 #ifndef _NFS_FH_H_
 #define _NFS_FH_H_
 
-#include <glusterfs/xlator.h>
 #include "xdr-nfs3.h"
 #include <glusterfs/iatt.h>
 #include <sys/types.h>

--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -9,8 +9,8 @@
 */
 
 #include <inttypes.h>
+#include <netdb.h>
 
-#include <glusterfs/xlator.h>
 #include "nfs3.h"
 #include "nfs3-fh.h"
 #include "msg-nfs3.h"
@@ -21,7 +21,6 @@
 #include "nfs3-helpers.h"
 #include "nfs-mem-types.h"
 #include <glusterfs/iatt.h>
-#include <glusterfs/common-utils.h>
 #include "nfs-messages.h"
 #include "mount3.h"
 #include <string.h>

--- a/xlators/nfs/server/src/nfs3-helpers.h
+++ b/xlators/nfs/server/src/nfs3-helpers.h
@@ -11,7 +11,6 @@
 #ifndef _NFS3_HELPER_H_
 #define _NFS3_HELPER_H_
 
-#include <glusterfs/xlator.h>
 #include "nfs3.h"
 #include "nfs3-fh.h"
 #include "msg-nfs3.h"

--- a/xlators/nfs/server/src/nfs3.h
+++ b/xlators/nfs/server/src/nfs3.h
@@ -11,15 +11,11 @@
 #ifndef _NFS3_H_
 #define _NFS3_H_
 
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/iobuf.h>
 #include "nfs.h"
 #include "nfs3-fh.h"
 #include "nfs-common.h"
 #include "xdr-nfs3.h"
-#include <glusterfs/mem-pool.h>
 #include "nlm4.h"
 #include "acl3-xdr.h"
 #include "acl3.h"

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -9,9 +9,7 @@
 */
 
 #include <glusterfs/defaults.h>
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "nfs.h"
 #include <glusterfs/mem-pool.h>
 #include <glusterfs/logging.h>

--- a/xlators/nfs/server/src/nlm4.h
+++ b/xlators/nfs/server/src/nlm4.h
@@ -13,10 +13,7 @@
 
 #include <sys/types.h>
 #include <signal.h>
-#include "rpcsvc.h"
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/iobuf.h>
 #include "nfs.h"
 #include <glusterfs/list.h>
 #include "xdr-nfs3.h"

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -12,7 +12,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "io-cache.h"
 #include "ioc-mem-types.h"
 #include <glusterfs/statedump.h>

--- a/xlators/performance/io-cache/src/io-cache.h
+++ b/xlators/performance/io-cache/src/io-cache.h
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 #include <glusterfs/compat-errno.h>
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/call-stub.h>
 #include <glusterfs/rbthash.h>

--- a/xlators/performance/io-cache/src/page.c
+++ b/xlators/performance/io-cache/src/page.c
@@ -11,7 +11,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "io-cache.h"
 #include "ioc-mem-types.h"
 #include <assert.h>

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -8,12 +8,12 @@
   cases as published by the Free Software Foundation.
 */
 
+#include <glusterfs/statedump.h>
 #include <glusterfs/call-stub.h>
 #include <glusterfs/defaults.h>
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "io-threads.h"
 #include <signal.h>
 #include <stdlib.h>

--- a/xlators/performance/io-threads/src/io-threads.h
+++ b/xlators/performance/io-threads/src/io-threads.h
@@ -12,17 +12,11 @@
 #define __IOT_H
 
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include <glusterfs/common-utils.h>
 #include <glusterfs/list.h>
 #include <stdlib.h>
-#include <glusterfs/locking.h>
 #include "iot-mem-types.h"
 #include <semaphore.h>
-#include <glusterfs/statedump.h>
 
 #define IOT_DEFAULT_IDLE 120 /* In secs. */
 

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -12,12 +12,10 @@
 #include <glusterfs/defaults.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/syncop.h>
 #include "md-cache-mem-types.h"
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/glusterfs-acl.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/upcall-utils.h>
 #include <assert.h>
 #include <sys/time.h>

--- a/xlators/performance/nl-cache/src/nl-cache.h
+++ b/xlators/performance/nl-cache/src/nl-cache.h
@@ -13,8 +13,6 @@
 
 #include "nl-cache-mem-types.h"
 #include "nl-cache-messages.h"
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
 #include <glusterfs/atomic.h>
 

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -9,10 +9,8 @@
 */
 
 #include "open-behind-mem-types.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/call-stub.h>
-#include <glusterfs/defaults.h>
 #include "open-behind-messages.h"
 #include <glusterfs/glusterfs-acl.h>
 

--- a/xlators/performance/quick-read/src/quick-read.h
+++ b/xlators/performance/quick-read/src/quick-read.h
@@ -11,15 +11,11 @@
 #ifndef __QUICK_READ_H
 #define __QUICK_READ_H
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/list.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
-#include <glusterfs/common-utils.h>
-#include <glusterfs/call-stub.h>
 #include <glusterfs/defaults.h>
 #include <libgen.h>
 #include <sys/time.h>

--- a/xlators/performance/read-ahead/src/page.c
+++ b/xlators/performance/read-ahead/src/page.c
@@ -11,7 +11,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "read-ahead.h"
 #include <assert.h>
 #include "read-ahead-messages.h"

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -18,7 +18,6 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include "read-ahead.h"
 #include <glusterfs/statedump.h>
 #include <assert.h>

--- a/xlators/performance/read-ahead/src/read-ahead.h
+++ b/xlators/performance/read-ahead/src/read-ahead.h
@@ -11,11 +11,9 @@
 #ifndef __READ_AHEAD_H
 #define __READ_AHEAD_H
 
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/xlator.h>
-#include <glusterfs/common-utils.h>
 #include "read-ahead-mem-types.h"
 
 struct ra_conf;

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -25,11 +25,9 @@
 
 #include <math.h>
 #include <glusterfs/glusterfs.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/call-stub.h>
 #include "readdir-ahead.h"
 #include "readdir-ahead-mem-types.h"
-#include <glusterfs/defaults.h>
 #include "readdir-ahead-messages.h"
 static int
 rda_fill_fd(call_frame_t *, xlator_t *, fd_t *);

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -11,14 +11,12 @@
 #include <glusterfs/glusterfs.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
 #include <glusterfs/list.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/common-utils.h>
 #include <glusterfs/call-stub.h>
 #include <glusterfs/statedump.h>
-#include <glusterfs/defaults.h>
 #include "write-behind-mem-types.h"
 #include "write-behind-messages.h"
 

--- a/xlators/protocol/client/src/client-callback.c
+++ b/xlators/protocol/client/src/client-callback.c
@@ -10,7 +10,6 @@
 
 #include "client.h"
 #include "rpc-clnt.h"
-#include <glusterfs/defaults.h>
 #include "client-messages.h"
 
 static int

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -9,10 +9,6 @@
 */
 
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
-#include "glusterfs3.h"
 #include "client.h"
 
 int32_t

--- a/xlators/protocol/client/src/client-common.h
+++ b/xlators/protocol/client/src/client-common.h
@@ -12,12 +12,8 @@
 #define __CLIENT_COMMON_H__
 
 #include <glusterfs/dict.h>
-#include <glusterfs/xlator.h>
-#include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
 #include "glusterfs3.h"
 #include "client.h"
-
 
 /* New functions for version 4 */
 int

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -8,18 +8,11 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/fd-lk.h>
 #include "client.h"
-#include "glusterfs4-xdr.h"
-#include <glusterfs/xlator.h>
-#include <glusterfs/defaults.h>
-#include <glusterfs/glusterfs.h>
-#include <glusterfs/statedump.h>
+#include "rpc-common-xdr.h"
 #include <glusterfs/compat-errno.h>
 
-#include "glusterfs3.h"
 #include "portmap-xdr.h"
-#include "rpc-common-xdr.h"
 #include "client-messages.h"
 #include "xdr-rpc.h"
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -9,12 +9,9 @@
 */
 
 #include "client.h"
-#include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
 #include "glusterfs3.h"
 #include <glusterfs/compat-errno.h>
 #include "client-messages.h"
-#include <glusterfs/defaults.h>
 #include "client-common.h"
 
 extern int32_t

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -8,15 +8,13 @@
   cases as published by the Free Software Foundation.
 */
 
+#include "socket.h"
 #include "client.h"
-#include <glusterfs/xlator.h>
 #include <glusterfs/defaults.h>
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/gf-event.h>
 
-#include "xdr-rpc.h"
 #include "glusterfs3.h"
 #include "client-messages.h"
 

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -17,11 +17,7 @@
 #include "rpc-clnt.h"
 #include <glusterfs/list.h>
 #include "client-mem-types.h"
-#include "protocol-common.h"
-#include "glusterfs3.h"
-#include "glusterfs4-xdr.h"
 #include <glusterfs/defaults.h>
-#include <glusterfs/default-args.h>
 #include "client-messages.h"
 
 /* Threading limits for client event threads. */

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -14,15 +14,12 @@
 #include <pthread.h>
 #include <stdint.h>
 
-#include "socket.h"
 #include "rpc-clnt.h"
 #include <glusterfs/list.h>
-#include <glusterfs/inode.h>
 #include "client-mem-types.h"
 #include "protocol-common.h"
 #include "glusterfs3.h"
 #include "glusterfs4-xdr.h"
-#include <glusterfs/fd-lk.h>
 #include <glusterfs/defaults.h>
 #include <glusterfs/default-args.h>
 #include "client-messages.h"

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -3,7 +3,6 @@
 #include <glusterfs/compat-errno.h>
 #include "server-messages.h"
 #include "server-helpers.h"
-#include <openssl/md5.h>
 
 #ifdef BUILD_GNFS
 #include "xdr-nfs3.h"

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -1,14 +1,13 @@
 #include "server.h"
-#include <glusterfs/defaults.h>
-#include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
 #include "glusterfs3.h"
 #include <glusterfs/compat-errno.h>
 #include "server-messages.h"
 #include "server-helpers.h"
-#include <glusterfs/defaults.h>
-#include <glusterfs/fd.h>
+#include <openssl/md5.h>
+
+#ifdef BUILD_GNFS
 #include "xdr-nfs3.h"
+#endif
 
 /* Version 4 helpers */
 

--- a/xlators/protocol/server/src/server-common.h
+++ b/xlators/protocol/server/src/server-common.h
@@ -1,13 +1,11 @@
 #include "server.h"
-#include <glusterfs/defaults.h>
-#include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
 #include "glusterfs3.h"
 #include <glusterfs/compat-errno.h>
 #include "server-messages.h"
-#include <glusterfs/defaults.h>
 
+#ifdef BUILD_GNFS
 #include "xdr-nfs3.h"
+#endif
 
 void
 server4_post_readlink(gfx_readlink_rsp *rsp, struct iatt *stbuf,

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -10,10 +10,8 @@
 
 #include "server.h"
 #include "server-helpers.h"
-#include <glusterfs/gidcache.h>
 #include "server-messages.h"
 #include <glusterfs/syscall.h>
-#include <glusterfs/defaults.h>
 #include <glusterfs/default-args.h>
 #include "server-common.h"
 

--- a/xlators/protocol/server/src/server-helpers.h
+++ b/xlators/protocol/server/src/server-helpers.h
@@ -11,7 +11,6 @@
 #ifndef _SERVER_HELPERS_H
 #define _SERVER_HELPERS_H
 
-#include "server.h"
 #include <glusterfs/defaults.h>
 
 #define CALL_STATE(frame) ((server_state_t *)frame->root->state)

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -8,8 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <openssl/md5.h>
-
 #include "server.h"
 #include "server-helpers.h"
 #include "rpc-common-xdr.h"

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -13,16 +13,15 @@
 #include "server.h"
 #include "server-helpers.h"
 #include "rpc-common-xdr.h"
-#include "glusterfs4-xdr.h"
 #include "glusterfs3.h"
 #include <glusterfs/compat-errno.h>
 #include "server-messages.h"
-#include <glusterfs/defaults.h>
 #include <glusterfs/default-args.h>
 #include "server-common.h"
-#include <glusterfs/xlator.h>
 
+#ifdef BUILD_GNFS
 #include "xdr-nfs3.h"
+#endif
 
 #define SERVER_REQ_SET_ERROR(req, ret)                                         \
     do {                                                                       \

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -11,6 +11,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
+#include "socket.h"
 #include "server.h"
 #include "server-helpers.h"
 #include <glusterfs/call-stub.h>

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -13,10 +13,8 @@
 
 #include "server.h"
 #include "server-helpers.h"
-#include "glusterfs4-xdr.h"
 #include <glusterfs/call-stub.h>
 #include <glusterfs/statedump.h>
-#include <glusterfs/defaults.h>
 #include "authenticate.h"
 #include <glusterfs/gf-event.h>
 #include <glusterfs/syncop.h>

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -14,7 +14,6 @@
 #include <pthread.h>
 
 #include "rpcsvc.h"
-#include "socket.h"
 #include "protocol-common.h"
 #include "server-mem-types.h"
 #include "glusterfs3.h"

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -13,17 +13,13 @@
 
 #include <pthread.h>
 
-#include <glusterfs/fd.h>
 #include "rpcsvc.h"
 #include "socket.h"
-#include <glusterfs/fd.h>
 #include "protocol-common.h"
 #include "server-mem-types.h"
 #include "glusterfs3.h"
-#include <glusterfs/timer.h>
 #include <glusterfs/client_t.h>
 #include <glusterfs/gidcache.h>
-#include <glusterfs/defaults.h>
 #include "authenticate.h"
 
 /* Threading limits for server event threads. */

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -35,14 +35,13 @@
 #include <fcntl.h>
 #endif /* HAVE_LINKAT */
 
+#include "posix.h"
 #include "posix-inode-handle.h"
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/locking.h>
-#include <glusterfs/timer.h>
-#include "glusterfs4-xdr.h"
 #include "posix-aio.h"
 #include "posix-io-uring.h"
 #include <glusterfs/glusterfs-acl.h>

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -14,7 +14,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include <openssl/md5.h>
 #include <stdint.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -44,8 +44,6 @@
 #include <glusterfs/syscall.h>
 #include <glusterfs/statedump.h>
 #include <glusterfs/locking.h>
-#include <glusterfs/timer.h>
-#include "glusterfs4-xdr.h"
 #include "posix-aio.h"
 #include <glusterfs/glusterfs-acl.h>
 #include "posix-messages.h"

--- a/xlators/storage/posix/src/posix-gfid-path.h
+++ b/xlators/storage/posix/src/posix-gfid-path.h
@@ -17,7 +17,6 @@
 #include "glusterfs/dict.h"       // for dict_t
 #include "glusterfs/glusterfs.h"  // for gf_boolean_t
 #include "glusterfs/inode.h"      // for inode_t
-#include "uuid.h"                 // for uuid_t
 #define MAX_GFID2PATH_LINK_SUP 500
 
 gf_boolean_t

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -11,6 +11,7 @@
 #define _POSIX_HANDLE_H
 
 #include "posix-inode-handle.h"
+#include "posix.h"
 
 #define HANDLE_ABSPATH_LEN(this)                                               \
     (POSIX_BASE_PATH_LEN(this) +                                               \

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -40,10 +40,7 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/statedump.h>
 #include <glusterfs/locking.h>
-#include <glusterfs/timer.h>
-#include "glusterfs4-xdr.h"
 #include <glusterfs/glusterfs-acl.h>
 #include "posix-gfid-path.h"
 #include <glusterfs/events.h>

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -43,17 +43,16 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/compat.h>
 #include <glusterfs/syscall.h>
-#include <glusterfs/statedump.h>
 #include <glusterfs/locking.h>
 #include <glusterfs/timer.h>
 #include "glusterfs4-xdr.h"
 #include <glusterfs/glusterfs-acl.h>
+#include "posix.h"
 #include "posix-messages.h"
 #include "posix-metadata.h"
 #include <glusterfs/events.h>
 #include "posix-gfid-path.h"
 #include <glusterfs/compat-uuid.h>
-#include <glusterfs/common-utils.h>
 
 extern char *marker_xattrs[];
 #define ALIGN_SIZE 4096

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -13,7 +13,6 @@
 #include <limits.h>
 #include <sys/types.h>
 #include <glusterfs/gf-dirent.h>
-#include "posix.h"
 
 /* From Open Group Base Specifications Issue 6 */
 #ifndef _XOPEN_PATH_MAX

--- a/xlators/storage/posix/src/posix-metadata.c
+++ b/xlators/storage/posix/src/posix-metadata.c
@@ -8,9 +8,8 @@
    cases as published by the Free Software Foundation.
 */
 
-#include <glusterfs/xlator.h>
+#include "posix.h"
 #include "posix-metadata.h"
-#include "posix-metadata-disk.h"
 #include "posix-handle.h"
 #include "posix-messages.h"
 #include <glusterfs/syscall.h>

--- a/xlators/storage/posix/src/posix.c
+++ b/xlators/storage/posix/src/posix.c
@@ -14,7 +14,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include <glusterfs/xlator.h>
 #include "posix.h"
 
 int32_t

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -30,7 +30,6 @@
 #endif
 
 #include <glusterfs/compat.h>
-#include <glusterfs/timer.h>
 #include "posix-mem-types.h"
 #include <glusterfs/call-stub.h>
 

--- a/xlators/system/posix-acl/src/posix-acl-xattr.c
+++ b/xlators/system/posix-acl/src/posix-acl-xattr.c
@@ -15,6 +15,7 @@
 #else
 #include <endian.h>
 #endif
+#include <glusterfs/xlator.h>
 #include "posix-acl.h"
 #include "posix-acl-xattr.h"
 

--- a/xlators/system/posix-acl/src/posix-acl-xattr.h
+++ b/xlators/system/posix-acl/src/posix-acl-xattr.h
@@ -11,9 +11,7 @@
 #ifndef _POSIX_ACL_XATTR_H
 #define _POSIX_ACL_XATTR_H
 
-#include <glusterfs/common-utils.h>
 #include "posix-acl.h"
-#include <glusterfs/glusterfs.h>
 #include <glusterfs/glusterfs-acl.h>
 
 struct posix_acl *

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -8,8 +8,6 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <errno.h>
-
 #include <glusterfs/defaults.h>
 
 #include "posix-acl.h"

--- a/xlators/system/posix-acl/src/posix-acl.h
+++ b/xlators/system/posix-acl/src/posix-acl.h
@@ -11,9 +11,6 @@
 #ifndef _POSIX_ACL_H
 #define _POSIX_ACL_H
 
-#include <glusterfs/xlator.h>
-#include <glusterfs/glusterfs-acl.h>
-
 struct posix_acl *
 posix_acl_new(xlator_t *this, int entry_count);
 struct posix_acl *


### PR DESCRIPTION
We have hundreds of redundant, or unused #include statements in the code. I have a WIP patch to remove many of them
We have several that are circular (include A calls B which calls A ...)
We have some unused statements in popular include file (glusterd.h is a good example).
The end goal would be to reduce the no. of include statements, include what's needed,
and thus improve code readability, maintainability and hopefully reduce compilation times.

Note: it is still not pretty, but it's a good step towards really including what is needed, per file/modulex/xlator/...

Updates: #3130
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

