### PR TITLE
afr-transaction: pass lock object between functions.

### DIFF
--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1067,9 +1067,6 @@ afr_lock_nonblocking(call_frame_t *frame, xlator_t *this);
 int
 afr_blocking_lock(call_frame_t *frame, xlator_t *this);
 
-int
-afr_internal_lock_finish(call_frame_t *frame, xlator_t *this);
-
 afr_fd_ctx_t *
 afr_fd_ctx_get(fd_t *fd, xlator_t *this);
 


### PR DESCRIPTION
Fetching the lock is a long operation:
lock = &local->inode_ctx->lock[local->transaction.type];

Try to fetch it less often and pass it around to functions that use it.
While at it, make the relevant functions static.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

