### PR TITLE
mem-pool.c/xlator.c: Remove xlator_mem_acct_unref() from __gf_free()

### DIFF
--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -1032,8 +1032,6 @@ gf_boolean_t
 loc_is_nameless(loc_t *loc);
 int
 xlator_mem_acct_init(xlator_t *xl, int num_types);
-void
-xlator_mem_acct_unref(struct mem_acct *mem_acct);
 int
 is_gf_log_command(xlator_t *trans, const char *name, char *value, size_t size);
 int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1116,7 +1116,6 @@ xlator_foreach
 xlator_foreach_depth_first
 xlator_init
 xlator_mem_acct_init
-xlator_mem_acct_unref
 xlator_notify
 xlator_option_info_list
 xlator_option_init_bool

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -334,7 +334,6 @@ __gf_free(void *free_ptr)
     void *ptr = NULL;
     struct mem_acct *mem_acct;
     struct mem_header *header = NULL;
-    uint64_t num_allocs = 0;
 
     if (caa_unlikely(!free_ptr))
         return;
@@ -363,7 +362,7 @@ __gf_free(void *free_ptr)
         GF_ASSERT(GF_MEM_TRAILER_MAGIC == __gf_mem_trailer_read(trailer));
     }
 
-    num_allocs = GF_ATOMIC_DEC(mem_acct->rec[header->type].num_allocs);
+    GF_ATOMIC_DEC(mem_acct->rec[header->type].num_allocs);
 #ifdef DEBUG
     LOCK(&mem_acct->rec[header->type].lock);
     {
@@ -371,9 +370,6 @@ __gf_free(void *free_ptr)
     }
     UNLOCK(&mem_acct->rec[header->type].lock);
 #endif
-    if (!num_allocs) {
-        xlator_mem_acct_unref(mem_acct);
-    }
 
 free:
 #ifdef DEBUG

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -754,7 +754,7 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
     return 0;
 }
 
-void
+static void
 xlator_mem_acct_unref(struct mem_acct *mem_acct)
 {
     uint32_t i;


### PR DESCRIPTION
It's not need, as it will decrement it by 1, and see if it is equal 0 -
but it was never 0 in the first place.

(see https://github.com/gluster/glusterfs/discussions/2775#discussioncomment-1363686 )

Fixes: #3143
Signed-up-by: Yaniv Kaul <ykaul@redhat.com>

