### PR TITLE
rpc clnt - cleanups

### DIFF
--- a/rpc/rpc-lib/src/libgfrpc.sym
+++ b/rpc/rpc-lib/src/libgfrpc.sym
@@ -5,7 +5,6 @@ rpc_clnt_connection_status
 rpc_clnt_disable
 rpc_clnt_new
 rpc_clnt_reconfig
-rpc_clnt_reconnect
 rpc_clnt_reconnect_cleanup
 rpc_clnt_ref
 rpc_clnt_register_notify

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -818,7 +818,7 @@ rpc_clnt_handle_disconnect(struct rpc_clnt *clnt, rpc_clnt_connection_t *conn)
     return 0;
 }
 
-int
+static int
 rpc_clnt_notify(rpc_transport_t *trans, void *mydata,
                 rpc_transport_event_t event, void *data, ...)
 {
@@ -1337,13 +1337,7 @@ rpc_clnt_fill_request(struct rpc_clnt *clnt, int prognum, int progver,
                       int procnum, const uint32_t xid, call_frame_t *fr,
                       struct rpc_msg *request, char *auth_data)
 {
-    int ret = -1;
-
-    if (!request) {
-        goto out;
-    }
-
-    memset(request, 0, sizeof(*request));
+    int ret;
 
     request->rm_xid = xid;
     request->rm_direction = CALL;
@@ -1358,6 +1352,7 @@ rpc_clnt_fill_request(struct rpc_clnt *clnt, int prognum, int progver,
         request->rm_call.cb_cred.oa_base = NULL;
         request->rm_call.cb_cred.oa_length = 0;
     } else {
+        memset(auth_data, 0, GF_MAX_AUTH_BYTES);
         ret = xdr_serialize_glusterfs_auth(clnt, fr, auth_data);
         if (ret == -1) {
             gf_log("rpc-clnt", GF_LOG_WARNING,
@@ -1431,9 +1426,7 @@ rpc_clnt_record_build_record(struct rpc_clnt *clnt, call_frame_t *fr,
     size_t pagesize = 0;
     int ret = -1;
     size_t xdr_size = 0;
-    char auth_data[GF_MAX_AUTH_BYTES] = {
-        0,
-    };
+    char auth_data[GF_MAX_AUTH_BYTES];
 
     if ((!clnt) || (!recbuf)) {
         goto out;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -66,7 +66,7 @@ __saved_frames_put(struct rpc_clnt *rpc_clnt, struct saved_frames *frames,
 
     INIT_LIST_HEAD(&saved_frame->list);
 
-    saved_frame->capital_this = THIS;
+    saved_frame->capital_this = rpc_clnt->owner;
     saved_frame->frame = frame;
     saved_frame->rpcreq = rpcreq;
     saved_frame->saved_at = gf_time();

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -244,9 +244,6 @@ rpc_clnt_status_t
 rpc_clnt_connection_status(rpc_clnt_connection_t *conn);
 
 void
-rpc_clnt_reconnect(void *trans_ptr);
-
-void
 rpc_clnt_reconfig(struct rpc_clnt *rpc, struct rpc_clnt_config *config);
 
 /* All users of RPC services should use this API to register their

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -31,9 +31,9 @@ typedef enum {
     RPC_STATUS_DISCONNECTED
 } rpc_clnt_status_t;
 
-#define SFRAME_GET_PROGNUM(sframe) (sframe->rpcreq->prog->prognum)
-#define SFRAME_GET_PROGVER(sframe) (sframe->rpcreq->prog->progver)
-#define SFRAME_GET_PROCNUM(sframe) (sframe->rpcreq->procnum)
+#define RPCREQ_GET_PROGNUM(_rpcreq) (_rpcreq->prog->prognum)
+#define RPCREQ_GET_PROGVER(_rpcreq) (_rpcreq->prog->progver)
+#define RPCREQ_GET_PROCNUM(_rpcreq) (_rpcreq->procnum)
 
 struct rpc_req;
 struct rpc_clnt;
@@ -176,7 +176,8 @@ typedef struct rpc_clnt {
     rpc_clnt_notify_t notifyfn;
     rpc_clnt_connection_t conn;
     void *mydata;
-    gf_atomic_t xid;
+    gf_atomic_uint32_t xid;
+    int auth_value;
 
     /* list of cb programs registered with rpc-clnt */
     struct list_head programs;
@@ -189,7 +190,6 @@ typedef struct rpc_clnt {
     glusterfs_ctx_t *ctx;
     gf_atomic_t refcount;
     xlator_t *owner;
-    int auth_value;
     char disabled;
 } rpc_clnt_t;
 


### PR DESCRIPTION
Multiple cleanups to the RPC client code, split to multiple commits:
- rpc-clnt: don't copy iovec header around
- rpc-clnt.c: _saved_frame_copy() should copy only relevant fields from the frame
- rpc-clnt.c: remove 'THIS' call from __saved_frames_put()
- rpc-clnt.c: do not zero structs until used, do not zero twice.
- rpc-clnt: cleanups