### PR TITLE
xlator.h/c: xlator struct cleanup

### DIFF
--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -814,10 +814,13 @@ struct _xlator {
 
     struct mem_pool *local_pool;
 
-    uint32_t is_autoloaded;
+    /* Flag to avoid throw duplicate PARENT_DOWN event */
+    uint32_t parent_down;
+
+    gf_boolean_t is_autoloaded;
 
     /* Is this pass_through? */
-    uint32_t pass_through;
+    gf_boolean_t pass_through;
     struct xlator_fops *pass_through_fops;
 
     struct {
@@ -827,7 +830,6 @@ struct _xlator {
         gf_atomic_t interval_fop_cbk;
         gf_latency_t latencies;
     } stats[GF_FOP_MAXVALUE] __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
-
 
     /* op_version: initialized in xlator code itself */
     uint32_t op_version[GF_MAX_RELEASES];
@@ -852,9 +854,6 @@ struct _xlator {
 
     /* Flag to notify got CHILD_DOWN event for detach brick */
     uint32_t notify_down;
-
-    /* Flag to avoid throw duplicate PARENT_DOWN event */
-    uint32_t parent_down;
 };
 
 /* This would be the only structure which needs to be exported by

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -796,6 +796,30 @@ struct _xlator {
 
     gf_loglevel_t loglevel; /* Log level for translator */
 
+    /* Its used as an index to inode_ctx*/
+    uint32_t xl_id;
+
+    /* Misc */
+    eh_t *history; /* event history context */
+    glusterfs_ctx_t *ctx;
+    glusterfs_graph_t *graph; /* not set for fuse */
+    inode_table_t *itable;
+    uint32_t init_succeeded;
+    uint32_t switched;
+    void *private;
+    struct mem_acct *mem_acct;
+    uint64_t winds;
+
+    /* for the memory pool of 'frame->local' */
+
+    struct mem_pool *local_pool;
+
+    uint32_t is_autoloaded;
+
+    /* Is this pass_through? */
+    uint32_t pass_through;
+    struct xlator_fops *pass_through_fops;
+
     struct {
         gf_atomic_t total_fop;
         gf_atomic_t interval_fop;
@@ -804,42 +828,18 @@ struct _xlator {
         gf_latency_t latencies;
     } stats[GF_FOP_MAXVALUE] __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
 
-    /* Misc */
-    eh_t *history; /* event history context */
-    glusterfs_ctx_t *ctx;
-    glusterfs_graph_t *graph; /* not set for fuse */
-    inode_table_t *itable;
-    char init_succeeded;
-    void *private;
-    struct mem_acct *mem_acct;
-    uint64_t winds;
-    char switched;
-
-    /* for the memory pool of 'frame->local' */
-    struct mem_pool *local_pool;
-    gf_boolean_t is_autoloaded;
-
-    /* Saved volfile ID (used for multiplexing) */
-    char *volfile_id;
-
-    /* Its used as an index to inode_ctx*/
-    uint32_t xl_id;
 
     /* op_version: initialized in xlator code itself */
     uint32_t op_version[GF_MAX_RELEASES];
 
-    /* flags: initialized in xlator code itself */
-    uint32_t flags;
-
-    /* id: unique, initialized in xlator code itself */
-    uint32_t id;
+    /* Saved volfile ID (used for multiplexing) */
+    char *volfile_id;
 
     /* identifier: a full string which can unique identify the xlator */
     char *identifier;
 
-    /* Is this pass_through? */
-    gf_boolean_t pass_through;
-    struct xlator_fops *pass_through_fops;
+    /* Variable to save xprt associated for detach brick */
+    gf_atomic_t xprtrefcnt;
 
     /* cleanup flag to avoid races during xlator cleanup */
     uint32_t cleanup_starting;
@@ -849,9 +849,6 @@ struct _xlator {
 
     /* Flag to understand how this xlator is categorized */
     gf_category_t category;
-
-    /* Variable to save xprt associated for detach brick */
-    gf_atomic_t xprtrefcnt;
 
     /* Flag to notify got CHILD_DOWN event for detach brick */
     uint32_t notify_down;
@@ -873,15 +870,6 @@ typedef struct {
        operating version.
        default value: 0, which means good to insert always */
     uint32_t op_version[GF_MAX_RELEASES];
-
-    /* flags: will be used by volume generation logic to optimize the
-       placements etc.
-       default value: 0, which means don't treat it specially */
-    uint32_t flags;
-
-    /* xlator_id: unique per xlator. make sure to have no collission
-       in this ID */
-    uint32_t xlator_id;
 
     /* identifier: a string constant */
     char *identifier;

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -350,8 +350,6 @@ xlator_dynload_apis(xlator_t *xl)
         list_add_tail(&vol_opt->list, &xl->volume_options);
     }
 
-    xl->id = xlapi->xlator_id;
-    xl->flags = xlapi->flags;
     xl->identifier = xlapi->identifier;
     xl->category = xlapi->category;
 

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -52,7 +52,7 @@ free_fuse_state(fuse_state_t *state)
     xlator_t *this = NULL;
     fuse_private_t *priv = NULL;
     uint64_t winds = 0;
-    char switched = 0;
+    uint32_t switched = 0;
 
     this = state->this;
 


### PR DESCRIPTION
- Removed unused members (and converted some char ones to uint32 instead)
Specifically, xlator_id and flags were not used.
- Aligned members, which removed a large hole.

Before:
```
        /* size: 4224, cachelines: 66, members: 46 */
        /* sum members: 4088, holes: 7, sum holes: 128 */
        /* padding: 8 */
        /* forced alignments: 1, forced holes: 1, sum forced holes: 92 */
```
After:
```
        /* size: 4096, cachelines: 64, members: 44 */
        /* sum members: 4086, holes: 1, sum holes: 2 */
        /* padding: 8 */
```
Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

