### PR TITLE
OpenSSL: Switch to EVP Message Digests

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -55,7 +55,12 @@ mgmt_process_volfile(const char *volfile, ssize_t size, char *volfile_id,
     int tmp_fd = -1;
     char template[] = "/tmp/glfs.volfile.XXXXXX";
 
-    glusterfs_compute_sha256((const unsigned char *)volfile, size, sha256_hash);
+    if (!glusterfs_compute_sha256((const unsigned char *)volfile, size,
+                                  sha256_hash)) {
+        ret = -1;
+        goto out;
+    }
+
     ctx = THIS->ctx;
     LOCK(&ctx->volfile_lock);
     {
@@ -2341,8 +2346,11 @@ volfile:
     }
 
     ret = 0;
-    glusterfs_compute_sha256((const unsigned char *)rsp.spec, size,
-                             sha256_hash);
+    if (!glusterfs_compute_sha256((const unsigned char *)rsp.spec, size,
+                                  sha256_hash)) {
+        ret = -1;
+        goto out;
+    }
 
     LOCK(&ctx->volfile_lock);
     {

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include <limits.h> /* For PATH_MAX */
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include "glusterfs/glusterfs-fops.h"
 #include "glusterfs/list.h"

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -1247,10 +1247,13 @@ glusterfs_graph_attach(glusterfs_graph_t *orig_graph, char *path,
     }
 
     ret = fread(volfile_content, sizeof(char), file_len, fp);
+    int sha_ret = 0;
     if (ret == file_len) {
-        glusterfs_compute_sha256((const unsigned char *)volfile_content,
-                                 file_len, sha256_hash);
-    } else {
+        sha_ret = glusterfs_compute_sha256(
+            (const unsigned char *)volfile_content, file_len, sha256_hash);
+    }
+
+    if (ret != file_len || !sha_ret) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "read failed on path %s. File size=%" GF_PRI_SIZET
                "read size=%d",


### PR DESCRIPTION
SHA256*() family of functions were deprecated in OpenSSL 3.0. Those
deprecated functions have been replaced with the newer alternatives.

Note: Using EVP makes changing the MD algorithm as easy as modifying just one
line of code (`EVP_xxx()`inside `EVP_DigestInit` where `xxx` is the name of the MD algorithm).

Change-Id: I2875693b44699e2d199e182f7915e46105965b7b
Updates: #2916
Signed-off-by: black-dragon74 <niryadav@redhat.com>

