### PR TITLE
afr: readdir(p) improvements

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -7358,9 +7358,8 @@ afr_set_need_heal(xlator_t *this, afr_local_t *local)
 }
 
 gf_boolean_t
-afr_get_need_heal(xlator_t *this)
+afr_get_need_heal(afr_private_t *priv)
 {
-    afr_private_t *priv = this->private;
     gf_boolean_t need_heal = _gf_true;
 
     LOCK(&priv->lock);

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1288,7 +1288,7 @@ int
 afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque);
 
 gf_boolean_t
-afr_get_need_heal(xlator_t *this);
+afr_get_need_heal(afr_private_t *priv);
 
 void
 afr_set_need_heal(xlator_t *this, afr_local_t *local);


### PR DESCRIPTION
Additional small changes to hopefully improve readdir(p) performance, this time in AFR loop:
- check for root gfid once instead of for every entry
- make relevant functions static

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

