### PR TITLE
md-cache.c: reuse result of mdc_inode_prep()

### DIFF
--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -133,7 +133,7 @@ struct mdc_local {
     bool update_cache;
 };
 
-int
+static int
 __mdc_inode_ctx_get(xlator_t *this, inode_t *inode, struct md_cache **mdc_p)
 {
     int ret = 0;
@@ -187,7 +187,7 @@ __mdc_inc_generation(xlator_t *this, struct md_cache *mdc)
     return gen;
 }
 
-uint64_t
+static uint64_t
 mdc_inc_generation(xlator_t *this, inode_t *inode)
 {
     struct mdc_conf *conf = NULL;
@@ -237,7 +237,7 @@ mdc_get_generation(xlator_t *this, inode_t *inode)
     return gen;
 }
 
-int
+static int
 __mdc_inode_ctx_set(xlator_t *this, inode_t *inode, struct md_cache *mdc)
 {
     int ret = 0;
@@ -331,7 +331,7 @@ out:
     return ret;
 }
 
-struct md_cache *
+static struct md_cache *
 mdc_inode_prep(xlator_t *this, inode_t *inode)
 {
     int ret = 0;
@@ -478,12 +478,11 @@ mdc_to_iatt(struct md_cache *mdc, struct iatt *iatt)
     iatt->ia_blocks = mdc->md_blocks;
 }
 
-int
+static struct md_cache *
 mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
                             struct iatt *iatt, gf_boolean_t update_time,
                             uint64_t incident_time)
 {
-    int ret = 0;
     struct md_cache *mdc = NULL;
     uint32_t rollover = 0;
     uint64_t gen = 0;
@@ -492,7 +491,6 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
 
     mdc = mdc_inode_prep(this, inode);
     if (!mdc) {
-        ret = -1;
         goto out;
     }
 
@@ -502,16 +500,17 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
     LOCK(&mdc->lock);
     {
         if (!iatt || !iatt->ia_ctime) {
-            gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
-                             "invalidating iatt(NULL)"
-                             "(%s)",
-                             uuid_utoa(inode->gfid));
             mdc->ia_time = 0;
             mdc->valid = 0;
 
             gen = __mdc_inc_generation(this, mdc);
             mdc->generation = (gen & 0xffffffff);
-            goto unlock;
+            UNLOCK(&mdc->lock);
+            gf_msg_callingfn("md-cache", GF_LOG_TRACE, 0, 0,
+                             "invalidating iatt(NULL)"
+                             "(%s)",
+                             uuid_utoa(inode->gfid));
+            goto out;
         }
 
         /* There could be a race in invalidation, where the
@@ -523,23 +522,25 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
          * changes, hence check for ctime only.
          */
         if (mdc->md_ctime > iatt->ia_ctime) {
+            UNLOCK(&mdc->lock);
             gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
                              MD_CACHE_MSG_DISCARD_UPDATE,
                              "discarding the iatt validate "
                              "request (%s)",
                              uuid_utoa(inode->gfid));
-            ret = -1;
-            goto unlock;
+            mdc = NULL;
+            goto out;
         }
         if ((mdc->md_ctime == iatt->ia_ctime) &&
             (mdc->md_ctime_nsec > iatt->ia_ctime_nsec)) {
+            UNLOCK(&mdc->lock);
             gf_msg_callingfn(this->name, GF_LOG_DEBUG, EINVAL,
                              MD_CACHE_MSG_DISCARD_UPDATE,
                              "discarding the iatt validate "
                              "request(ctime_nsec) (%s)",
                              uuid_utoa(inode->gfid));
-            ret = -1;
-            goto unlock;
+            mdc = NULL;
+            goto out;
         }
 
         /*
@@ -599,14 +600,13 @@ mdc_inode_iatt_set_validate(xlator_t *this, inode_t *inode, struct iatt *prebuf,
                              (unsigned long long)incident_time);
         }
     }
-unlock:
     UNLOCK(&mdc->lock);
 
 out:
-    return ret;
+    return mdc;
 }
 
-int
+static struct md_cache *
 mdc_inode_iatt_set(xlator_t *this, inode_t *inode, struct iatt *iatt,
                    uint64_t incident_time)
 {
@@ -740,32 +740,38 @@ mdc_dict_update(dict_t **tgt, dict_t *src)
     return u.ret;
 }
 
-int
-mdc_inode_xatt_set(xlator_t *this, inode_t *inode, dict_t *dict)
+static int
+mdc_inode_xatt_set(xlator_t *this, inode_t *inode, dict_t *dict,
+                   struct md_cache *mdc)
 {
     int ret = -1;
-    struct md_cache *mdc = NULL;
     dict_t *newdict = NULL;
+    char inode_gfid[GF_UUID_BUF_SIZE];
+    time_t xa_time;
 
-    mdc = mdc_inode_prep(this, inode);
-    if (!mdc)
-        goto out;
+    if (!mdc) {
+        mdc = mdc_inode_prep(this, inode);
+        if (!mdc)
+            goto out;
+    }
 
+    uuid_utoa_r(inode->gfid, inode_gfid);
     if (!dict) {
         gf_msg_trace("md-cache", 0,
                      "mdc_inode_xatt_set failed (%s) "
                      "dict NULL",
-                     uuid_utoa(inode->gfid));
+                     inode_gfid);
         goto out;
     }
 
+    xa_time = gf_time();
     LOCK(&mdc->lock);
     {
         if (mdc->xattr) {
             gf_msg_trace("md-cache", 0,
                          "deleting the old xattr "
                          "cache (%s)",
-                         uuid_utoa(inode->gfid));
+                         inode_gfid);
             dict_unref(mdc->xattr);
             mdc->xattr = NULL;
         }
@@ -779,11 +785,11 @@ mdc_inode_xatt_set(xlator_t *this, inode_t *inode, dict_t *dict)
         if (newdict)
             mdc->xattr = newdict;
 
-        mdc->xa_time = gf_time();
-        gf_msg_trace("md-cache", 0, "xatt cache set for (%s) time:%lld",
-                     uuid_utoa(inode->gfid), (long long)mdc->xa_time);
+        mdc->xa_time = xa_time;
     }
     UNLOCK(&mdc->lock);
+    gf_msg_trace("md-cache", 0, "xatt cache set for (%s) time:%lld", inode_gfid,
+                 (long long)xa_time);
     ret = 0;
 out:
     return ret;
@@ -919,7 +925,7 @@ out:
     return;
 }
 
-void
+static void
 mdc_inode_iatt_invalidate(xlator_t *this, inode_t *inode)
 {
     struct md_cache *mdc = NULL;
@@ -961,23 +967,22 @@ out:
     return ret;
 }
 
-static int
+static struct md_cache *
 mdc_update_gfid_stat(xlator_t *this, struct iatt *iatt)
 {
-    int ret = 0;
+    static struct md_cache *mdc = NULL;
     inode_table_t *itable = NULL;
     inode_t *inode = NULL;
 
     itable = ((xlator_t *)this->graph->top)->itable;
     inode = inode_find(itable, iatt->ia_gfid);
     if (!inode) {
-        ret = -1;
         goto out;
     }
-    ret = mdc_inode_iatt_set_validate(this, inode, NULL, iatt, _gf_true,
+    mdc = mdc_inode_iatt_set_validate(this, inode, NULL, iatt, _gf_true,
                                       mdc_inc_generation(this, inode));
 out:
-    return ret;
+    return mdc;
 }
 
 static bool
@@ -1209,6 +1214,7 @@ mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     mdc_local_t *local = NULL;
     struct mdc_conf *conf = this->private;
+    static struct md_cache *mdc;
 
     local = frame->local;
 
@@ -1238,9 +1244,10 @@ mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     if (local->loc.inode) {
-        mdc_inode_iatt_set(this, local->loc.inode, stbuf, local->incident_time);
+        mdc = mdc_inode_iatt_set(this, local->loc.inode, stbuf,
+                                 local->incident_time);
         if (local->update_cache) {
-            mdc_inode_xatt_set(this, local->loc.inode, dict);
+            mdc_inode_xatt_set(this, local->loc.inode, dict, mdc);
         }
     }
 out:
@@ -1330,6 +1337,7 @@ mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
              int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
+    static struct md_cache *mdc;
 
     local = frame->local;
     if (!local)
@@ -1343,9 +1351,9 @@ mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         goto out;
     }
 
-    mdc_inode_iatt_set(this, local->loc.inode, buf, local->incident_time);
+    mdc = mdc_inode_iatt_set(this, local->loc.inode, buf, local->incident_time);
     if (local->update_cache) {
-        mdc_inode_xatt_set(this, local->loc.inode, xdata);
+        mdc_inode_xatt_set(this, local->loc.inode, xdata, mdc);
     }
 
 out:
@@ -1401,6 +1409,7 @@ mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
+    static struct md_cache *mdc;
 
     local = frame->local;
     if (!local)
@@ -1414,9 +1423,9 @@ mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         goto out;
     }
 
-    mdc_inode_iatt_set(this, local->fd->inode, buf, local->incident_time);
+    mdc = mdc_inode_iatt_set(this, local->fd->inode, buf, local->incident_time);
     if (local->update_cache) {
-        mdc_inode_xatt_set(this, local->fd->inode, xdata);
+        mdc_inode_xatt_set(this, local->fd->inode, xdata, mdc);
     }
 
 out:
@@ -2464,7 +2473,7 @@ mdc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     if (local->update_cache) {
-        mdc_inode_xatt_set(this, local->loc.inode, xdata);
+        mdc_inode_xatt_set(this, local->loc.inode, xdata, NULL);
     }
 
 out:
@@ -2553,7 +2562,7 @@ mdc_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     if (local->update_cache) {
-        mdc_inode_xatt_set(this, local->fd->inode, xdata);
+        mdc_inode_xatt_set(this, local->fd->inode, xdata, NULL);
     }
 
 out:
@@ -2862,12 +2871,13 @@ mdc_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     return 0;
 }
 
-int
+static int
 mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                  int op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     mdc_local_t *local = NULL;
+    static struct md_cache *mdc;
 
     local = frame->local;
     if (!local)
@@ -2883,10 +2893,10 @@ mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     {
         if (!entry->inode)
             continue;
-        mdc_inode_iatt_set(this, entry->inode, &entry->d_stat,
-                           local->incident_time);
+        mdc = mdc_inode_iatt_set(this, entry->inode, &entry->d_stat,
+                                 local->incident_time);
         if (local->update_cache) {
-            mdc_inode_xatt_set(this, entry->inode, entry->dict);
+            mdc_inode_xatt_set(this, entry->inode, entry->dict, mdc);
         }
     }
 
@@ -2895,7 +2905,7 @@ unwind:
     return 0;
 }
 
-int
+static int
 mdc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
              off_t offset, dict_t *xdata)
 {
@@ -2922,7 +2932,7 @@ out:
     return 0;
 }
 
-int
+static int
 mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                 int op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
@@ -2942,7 +2952,7 @@ out:
     return 0;
 }
 
-int
+static int
 mdc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
             off_t offset, dict_t *xdata)
 {
@@ -3415,6 +3425,7 @@ mdc_invalidate(xlator_t *this, void *data)
     inode_table_t *itable = NULL;
     struct mdc_conf *conf = this->private;
     uint64_t gen = 0;
+    static struct md_cache *mdc;
 
     up_data = (struct gf_upcall *)data;
 
@@ -3451,14 +3462,16 @@ mdc_invalidate(xlator_t *this, void *data)
 
     if (up_ci->flags & IATT_UPDATE_FLAGS) {
         gen = mdc_inc_generation(this, inode);
-        ret = mdc_inode_iatt_set_validate(this, inode, NULL, &up_ci->stat,
+        mdc = mdc_inode_iatt_set_validate(this, inode, NULL, &up_ci->stat,
                                           _gf_false, gen);
         /* one of the scenarios where ret < 0 is when this invalidate
          * is older than the current stat, in that case do not
          * update the xattrs as well
          */
-        if (ret < 0)
+        if (!mdc) {
+            ret = -1;
             goto out;
+        }
         GF_ATOMIC_INC(conf->mdc_counter.stat_invals);
     }
 


### PR DESCRIPTION
mdc_inode_prep() is called in mdc_inode_xatt_set(), which is almost always called after mdc_inode_iatt_set_validate().
The latter already calls mdc_inode_prep(), so we can re-use its result.
Adjust callers after this change (specifically intended for mdc_readdirp_cbk() which is in a loop doing it for all entries)

Move related functions to static.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>
Updates: #1000

