### PR TITLE
protocol/client: remove dead code - coverity fix

### DIFF
--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -4578,7 +4578,6 @@ client3_3_getxattr(call_frame_t *frame, xlator_t *this, void *data)
             0,
         },
     };
-    dict_t *dict = NULL;
     int ret = 0;
     int32_t op_ret = -1;
     int op_errno = ESTALE;
@@ -4662,11 +4661,7 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
-
-    if (dict) {
-        dict_unref(dict);
-    }
+    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -4343,7 +4343,6 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
             0,
         },
     };
-    dict_t *dict = NULL;
     int ret = 0;
     int32_t op_ret = -1;
     int op_errno = ESTALE;
@@ -4388,11 +4387,7 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
-
-    if (dict) {
-        dict_unref(dict);
-    }
+    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 


### PR DESCRIPTION
dict is never allocated or used, so remove its reference.
Coverity defect IDs: CID 1469022 and CID 1469021.
Reported after merging https://github.com/gluster/glusterfs/pull/3106

Change-Id: Ib493e98fe886f7d9f16fadbd8d29374e2b0edd90
Updates: #1000
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

