### PR TITLE
libglusterfs, afr: add and use volume option with no effect

### DIFF
--- a/libglusterfs/src/glusterfs/options.h
+++ b/libglusterfs/src/glusterfs/options.h
@@ -66,7 +66,10 @@ typedef enum {
     OPT_FLAG_DOC = 1 << 5,
 
     /* Numerical with specified mininum and maximum values. */
-    OPT_FLAG_RANGE = 1 << 6
+    OPT_FLAG_RANGE = 1 << 6,
+
+    /* Has no effect but retained for the backward compatibility. */
+    OPT_FLAG_NOEFFECT = 1 << 7
 } opt_flags_t;
 
 typedef enum {

--- a/libglusterfs/src/options.c
+++ b/libglusterfs/src/options.c
@@ -1169,7 +1169,7 @@ xlator_option_info_list(volume_opt_list_t *list, char *key, char **def_val,
     if (descr) {
         if (opt->flags & OPT_FLAG_NOEFFECT)
             gf_asprintf(descr,
-                        "%s This option has no effect but retained for the "
+                        "%s This option has no effect but retained for "
                         "backward compatibility.", opt->description);
         else if (opt->flags & OPT_FLAG_RANGE)
             gf_asprintf(descr,

--- a/libglusterfs/src/options.c
+++ b/libglusterfs/src/options.c
@@ -1167,7 +1167,11 @@ xlator_option_info_list(volume_opt_list_t *list, char *key, char **def_val,
     if (def_val)
         *def_val = opt->default_value;
     if (descr) {
-        if (opt->flags & OPT_FLAG_RANGE)
+        if (opt->flags & OPT_FLAG_NOEFFECT)
+            gf_asprintf(descr,
+                        "%s This option has no effect but retained for the "
+                        "backward compatibility.", opt->description);
+        else if (opt->flags & OPT_FLAG_RANGE)
             gf_asprintf(descr,
                         "%s Minimum value is %.0lf, maximum value "
                         "is %.0lf.",

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -171,7 +171,6 @@ reconfigure(xlator_t *this, dict_t *options)
     char *fav_child_policy = NULL;
     char *data_self_heal = NULL;
     char *data_self_heal_algorithm = NULL;
-    char *locking_scheme = NULL;
     gf_boolean_t consistent_io = _gf_false;
     gf_boolean_t choose_local_old = _gf_false;
     gf_boolean_t enabled_old = _gf_false;
@@ -258,8 +257,6 @@ reconfigure(xlator_t *this, dict_t *options)
     }
 
     GF_OPTION_RECONF("pre-op-compat", priv->pre_op_compat, options, bool, out);
-    GF_OPTION_RECONF("locking-scheme", locking_scheme, options, str, out);
-    priv->granular_locks = (strcmp(locking_scheme, "granular") == 0);
     GF_OPTION_RECONF("full-lock", priv->full_lock, options, bool, out);
     GF_OPTION_RECONF("granular-entry-heal", priv->esh_granular, options, bool,
                      out);
@@ -424,7 +421,6 @@ init(xlator_t *this)
     char *fav_child_policy = NULL;
     char *thin_arbiter = NULL;
     char *data_self_heal = NULL;
-    char *locking_scheme = NULL;
     char *data_self_heal_algorithm = NULL;
 
     if (!this->children) {
@@ -544,8 +540,6 @@ init(xlator_t *this)
                    out);
 
     GF_OPTION_INIT("pre-op-compat", priv->pre_op_compat, bool, out);
-    GF_OPTION_INIT("locking-scheme", locking_scheme, str, out);
-    priv->granular_locks = (strcmp(locking_scheme, "granular") == 0);
     GF_OPTION_INIT("full-lock", priv->full_lock, bool, out);
     GF_OPTION_INIT("granular-entry-heal", priv->esh_granular, bool, out);
 
@@ -1269,11 +1263,12 @@ struct volume_options options[] = {
         .value = {"full", "granular"},
         .default_value = "full",
         .op_version = {GD_OP_VERSION_3_7_12},
-        .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC,
+        .flags = OPT_FLAG_CLIENT_OPT | OPT_FLAG_SETTABLE | OPT_FLAG_DOC |
+                 OPT_FLAG_NOEFFECT,
         .tags = {"replicate"},
         .description = "If this option is set to granular, self-heal will "
                        "stop being compatible with afr-v1, which helps afr "
-                       "be more granular while self-healing",
+                       "be more granular while self-healing.",
     },
     {.key = {"full-lock"},
      .type = GF_OPTION_TYPE_BOOL,

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -256,7 +256,7 @@ typedef struct _afr_private {
     gf_boolean_t halo_enabled;
     gf_boolean_t consistent_metadata;
     gf_boolean_t need_heal;
-    gf_boolean_t granular_locks;
+
     char *sh_domain;
     char *afr_dirty;
 


### PR DESCRIPTION
Introduce `OPT_FLAG_NOEFFECT` option flag to denote an option which
has no effect but have to be retained for some reason (mostly to
implement some kind of backward compatibility), and mark
`cluster.locking-scheme` as an example of such option. Drop
related AFR internals and adjust related code as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000