### PR TITLE
afr: cleanup locking

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -2444,8 +2444,6 @@ afr_local_transaction_cleanup(afr_local_t *local, xlator_t *this)
 
     afr_matrix_cleanup(local->pending, priv->child_count);
 
-    GF_FREE(local->internal_lock.lower_locked_nodes);
-
     afr_lockees_cleanup(&local->internal_lock);
 
     GF_FREE(local->transaction.pre_op);
@@ -6543,22 +6541,11 @@ out:
     return -1;
 }
 
-int
+static inline void
 afr_internal_lock_init(afr_internal_lock_t *lk, size_t child_count)
 {
-    int ret = -ENOMEM;
-
-    lk->lower_locked_nodes = GF_CALLOC(sizeof(*lk->lower_locked_nodes),
-                                       child_count, gf_afr_mt_char);
-    if (NULL == lk->lower_locked_nodes)
-        goto out;
-
     lk->lock_op_ret = -1;
     lk->lock_op_errno = EUCLEAN;
-
-    ret = 0;
-out:
-    return ret;
 }
 
 void
@@ -6609,9 +6596,7 @@ afr_transaction_local_init(afr_local_t *local, xlator_t *this)
     INIT_LIST_HEAD(&local->transaction.owner_list);
     INIT_LIST_HEAD(&local->ta_waitq);
     INIT_LIST_HEAD(&local->ta_onwireq);
-    ret = afr_internal_lock_init(&local->internal_lock, priv->child_count);
-    if (ret < 0)
-        goto out;
+    afr_internal_lock_init(&local->internal_lock, priv->child_count);
 
     ret = -ENOMEM;
     local->pre_op_compat = priv->pre_op_compat;

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -2092,7 +2092,6 @@ afr_lock(call_frame_t *frame, xlator_t *this)
             break;
 
         case AFR_ENTRY_TRANSACTION:
-            int_lock->lk_basename = local->transaction.basename;
             if (local->transaction.parent_loc.path)
                 int_lock->lk_loc = &local->transaction.parent_loc;
             else

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -343,18 +343,11 @@ afr_entry_lockee_cmp(const void *l1, const void *l2);
 
 typedef struct {
     loc_t *lk_loc;
-
     afr_lockee_t lockee[AFR_LOCKEE_COUNT_MAX];
-
-    const char *lk_basename;
-    const char *lower_basename;
-    const char *higher_basename;
-
-    unsigned char *lower_locked_nodes;
-
     afr_lock_cbk_t lock_cbk;
 
-    int lockee_count;
+    int32_t lock_count;
+    int32_t lockee_count;
 
     int32_t lk_call_count;
     int32_t lk_expected_count;
@@ -362,10 +355,7 @@ typedef struct {
 
     int32_t lock_op_ret;
     int32_t lock_op_errno;
-    char *domain; /* Domain on which inode/entry lock/unlock in progress.*/
-    int32_t lock_count;
-    char lower_locked;
-    char higher_locked;
+    char *domain; /* Domain on which inode/entry lock/unlock in progress. */
 } afr_internal_lock_t;
 
 struct afr_reply {
@@ -1196,9 +1186,6 @@ afr_marker_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int
 afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno);
-
-int
-afr_internal_lock_init(afr_internal_lock_t *lk, size_t child_count);
 
 int
 afr_higher_errno(int32_t old_errno, int32_t new_errno);


### PR DESCRIPTION
Drop unused or assigned-only `lk_basename`, `lower_basename`,
`higher_basename`, `lower_locked_nodes`, `lower_locked` and
`higher_locked` members of `afr_internal_lock_t`, convert
`afr_internal_lock_init()` to an inline function, adjust
related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
