### PR TITLE
Coverity: Fix resource leak

### DIFF
--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -1292,21 +1292,23 @@ br_scrubber_scale_up(xlator_t *this, struct br_scrubber *fsscrub,
            "Scaling up scrubbers [%d => %d]", v1, v2);
 
     for (i = 0; i < diff; i++) {
-        scrub = GF_CALLOC(diff, sizeof(*scrub), gf_br_mt_br_scrubber_t);
+        scrub = GF_CALLOC(1, sizeof(*scrub), gf_br_mt_br_scrubber_t);
         if (!scrub)
             break;
 
         INIT_LIST_HEAD(&scrub->list);
         ret = gf_thread_create(&scrub->scrubthread, NULL, br_scrubber_proc,
                                fsscrub, "brsproc");
-        if (ret)
+        if (ret) {
+            GF_FREE(scrub);
             break;
+        }
 
         fsscrub->nr_scrubbers++;
         list_add_tail(&scrub->list, &fsscrub->scrubbers);
     }
 
-    if ((i != diff) && !scrub)
+    if (ret && i == 0)
         goto error_return;
 
     if (i != diff) /* degraded scaling.. */


### PR DESCRIPTION
Free the scrub if it fails to start even a single thread while scaling
up the scrubbers and return failure in that case.

CID #1430144

Updates #1060
Signed-off-by: karthik-us <ksubrahm@redhat.com>

Change-Id: I45dc4715e09af11cd3467536ab88c797d85f75b4

