### PR TITLE
fix: Improved macOS version assertion in configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -424,7 +424,8 @@ fi
 
 case $host_os in
   darwin*)
-    if ! test "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f2`" -ge 7; then
+    if ! test "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f2`" -ge 7 -o \
+       "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f1`" -ge 10; then
        AC_MSG_ERROR([You need at least OS X 10.7 (Lion) to build Glusterfs])
     fi
     # OSX version lesser than 9 has llvm/clang optimization issues which leads to various segfaults

--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,7 @@ fi
 case $host_os in
   darwin*)
     if ! test "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f2`" -ge 7 -o \
-       "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f1`" -ge 10; then
+       "`/usr/bin/sw_vers | grep ProductVersion: | cut -f 2 | cut -d. -f1`" -gt 10; then
        AC_MSG_ERROR([You need at least OS X 10.7 (Lion) to build Glusterfs])
     fi
     # OSX version lesser than 9 has llvm/clang optimization issues which leads to various segfaults


### PR DESCRIPTION
On major versions of macOS > 10, this assertion could fail if the minor
version of the developer's OS is less than 7. This corrects that by also
asserting that the major version can be greater than 10. When the
version is greater than 10 the minor version is no longer important for
this assertion.

Resolves #3166

