### PR TITLE
quota: miscellaneous cleanups

### DIFF
--- a/xlators/features/quota/src/quota-mem-types.h
+++ b/xlators/features/quota/src/quota-mem-types.h
@@ -16,14 +16,7 @@ enum gf_quota_mem_types_ {
     /* Those are used by QUOTA_ALLOC_OR_GOTO macro */
     gf_quota_mt_quota_priv_t = gf_common_mt_end + 1,
     gf_quota_mt_quota_inode_ctx_t,
-    gf_quota_mt_loc_t,
-    gf_quota_mt_char,
-    gf_quota_mt_int64_t,
-    gf_quota_mt_int32_t,
-    gf_quota_mt_limits_t,
     gf_quota_mt_quota_dentry_t,
-    gf_quota_mt_quota_limits_level_t,
-    gf_quota_mt_qd_vols_conf_t,
     gf_quota_mt_aggregator_state_t,
     gf_quota_mt_end
 };

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -33,10 +33,6 @@
 #define VAL_LENGTH 8
 #define READDIR_BUF 4096
 
-#ifndef UUID_CANONICAL_FORM_LEN
-#define UUID_CANONICAL_FORM_LEN 36
-#endif
-
 #define WIND_IF_QUOTAOFF(is_quota_on, label)                                   \
     if (!is_quota_on)                                                          \
         goto label;
@@ -176,14 +172,12 @@ struct quota_local {
     int8_t object_delta;
     int32_t op_ret;
     int32_t op_errno;
-    int64_t size;
     char just_validated;
     fop_lookup_cbk_t validate_cbk;
     quota_fop_continue_t fop_continue_cbk;
     inode_t *inode;
     uuid_t common_ancestor; /* Used by quota_rename */
     call_stub_t *stub;
-    struct iobref *iobref;
     quota_limits_t limit;
     quota_limits_t object_limit;
     int64_t space_available;


### PR DESCRIPTION
Drop unused `size` and `iobref` from `quota_local_t`
and unused memory types from `gf_quota_mem_types_`,
drop duplicated `UUID_CANONICAL_FORM_LEN`, simplify
`quota_enforcer_submit_request()` and related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000