### PR TITLE
dht: use 64-bit values for seconds in DHT stat

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -106,11 +106,11 @@ struct dht_layout {
 typedef struct dht_layout dht_layout_t;
 
 struct dht_stat_time {
-    uint32_t atime;
+    uint64_t atime;
     uint32_t atime_nsec;
-    uint32_t ctime;
+    uint64_t ctime;
     uint32_t ctime_nsec;
-    uint32_t mtime;
+    uint64_t mtime;
     uint32_t mtime_nsec;
 };
 


### PR DESCRIPTION
Use 64-bit values for seconds in `dht_stat_time_t` and so
avoid possible truncation in `dht_inode_ctx_time_set()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

