### PR TITLE
quick-read: use 64-bit values for seconds in inode

### DIFF
--- a/xlators/performance/quick-read/src/quick-read.h
+++ b/xlators/performance/quick-read/src/quick-read.h
@@ -33,9 +33,9 @@ struct qr_inode {
     void *data;
     size_t size;
     int priority;
-    uint32_t ia_mtime;
+    uint64_t ia_mtime;
     uint32_t ia_mtime_nsec;
-    uint32_t ia_ctime;
+    uint64_t ia_ctime;
     uint32_t ia_ctime_nsec;
     uint32_t gen_rollover;
     struct iatt buf;


### PR DESCRIPTION
Use 64-bit values for seconds in `qr_inode_t` and so
avoid possible truncation in `qr_content_update()`.

Signed-off-by: Dmitry Antipov dantipov@cloudlinux.com
Updates: #1000
