### PR TITLE
afr: use 64-bit values for seconds in self-heal code

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -220,7 +220,7 @@ afr_gfid_sbrain_source_from_latest_mtime(struct afr_reply *replies,
 {
     int i = 0;
     int src = -1;
-    uint32_t mtime = 0;
+    uint64_t mtime = 0;
     uint32_t mtime_nsec = 0;
 
     for (i = 0; i < child_count; i++) {
@@ -856,7 +856,7 @@ afr_mark_latest_mtime_file_as_source(xlator_t *this, unsigned char *sources,
 {
     int i = 0;
     afr_private_t *priv = NULL;
-    uint32_t mtime = 0;
+    uint64_t mtime = 0;
     uint32_t mtime_nsec = 0;
 
     priv = this->private;
@@ -1106,7 +1106,7 @@ afr_sh_fav_by_mtime(xlator_t *this, struct afr_reply *replies, inode_t *inode)
     afr_private_t *priv;
     int fav_child = -1;
     int i = 0;
-    uint32_t cmp_mtime = 0;
+    uint64_t cmp_mtime = 0;
     uint32_t cmp_mtime_nsec = 0;
 
     priv = this->private;
@@ -1144,7 +1144,7 @@ afr_sh_fav_by_ctime(xlator_t *this, struct afr_reply *replies, inode_t *inode)
     afr_private_t *priv;
     int fav_child = -1;
     int i = 0;
-    uint32_t cmp_ctime = 0;
+    uint64_t cmp_ctime = 0;
     uint32_t cmp_ctime_nsec = 0;
 
     priv = this->private;

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -524,7 +524,7 @@ afr_mark_newest_file_as_source(xlator_t *this, unsigned char *sources,
     int i = 0;
     afr_private_t *priv = NULL;
     int source = -1;
-    uint32_t max_ctime = 0;
+    uint64_t max_ctime = 0;
 
     priv = this->private;
     /* Find source with latest ctime */


### PR DESCRIPTION
Use 64-bit values when comparing seconds in self-heal code,
thus avoiding weird errors when selecting sources vs. sinks.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000