### PR TITLE
[configure] Improve sanitizer detection & linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,9 +288,9 @@ AC_ARG_ENABLE([asan],
                              [Enable Address Sanitizer support]))
 if test "x$enable_asan" = "xyes"; then
         SANITIZER=asan
-        AC_CHECK_LIB([asan], [__asan_init], ,
+        AC_CHECK_LIB([asan], [_init], ,
                 [AC_MSG_ERROR([--enable-asan requires libasan.so, exiting])])
-        if test "x$ac_cv_lib_asan___asan_init" = xyes; then
+        if test "x$ac_cv_lib_asan__init" = xyes; then
                 AC_MSG_CHECKING([whether asan API can be used])
                 saved_CFLAGS=${CFLAGS}
                 CFLAGS="${CFLAGS} -fsanitize=address"
@@ -306,7 +306,9 @@ if test "x$enable_asan" = "xyes"; then
                 CFLAGS=${saved_CFLAGS}
         fi
         GF_CFLAGS="${GF_CFLAGS} -O2 -g -fsanitize=address -fno-omit-frame-pointer"
-        GF_LDFLAGS="${GF_LDFLAGS} -lasan"
+
+        dnl See: https://groups.google.com/d/msg/address-sanitizer/SD590XDinfQ/NMUPj_G0BgAJ
+        GF_LDFLAGS="${GF_LDFLAGS} -fsanitize=address"
 fi
 
 AC_ARG_ENABLE([tsan],
@@ -317,9 +319,9 @@ if test "x$enable_tsan" = "xyes"; then
                 AC_MSG_ERROR([only one sanitizer can be enabled at once])
         fi
         SANITIZER=tsan
-        AC_CHECK_LIB([tsan], [__tsan_init], ,
+        AC_CHECK_LIB([tsan], [_init], ,
                 [AC_MSG_ERROR([--enable-tsan requires libtsan.so, exiting])])
-        if test "x$ac_cv_lib_tsan___tsan_init" = xyes; then
+        if test "x$ac_cv_lib_tsan__init" = xyes; then
                 AC_MSG_CHECKING([whether tsan API can be used])
                 saved_CFLAGS=${CFLAGS}
                 CFLAGS="${CFLAGS} -fsanitize=thread"
@@ -335,7 +337,7 @@ if test "x$enable_tsan" = "xyes"; then
                 CFLAGS=${saved_CFLAGS}
         fi
         GF_CFLAGS="${GF_CFLAGS} -O2 -g -fsanitize=thread -fno-omit-frame-pointer"
-        GF_LDFLAGS="${GF_LDFLAGS} -ltsan"
+        GF_LDFLAGS="${GF_LDFLAGS} -fsanitize=thread"
 fi
 
 AC_ARG_ENABLE([ubsan],
@@ -346,10 +348,10 @@ if test "x$enable_ubsan" = "xyes"; then
                 AC_MSG_ERROR([only one sanitizer can be enabled at once])
         fi
         SANITIZER=ubsan
-        AC_CHECK_LIB([ubsan], [__ubsan_default_options], ,
+        AC_CHECK_LIB([ubsan], [_init], ,
                 [AC_MSG_ERROR([--enable-ubsan requires libubsan.so, exiting])])
         GF_CFLAGS="${GF_CFLAGS} -O2 -g -fsanitize=undefined -fno-omit-frame-pointer"
-        GF_LDFLAGS="${GF_LDFLAGS} -lubsan"
+        GF_LDFLAGS="${GF_LDFLAGS} -fsanitize=undefined"
 fi
 
 # Initialize CFLAGS before usage


### PR DESCRIPTION
It is not a good idea to check for symbol `__xsan_init` as its newer
alternative `__xsan_init_vN` changes everytime the ABI changes.
`_init` symbol is present in all of the sanitizers as is also backwards
compatible.

Older versions of `gcc` were unable to link properly with sanitizers but
as of ver 5 they can link properly using `-fsanitize=xxx`. Using
`-lxsan` is discouraged as it misses a few extra flags that `-fsanitize`
includes. Bear in mind that flags `-W1,-z,defs` will cause linker to
fail as san runtime is not linked when linking shared libraries.

Change-Id: I12e0a431feabfc9cee22503ed5afa7e06b44c366
Signed-off-by: black-dragon74 <niryadav@redhat.com>

