### PR TITLE
rpc: Log xid as unsigned integer

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -428,7 +428,7 @@ rpc_clnt_fill_request_info(struct rpc_clnt *clnt, rpc_request_info_t *info)
     if (ret == -1) {
         gf_log(clnt->conn.name, GF_LOG_CRITICAL,
                "cannot lookup the saved "
-               "frame corresponding to xid (%d)",
+               "frame corresponding to xid (%u)",
                info->xid);
         goto out;
     }


### PR DESCRIPTION
This fixes an issue where a critical log message could be misleading due
to a negative xid, e.g.

```
[2022-01-30 14:16:57.436942] C [rpc-clnt.c:441:rpc_clnt_fill_request_info] 0-general-client-11: cannot lookup the saved frame corresponding to xid (-990066842)
```

This can easily be verified by compiling and running the following C
code:

```clang

int main()
{
    uint32_t i = 2147483647;
    while (1 == 1)
    {
        printf("i as signed is (%d). i as unsigned is (%u).\n", i);
        i++;
    }
    return 0;
}
```

Fixes: #3194

Signed-off-by: Robert Lützner <robert.luetzner@iternity.com>

