### PR TITLE
index.c: dereference of null

### DIFF
--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1756,7 +1756,8 @@ index_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
         goto done;
     }
 
-    dir = fctx->dir;
+    if (fctx)
+        dir = fctx->dir;
     if (!dir) {
         op_errno = EINVAL;
         gf_msg(this->name, GF_LOG_WARNING, op_errno,


### PR DESCRIPTION
fctx can be null so check
Issue: [24](https://build.gluster.org/job/clang-scan/lastBuild/clangScanBuildBugs/browse/report-39098c.html#EndPath)

Change-Id: Ib1ba3d36b9b1ec83a1d92b9cb58f9a0d1af08003
Updates: #1060
Signed-off-by: Preet Bhatia pbhatia@redhat.com
