### PR TITLE
dht: Resolve double free in function dht_common_mark_mdsxattr_cbk

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -719,6 +719,7 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local->mds_heal_fresh_lookup && layout) {
         dht_selfheal_dir_setattr(frame, &local->loc, &local->stbuf, 0xffffffff,
                                  layout);
+        return 0;
     }
 out:
     if (mds_heal_fresh_lookup)


### PR DESCRIPTION
During fresh lookup for directory dht set and heal mds xattr on the directory.
The function dht_common_mark_mdsxattr_cbk is trying to destroy frame->root
even the same frame is passed to the function(dht_selfheal_dir_setattr) to
heal the xattr.Ideally we have this bug from the day when a feature was
implemented but the bug is not caught till today.After move on tcmalloc
it was easily caught and a client process was crashed.It depends memory
allocator behavior and we can't expect every time an allocator should crash.
As per free man page the behavior is undefined in case if ptr has already
been called before so it was expected.

Solution: After call dht_selfheal_dir_setattr return 0 to avoid stack cleanup.

> Change-Id: I6a6c3aff1b9984ee764948c754731574433b1d28
> Updates: #3191
> Credits: Xavi Hernandez xhernandez@redhat.com
> Signed-off-by: Mohit Agrawal moagrawa@redhat.com
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/3192)
> (Cherry-pick from commit 2c8505931a1567f727e763132d35270cdb4f11d3)

Change-Id: I56c5fe849b0d938d80981cc83bfe4f794c833fc3
Updates: #3191
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

