### PR TITLE
Arbiter: Do not compare file size against arbiter brick

### DIFF
--- a/tests/afr.rc
+++ b/tests/afr.rc
@@ -11,7 +11,7 @@ function create_brick_xattrop_entry {
         for file in $params
         do
                 gfid_str=$(gf_gfid_xattr_to_str $(gf_get_gfid_xattr $1/$file))
-                if [ -z "$base_entry"];
+                if [ -z "$base_entry" ];
                 then
                         touch $xattrop_dir/$gfid_str
                 else

--- a/tests/basic/afr/arbiter-do-not-compare-size.t
+++ b/tests/basic/afr/arbiter-do-not-compare-size.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../afr.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 2 arbiter 1 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume start $V0
+TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0
+TEST kill_brick $V0 $H0 $B0/${V0}2
+# Create base entry in indices/xattrop
+echo "Data" > $M0/file
+EXPECT "^3$" count_index_entries $B0/$V0"0"
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+EXPECT "^1$" count_index_entries $B0/$V0"0"
+
+
+# Simulate a stale indices entry by manually creating a link to xattrop base
+# entry with an existing entry which does not need any heal
+TEST create_brick_xattrop_entry $B0/$V0"0" file
+EXPECT "^2$" count_index_entries $B0/$V0"0"
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+
+cleanup;

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -2391,7 +2391,7 @@ afr_selfheal_unlocked_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
                 *metadata_selfheal = _gf_true;
         }
 
-        if (IA_ISREG(first.ia_type) &&
+        if (IA_ISREG(first.ia_type) && !(AFR_IS_ARBITER_BRICK(priv, i)) &&
             !IA_EQUAL(first, replies[i].poststat, size)) {
             gf_msg_debug(this->name, 0,
                          "SIZE mismatch "


### PR DESCRIPTION
Problem:
In afr_selfheal_unlocked_inspect(), if there are no pending xattrs
set for the entries inside indices folder it checks for other fileds
to identify anything is actually pending. Doing so, it will check for
the file size on all the bricks. If the volume is of arbiter type, the
size comparision will always fail for the files which does have some
data in it, when compared against the arbiter brick.

Fix:
Do not check for the file size against arbiter brick.

Fixes: #3200
Change-Id: I9ed31a49ae9fcb1a99dec2933a66e27af65fbf78
Signed-off-by: karthik-us <ksubrahm@redhat.com>

