### PR TITLE
clang: fix uninitialized args

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -299,6 +299,8 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
                      "ip-%s port-%s",
                      host, service);
     }
+    if (!cache->next)
+        goto err;
 
     return 0;
 

--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -7,6 +7,7 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
+// test
 #include <glusterfs/compat.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/list.h>


### PR DESCRIPTION

Issue
1st function call argument is an uninitialized value in afr_ta_process_waitq().
**Description**
Initialization of list not taking place due return from list_splice_init()
Fix: Hence check if the list has any valid entry before calling afr_ta_decide_post_op_state()

Updates #1060

Signed-off-by : Harshita Shree hshree@redhat.com