### PR TITLE
[inode.c] Optimize setting `xl_key` on inode's ctx

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -524,8 +524,9 @@ __inode_unref(inode_t *inode, bool clear)
     --inode->ref;
 
     index = __inode_get_xl_index(inode, this);
-    if (index >= 0)
+    if (index >= 0) {
         inode->_ctx[index].ref--;
+    }
 
     if (!inode->ref && !inode->in_invalidate_list) {
         inode->table->active_size--;

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -524,10 +524,8 @@ __inode_unref(inode_t *inode, bool clear)
     --inode->ref;
 
     index = __inode_get_xl_index(inode, this);
-    if (index >= 0) {
-        inode->_ctx[index].xl_key = this;
+    if (index >= 0)
         inode->_ctx[index].ref--;
-    }
 
     if (!inode->ref && !inode->in_invalidate_list) {
         inode->table->active_size--;
@@ -586,10 +584,8 @@ __inode_ref(inode_t *inode, bool is_invalidate)
     inode->ref++;
 
     index = __inode_get_xl_index(inode, this);
-    if (index >= 0) {
-        inode->_ctx[index].xl_key = this;
+    if (index >= 0)
         inode->_ctx[index].ref++;
-    }
 
     return inode;
 }
@@ -2106,10 +2102,8 @@ __inode_ctx_set2(inode_t *inode, xlator_t *xlator, uint64_t *value1_p,
     if (set_idx == -1) {
         ret = -1;
         goto out;
-        ;
     }
 
-    inode->_ctx[set_idx].xl_key = xlator;
     if (value1_p)
         inode->_ctx[set_idx].value1 = *value1_p;
     if (value2_p)

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -2099,7 +2099,7 @@ __inode_ctx_set2(inode_t *inode, xlator_t *xlator, uint64_t *value1_p,
         return -1;
 
     set_idx = __inode_get_xl_index(inode, xlator);
-    if (set_idx == -1) {
+    if (set_idx < 0) {
         ret = -1;
         goto out;
     }


### PR DESCRIPTION
`xl_key` on an inode's ctx is already set to `xlator` when index >= 0
inside `__inode_get_xl_index`. There is no need to set it again after
getting the index.

Change-Id: I606307653c47f3a57cfe355e290468f3e68e0d33
Signed-off-by: black-dragon74 <niryadav@redhat.com>

