### PR TITLE
[autogen] Add check for pkg-config

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -39,6 +39,15 @@ else
   MISSING="$MISSING automake"
 fi
 
+# Check for pkg-config, if it is missing 
+# configure generates some weird error messages
+# that are not at all helpful.
+# See: https://tirania.org/blog/archive/2012/Oct-20.html
+env pkg-config --version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  MISSING="$MISSING pkg-config"
+fi
+
 # Check for libtoolize or glibtoolize
 env libtoolize --version > /dev/null 2>&1
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
On some platforms, pkg-config is not bundled with autoconf or is installed
at some non standard location due to which aclocal is unable to find it. It leads
to some very unhelpful error messages when running configure. This patch adds a check
for the same. See https://tirania.org/blog/archive/2012/Oct-20.html for more on this.

Signed-off-by: black-dragon74 <niryadav@redhat.com>

