### PR TITLE
clang fix- null dereference

### DIFF
--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -3498,6 +3498,7 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
         0,
     };
 
+    INIT_LIST_HEAD(&args->locklist.list);
     SYNCOP(subvol, (&args), syncop_getactivelk_cbk, subvol->fops->getactivelk,
            loc, xdata_in);
 

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -3498,7 +3498,7 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
         0,
     };
 
-    INIT_LIST_HEAD(&args->locklist.list);
+    INIT_LIST_HEAD(&args.locklist.list);
     SYNCOP(subvol, (&args), syncop_getactivelk_cbk, subvol->fops->getactivelk,
            loc, xdata_in);
 


### PR DESCRIPTION
Issue:
Access to field 'next' results in a dereference of a null pointer (loaded from field 'prev') in __list_splice
Fix: 
Initialize the list in the function (syncop_getactivelk) where __list_splice_init is being called so that list->prev is valid( not point to null)
Change-Id: If35b68b4c1def9bd335e056bb77e486c4610cf9a
Updates: #1060


Signed-off-by: harshita-shree hshree@redhat.com

