### PR TITLE
[inode.c] Improve `dentry_create`

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -639,22 +639,21 @@ dentry_create(inode_t *inode, inode_t *parent, const char *name)
 {
     dentry_t *newd = NULL;
 
-    newd = mem_get0(parent->table->dentry_pool);
-    if (newd == NULL) {
+    newd = mem_get(parent->table->dentry_pool);
+    if (newd == NULL)
         goto out;
-    }
 
     INIT_LIST_HEAD(&newd->inode_list);
     INIT_LIST_HEAD(&newd->hash);
 
+    newd->inode = inode;
     newd->name = gf_strdup(name);
+
     if (newd->name == NULL) {
         mem_put(newd);
         newd = NULL;
         goto out;
     }
-
-    newd->inode = inode;
 
 out:
     return newd;


### PR DESCRIPTION
Replaced `mem_get0` by `mem_get`(saves calloc) as we are polulating all of the fields
and modified the order in which we are setting the fields to match the structure's
definition.

Updates: #3216 
Change-Id: I7b96887e736d9c92b54c954fdf4fd6b38f24bb7e
Signed-off-by: black-dragon74 <niryadav@redhat.com>

