### PR TITLE
[socket.c] Enable AES for SSL by default

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -56,7 +56,7 @@
 #if !defined(DEFAULT_VERIFY_DEPTH)
 #define DEFAULT_VERIFY_DEPTH 1
 #endif
-#define DEFAULT_CIPHER_LIST "EECDH:EDH:HIGH:!3DES:!RC4:!DES:!MD5:!aNULL:!eNULL"
+#define DEFAULT_CIPHER_LIST "AES128:EECDH:EDH:HIGH:!3DES:!RC4:!DES:!MD5:!aNULL:!eNULL"
 #define DEFAULT_DH_PARAM SSL_CERT_PATH "/dhparam.pem"
 #define DEFAULT_EC_CURVE "prime256v1"
 
@@ -4038,34 +4038,6 @@ static void __attribute__((destructor)) fini_openssl_mt(void)
     ERR_free_strings();
 }
 
-/* The function returns 0 if AES bit is enabled on the CPU */
-static int
-ssl_check_aes_bit(void)
-{
-    FILE *fp = fopen("/proc/cpuinfo", "r");
-    int ret = 1;
-    size_t len = 0;
-    char *line = NULL;
-    char *match = NULL;
-
-    GF_ASSERT(fp != NULL);
-
-    while (getline(&line, &len, fp) > 0) {
-        if (!strncmp(line, "flags", 5)) {
-            match = strstr(line, " aes");
-            if ((match != NULL) && ((match[4] == ' ') || (match[4] == 0))) {
-                ret = 0;
-                break;
-            }
-        }
-    }
-
-    free(line);
-    fclose(fp);
-
-    return ret;
-}
-
 static int
 ssl_setup_connection_params(rpc_transport_t *this)
 {
@@ -4087,10 +4059,6 @@ ssl_setup_connection_params(rpc_transport_t *this)
 
     if (!priv->ssl_enabled && !priv->mgmt_ssl) {
         return 0;
-    }
-
-    if (!ssl_check_aes_bit()) {
-        cipher_list = "AES128:" DEFAULT_CIPHER_LIST;
     }
 
     priv->ssl_own_cert = DEFAULT_CERT_PATH;


### PR DESCRIPTION
`/proc/cpuinfo` file is only present on Linux hosts which leads to AES
cipher not being enabled for SSL on other hosts despite the CPU
supporting the hw accel.

This approach uses the assembly instruction `cpuid` to check for AES bit
presence, making it a global solution on *NIX hosts. Perks; we don't have
to deal with files which helps with performance and efficiency.

Change-Id: Ide9ebc0a39da2b02c71d7f766f6b0473433b8b8a
Signed-off-by: black-dragon74 <niryadav@redhat.com>

