### PR TITLE
[gsyncd] Use `execv` when explicit path is present

### DIFF
--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -299,8 +299,8 @@ invoke_gluster(int argc, char **argv)
         }
     }
 
-    argv[0] = "gluster";
-    execvp(SBIN_DIR "/gluster", argv);
+    argv[0] = SBIN_DIR "/gluster";
+    execv(SBIN_DIR "/gluster", argv);
     fprintf(stderr, "exec of gluster failed\n");
     return 127;
 


### PR DESCRIPTION
There is no use of calling `execvp` when the filename has a "/"
character in it. Also, as per convention first member of argv should be
the same as the filename.

Gotcha: You can also pass some random value to argv[0], in my tests the
operation was always successful as long as argv[0] was not NULL.

Change-Id: I9eeb9481d434237e9c19a0069dbe24af8df20c64
Signed-off-by: black-dragon74 <niryadav@redhat.com>

