### PR TITLE
clang fix-null pointer dereference

### DIFF
--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -21,9 +21,9 @@ ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
-    ec_fop_data_t *fop = cookie;
-    if (fop == NULL)
+    if (!cookie)
         goto out;
+    ec_fop_data_t *fop = cookie;
     ec_cbk_data_t *cbk = NULL;
     ec_fop_data_t *parent = fop->parent;
     int i = 0;

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -22,6 +22,8 @@ ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
+    if (fop == NULL)
+        goto out;
     ec_cbk_data_t *cbk = NULL;
     ec_fop_data_t *parent = fop->parent;
     int i = 0;


### PR DESCRIPTION
Issue:
Access to field 'parent' results in a dereference of a null pointer in ec_update_writev_cbk()
Fix : 
Assignment of fop may be lead to fop being null in cases where cookie is null. So check and return if null.

Updates #1060 
Change-Id: I577778d1ad03218f365ce53e84396b2121c00396

Signed-off-by : Harshita Shree hshree@redhat.com