### PR TITLE
lib/event-epoll: [Coverity] Fix un-initialised variable

### DIFF
--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -351,7 +351,7 @@ event_register_epoll(struct event_pool *event_pool, int fd,
                      event_handler_t handler, void *data, int poll_in,
                      int poll_out, int notify_poller_death)
 {
-    int idx;
+    int idx = -1;
     int ret = -1;
     int destroy = 0;
     struct epoll_event epoll_event = {


### PR DESCRIPTION
When destroy is called to `goto out;`, leads to returning the variable `idx` without initialising.

Fixes: #1060
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>

