### PR TITLE
Multiple improvements to inode_link

### DIFF
--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -182,10 +182,6 @@ inode_rename(inode_table_t *table, inode_t *olddir, const char *oldname,
 inode_t *
 inode_grep(inode_table_t *table, inode_t *parent, const char *name);
 
-int
-inode_grep_for_gfid(inode_table_t *table, inode_t *parent, const char *name,
-                    uuid_t gfid, ia_type_t *type);
-
 inode_t *
 inode_find(inode_table_t *table, uuid_t gfid);
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -978,7 +978,6 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
     inode_t *old_inode = NULL;
     inode_table_t *table = NULL;
     inode_t *link_inode = NULL;
-    char link_uuid_str[64] = {0}, parent_uuid_str[64] = {0};
 
     table = inode->table;
 
@@ -1031,7 +1030,8 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
 
         if (!old_dentry || old_dentry->inode != link_inode) {
             dentry = dentry_create(link_inode, parent, name);
-            if (!dentry) {
+            if (caa_unlikely(!dentry)) {
+                char link_uuid_str[64], parent_uuid_str[64];
                 gf_msg_callingfn(THIS->name, GF_LOG_ERROR, 0,
                                  LG_MSG_DENTRY_CREATE_FAILED,
                                  "dentry create failed on "

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -750,7 +750,7 @@ inode_forget_atomic(inode_t *inode, uint64_t nlookup)
     }
 }
 
-dentry_t *
+static dentry_t *
 __dentry_grep(inode_t *parent, const char *name, struct list_head *hash_loc)
 {
     dentry_t *tmp = NULL;

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -839,40 +839,6 @@ out:
     return inode;
 }
 
-int
-inode_grep_for_gfid(inode_table_t *table, inode_t *parent, const char *name,
-                    uuid_t gfid, ia_type_t *type)
-{
-    inode_t *inode = NULL;
-    dentry_t *dentry = NULL;
-    int ret = -1;
-
-    if (!table || !parent || !name) {
-        gf_msg_callingfn(THIS->name, GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
-                         "table || parent || name"
-                         " not found");
-        return ret;
-    }
-
-    struct list_head *hash_loc = hash_dentry(parent, name, table);
-
-    pthread_mutex_lock(&table->lock);
-    {
-        dentry = __dentry_grep(parent, name, hash_loc);
-        if (dentry) {
-            inode = dentry->inode;
-            if (inode) {
-                gf_uuid_copy(gfid, inode->gfid);
-                *type = inode->ia_type;
-                ret = 0;
-            }
-        }
-    }
-    pthread_mutex_unlock(&table->lock);
-
-    return ret;
-}
-
 /* return 1 if gfid is of root, 0 if not */
 gf_boolean_t
 __is_root_gfid(uuid_t gfid)

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -179,17 +179,6 @@ hash_gfid(uuid_t uuid, int mod)
     return ((int *)uuid)[0] & (mod - 1);
 }
 
-static void
-__dentry_hash(dentry_t *dentry, const int hash)
-{
-    inode_table_t *table = NULL;
-
-    table = dentry->inode->table;
-
-    list_del_init(&dentry->hash);
-    list_add(&dentry->hash, &table->name_hash[hash]);
-}
-
 static int
 __is_dentry_hashed(dentry_t *dentry)
 {
@@ -1048,7 +1037,7 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
                 dentry_destroy(__dentry_unset(dentry));
                 return NULL;
             }
-            __dentry_hash(dentry, dhash);
+            list_add(&dentry->hash, &link_inode->table->name_hash[dhash]);
 
             if (old_dentry)
                 dentry_destroy(__dentry_unset(old_dentry));

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -967,7 +967,7 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
             } else {
                 gf_uuid_copy(inode->gfid, iatt->ia_gfid);
                 inode->ia_type = iatt->ia_type;
-                __inode_hash(inode, ihash);
+                list_add(&inode->hash, &table->inode_hash[ihash]);
             }
         }
     } else {
@@ -1612,7 +1612,7 @@ __inode_table_init_root(inode_table_t *table)
 
     gf_uuid_copy(root->gfid, root_gfid);
     root->ia_type = IA_IFDIR;
-    __inode_hash(root, hash_gfid(root_gfid, table->inode_hashsize));
+    list_add(&root->hash, &table->inode_hash[hash_gfid(root_gfid, table->inode_hashsize)]);
 
     root = __inode_ref(root, _gf_false);
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1612,7 +1612,8 @@ __inode_table_init_root(inode_table_t *table)
 
     gf_uuid_copy(root->gfid, root_gfid);
     root->ia_type = IA_IFDIR;
-    list_add(&root->hash, &table->inode_hash[hash_gfid(root_gfid, table->inode_hashsize)]);
+    list_add(&root->hash,
+             &table->inode_hash[hash_gfid(root_gfid, table->inode_hashsize)]);
 
     root = __inode_ref(root, _gf_false);
 
@@ -1667,7 +1668,8 @@ inode_table_with_invalidator(uint32_t lru_limit, xlator_t *xl,
         if (inode_hashsize > 0)
             gf_log(THIS->name, GF_LOG_WARNING,
                    "Set inode table size to minimum value of 65536 rather than "
-                   "the configured %u", inode_hashsize);
+                   "the configured %u",
+                   inode_hashsize);
         new->inode_hashsize = 65536;
     } else {
         new->inode_hashsize = inode_hashsize;

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -297,15 +297,6 @@ __is_inode_hashed(inode_t *inode)
     return !list_empty(&inode->hash);
 }
 
-static void
-__inode_hash(inode_t *inode, const int hash)
-{
-    inode_table_t *table = inode->table;
-
-    list_del_init(&inode->hash);
-    list_add(&inode->hash, &table->inode_hash[hash]);
-}
-
 static dentry_t *
 __dentry_search_for_inode(inode_t *inode, uuid_t pargfid, const char *name)
 {

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -776,7 +776,6 @@ inode_forget
 inode_forget_with_unref
 inode_from_path
 inode_grep
-inode_grep_for_gfid
 inode_has_dentry
 inode_invalidate
 inode_is_linked


### PR DESCRIPTION
- [x] Improve inode_link(): pass table->name_hash[hash] list_head
    Instead of passing just the index, pass table->name_hash[index] (list_head structure) to the functions that use it.
    
- [x] Improve inode_link(): move the error logging allocation to where it's needed.
    No need to declare and certainly not memset, by default, two 64 byte arrays for an error message.
    Do it when needed.

- [x] Improve inode_link(): extract checks outside the lock, before the action
    There are multiple checks taking place under the lock on __inode_link().
    They were extracted to pre_inode_link_checks() function that takes place before.
    
- [x] Improve inode_link(): remove __dentry_hash()
    No need to list_del anything - it's empty already.
    
- [x] Improve inode_link(): Remove inode_hash()
    No need to list_del(inode->hash) - it's empty already, sincde __is_inode_hashed() returned false earlier.
    So just called directly the one liner left - adding it to the table inode_hash in the right location.

Updates: #3216
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>
