### PR TITLE
mount: fix typo in parsing fopen-keep-cache

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -641,7 +641,7 @@ with_options()
             ;;
         # Values that are optional
         "fopen-keep-cache")
-            fopen_keep_cache="=$value"
+            fopen_keep_cache="$value"
             ;;
         "io-engine")
             io_engine="${value}"


### PR DESCRIPTION
Without fix:
------------
$ gluster v create testvol  192.168.1.16:/data/bricks/brick1
$ gluster v start testvol
$ mount -t glusterfs -o fopen-keep-cache=0 192.168.1.16:testvol /mnt/fuse_mnt
glusterfs: unknown cache setting "=0"
Mounting glusterfs on /mnt/fuse_mnt failed.

With fix:
---------
$ mount -t glusterfs -o fopen-keep-cache=0 192.168.1.16:testvol /mnt/fuse_mnt
$echo $?
0
$ ps x|grep fopen|grep -v grep
96375 ?  SLsl  0:00 /usr/local/sbin/glusterfs --fopen-keep-cache=0 --process-name fuse --volfile-server=192.168.1.16 --volfile-id=testvol /mnt/fuse_mnt

Change-Id: I1e39a89e17943f6dd83d6740aa315fcc03a76a03
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>
Updates: #1000

