### PR TITLE
xlator/protocol/client: handle 'remote-port' option on disconnect

### DIFF
--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2303,7 +2303,7 @@ client_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
                 int32_t remote_port = 0;
                 ret = dict_get_int32(this->options, "remote-port",
                                      &remote_port);
-                if (!ret) {
+                if (IS_ERROR(ret)) {
                     /* this is optional, so it may be error in most cases. Add a
                      * trace log */
                     gf_msg_trace(

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -2300,7 +2300,17 @@ client_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
                 rpc_clnt_cleanup_and_start(rpc);
 
             } else {
-                rpc->conn.config.remote_port = 0;
+                int32_t remote_port = 0;
+                ret = dict_get_int32(this->options, "remote-port",
+                                     &remote_port);
+                if (!ret) {
+                    /* this is optional, so it may be error in most cases. Add a
+                     * trace log */
+                    gf_msg_trace(
+                        this->name, 0,
+                        "volfile doesn't have remote-port, resetting to 0");
+                }
+                conf->rpc_conf.remote_port = remote_port;
                 conf->connection_to_brick = _gf_false;
             }
             break;


### PR DESCRIPTION
instead of always resetting to 0, check if remote port is present, and use it.

Fixes: #3229
Change-Id: I899c2e84a44ff2baadfaeff20528ff250f43e6b8
Signed-off-by: Amar Tumballi <amar@kadalu.io>

