### PR TITLE
[syncdaemon] Use AES128 encryption for rsync SSH

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -39,7 +39,8 @@ from syncdutils import (GsyncdError, select, privileged, funcode,
                         GX_GFID_CANONICAL_LEN,
                         gf_mount_ready, lf, Popen, sup,
                         Xattr, matching_disk_gfid, get_gfid_from_mnt,
-                        unshare_propagation_supported, get_slv_dir_path)
+                        unshare_propagation_supported, get_slv_dir_path,
+                        ssh_cipher_present)
 from gsyncdstatus import GeorepStatus
 from py2py3 import (pipe, str_to_bytearray, entry_pack_reg,
                     entry_pack_reg_stat, entry_pack_mkdir,
@@ -1453,6 +1454,9 @@ class SSH(object):
             ["-p", str(gconf.get("ssh-port"))] + \
             rconf.ssh_ctl_args + \
             gconf.get("rsync-ssh-options").split()
+
+        if not ssh_cipher_present(rsync_ssh_opts):
+            rsync_ssh_opts += ["-caes128-ctr"]
 
         argv = [
             gconf.get("rsync-command"),

--- a/geo-replication/syncdaemon/syncdutils.py
+++ b/geo-replication/syncdaemon/syncdutils.py
@@ -1113,3 +1113,18 @@ def get_up_nodes(hosts, port):
             up_nodes.append(h)
 
     return up_nodes
+
+
+def ssh_cipher_present(sshopts):
+    """
+    Returns True if user has defined a custom cipher to
+    use for the SSH connection under rysnc-ssh-options.
+    """
+    if not sshopts:
+        return False
+
+    for opt in sshopts:
+        if opt[:2] == "-c":
+            return True
+
+    return False


### PR DESCRIPTION
This patch enables `aes128-ctr` cipher by default for ssh connections
of rsync. However, if a user has defined some custom cipher to use that is
preferred.

Fixes: #3213

Signed-off-by: black-dragon74 <niryadav@redhat.com>

