### PR TITLE
build: deploy /usr/lib/tmpfiles.d/gluster.conf during client installation

### DIFF
--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -52,13 +52,13 @@ EXTRA_DIST = glusterfs-logrotate gluster-rsyslog-7.2.conf gluster-rsyslog-5.8.co
 	control-cpu-load.sh control-mem.sh group-distributed-virt \
 	thin-arbiter/thin-arbiter.vol thin-arbiter/setup-thin-arbiter.sh
 
-if WITH_SERVER
 install-data-local:
 	if [ -n "$(tmpfilesdir)" ]; then \
 		$(mkdir_p) $(DESTDIR)$(tmpfilesdir); \
 		$(INSTALL_DATA) run-gluster.tmpfiles \
 			$(DESTDIR)$(tmpfilesdir)/gluster.conf; \
 	fi
+if WITH_SERVER
 	$(mkdir_p) $(DESTDIR)$(GLUSTERD_WORKDIR)/groups
 	$(INSTALL_DATA) $(top_srcdir)/extras/group-virt.example \
 		$(DESTDIR)$(GLUSTERD_WORKDIR)/groups/virt

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -1296,7 +1296,7 @@ exit 0
 %dir %{_libdir}/glusterfs/%{version}%{?prereltag}/xlator/system
      %{_libdir}/glusterfs/%{version}%{?prereltag}/xlator/system/posix-acl.so
 %dir %attr(0775,gluster,gluster) %{_rundir}/gluster
-%if 0%{?_tmpfilesdir:1} && 0%{!?_without_server:1}
+%if 0%{?_tmpfilesdir:1}
 %{_tmpfilesdir}/gluster.conf
 %endif
 


### PR DESCRIPTION
The config file for creating /run/gluster on boot is available only with the glusterfs-server package.
As a result on a machine with only client installation, the path isn't created after reboot.
Install the conf file also during client installation.

Fixes:	#3232
Change-Id: Idbbc209b1bd0e82286eb9160c103bf0755cb90b9
Signed-off-by: Tamar Shacked <tshacked@redhat.com>

