### PR TITLE
null dereference fix-clang

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -248,11 +248,12 @@ glusterd_snap_volinfo_restore(dict_t *dict, dict_t *rsp_dict,
             /* To use generic functions from the plugin */
             glusterd_snapshot_plugin_by_name(snap_volinfo->snap_plugin,
                                              &snap_ops);
-
-            snap_ops->brick_path(snap_mount_dir, brickinfo->origin_path, 0,
-                                 snap_volinfo->snapshot->snapname,
-                                 snap_volinfo->volname, brickinfo->mount_dir,
-                                 brick_count - 1, new_brickinfo, 1);
+            if (snap_ops) {
+                snap_ops->brick_path(
+                    snap_mount_dir, brickinfo->origin_path, 0,
+                    snap_volinfo->snapshot->snapname, snap_volinfo->volname,
+                    brickinfo->mount_dir, brick_count - 1, new_brickinfo, 1);
+            }
         }
 
         snprintf(key, sizeof(key), "snap%d.brick%d.snap_status", volcount,
@@ -3330,8 +3331,11 @@ glusterd_snap_unmount(xlator_t *this, glusterd_volinfo_t *volinfo)
         retry_count = 0;
         while (retry_count <= 2) {
             retry_count++;
-            ret = snap_ops->deactivate(brickinfo, volinfo->snapshot->snapname,
-                                       volinfo->volname, brick_count);
+            if (snap_ops) {
+                ret = snap_ops->deactivate(brickinfo,
+                                           volinfo->snapshot->snapname,
+                                           volinfo->volname, brick_count);
+            }
             if (!ret)
                 break;
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GLUSTERD_UMOUNT_FAIL,


### PR DESCRIPTION
Issue:
1.Access to field 'brick_path' results in a dereference of a null pointer (loaded from variable 'snap_ops')
2.Access to field 'deactivate' results in a dereference of a null pointer (loaded from variable 'snap_ops')
Fix:
snap_ops is initially NULL. After returning from glusterd_snapshot_plugin_by_name() snap_ops may not be assigned a value.So check for NULL before accessing it.

Updates: #1060 
Change-Id: I1f8a8ae054b61ca6bd9985819f09179b75cef4d1
Signed-off-by : Harshita Shree hshree@redhat.com

