### PR TITLE
api, xlators: fix warnings found by clang-15

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -6335,7 +6335,7 @@ pub_glfs_xreaddirplus_get_stat(struct glfs_xreaddirp_stat *xstat)
 {
     GF_VALIDATE_OR_GOTO("glfs_xreaddirplus_get_stat", xstat, out);
 
-    if (!xstat->flags_handled & GFAPI_XREADDIRP_STAT)
+    if (!(xstat->flags_handled & GFAPI_XREADDIRP_STAT))
         gf_smsg(THIS->name, GF_LOG_ERROR, errno, API_MSG_FLAGS_HANDLE,
                 "GFAPI_XREADDIRP_STAT"
                 "xstat=%p",

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -443,7 +443,6 @@ dht_layout_anomalies(xlator_t *this, loc_t *loc, dht_layout_t *layout,
                      uint32_t *missing_p, uint32_t *down_p, uint32_t *misc_p,
                      uint32_t *no_space_p)
 {
-    uint32_t overlaps = 0;
     uint32_t missing = 0;
     uint32_t down = 0;
     uint32_t misc = 0;
@@ -507,7 +506,6 @@ dht_layout_anomalies(xlator_t *this, loc_t *loc, dht_layout_t *layout,
 
         if ((prev_stop + 1) > layout->list[i].start) {
             overlap_cnt++;
-            overlaps += ((prev_stop + 1) - layout->list[i].start);
         }
         prev_stop = layout->list[i].stop;
     }

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -356,21 +356,15 @@ __qr_cache_prune(xlator_t *this, qr_inode_table_t *table, qr_conf_t *conf)
     qr_inode_t *curr = NULL;
     qr_inode_t *next = NULL;
     int index = 0;
-    size_t size_pruned = 0;
 
     for (index = 0; index < conf->max_pri; index++) {
         list_for_each_entry_safe(curr, next, &table->lru[index], lru)
         {
-            size_pruned += curr->size;
-
             __qr_inode_prune(this, table, curr, 0);
-
             if (table->cache_used < conf->cache_size)
                 return;
         }
     }
-
-    return;
 }
 
 void


### PR DESCRIPTION
Fix the following warnings found by `clang-15`:
```
glfs-fops.c:6338:9: warning: logical not is only applied to the left
hand side of this bitwise operator [-Wlogical-not-parentheses]
    if (!xstat->flags_handled & GFAPI_XREADDIRP_STAT)
```
```
dht-layout.c:446:14: warning: variable 'overlaps' set but not used
[-Wunused-but-set-variable]
    uint32_t overlaps = 0;
```
```
quick-read.c:359:12: warning: variable 'size_pruned' set but not
used [-Wunused-but-set-variable]
    size_t size_pruned = 0;
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000