### PR TITLE
dht: fix dht_revalidate_cbk() triggering directory heal as non root

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -1575,7 +1575,6 @@ unlock:
     return 0;
 
 selfheal:
-    FRAME_SU_DO(frame, dht_local_t);
     ret = dht_selfheal_directory(frame, dht_lookup_selfheal_cbk, &local->loc,
                                  layout);
 out:
@@ -9488,7 +9487,6 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (local->call_cnt == 0) {
         /*Unlock namespace lock once mkdir is done on all subvols*/
         dht_unlock_namespace(frame, &local->lock[0]);
-        FRAME_SU_DO(frame, dht_local_t);
         dht_selfheal_directory(frame, dht_mkdir_selfheal_cbk, &local->loc,
                                layout);
         return 0;

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -1954,6 +1954,8 @@ dht_selfheal_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     char gfid[GF_UUID_BUF_SIZE] = {0};
     inode_t *linked_inode = NULL, *inode = NULL;
 
+    FRAME_SU_DO(frame, dht_local_t);
+
     local = frame->local;
     this = frame->this;
 


### PR DESCRIPTION
Problem:
dht_selfheal_directory() needs to be called with root permissions and
negative pid. Otherwise, in certain cases like geo-rep where the secondary
volumes have read-only xlator enabled for the bricks, the healing might
fail with EROFS due to the is_readonly_or_worm_enabled() check.

While fresh lookup code path and mkdir code path does this with FRAME_SU_DO,
revalidate lookup code path does not.

Fix:
Instead of adding FRAME_SU_DO() to every caller of
dht_selfheal_directory(), move the logic to inside the function itself.

Updates: #3240
Change-Id: Iaaf3ae3b9fdc82e784985b8d1b0425d39c9c29a3
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

