### PR TITLE
locks: fix race on client disconnect to avoid stale locks

### DIFF
--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -1040,12 +1040,19 @@ int
 pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
          int can_block)
 {
-    int ret = 0;
-
-    errno = 0;
+    int ret;
 
     pthread_mutex_lock(&pl_inode->mutex);
     {
+        if (GF_ATOMIC_GET(((client_t *)lock->client)->bind) == 0) {
+            /* The client that sent the lock request has disconnected. Unless
+             * this is an unlock request or it's non-blocking, we forbid it. */
+            if (can_block && (lock->fl_type != F_UNLCK)) {
+                pthread_mutex_unlock(&pl_inode->mutex);
+                ret = -ENOTCONN;
+                goto out;
+            }
+        }
         /* Send unlock before the actual lock to
            prevent lock upgrade / downgrade
            problems only if:
@@ -1055,17 +1062,20 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
 
         if (can_block && !(__is_lock_grantable(pl_inode, lock))) {
             ret = pl_send_prelock_unlock(this, pl_inode, lock);
-            if (ret)
+            if (ret) {
                 gf_log(this->name, GF_LOG_DEBUG,
                        "Could not send pre-lock "
                        "unlock");
+            }
         }
+
+        ret = PL_LOCK_GRANTED;
 
         if (__is_lock_grantable(pl_inode, lock)) {
             if (pl_metalock_is_active(pl_inode)) {
                 __pl_queue_lock(pl_inode, lock);
                 pthread_mutex_unlock(&pl_inode->mutex);
-                ret = -2;
+                ret = PL_LOCK_QUEUED;
                 goto out;
             }
             gf_log(this->name, GF_LOG_TRACE,
@@ -1078,7 +1088,7 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
             if (pl_metalock_is_active(pl_inode)) {
                 __pl_queue_lock(pl_inode, lock);
                 pthread_mutex_unlock(&pl_inode->mutex);
-                ret = -2;
+                ret = PL_LOCK_QUEUED;
                 goto out;
             }
             gf_log(this->name, GF_LOG_TRACE,
@@ -1093,15 +1103,14 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
 
             lock->blocked = 1;
             __insert_lock(pl_inode, lock);
-            ret = -1;
+            ret = PL_LOCK_WOULD_BLOCK;
         } else {
             gf_log(this->name, GF_LOG_TRACE,
                    "%s (pid=%d) lk-owner:%s %" PRId64 " - %" PRId64 " => NOK",
                    lock->fl_type == F_UNLCK ? "Unlock" : "Lock",
                    lock->client_pid, lkowner_utoa(&lock->owner),
                    lock->user_flock.l_start, lock->user_flock.l_len);
-            errno = EAGAIN;
-            ret = -1;
+            ret = PL_LOCK_WOULD_BLOCK;
         }
     }
     pthread_mutex_unlock(&pl_inode->mutex);

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -52,6 +52,12 @@
         }                                                                      \
     } while (0)
 
+enum {
+    PL_LOCK_GRANTED = 0,
+    PL_LOCK_WOULD_BLOCK,
+    PL_LOCK_QUEUED
+};
+
 posix_lock_t *
 new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
                gf_lkowner_t *owner, fd_t *fd, uint32_t lk_flags, int blocking,

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2755,7 +2755,13 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             }
 
             ret = pl_setlk(this, pl_inode, reqlock, can_block);
-            if (ret == -1) {
+            if (ret < 0) {
+                op_ret = -1;
+                op_errno = -ret;
+                __destroy_lock(reqlock);
+                goto out;
+            }
+            if (ret == PL_LOCK_WOULD_BLOCK) {
                 if ((can_block) && (F_UNLCK != lock_type)) {
                     goto out;
                 }
@@ -2763,7 +2769,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 op_ret = -1;
                 op_errno = EAGAIN;
                 __destroy_lock(reqlock);
-            } else if (ret == -2) {
+            } else if (ret == PL_LOCK_QUEUED) {
                 goto out;
             } else if ((0 == ret) && (F_UNLCK == flock->l_type)) {
                 /* For NLM's last "unlock on fd" detection */

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -282,6 +282,8 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
     posix_lock_t *lock = NULL;
     posix_lock_t *tmp = NULL;
     fd_t *fd = NULL;
+    pl_local_t *local;
+    int32_t op_errno;
 
     int can_block = 0;
     int32_t cmd = 0;
@@ -310,19 +312,26 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
 
         lock->blocked = 0;
         ret = pl_setlk(this, pl_inode, lock, can_block);
-        if (ret == -1) {
+        if (ret < 0) {
+            op_errno = -ret;
+        } else if (ret == PL_LOCK_WOULD_BLOCK) {
             if (can_block) {
                 continue;
             } else {
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
-                pl_trace_out(this, lock->frame, fd, NULL, cmd,
-                             &lock->user_flock, -1, EAGAIN, NULL);
-                pl_update_refkeeper(this, fd->inode);
-                STACK_UNWIND_STRICT(lk, lock->frame, -1, EAGAIN,
-                                    &lock->user_flock, NULL);
-                __destroy_lock(lock);
+                op_errno = EAGAIN;
             }
+        } else {
+            continue;
         }
+
+        pl_trace_out(this, lock->frame, fd, NULL, cmd, &lock->user_flock, -1,
+                     op_errno, NULL);
+        pl_update_refkeeper(this, fd->inode);
+        local = lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, lock->frame, -1, op_errno,
+                                 &lock->user_flock, NULL);
+        __destroy_lock(lock);
     }
 }
 


### PR DESCRIPTION
The following sequence of actions leads to a stale posix lock:

1. Client C1 sends write lock request L1. It's granted.

2. Client C2 sends write lock request L2.

3. L2 starts being processed by the brick's locks xlator, but nothing
   is created yet (an fd reference is held for this request).

4. C2 disconnects.

5. Brick's server xlator flushes all open fd's. This causes the removal
   of all locks from C2 (none in this case).

6. Brick's server releases it's fd reference (in normal circumstances
   this should be the last one, but not in this case).

7. Locks xlator continues processing L2 and adds it to the blocked
   list.

8. Eventually C1 releases L1. L2 is granted.

9. At this point the fd reference of L2 request is released. If it's
   the last one, pl_release() is called, which removes all locks on the
   fd. Otherwise L2 remains active indefinitely and blocks all other
   requests.

This patch makes sure that the client is alive before adding a new lock.

Fixes: #3182
Change-Id: I8f2afa310388fbee159a60478ac72e371cd030e1
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>