### PR TITLE
locks: fix race on client disconnect to avoid stale locks

### DIFF
--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -52,6 +52,12 @@
         }                                                                      \
     } while (0)
 
+enum {
+    PL_LOCK_GRANTED = 0,
+    PL_LOCK_WOULD_BLOCK,
+    PL_LOCK_QUEUED
+};
+
 posix_lock_t *
 new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
                gf_lkowner_t *owner, fd_t *fd, uint32_t lk_flags, int blocking,

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -282,6 +282,8 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
     posix_lock_t *lock = NULL;
     posix_lock_t *tmp = NULL;
     fd_t *fd = NULL;
+    pl_local_t *local;
+    int32_t op_errno;
 
     int can_block = 0;
     int32_t cmd = 0;
@@ -310,19 +312,26 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
 
         lock->blocked = 0;
         ret = pl_setlk(this, pl_inode, lock, can_block);
-        if (ret == -1) {
+        if (ret < 0) {
+            op_errno = -ret;
+        } else if (ret == PL_LOCK_WOULD_BLOCK) {
             if (can_block) {
                 continue;
             } else {
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
-                pl_trace_out(this, lock->frame, fd, NULL, cmd,
-                             &lock->user_flock, -1, EAGAIN, NULL);
-                pl_update_refkeeper(this, fd->inode);
-                STACK_UNWIND_STRICT(lk, lock->frame, -1, EAGAIN,
-                                    &lock->user_flock, NULL);
-                __destroy_lock(lock);
+                op_errno = EAGAIN;
             }
+        } else {
+            continue;
         }
+
+        pl_trace_out(this, lock->frame, fd, NULL, cmd, &lock->user_flock, -1,
+                     op_errno, NULL);
+        pl_update_refkeeper(this, fd->inode);
+        local = lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, lock->frame, -1, op_errno,
+                                 &lock->user_flock, NULL);
+        __destroy_lock(lock);
     }
 }
 


### PR DESCRIPTION
The following sequence of actions leads to a stale posix lock:

1. Client C1 sends write lock request L1. It's granted.

2. Client C2 sends write lock request L2.

3. L2 starts being processed by the brick's locks xlator, but nothing
   is created yet (an fd reference is held for this request).

4. C2 disconnects.

5. Brick's server xlator flushes all open fd's. This causes the removal
   of all locks from C2 (none in this case).

6. Brick's server releases it's fd reference (in normal circumstances
   this should be the last one, but not in this case).

7. Locks xlator continues processing L2 and adds it to the blocked
   list.

8. Eventually C1 releases L1. L2 is granted.

9. At this point the fd reference of L2 request is released. If it's
   the last one, pl_release() is called, which removes all locks on the
   fd. Otherwise L2 remains active indefinitely and blocks all other
   requests.

This patch makes sure that the client is alive before adding a new lock.

Fixes: #3182
Change-Id: I8f2afa310388fbee159a60478ac72e371cd030e1
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>