### PR TITLE
locks: fix fd leaks

### DIFF
--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -151,6 +151,7 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
 {
     posix_lock_t *plock = NULL;
     posix_lock_t *tmp = NULL;
+    pl_local_t *local;
     struct gf_flock ulock = {
         0,
     };
@@ -183,8 +184,9 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
                 pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
                              &plock->user_flock, -1, EINTR, NULL);
 
-                STACK_UNWIND_STRICT(lk, plock->frame, -1, EINTR,
-                                    &plock->user_flock, NULL);
+                local = plock->frame->local;
+                PL_STACK_UNWIND_AND_FREE(local, lk, plock->frame, -1, EINTR,
+                                         &plock->user_flock, NULL);
 
             } else {
                 gcount++;

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -1151,6 +1151,7 @@ pl_lock_preempt(pl_inode_t *pl_inode, posix_lock_t *reqlock)
     posix_lock_t *i = NULL;
     pl_rw_req_t *rw = NULL;
     pl_rw_req_t *itr = NULL;
+    pl_local_t *local;
     struct list_head unwind_blist = {
         0,
     };
@@ -1203,9 +1204,9 @@ pl_lock_preempt(pl_inode_t *pl_inode, posix_lock_t *reqlock)
     /* unwind blocked locks */
     list_for_each_entry_safe(lock, i, &unwind_blist, list)
     {
-        PL_STACK_UNWIND_AND_FREE(((pl_local_t *)lock->frame->local), lk,
-                                 lock->frame, -1, EBUSY, &lock->user_flock,
-                                 NULL);
+        local = lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, lock->frame, -1, EBUSY,
+                                 &lock->user_flock, NULL);
         __destroy_lock(lock);
     }
 

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -1164,6 +1164,7 @@ delete_locks_of_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd)
 {
     posix_lock_t *tmp = NULL;
     posix_lock_t *l = NULL;
+    pl_local_t *local;
 
     struct list_head blocked_list;
 
@@ -1188,7 +1189,9 @@ delete_locks_of_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd)
     list_for_each_entry_safe(l, tmp, &blocked_list, list)
     {
         list_del_init(&l->list);
-        STACK_UNWIND_STRICT(lk, l->frame, -1, EAGAIN, &l->user_flock, NULL);
+        local = l->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, l->frame, -1, EAGAIN,
+                                 &l->user_flock, NULL);
         __destroy_lock(l);
     }
 
@@ -2731,7 +2734,8 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 if (pl_inode->migrated) {
                     op_errno = EREMOTE;
                     pthread_mutex_unlock(&pl_inode->mutex);
-                    STACK_UNWIND_STRICT(lk, frame, -1, op_errno, flock, xdata);
+                    PL_STACK_UNWIND(lk, xdata, frame, -1, op_errno, flock,
+                                    xdata);
 
                     __destroy_lock(reqlock);
                     goto out;
@@ -2794,6 +2798,7 @@ int
 pl_forget(xlator_t *this, inode_t *inode)
 {
     pl_inode_t *pl_inode = NULL;
+    pl_local_t *local;
 
     posix_lock_t *ext_tmp = NULL;
     posix_lock_t *ext_l = NULL;
@@ -2894,8 +2899,9 @@ pl_forget(xlator_t *this, inode_t *inode)
     if (!list_empty(&posixlks_released)) {
         list_for_each_entry_safe(ext_l, ext_tmp, &posixlks_released, list)
         {
-            STACK_UNWIND_STRICT(lk, ext_l->frame, -1, 0, &ext_l->user_flock,
-                                NULL);
+            local = ext_l->frame->local;
+            PL_STACK_UNWIND_AND_FREE(local, lk, ext_l->frame, -1, 0,
+                                     &ext_l->user_flock, NULL);
             __destroy_lock(ext_l);
         }
     }
@@ -3438,6 +3444,7 @@ int
 pl_metaunlock(call_frame_t *frame, xlator_t *this, inode_t *inode, dict_t *dict)
 {
     pl_inode_t *pl_inode = NULL;
+    pl_local_t *local;
     int ret = 0;
     pl_meta_lock_t *meta_lock = NULL;
     pl_meta_lock_t *tmp_metalk = NULL;
@@ -3523,8 +3530,9 @@ out:
     {
         list_del_init(&posix_lock->list);
 
-        STACK_UNWIND_STRICT(lk, posix_lock->frame, -1, EREMOTE,
-                            &posix_lock->user_flock, NULL);
+        local = posix_lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, posix_lock->frame, -1, EREMOTE,
+                                 &posix_lock->user_flock, NULL);
 
         __destroy_lock(posix_lock);
     }
@@ -3988,6 +3996,7 @@ pl_metalk_client_cleanup(xlator_t *this, pl_ctx_t *ctx)
     pl_inode_t *pl_inode = NULL;
     posix_lock_t *posix_lock = NULL;
     posix_lock_t *tmp_posixlk = NULL;
+    pl_local_t *local;
     struct list_head tmp_posixlk_list;
 
     INIT_LIST_HEAD(&tmp_posixlk_list);
@@ -4037,8 +4046,9 @@ unlock:
     {
         list_del_init(&posix_lock->list);
 
-        STACK_UNWIND_STRICT(lk, posix_lock->frame, -1, EREMOTE,
-                            &posix_lock->user_flock, NULL);
+        local = posix_lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, posix_lock->frame, -1, EREMOTE,
+                                 &posix_lock->user_flock, NULL);
 
         __destroy_lock(posix_lock);
     }


### PR DESCRIPTION
In some cases fd's were not released after waking a blocked lock.

Fixes: #3187
Change-Id: I4c138acf1d3b38334539334be3f68ec9c6b583f2
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

