### PR TITLE
configure: Fix incorrect directory check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -798,7 +798,7 @@ AS_IF([test "x$enable_fuse_notifications" != "xno"], [
 dnl Find out OpenSSL trusted certificates path
 AC_MSG_CHECKING([for OpenSSL trusted certificates path])
 SSL_CERT_PATH=$(openssl version -d | sed -e 's|OPENSSLDIR: "\(.*\)".*|\1|')
-if test -d $SSL_CERT_PATH 1>/dev/null 2>&1; then
+if test -d "${SSL_CERT_PATH}" 1>/dev/null 2>&1; then
    AC_MSG_RESULT([$SSL_CERT_PATH])
    AC_DEFINE_UNQUOTED(SSL_CERT_PATH, ["$SSL_CERT_PATH"], [Path to OpenSSL trusted certificates.])
    AC_SUBST(SSL_CERT_PATH)
@@ -1425,7 +1425,7 @@ exec_prefix=$old_exec_prefix
 
 ### Dirty hacky stuff to make LOCALSTATEDIR work
 if test "x$prefix" = xNONE; then
-   test $localstatedir = '${prefix}/var' && localstatedir=$ac_default_prefix/var
+   test "${localstatedir}" = '${prefix}/var' && localstatedir=$ac_default_prefix/var
    localstatedir=/var
 fi
 localstatedir="$(eval echo ${localstatedir})"
@@ -1856,7 +1856,7 @@ AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
 
 AC_SUBST(GLUSTERD_WORKDIR)
-AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d ${GLUSTERD_WORKDIR} && test -d ${sysconfdir}/glusterd )
+AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d "${GLUSTERD_WORKDIR}" && test -d "${sysconfdir}/glusterd" )
 AC_SUBST(GLUSTERD_VOLFILE)
 AC_SUBST(GLUSTERFS_LIBEXECDIR)
 AC_SUBST(GLUSTERFSD_MISCDIR)

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -276,7 +276,7 @@ BuildRequires:    libtsan
 BuildRequires:    bison flex
 BuildRequires:    gcc make libtool
 BuildRequires:    ncurses-devel readline-devel
-BuildRequires:    libxml2-devel openssl-devel
+BuildRequires:    libxml2-devel openssl-devel openssl
 BuildRequires:    libaio-devel libacl-devel
 BuildRequires:    python%{_pythonver}-devel
 %if ( 0%{!?_without_tcmalloc:1} )
@@ -1663,6 +1663,9 @@ exit 0
 %endif
 
 %changelog
+* Mon Feb 21 2022 Xavi Hernandez <xhernandez@redhat.com>
+- add openssl as a build dependency.
+
 * Mon Nov 1 2021 Kaleb S. KEITHLEY <kkeithle [at] redhat.com>
 - tcmalloc issues
 


### PR DESCRIPTION
Running 'test -d $VAR' with 'VAR' empty should fail, but it actually
succeeds. To fix this problem, the variables have been enclosed in
quotes.

Updates: #3234
Change-Id: Ic0ba43eec06335b905caf93520cade5ef019c36a
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

