### PR TITLE
glusterd: fix -Wstringop-overflow and -Wstringop-truncation

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -14815,7 +14815,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
         if (tmpptr == NULL)
             goto check_failed;
         addrlen = strlen(brick) - strlen(tmpptr);
-        strncpy(brick_addr, brick, addrlen);
+        strncpy(brick_addr, brick, sizeof(brick_addr));
         brick_addr[addrlen] = '\0';
         ret = getaddrinfo(brick_addr, NULL, NULL, &ai_info);
         if (ret != 0) {
@@ -14974,6 +14974,7 @@ glusterd_add_peers_to_auth_list(char *volname)
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;
     int32_t len = 0;
+    char *ptr = NULL;
     char *auth_allow_list = NULL;
     char *new_auth_allow_list = NULL;
 
@@ -15009,18 +15010,17 @@ glusterd_add_peers_to_auth_list(char *volname)
 
     new_auth_allow_list = GF_CALLOC(1, len, gf_common_mt_char);
 
-    new_auth_allow_list = strncat(new_auth_allow_list, auth_allow_list,
-                                  strlen(auth_allow_list));
+    strncat(new_auth_allow_list, auth_allow_list, len);
+    ptr = new_auth_allow_list + strlen(auth_allow_list);
+
     cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
     {
         ret = search_peer_in_auth_list(peerinfo->hostname, new_auth_allow_list);
         if (!ret) {
             gf_log(this->name, GF_LOG_DEBUG,
                    "peer %s not found in auth.allow list", peerinfo->hostname);
-            new_auth_allow_list = strcat(new_auth_allow_list, ",");
-            new_auth_allow_list = strncat(new_auth_allow_list,
-                                          peerinfo->hostname,
-                                          strlen(peerinfo->hostname));
+            ptr += snprintf(ptr, len - (ptr - new_auth_allow_list), ",%s",
+                            peerinfo->hostname);
         }
     }
     if (strcmp(new_auth_allow_list, auth_allow_list) != 0) {


### PR DESCRIPTION
Fix the following `-Wstringop-overflow` and `-Wstringop-truncation` warnings:
```
glusterd-volgen.c:3760:9: warning: ‘strncat’ specified bound depends on
the length of the source argument [-Wstringop-overflow=]
 3760 |         strncat(ptr, brick->brick_id, strlen(brick->brick_id));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
glusterd-volgen.c:3781:21: warning: ‘strncat’ specified bound depends on
the length of the source argument [-Wstringop-overflow=]
 3781 |                     strncat(ptr, ta_brick->brick_id,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3782 |                             strlen(ta_brick->brick_id));
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
glusterd-utils.c:14818:9: warning: ‘strncpy’ specified bound depends on
the length of the source argument [-Wstringop-truncation]
14818 |         strncpy(brick_addr, brick, addrlen);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glusterd-utils.c:14817:19: note: length computed here
14817 |         addrlen = strlen(brick) - strlen(tmpptr);
      |                   ^~~~~~~~~~~~~
```
```
glusterd-utils.c:15012:27: warning: ‘strncat’ specified bound depends on
the length of the source argument [-Wstringop-overflow=]
15012 |     new_auth_allow_list = strncat(new_auth_allow_list, auth_allow_list,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
15013 |                                   strlen(auth_allow_list));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
```
```
glusterd-utils.c:15021:35: warning: ‘strncat’ specified bound depends on
the length of the source argument [-Wstringop-overflow=]
15021 |             new_auth_allow_list = strncat(new_auth_allow_list,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
15022 |                                           peerinfo->hostname,
      |                                           ~~~~~~~~~~~~~~~~~~~
15023 |                                           strlen(peerinfo->hostname));
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

