### PR TITLE
garbage value fix

### DIFF
--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -290,7 +290,7 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
         gf_log(this->name, GF_LOG_TRACE, "No blocked lock calls to be granted");
         return;
     }
-
+    INIT_LIST_HEAD(&granted);
     pthread_mutex_lock(&pl_inode->mutex);
     {
         __grant_blocked_lock_calls(this, pl_inode, &granted);


### PR DESCRIPTION
Issue: The left operand of '-' is a garbage value at 300
Fix: granted is declared in grant_blocked_lock_calls() but not initialized. Hence later access to field 'next' in list_entry_lst_safe leads to invalid access location. So initialize granted before use.

Updates: #1060 
Change-Id: I3307c318acb60cc105ab59f44132d751046b2bac

Signed-off-by: Harshita Shree hshree@redhat.com

