### PR TITLE
afr/notify: Fix notify argument for upcall

### DIFF
--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -183,11 +183,12 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
             xlator_list_t *parent = this->parents;
 
             if (!parent && this->ctx && this->ctx->root)
-                xlator_notify(this->ctx->root, event, data, NULL);
+                XLATOR_NOTIFY(ret, ((xlator_t *)(this->ctx->root)), event, data,
+                              this);
 
             while (parent) {
                 if (parent->xlator->init_succeeded)
-                    xlator_notify(parent->xlator, event, data, NULL);
+                    XLATOR_NOTIFY(ret, (parent->xlator), event, data, this);
                 parent = parent->next;
             }
         } break;
@@ -196,7 +197,7 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
 
             while (parent) {
                 if (parent->xlator->init_succeeded)
-                    XLATOR_NOTIFY(ret, parent->xlator, event, this, data);
+                    XLATOR_NOTIFY(ret, parent->xlator, event, data, this);
                 parent = parent->next;
             }
         } break;

--- a/tests/bugs/replicate/issue-3252-arbiter-invalid-size.t
+++ b/tests/bugs/replicate/issue-3252-arbiter-invalid-size.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 2 arbiter 1 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume set $V0 features.cache-invalidation on
+TEST $CLI volume set $V0 performance.cache-invalidation on
+TEST $CLI volume set $V0 features.cache-invalidation-timeout 600
+TEST $CLI volume set $V0 performance.md-cache-timeout 600
+TEST $CLI volume set $V0 performance.write-behind off
+
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M1;
+
+#Kill the arbiter brick and restart it to minimize the impact of setattr delay
+TEST $CLI volume set $V0 delay-gen arbiter
+TEST $CLI volume set $V0 delay-gen.enable setattr,fsetattr
+TEST $CLI volume set $V0 delay-gen.delay-percentage 100
+TEST $CLI volume set $V0 delay-gen.delay-duration 5000000
+
+TEST kill_brick $V0 $H0 $B0/${V0}2
+TEST $CLI volume start $V0 force
+
+dd if=/dev/zero of=$M0/datafile bs=1024 count=1024
+EXPECT "^0$" echo $?
+
+TEST ls $M1/datafile
+TEST touch -m -t 203012311159.59 $M0/datafile
+#touch command will have a delay in arbiter xlator and the upcall will be delayed
+fileSize=`stat -c '%s' $M1/datafile`
+EXPECT_NOT "^0$" echo $fileSize
+cleanup;

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -37,7 +37,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
     void *data2 = NULL;
 
     va_start(ap, data);
-    data2 = va_arg(ap, dict_t *);
+    data2 = va_arg(ap, void *);
     va_end(ap);
     ret = afr_notify(this, event, data, data2);
 


### PR DESCRIPTION
upcall notification expects the upcall data struct
gf_upcall_cache_invalidation as the main argument.
While AFR requires another argument to identify the
child xlator who send the upcall. As of now, afr_notify
was using the upcall structure as the xlator variable
and was calculating the child xlator index value to
a wrong value.

This patch fixes the child index calculation, as well
as tries to have a uniform way to calculate it. This
patch has also moved the handling of notification for
GF_EVENT_TRANSLATOR_OP is the first one to process since
this event doesn't have any meaningful child_xlator
computation.

Change-Id: I7bf03aea53fdedec298869a82efd9b2c6b4e867c
fixes: https://github.com/gluster/glusterfs/issues/3253
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

