### PR TITLE
afr/upcall: Skip upcall notification from Arbiter

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -6187,7 +6187,7 @@ afr_handle_inodelk_contention(xlator_t *this, struct gf_upcall *upcall)
 }
 
 static void
-afr_handle_upcall_event(xlator_t *this, struct gf_upcall *upcall)
+afr_handle_upcall_event(xlator_t *this, struct gf_upcall *upcall, const int idx)
 {
     struct gf_upcall_cache_invalidation *up_ci = NULL;
     afr_private_t *priv = this->private;
@@ -6202,6 +6202,13 @@ afr_handle_upcall_event(xlator_t *this, struct gf_upcall *upcall)
         case GF_UPCALL_CACHE_INVALIDATION:
             up_ci = (struct gf_upcall_cache_invalidation *)upcall->data;
 
+            if (AFR_IS_ARBITER_BRICK(priv, idx)) {
+                /* Skip all update involving iatt from arbiter
+                 * node, since the size contains invalid info
+                 */
+                up_ci->flags &= ~UP_ATTR_FLAGS;
+                up_ci->flags &= ~UP_PARENT_DENTRY_FLAGS;
+            }
             /* Since md-cache will be aggressively filtering
              * lookups, the stale read issue will be more
              * pronounced. Hence when a pending xattr is set notify
@@ -6329,7 +6336,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
     }
 
     if (event == GF_EVENT_UPCALL) {
-        afr_handle_upcall_event(this, data);
+        afr_handle_upcall_event(this, data, idx);
     }
 
     LOCK(&priv->lock);


### PR DESCRIPTION
We never used to select Arbiter node as read subvol, hence
it is not a wise decesion to send an upcall notification
from Arbiter node that has an iatt update flag.

But we may need to invalidate the entries if pending xatrrs
are present on the dict. So we strip out only the flag that
request iatt update.

Change-Id: I3629d33019c93944b61b0de2d040000cb95a64df
fixes: https://github.com/gluster/glusterfs/issues/3252
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

