### PR TITLE
Fixes:3177 Multiple posix locks are aborted with EINTR when one of them is interrupted

### DIFF
--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -144,7 +144,8 @@ out:
 
 int
 clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
-                    int *blkd, int *granted, int *op_errno)
+                    int *blkd, int *granted, int *op_errno, char *client_uid,
+                    pid_t client_pid)
 {
     posix_lock_t *plock = NULL;
     posix_lock_t *tmp = NULL;
@@ -174,6 +175,11 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
                               plock->user_flock.l_start != ulock.l_start ||
                               plock->user_flock.l_len != ulock.l_len))
                 continue;
+
+            if (strcmp(plock->client_uid, client_uid) != 0 ||
+                plock->client_pid != client_pid) {
+                continue;
+            }
 
             list_del_init(&plock->list);
             if (plock->blocked) {

--- a/xlators/features/locks/src/clear.h
+++ b/xlators/features/locks/src/clear.h
@@ -57,7 +57,8 @@ clrlk_parse_args(const char *cmd, clrlk_args *args);
 
 int
 clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
-                    int *blkd, int *granted, int *op_errno);
+                    int *blkd, int *granted, int *op_errno, char *client_uid,
+                    pid_t client_pid);
 int
 clrlk_clear_inodelk(xlator_t *this, pl_inode_t *pl_inode, pl_dom_list_t *dom,
                     clrlk_args *args, int *blkd, int *granted, int *op_errno);


### PR DESCRIPTION
Change-Id: I406e138ff7cf1647cedef0ad7e3cfbd56e629742

After this modification, the specified POSIX lock can be closed, while other POSIX locks are not affected.

Using the program provided [here](https://gist.github.com/xhernandez/27ca2aa06bcb36a3134a7ba4511e6283), this issue can be seen running these tests.
    test_wrlock(0, 1); /* this lock is granted. */
    test_wrlock(1, 0); /* this lock is blocked. */
    test_wrlock(2, 1); /* this lock is blocked. */
    test_interrupt(1, 1); /* only lock 1 should be unblocked. */
    test_unlock(0, 1);

The result is as follow after modification:
     [root@paas-controller:/mnt/test]$ ./test-1 /mnt/test/file
        0: Locking
        0: Locked
        1: Locking
        2: Locking
        1: Received signal 18
        1: fcntl() failed: (11) Resource temporarily unavailable
        0: Unlocking
        2: Locked
        0: Unlocked

So the specified POSIX lock are aborted with EINTR when the posix lock is interrupted. Other POSIX locks are not affected.

Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>

