### PR TITLE
afr/metadata-heal: Avoid healing mdata for Arbiter node

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -269,7 +269,7 @@ gf_boolean_t
 are_dicts_equal(dict_t *one, dict_t *two,
                 gf_boolean_t (*match)(dict_t *d, char *k, data_t *v,
                                       void *data),
-                gf_boolean_t (*value_ignore)(char *k))
+                void *match_data, gf_boolean_t (*value_ignore)(char *k))
 {
     int num_matches1 = 0;
     int num_matches2 = 0;
@@ -289,7 +289,8 @@ are_dicts_equal(dict_t *one, dict_t *two,
 
     cmp.dict = two;
     cmp.value_ignore = value_ignore;
-    num_matches1 = dict_foreach_match(one, match, NULL, key_value_cmp, &cmp);
+    num_matches1 = dict_foreach_match(one, match, match_data, key_value_cmp,
+                                      &cmp);
 
     if (num_matches1 == -1)
         return _gf_false;
@@ -297,8 +298,8 @@ are_dicts_equal(dict_t *one, dict_t *two,
     if ((num_matches1 == one->count) && (one->count == two->count))
         return _gf_true;
 
-    num_matches2 = dict_foreach_match(two, match, NULL, dict_null_foreach_fn,
-                                      NULL);
+    num_matches2 = dict_foreach_match(two, match, match_data,
+                                      dict_null_foreach_fn, NULL);
 done:
     /* If the number of matches is same in 'two' then for all the
      * valid-keys that exist in 'one' the value matched and no extra valid

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -420,7 +420,7 @@ gf_boolean_t
 are_dicts_equal(dict_t *one, dict_t *two,
                 gf_boolean_t (*match)(dict_t *d, char *k, data_t *v,
                                       void *data),
-                gf_boolean_t (*value_ignore)(char *k));
+                void *match_data, gf_boolean_t (*value_ignore)(char *k));
 int
 dict_has_key_from_array(dict_t *dict, char **strings, gf_boolean_t *result);
 

--- a/tests/bugs/replicate/issue-3238-mdata-unnecessary-heal.t
+++ b/tests/bugs/replicate/issue-3238-mdata-unnecessary-heal.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 2 arbiter 1 $H0:$B0/${V0}{0,1,2}
+TEST $CLI volume set $V0 cluster.self-heal-daemon off
+TEST $CLI volume set $V0 cluster.entry-self-heal off
+TEST $CLI volume set $V0 cluster.data-self-heal off
+TEST $CLI volume set $V0 cluster.metadata-self-heal on
+TEST $CLI volume profile $V0 start
+
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M1;
+dd if=/dev/zero of=$M0/datafile bs=1024 count=1024
+EXPECT "^0$" echo $?
+
+#Perform a lookup from second client to validate the metadata
+
+$CLI volume profile $V0 info clear>>/dev/null
+TEST ls $M1/datafile
+#Check whether SETATTR present in the profile, a normal lookup should not trigger setattr unless client side heal is performed
+setattrCount=`$CLI volume profile $V0 info increment | grep SETATTR | awk '{print $8}'|tr -d '\n'`
+EXPECT "^$" echo $setattrCount
+
+cleanup;

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -1360,7 +1360,9 @@ afr_mark_source_sinks_if_file_empty(xlator_t *this, unsigned char *sources,
             return -1;
     }
     for (i = 1; i < priv->child_count; i++) {
-        if (!afr_xattrs_are_equal(replies[0].xdata, replies[i].xdata))
+        if (!afr_xattrs_are_equal(
+                replies[0].xdata, replies[i].xdata,
+                AFR_IS_ARBITER_BRICK(priv, i) ? _gf_true : _gf_false))
             return -1;
     }
 

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -176,7 +176,9 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
             !IA_EQUAL(source_ia, child_ia, prot) ||
             !IA_EQUAL(source_ia, child_ia, uid) ||
             !IA_EQUAL(source_ia, child_ia, gid) ||
-            !afr_xattrs_are_equal(replies[source].xdata, replies[i].xdata))
+            !afr_xattrs_are_equal(
+                replies[source].xdata, replies[i].xdata,
+                AFR_IS_ARBITER_BRICK(priv, i) ? _gf_true : _gf_false))
             goto out;
     }
 
@@ -343,7 +345,9 @@ __afr_selfheal_metadata_finalize_source(call_frame_t *frame, xlator_t *this,
     for (i = 0; i < priv->child_count; i++) {
         if (!sources[i] || i == source)
             continue;
-        if (!afr_xattrs_are_equal(replies[source].xdata, replies[i].xdata)) {
+        if (!afr_xattrs_are_equal(
+                replies[source].xdata, replies[i].xdata,
+                AFR_IS_ARBITER_BRICK(priv, i) ? _gf_true : _gf_false)) {
             gf_msg_debug(this->name, 0,
                          "%s: xattr mismatch "
                          "for source(%d) vs (%d)",
@@ -353,6 +357,7 @@ __afr_selfheal_metadata_finalize_source(call_frame_t *frame, xlator_t *this,
             healed_sinks[i] = 1;
         }
     }
+
     if ((sources_count == priv->child_count) && (source > -1) &&
         (AFR_COUNT(healed_sinks, priv->child_count) != 0)) {
         ret = __afr_selfheal_metadata_mark_pending_xattrs(frame, this, inode,

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -764,7 +764,7 @@ afr_shd_ta_check_and_unset_xattrs(xlator_t *this, loc_t *loc,
     if (ret)
         goto unref;
 
-    if (!are_dicts_equal(pre_crawl_xdata, post_crawl_xdata, NULL, NULL)) {
+    if (!are_dicts_equal(pre_crawl_xdata, post_crawl_xdata, NULL, NULL, NULL)) {
         ret = -1;
         goto unref;
     }

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1170,7 +1170,7 @@ void
 afr_replies_wipe(struct afr_reply *replies, int count);
 
 gf_boolean_t
-afr_xattrs_are_equal(dict_t *dict1, dict_t *dict2);
+afr_xattrs_are_equal(dict_t *dict1, dict_t *dict2, gf_boolean_t is_arbiter);
 
 gf_boolean_t
 afr_is_xattr_ignorable(char *key);

--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -259,7 +259,7 @@ ec_value_ignore(char *key)
 int32_t
 ec_dict_compare(dict_t *dict1, dict_t *dict2)
 {
-    if (are_dicts_equal(dict1, dict2, ec_xattr_match, ec_value_ignore))
+    if (are_dicts_equal(dict1, dict2, ec_xattr_match, NULL, ec_value_ignore))
         return 1;
     return 0;
 }

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -647,7 +647,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
                 !IA_EQUAL(source_ia, child_ia, gid))
                 continue;
             if (!are_dicts_equal(replies[i].xdata, replies[j].xdata,
-                                 ec_sh_key_match, NULL))
+                                 ec_sh_key_match, NULL, NULL))
                 continue;
             groups[j] = i;
             same_count++;


### PR DESCRIPTION
afr/metadata-heal: Avoid healing mdata for Arbiter node
    
It is expected to have differences in time attributes for
Arbiter node as we are not doing most of the operations
on Arbiter node. Hence we don't need to check for mdata
value in the dict while calculating sinks for a metadata
heal.
    
Change-Id: I326017fcb5810d7ce765e189167a4101c6b0a046
fixes: https://github.com/gluster/glusterfs/issues/3238
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>
