### PR TITLE
dht: Synchronize layout_(ref|unref) during layout_(get|set) in dht co…

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -11213,7 +11213,7 @@ dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this, dht_layout_t **layout)
             if (ctx && ctx->layout) {
                 if (layout) {
                     *layout = ctx->layout;
-                    GF_ATOMIC_INC((*layout)->ref);
+                    dht_layout_ref(ctx->layout);
                 }
             } else {
                 ret = -1;

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -533,7 +533,6 @@ struct dht_conf {
     int32_t refresh_interval;
     gf_lock_t subvolume_lock;
     time_t last_stat_fetch;
-    gf_lock_t layout_lock;
     dict_t *leaf_to_subvol;
     void *private; /* Can be used by wrapper xlators over
                       dht */

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -1150,7 +1150,7 @@ dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this,
                          dht_layout_t **layout_int);
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int, dht_layout_t **old_layout);
+                         dht_layout_t *layout_int);
 int
 dht_inode_ctx_time_update(inode_t *inode, xlator_t *this, struct iatt *prestat,
                           struct iatt *poststat);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -865,7 +865,7 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout);
 void
 dht_layout_unref(dht_layout_t *layout);
 dht_layout_t *
-dht_layout_ref(xlator_t *this, dht_layout_t *layout);
+dht_layout_ref(dht_layout_t *layout);
 int
 dht_layout_index_for_subvol(dht_layout_t *layout, xlator_t *subvol);
 xlator_t *

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -673,7 +673,7 @@ typedef struct dht_fd_ctx {
 #define ENTRY_MISSING(op_ret, op_errno) (op_ret == -1 && op_errno == ENOENT)
 
 #define is_revalidate(loc)                                                     \
-    (dht_inode_ctx_layout_get((loc)->inode, this, NULL, 0) == 0)
+    (dht_inode_ctx_layout_get((loc)->inode, this, NULL) == 0)
 
 #define is_last_call(cnt) (cnt == 0)
 
@@ -1147,10 +1147,11 @@ gf_defrag_handle_hardlink(xlator_t *this, loc_t *loc, int *fop_errno);
 
 int
 dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this,
-                         dht_layout_t **layout_int, int ref);
+                         dht_layout_t **layout_int);
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int);
+                         dht_layout_t *layout_int, dht_layout_t **old_layout,
+                         int ref);
 int
 dht_inode_ctx_time_update(inode_t *inode, xlator_t *this, struct iatt *prestat,
                           struct iatt *poststat);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -1150,8 +1150,7 @@ dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this,
                          dht_layout_t **layout_int);
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int, dht_layout_t **old_layout,
-                         int ref);
+                         dht_layout_t *layout_int, dht_layout_t **old_layout);
 int
 dht_inode_ctx_time_update(inode_t *inode, xlator_t *this, struct iatt *prestat,
                           struct iatt *poststat);

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -673,7 +673,7 @@ typedef struct dht_fd_ctx {
 #define ENTRY_MISSING(op_ret, op_errno) (op_ret == -1 && op_errno == ENOENT)
 
 #define is_revalidate(loc)                                                     \
-    (dht_inode_ctx_layout_get((loc)->inode, this, NULL) == 0)
+    (dht_inode_ctx_layout_get((loc)->inode, this, NULL, 0) == 0)
 
 #define is_last_call(cnt) (cnt == 0)
 
@@ -1147,7 +1147,7 @@ gf_defrag_handle_hardlink(xlator_t *this, loc_t *loc, int *fop_errno);
 
 int
 dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this,
-                         dht_layout_t **layout_int);
+                         dht_layout_t **layout_int, int ref);
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
                          dht_layout_t *layout_int);

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -307,7 +307,7 @@ dht_free_disk_available_subvol(xlator_t *this, xlator_t *subvol,
             goto out;
         }
     } else {
-        layout = dht_layout_ref(this, local->layout);
+        layout = dht_layout_ref(local->layout);
     }
 
     LOCK(&conf->subvolume_lock);

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1788,8 +1788,7 @@ dht_rebalance_in_progress_check(xlator_t *this, call_frame_t *frame)
 
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int, dht_layout_t **old_layout,
-                         int ref)
+                         dht_layout_t *layout_int, dht_layout_t **old_layout)
 {
     dht_inode_ctx_t *ctx = NULL;
     int ret = -1;
@@ -1819,7 +1818,7 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
                 ret = -1;
             }
         }
-        if (!ret && layout_int && ref)
+        if (!ret && layout_int)
             GF_ATOMIC_INC(layout_int->ref);
     }
     UNLOCK(&inode->lock);

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1819,7 +1819,7 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
             }
         }
         if (!ret && layout_int)
-            GF_ATOMIC_INC(layout_int->ref);
+            dht_layout_ref(ctx->layout);
     }
     UNLOCK(&inode->lock);
 

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1788,11 +1788,12 @@ dht_rebalance_in_progress_check(xlator_t *this, call_frame_t *frame)
 
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int, dht_layout_t **old_layout)
+                         dht_layout_t *layout_int)
 {
     dht_inode_ctx_t *ctx = NULL;
     int ret = -1;
     uint64_t ctx_int = 0;
+    dht_layout_t *old_layout = NULL;
 
     LOCK(&inode->lock);
     {
@@ -1800,8 +1801,7 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
         if (!ret) {
             ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
             if (ctx) {
-                if (ctx->layout && old_layout)
-                    (*old_layout) = ctx->layout;
+                old_layout = ctx->layout;
                 ctx->layout = layout_int;
             }
         }
@@ -1822,6 +1822,9 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
             dht_layout_ref(ctx->layout);
     }
     UNLOCK(&inode->lock);
+
+    if (old_layout)
+        dht_layout_unref(old_layout);
 
     return ret;
 }

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1788,7 +1788,8 @@ dht_rebalance_in_progress_check(xlator_t *this, call_frame_t *frame)
 
 int
 dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
-                         dht_layout_t *layout_int)
+                         dht_layout_t *layout_int, dht_layout_t **old_layout,
+                         int ref)
 {
     dht_inode_ctx_t *ctx = NULL;
     int ret = -1;
@@ -1800,6 +1801,8 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
         if (!ret) {
             ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
             if (ctx) {
+                if (ctx->layout && old_layout)
+                    (*old_layout) = ctx->layout;
                 ctx->layout = layout_int;
             }
         }
@@ -1814,6 +1817,8 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
                     GF_FREE(ctx);
             }
         }
+        if (!ret && layout_int && ref)
+            GF_ATOMIC_INC(layout_int->ref);
     }
     UNLOCK(&inode->lock);
 

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1815,6 +1815,8 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
                 ret = __inode_ctx_set0(inode, this, &ctx_int);
                 if (ret)
                     GF_FREE(ctx);
+            } else {
+                ret = -1;
             }
         }
         if (!ret && layout_int && ref)

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -72,7 +72,7 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
     if (!conf || !layout)
         goto out;
 
-    ret = dht_inode_ctx_layout_set(inode, this, layout, &old_layout, 1);
+    ret = dht_inode_ctx_layout_set(inode, this, layout, &old_layout);
 
     if (old_layout)
         dht_layout_unref(old_layout);
@@ -706,7 +706,7 @@ dht_layout_preset(xlator_t *this, xlator_t *subvol, inode_t *inode)
     gf_msg_debug(this->name, 0, "file = %s, subvol = %s",
                  uuid_utoa(inode->gfid), subvol ? subvol->name : "<nil>");
 
-    ret = dht_inode_ctx_layout_set(inode, this, layout, NULL, 0);
+    ret = dht_inode_ctx_layout_set(inode, this, layout, NULL);
 
 out:
     return ret;

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -66,8 +66,7 @@ dht_layout_get(xlator_t *this, inode_t *inode)
             ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
             if (ctx && ctx->layout) {
                 layout = ctx->layout;
-                if (layout)
-                    GF_ATOMIC_INC(layout->ref);
+                GF_ATOMIC_INC(layout->ref);
             }
         }
     }
@@ -81,7 +80,6 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
 {
     dht_conf_t *conf = NULL;
     int ret = -1;
-    dht_layout_t *old_layout;
     uint64_t ctx_int = 0;
     dht_inode_ctx_t *ctx = NULL;
 
@@ -95,9 +93,7 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
         if (!ret) {
             ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
             if (ctx && ctx->layout) {
-                old_layout = ctx->layout;
-                if (old_layout)
-                    dht_layout_unref(old_layout);
+                dht_layout_unref(ctx->layout);
             }
         }
 
@@ -117,8 +113,8 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
                 ret = __inode_ctx_set0(inode, this, &ctx_int);
                 if (ret)
                     GF_ATOMIC_DEC(layout->ref);
-           }
-       }
+            }
+        }
     }
     UNLOCK(&inode->lock);
 out:
@@ -752,7 +748,6 @@ dht_layout_preset(xlator_t *this, xlator_t *subvol, inode_t *inode)
     gf_msg_debug(this->name, 0, "file = %s, subvol = %s",
                  uuid_utoa(inode->gfid), subvol ? subvol->name : "<nil>");
 
-
     LOCK(&inode->lock);
     {
         ret = __inode_ctx_get(inode, this, &ctx_int);
@@ -771,7 +766,6 @@ dht_layout_preset(xlator_t *this, xlator_t *subvol, inode_t *inode)
                 ret = __inode_ctx_set0(inode, this, &ctx_int);
             }
         }
-
     }
     UNLOCK(&inode->lock);
 out:

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -96,9 +96,9 @@ dht_layout_unref(dht_layout_t *layout)
 }
 
 dht_layout_t *
-dht_layout_ref(xlator_t *this, dht_layout_t *layout)
+dht_layout_ref(dht_layout_t *layout)
 {
-    if (layout->preset || !this->private)
+    if (layout->preset)
         return layout;
 
     GF_ATOMIC_INC(layout->ref);

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -66,16 +66,12 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
 {
     dht_conf_t *conf = NULL;
     int ret = -1;
-    dht_layout_t *old_layout = NULL;
 
     conf = this->private;
     if (!conf || !layout)
         goto out;
 
-    ret = dht_inode_ctx_layout_set(inode, this, layout, &old_layout);
-
-    if (old_layout)
-        dht_layout_unref(old_layout);
+    ret = dht_inode_ctx_layout_set(inode, this, layout);
 
 out:
     return ret;
@@ -706,7 +702,7 @@ dht_layout_preset(xlator_t *this, xlator_t *subvol, inode_t *inode)
     gf_msg_debug(this->name, 0, "file = %s, subvol = %s",
                  uuid_utoa(inode->gfid), subvol ? subvol->name : "<nil>");
 
-    ret = dht_inode_ctx_layout_set(inode, this, layout, NULL);
+    ret = dht_inode_ctx_layout_set(inode, this, layout);
 
 out:
     return ret;

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -534,7 +534,7 @@ dht_selfheal_layout_lock(call_frame_t *frame, dht_layout_t *layout,
     local->selfheal.should_heal = should_heal;
 
     tmp = local->selfheal.layout;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
     dht_layout_unref(tmp);
 
     if (!newdir) {
@@ -1898,7 +1898,7 @@ dht_selfheal_new_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     inode_unref(inode);
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     dht_layout_sort_volname(layout);
     dht_selfheal_layout_new_directory(frame, &local->loc, layout);
@@ -1927,7 +1927,7 @@ dht_fix_directory_layout(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     local = frame->local;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     /* No layout sorting required here */
     tmp_layout = dht_fix_layout_of_directory(frame, &local->loc, layout);
@@ -1960,7 +1960,7 @@ dht_selfheal_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     this = frame->this;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     if (local->need_attrheal) {
         if (__is_root_gfid(local->stbuf.ia_gfid)) {
@@ -2065,7 +2065,7 @@ dht_selfheal_restore(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     local = frame->local;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     ret = dht_selfheal_dir_mkdir(frame, loc, layout, 1);
 

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -643,7 +643,6 @@ dht_init(xlator_t *this)
     }
 
     LOCK_INIT(&conf->subvolume_lock);
-    LOCK_INIT(&conf->layout_lock);
     LOCK_INIT(&conf->lock);
     synclock_init(&conf->link_lock, SYNC_LOCK_DEFAULT);
 

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -161,7 +161,7 @@ dht_inodectx_dump(xlator_t *this, inode_t *inode)
     if (!inode)
         goto out;
 
-    ret = dht_inode_ctx_layout_get(inode, this, &layout);
+    ret = dht_inode_ctx_layout_get(inode, this, &layout, 0);
 
     if ((ret != 0) || !layout)
         return ret;

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -161,7 +161,7 @@ dht_inodectx_dump(xlator_t *this, inode_t *inode)
     if (!inode)
         goto out;
 
-    ret = dht_inode_ctx_layout_get(inode, this, &layout, 0);
+    ret = dht_inode_ctx_layout_get(inode, this, &layout);
 
     if ((ret != 0) || !layout)
         return ret;
@@ -169,6 +169,8 @@ dht_inodectx_dump(xlator_t *this, inode_t *inode)
     gf_proc_dump_add_section("xlator.cluster.dht.%s.inode", this->name);
     dht_layout_dump(layout, "layout");
 
+    if (!ret)
+        dht_layout_unref(layout);
 out:
     return ret;
 }


### PR DESCRIPTION
…de path

Currently dht_layout(ref|unref) is happening after increase/decreate
atomic counter. There is some race condition during new layout has been
changed at the same time old layout is using in other thread.Due to this
a client process is getting crashed.

Solution: Remove layout->ref_lock and use inode->lock to synchronize
          layout.

Fixes: #3262
Change-Id: I55952484bd651176f818b9cab54274f37dbca1a6
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

