### PR TITLE
struct posix_private: remove handledir and store ino and dev directly

### DIFF
--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -507,6 +507,7 @@ posix_handle_init(xlator_t *this)
     char *rootstr = NULL;
     static uuid_t gfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
     int dfd = 0;
+    struct stat handledir;
 
     priv = this->private;
 
@@ -548,13 +549,16 @@ posix_handle_init(xlator_t *this)
             break;
     }
 
-    ret = sys_stat(handle_pfx, &priv->handledir);
+    ret = sys_stat(handle_pfx, &handledir);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                "stat for %s failed", handle_pfx);
         return -1;
     }
+
+    priv->handledir_st_ino = handledir.st_ino;
+    priv->handledir_st_dev = handledir.st_dev;
 
     MAKE_HANDLE_ABSPATH_FD(rootstr, this, gfid, dfd);
     ret = sys_fstatat(dfd, rootstr, &rootbuf, 0);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -745,8 +745,8 @@ posix_istat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *basename,
         goto out;
     }
 
-    if ((lstatbuf.st_ino == priv->handledir.st_ino) &&
-        (lstatbuf.st_dev == priv->handledir.st_dev)) {
+    if ((lstatbuf.st_ino == priv->handledir_st_ino) &&
+        (lstatbuf.st_dev == priv->handledir_st_dev)) {
         errno = ENOENT;
         return -1;
     }
@@ -817,8 +817,8 @@ posix_pstat(xlator_t *this, inode_t *inode, uuid_t gfid, const char *path,
         goto out;
     }
 
-    if ((lstatbuf.st_ino == priv->handledir.st_ino) &&
-        (lstatbuf.st_dev == priv->handledir.st_dev)) {
+    if ((lstatbuf.st_ino == priv->handledir_st_ino) &&
+        (lstatbuf.st_dev == priv->handledir_st_dev)) {
         errno = ENOENT;
         return -1;
     }

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -158,9 +158,9 @@ struct posix_private {
     char *base_path;
     int32_t base_path_length;
 
-    long base_bsize;
-
     int32_t path_max;
+
+    long base_bsize;
 
     gf_lock_t lock;
 
@@ -178,10 +178,12 @@ struct posix_private {
     /* lock for brick dir */
     int mount_lock;
 
+    int fsync_queue_count;
+
     ino_t handledir_st_ino;
     dev_t handledir_st_dev;
 
-    /* uuid of glusterd that swapned the brick process */
+    /* uuid of glusterd that spawned the brick process */
     uuid_t glusterd_uuid;
 
 #ifdef HAVE_LIBAIO
@@ -197,7 +199,6 @@ struct posix_private {
     pthread_cond_t janitor_cond;
     pthread_cond_t fd_cond;
     pthread_cond_t disk_cond;
-    int fsync_queue_count;
     time_t janitor_sleep_duration;
 
     enum {
@@ -243,6 +244,7 @@ struct posix_private {
     uint32_t max_hardlinks;
     int32_t arrdfd[256];
     int dirfd;
+    uint32_t rel_fdcount;
 
     /* This option is used for either to call a landfill_purge or not */
     gf_boolean_t disable_landfill_purge;
@@ -280,15 +282,15 @@ struct posix_private {
     gf_boolean_t aio_configured;
     gf_boolean_t aio_init_done;
     gf_boolean_t aio_capable;
-    uint32_t rel_fdcount;
+
+    gf_boolean_t io_uring_configured;
 
     /*io_uring related.*/
-    gf_boolean_t io_uring_configured;
 #ifdef HAVE_LIBURING
-    struct io_uring ring;
     gf_boolean_t io_uring_init_done;
     gf_boolean_t io_uring_capable;
     gf_boolean_t uring_thread_exit;
+    struct io_uring ring;
     pthread_t uring_thread;
     pthread_mutex_t sq_mutex;
     pthread_mutex_t cq_mutex;

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -178,7 +178,8 @@ struct posix_private {
     /* lock for brick dir */
     int mount_lock;
 
-    struct stat handledir;
+    ino_t handledir_st_ino;
+    dev_t handledir_st_dev;
 
     /* uuid of glusterd that swapned the brick process */
     uuid_t glusterd_uuid;


### PR DESCRIPTION
Instead of the whole stat struct, we can just save the 2 items we need.
So instead of 144 bytes, we save just 16 bytes.

Updates: #3264
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

