### PR TITLE
null dereference[inodelk.c]

### DIFF
--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -7,6 +7,7 @@
    later), or the GNU General Public License, version 2 (GPLv2), in all
    cases as published by the Free Software Foundation.
 */
+// test
 #include <glusterfs/compat.h>
 #include <glusterfs/logging.h>
 #include <glusterfs/list.h>

--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -1084,6 +1084,8 @@ pl_entrylk_client_cleanup(xlator_t *this, pl_ctx_t *ctx)
             pinode = l->pinode;
 
             dom = get_domain(pinode, l->volume);
+            if (dom)
+                INIT_LIST_HEAD(&dom->entrylk_list);
 
             grant_blocked_entry_locks(this, pinode, dom, &now, pcontend);
 

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -1029,7 +1029,7 @@ pl_common_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = ENOMEM;
         goto unwind;
     }
-
+    INIT_LIST_HEAD(&dom->inodelk_list);
     reqlock = new_inode_lock(flock, frame->root->client, frame->root->pid,
                              frame, this, dom->domain, conn_id, &op_errno);
 


### PR DESCRIPTION
Issue: Null pointer being dereferenced in list_add()
Fix : The caller function in inodelk.c/entrylk.c  is passing a bad list to the function list_add() which results in null 
        dereference.
        list_add(&lock->list, &dom->inodelk_list).
        list_add(&lock->list, &dom->entrylk_list).
        So initialize the argument correctly.

Updates: #1060        
Change-Id: Ib7456483870b5dcfeb182a5a9aab15ea0ca2a6c9

Signed-off-by : Harshita Shree hshree@redhat.com