### PR TITLE
libglusterfs: cleanup iobufs

### DIFF
--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -55,13 +55,8 @@ struct iobuf_init_config {
 };
 
 struct iobuf {
-    union {
-        struct list_head list;
-        struct {
-            struct iobuf *next;
-            struct iobuf *prev;
-        };
-    };
+    /* Linked into arena's passive or active list. */
+    struct list_head list;
     struct iobuf_arena *iobuf_arena;
 
     gf_lock_t lock;  /* for ->ptr and ->ref */
@@ -69,21 +64,14 @@ struct iobuf {
 
     void *ptr; /* usable memory region by the consumer */
 
-    void *free_ptr;   /* in case of stdalloc, this is the
-                         one to be freed */
+    void *free_ptr; /* in case of stdalloc, this is the
+                       one to be freed */
     size_t page_size;
 };
 
 struct iobuf_arena {
-    union {
-        struct list_head list;
-        struct {
-            struct iobuf_arena *next;
-            struct iobuf_arena *prev;
-        };
-    };
-
-    struct list_head all_list;
+    /* Linked into pool's arenas, filled, or purge array lists. */
+    struct list_head list;
     size_t page_size; /* size of all iobufs in this arena */
     size_t arena_size;
     /* this is equal to rounded_size * num_iobufs.
@@ -109,7 +97,6 @@ struct iobuf_pool {
                                  arena */
     size_t default_page_size; /* default size of iobuf */
 
-    struct list_head all_arenas;
     struct list_head arenas[GF_VARIABLE_IOBUF_COUNT];
     /* array of arenas. Each element of the array is a list of arenas
        holding iobufs of particular page_size */
@@ -141,7 +128,6 @@ void
 iobuf_to_iovec(struct iobuf *iob, struct iovec *iov);
 
 #define iobuf_ptr(iob) ((iob)->ptr)
-#define iobpool_default_pagesize(iobpool) ((iobpool)->default_page_size)
 #define iobuf_pagesize(iob) (iob->page_size)
 
 struct iobref {

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -85,8 +85,6 @@ __iobuf_arena_init_iobufs(struct iobuf_arena *iobuf_arena)
         offset += iobuf_arena->page_size;
         iobuf++;
     }
-
-    return;
 }
 
 static void
@@ -113,13 +111,10 @@ __iobuf_arena_destroy_iobufs(struct iobuf_arena *iobuf_arena)
     }
 
     GF_FREE(iobuf_arena->iobufs);
-
-    return;
 }
 
 static void
-__iobuf_arena_destroy(struct iobuf_pool *iobuf_pool,
-                      struct iobuf_arena *iobuf_arena)
+__iobuf_arena_destroy(struct iobuf_arena *iobuf_arena)
 {
     GF_VALIDATE_OR_GOTO("iobuf", iobuf_arena, out);
 
@@ -148,7 +143,6 @@ __iobuf_arena_alloc(struct iobuf_pool *iobuf_pool, size_t page_size,
         goto err;
 
     INIT_LIST_HEAD(&iobuf_arena->list);
-    INIT_LIST_HEAD(&iobuf_arena->all_list);
     INIT_LIST_HEAD(&iobuf_arena->passive_list);
     INIT_LIST_HEAD(&iobuf_arena->active_list);
     iobuf_arena->iobuf_pool = iobuf_pool;
@@ -168,8 +162,6 @@ __iobuf_arena_alloc(struct iobuf_pool *iobuf_pool, size_t page_size,
         goto err;
     }
 
-    list_add_tail(&iobuf_arena->all_list, &iobuf_pool->all_arenas);
-
     __iobuf_arena_init_iobufs(iobuf_arena);
     if (!iobuf_arena->iobufs) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INIT_IOBUF_FAILED, NULL);
@@ -181,15 +173,14 @@ __iobuf_arena_alloc(struct iobuf_pool *iobuf_pool, size_t page_size,
     return iobuf_arena;
 
 err:
-    __iobuf_arena_destroy(iobuf_pool, iobuf_arena);
+    __iobuf_arena_destroy(iobuf_arena);
 
 out:
     return NULL;
 }
 
 static struct iobuf_arena *
-__iobuf_arena_unprune(struct iobuf_pool *iobuf_pool, const size_t page_size,
-                      const int index)
+__iobuf_arena_unprune(struct iobuf_pool *iobuf_pool, const int index)
 {
     struct iobuf_arena *iobuf_arena = NULL;
     struct iobuf_arena *tmp = NULL;
@@ -212,7 +203,7 @@ __iobuf_pool_add_arena(struct iobuf_pool *iobuf_pool, const size_t page_size,
 {
     struct iobuf_arena *iobuf_arena = NULL;
 
-    iobuf_arena = __iobuf_arena_unprune(iobuf_pool, page_size, index);
+    iobuf_arena = __iobuf_arena_unprune(iobuf_pool, index);
 
     if (!iobuf_arena) {
         iobuf_arena = __iobuf_arena_alloc(iobuf_pool, page_size, num_pages);
@@ -246,14 +237,14 @@ iobuf_pool_destroy(struct iobuf_pool *iobuf_pool)
                 list_del_init(&iobuf_arena->list);
                 iobuf_pool->arena_cnt--;
 
-                __iobuf_arena_destroy(iobuf_pool, iobuf_arena);
+                __iobuf_arena_destroy(iobuf_arena);
             }
             list_for_each_entry_safe(iobuf_arena, tmp, &iobuf_pool->purge[i],
                                      list)
             {
                 list_del_init(&iobuf_arena->list);
                 iobuf_pool->arena_cnt--;
-                __iobuf_arena_destroy(iobuf_pool, iobuf_arena);
+                __iobuf_arena_destroy(iobuf_arena);
             }
             /* If there are no iobuf leaks, there should be no
              * arenas in the filled list. If at all there are any
@@ -265,7 +256,7 @@ iobuf_pool_destroy(struct iobuf_pool *iobuf_pool)
             {
                 list_del_init(&iobuf_arena->list);
                 iobuf_pool->arena_cnt--;
-                __iobuf_arena_destroy(iobuf_pool, iobuf_arena);
+                __iobuf_arena_destroy(iobuf_arena);
             }
             /* If there are no iobuf leaks, there shoould be
              * no standard allocated arenas, iobuf_put will free
@@ -321,7 +312,7 @@ iobuf_pool_new(void)
     iobuf_pool = GF_CALLOC(sizeof(*iobuf_pool), 1, gf_common_mt_iobuf_pool);
     if (!iobuf_pool)
         goto out;
-    INIT_LIST_HEAD(&iobuf_pool->all_arenas);
+
     pthread_mutex_init(&iobuf_pool->mutex, NULL);
     for (i = 0; i <= IOBUF_ARENA_MAX_INDEX; i++) {
         INIT_LIST_HEAD(&iobuf_pool->arenas[i]);
@@ -365,10 +356,9 @@ __iobuf_arena_prune(struct iobuf_pool *iobuf_pool,
 
     /* All cases matched, destroy */
     list_del_init(&iobuf_arena->list);
-    list_del_init(&iobuf_arena->all_list);
     iobuf_pool->arena_cnt--;
 
-    __iobuf_arena_destroy(iobuf_pool, iobuf_arena);
+    __iobuf_arena_destroy(iobuf_arena);
 
 out:
     return;
@@ -466,6 +456,14 @@ __iobuf_get(struct iobuf_pool *iobuf_pool, const size_t page_size,
     return iobuf;
 }
 
+static void
+__iobuf_free(struct iobuf *iobuf)
+{
+    LOCK_DESTROY(&iobuf->lock);
+    GF_FREE(iobuf->free_ptr);
+    GF_FREE(iobuf);
+}
+
 static struct iobuf *
 iobuf_get_from_stdalloc(struct iobuf_pool *iobuf_pool, const size_t page_size)
 {
@@ -502,8 +500,7 @@ iobuf_get_from_stdalloc(struct iobuf_pool *iobuf_pool, const size_t page_size)
     ret = 0;
 out:
     if (ret && iobuf) {
-        GF_FREE(iobuf->free_ptr);
-        GF_FREE(iobuf);
+        __iobuf_free(iobuf);
         iobuf = NULL;
     }
 
@@ -535,8 +532,7 @@ iobuf_get_from_small(const size_t page_size)
     ret = 0;
 out:
     if (ret && iobuf) {
-        GF_FREE(iobuf->free_ptr);
-        GF_FREE(iobuf);
+        __iobuf_free(iobuf);
         iobuf = NULL;
     }
 
@@ -667,9 +663,7 @@ __iobuf_put(struct iobuf *iobuf, struct iobuf_arena *iobuf_arena)
                      iobuf);
 
         /* free up properly without bothering about lists and all */
-        LOCK_DESTROY(&iobuf->lock);
-        GF_FREE(iobuf->free_ptr);
-        GF_FREE(iobuf);
+        __iobuf_free(iobuf);
         return;
     }
 
@@ -709,9 +703,7 @@ iobuf_put(struct iobuf *iobuf)
 
     iobuf_arena = iobuf->iobuf_arena;
     if (!iobuf_arena) {
-        LOCK_DESTROY(&iobuf->lock);
-        GF_FREE(iobuf->free_ptr);
-        GF_FREE(iobuf);
+        __iobuf_free(iobuf);
         return;
     }
 


### PR DESCRIPTION
Remove useless linkage fields from `struct iobuf_arena` and
`struct iobuf_pool`, drop unused `iobpool_default_pagesize()`
macro as well as unused arguments of `__iobuf_arena_destroy()`
and `__iobuf_arena_unprune()`, add trivial `__iobuf_free()`
and so ensure that iobuf's lock is destroyed on all paths,
adjust related code and comments.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000