### PR TITLE
[DO NOT MERGE] add better musl compatibility

### DIFF
--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -54,6 +54,11 @@
 #include <stdint.h>
 #include <sys/time.h>
 
+
+#if (defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)) && !defined(__off64_t_defined)
+#define __off64_t_defined
+#endif
+
 /*
  * For off64_t to be defined, we need both
  * __USE_LARGEFILE64 to be true and __off64_t_defnined to be

--- a/contrib/fuse-lib/mount-common.c
+++ b/contrib/fuse-lib/mount-common.c
@@ -8,6 +8,7 @@
 */
 
 #include "mount-gluster-compat.h"
+#include <string.h>
 
 /*
  * These functions (and gf_fuse_umount() in mount.c)

--- a/contrib/fuse-lib/mount-gluster-compat.h
+++ b/contrib/fuse-lib/mount-gluster-compat.h
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <signal.h>
 #if defined(GF_LINUX_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #endif /* GF_LINUX_HOST_OS */
 #include <sys/stat.h>
 #include <sys/poll.h>

--- a/contrib/fuse-lib/mount-gluster-compat.h
+++ b/contrib/fuse-lib/mount-gluster-compat.h
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <signal.h>
 #if defined(GF_LINUX_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #endif /* GF_LINUX_HOST_OS */
 #include <sys/stat.h>
 #include <sys/poll.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,7 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>
 #include <sys/stat.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,6 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
+#include <mntent.h>
 #include <paths.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,7 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>
 #include <sys/stat.h>

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,7 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #else
 #include "mntent_compat.h"
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,7 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #else
 #include "mntent_compat.h"
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
+#include <mntent.h>
 #include <paths.h>
 #else
 #include "mntent_compat.h"


### PR DESCRIPTION
**This is just a test  pull request, i never did one before for glusterfs.**

It is related to [issue 268](https://github.com/gluster/glusterfs/issues/268), and shall make it possible to compile 
the release-10 branch on alpine-linux with musl.

before the configure step, the following things have to be done, to make it actually work:
```
# add ucontext and argp libs, which are not included in musl:
apk add libucontext-dev
apk add argp_standalone
export LIBS="-lucontext -largp"
# #define __WORDSIZE 64 because its not defined in the expected file in musl
export CFLAGS="-D__WORDSIZE=64"
export CPPFLAGS="-D__WORDSIZE=64" # maybe that is not need
```

This was tested on aarch64-alpine-linux-musl.
This PR is also to test if the Pipeline is passing still for the other operating systems.
