### PR TITLE
add better musl compatiblity

### DIFF
--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -54,7 +54,8 @@
 #include <sys/time.h>
 
 
-#if (defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)) && !defined(__off64_t_defined)
+#if (defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)) && \
+    !defined(__off64_t_defined)
 #define __off64_t_defined
 #endif
 

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -53,6 +53,11 @@
 #include <stdint.h>
 #include <sys/time.h>
 
+
+#if (defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)) && !defined(__off64_t_defined)
+#define __off64_t_defined
+#endif
+
 /*
  * For off64_t to be defined, we need both
  * __USE_LARGEFILE64 to be true and __off64_t_defnined to be

--- a/contrib/fuse-lib/mount-common.c
+++ b/contrib/fuse-lib/mount-common.c
@@ -8,6 +8,7 @@
 */
 
 #include "mount-gluster-compat.h"
+#include <string.h>
 
 /*
  * These functions (and gf_fuse_umount() in mount.c)

--- a/contrib/fuse-lib/mount-gluster-compat.h
+++ b/contrib/fuse-lib/mount-gluster-compat.h
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <signal.h>
 #if defined(GF_LINUX_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #endif /* GF_LINUX_HOST_OS */
 #include <sys/stat.h>
 #include <sys/poll.h>

--- a/contrib/fuse-lib/mount-gluster-compat.h
+++ b/contrib/fuse-lib/mount-gluster-compat.h
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <signal.h>
 #if defined(GF_LINUX_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #endif /* GF_LINUX_HOST_OS */
 #include <sys/stat.h>
 #include <sys/poll.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,7 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>
 #include <sys/stat.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,6 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
+#include <mntent.h>
 #include <paths.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>

--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -26,7 +26,7 @@
 #include <pwd.h>
 #include <limits.h>
 #if !defined(__NetBSD__) && !defined(GF_DARWIN_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #endif /* __NetBSD__ */
 #include <sys/wait.h>
 #include <sys/stat.h>

--- a/libglusterfs/src/glusterfs/compat-errno.h
+++ b/libglusterfs/src/glusterfs/compat-errno.h
@@ -231,6 +231,8 @@
 #define ENODATA 61
 #endif
 
+#include <stdint.h>
+
 /* These functions are defined for all the OS flags, but content will
  * be different for each OS flag.
  */

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,7 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
-#include <mntent.h>
+#include <path.h>
 #else
 #include "mntent_compat.h"
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,7 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
-#include <path.h>
+#include <paths.h>
 #else
 #include "mntent_compat.h"
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 
 #if defined(GF_LINUX_HOST_OS)
+#include <mntent.h>
 #include <paths.h>
 #else
 #include "mntent_compat.h"


### PR DESCRIPTION
This PR is related to [issue 268](https://github.com/gluster/glusterfs/issues/268), and shall make it possible to compile glusterfs on **alpine-linux with musl**. It replaces [PR #3281](https://github.com/gluster/glusterfs/pull/3281).

before the configure step, the following things have to be done, to make it actually work:
```
# add ucontext and argp libs, which are not included in musl:
apk add libucontext-dev
apk add argp_standalone
export LIBS="-lucontext -largp"
# #define __WORDSIZE 64 because its not defined in the expected file in musl
export CFLAGS="-D__WORDSIZE=64"
export CPPFLAGS="-D__WORDSIZE=64" # maybe that is not need
```

This was tested on aarch64-alpine-linux-musl.

## Some notes:

I have added the ```#include <stdint.h>``` to [libglusterfs/src/glusterfs/compat-errno.h](https://github.com/gluster/glusterfs/commit/b93ec139d4bc45f96f17b0ab634bcca6ca69170c#diff-b2f1635b3b160ada48c53c919fef849e2dd7192858a60ce35635ee8b7bc4fb60). I wonder how this could have compiled before? 
Because the only other include is ```<errno.h>``` and in glibc i couldn't see, that it includes something that defines int32_t.

In api/src/glfs.h i have added 
```diff
+#if (defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)) && \
+    !defined(__off64_t_defined)
+#define __off64_t_defined
+#endif
...
#ifndef GF_BSD_HOST_OS
#if defined(__USE_FILE_OFFSET64) && !defined(__off64_t_defined)
```
here is an important comment regarding this:
[https://github.com/gluster/glusterfs/blob/2bd36b3c158dff8704cf063601a96c19e791fa82/api/src/glfs.h#L56-L68](https://github.com/gluster/glusterfs/blob/2bd36b3c158dff8704cf063601a96c19e791fa82/api/src/glfs.h#L56-L68)
I think that is not the cleanest solution, but i don't have an better idea. Maybe you have some suggestions? Then i will change that before merge.