### PR TITLE
afr/upcall: Optimize upcall event handling

### DIFF
--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -2272,6 +2272,18 @@ afr_is_entry_set(xlator_t *this, dict_t *xdata)
     return afr_is_pending_set(this, xdata, AFR_ENTRY_TRANSACTION);
 }
 
+gf_boolean_t
+afr_is_any_pending_key_set(xlator_t *this, dict_t *xdata)
+{
+    if (!this || !xdata) {
+        return _gf_false;
+    }
+    if (afr_is_data_set(this, xdata) || afr_is_metadata_set(this, xdata) ||
+        afr_is_entry_set(this, xdata)) {
+        return _gf_true;
+    }
+    return _gf_false;
+}
 /*
  * This function inspects the looked up replies (in an unlocked manner)
  * and decides whether a locked verification and possible healing is

--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -386,4 +386,7 @@ afr_anon_inode_create(xlator_t *this, int child, inode_t **linked_inode);
 void
 afr_selfheal_fill_cell(afr_private_t *priv, dict_t *src_xdata, int *cell,
                        int sink, int idx);
+gf_boolean_t
+afr_is_any_pending_key_set(xlator_t *this, dict_t *xdata);
+
 #endif /* !_AFR_SELFHEAL_H */


### PR DESCRIPTION
If the pending keys are present on the dict, it might not
be a good idea to blindly invalidate the cache. We can go
one step further and check the pending key and examine
the value, Since it is also possible that an already healed
the file can have a pending key set with zero values.

Change-Id: I29bd4fd688649b5aa151321e8a043729032ad0dd
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

