### PR TITLE
Fix for Wstringop-truncation warning

### DIFF
--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -1727,6 +1727,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             real_path[sizeof(real_path) - 1] = 0;
             strncat(real_path, local->origpath,
                     sizeof(real_path) - strlen(real_path) - 1);
+            real_path[sizeof(real_path) - 1] = 0;
             /* Call create again once directory structure
                is created. */
 

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -755,7 +755,7 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
            It would be '0', but not '\0' :-) */
         if (!this->ctx->volume_id[0]) {
             strncpy(this->ctx->volume_id, this->graph->volume_id,
-                    GF_UUID_BUF_SIZE - 1);
+                    GF_UUID_BUF_SIZE);
             this->ctx->volume_id[GF_UUID_BUF_SIZE - 1] = '\0';
         }
         if (this->ctx->volume_id[0]) {


### PR DESCRIPTION
Description : Wstringop-truncation warnings  arises as output may be truncated 
                     so terminating buffer manually for strncat and for strncpy using 
                     complete size of buffer to copy as we already terminate it manually.


```
client-handshake.c: In function ‘client_setvolume’:
client-handshake.c:757:13: warning: ‘strncpy’ output may be truncated copying 36 bytes from a string of length 36 [-Wstringop-truncation]
             strncpy(this->ctx->volume_id, this->graph->volume_id,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     GF_UUID_BUF_SIZE - 1);
                     ~~~~~~~~~~~~~~~~~~~~~
```

```
trash.c: In function ‘trash_truncate_mkdir_cbk’:
trash.c:1728:13: warning: ‘strncat’ output may be truncated copying between 0 and 4095 bytes from a string of length 4095 [-Wstringop-truncation]
             strncat(real_path, local->origpath,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     sizeof(real_path) - strlen(real_path) - 1);
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Issue : #1000 
Change-Id: I9b4f00cdec098bcdc481129e00e09e2b166a3aa7
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>