### PR TITLE
rpc: cleanup data structures once again

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1675,7 +1675,6 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
     req.rsp.rsp_payload = rsp_payload;
     req.rsp.rsp_payload_count = rsp_payload_count;
     req.rsp.rsp_iobref = rsp_iobref;
-    req.rpc_req = rpcreq;
 
     pthread_mutex_lock(&conn->lock);
     {

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -155,16 +155,12 @@ typedef struct rpc_clnt_connection rpc_clnt_connection_t;
 
 struct rpc_req {
     rpc_clnt_connection_t *conn;
-    struct iovec req[2];
-    struct iobref *req_iobref;
     struct iovec rsp[2];
     int rspcnt;
-    int reqcnt;
     struct iobref *rsp_iobref;
     rpc_clnt_prog_t *prog;
     rpc_auth_data_t verf;
     fop_cbk_fn_t cbkfn;
-    void *conn_private;
     int procnum;
     int rpc_status;
     uint32_t xid;

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -118,7 +118,6 @@ struct rpc_transport_rsp {
 typedef struct rpc_transport_rsp rpc_transport_rsp_t;
 
 struct rpc_transport_req {
-    struct rpc_req *rpc_req;
     rpc_transport_msg_t msg;
     rpc_transport_rsp_t rsp;
 };
@@ -129,15 +128,6 @@ struct rpc_transport_reply {
     rpc_transport_msg_t msg;
 };
 typedef struct rpc_transport_reply rpc_transport_reply_t;
-
-struct rpc_transport_data {
-    union {
-        rpc_transport_req_t req;
-        rpc_transport_reply_t reply;
-    } data;
-    char is_request;
-};
-typedef struct rpc_transport_data rpc_transport_data_t;
 
 /* FIXME: prognum, procnum and progver are already present in
  * rpc_request, hence these should be removed from request_info


### PR DESCRIPTION
Drop unused `rpc_transport_data_t` as well as a few unused
members of `struct rpc_req` and `struct rpc_transport_req`,
adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000