### PR TITLE
dht-helper.c: simplify dht_local_init()

### DIFF
--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -837,9 +837,7 @@ dht_local_init(call_frame_t *frame, loc_t *loc, fd_t *fd, glusterfs_fop_t fop)
     if (inode) {
         local->layout = dht_layout_get(frame->this, inode);
         if (local->layout) {
-            dht_layout_ref(local->layout);
             local->cached_subvol = local->layout->list[0].xlator;
-            dht_layout_unref(local->layout);
         }
     }
 

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -812,7 +812,7 @@ dht_local_init(call_frame_t *frame, loc_t *loc, fd_t *fd, glusterfs_fop_t fop)
     inode_t *inode = NULL;
     int ret = 0;
 
-    local = mem_get0(THIS->local_pool);
+    local = mem_get0(frame->this->local_pool);
     if (!local)
         goto out;
 
@@ -836,7 +836,11 @@ dht_local_init(call_frame_t *frame, loc_t *loc, fd_t *fd, glusterfs_fop_t fop)
 
     if (inode) {
         local->layout = dht_layout_get(frame->this, inode);
-        local->cached_subvol = dht_subvol_get_cached(frame->this, inode);
+        if (local->layout) {
+            dht_layout_ref(local->layout);
+            local->cached_subvol = local->layout->list[0].xlator;
+            dht_layout_unref(local->layout);
+        }
     }
 
     frame->local = local;


### PR DESCRIPTION
1. Remove a call to 'THIS' and use frame->this instead
2. Re-use the previous result of dht_layout_get() to fetch the cached_subvol.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

