### PR TITLE
readdir-ahead.c: few improvements

### DIFF
--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -112,9 +112,7 @@ __rda_inode_ctx_update_iatts(inode_t *inode, xlator_t *this,
                              uint64_t generation)
 {
     rda_inode_ctx_t *ctx_p = NULL;
-    struct iatt tmp_stat = {
-        0,
-    };
+    struct iatt *tmp_stat;
 
     ctx_p = __rda_inode_ctx_get(inode, this);
     if (!ctx_p)
@@ -129,12 +127,12 @@ __rda_inode_ctx_update_iatts(inode_t *inode, xlator_t *this,
          * that is cached in write-behind.
          */
         if (stbuf_in)
-            tmp_stat = *stbuf_in;
+            tmp_stat = stbuf_in;
         else
-            tmp_stat = ctx_p->statbuf;
+            tmp_stat = &ctx_p->statbuf;
         memset(&ctx_p->statbuf, 0, sizeof(ctx_p->statbuf));
-        gf_uuid_copy(ctx_p->statbuf.ia_gfid, tmp_stat.ia_gfid);
-        ctx_p->statbuf.ia_type = tmp_stat.ia_type;
+        gf_uuid_copy(ctx_p->statbuf.ia_gfid, tmp_stat->ia_gfid);
+        ctx_p->statbuf.ia_type = tmp_stat->ia_type;
         GF_ATOMIC_INC(ctx_p->generation);
     } else {
         if (ctx_p->statbuf.ia_ctime) {
@@ -167,7 +165,7 @@ rda_inode_ctx_update_iatts(inode_t *inode, xlator_t *this,
                            struct iatt *stbuf_in, struct iatt *stbuf_out,
                            uint64_t generation)
 {
-    int ret = -1;
+    int ret;
 
     LOCK(&inode->lock);
     {
@@ -226,9 +224,10 @@ rda_mark_inode_dirty(xlator_t *this, inode_t *inode)
                     continue;
 
                 fd_ctx = (void *)(uintptr_t)val;
-                uuid_utoa_r(inode->gfid, gfid);
                 if (!GF_ATOMIC_GET(fd_ctx->prefetching))
                     continue;
+
+                uuid_utoa_r(inode->gfid, gfid);
 
                 LOCK(&fd_ctx->lock);
                 {
@@ -275,13 +274,10 @@ rda_can_serve_readdirp(struct rda_fd_ctx *ctx, size_t request_size)
     return _gf_false;
 }
 
-void
+static void
 rda_inode_ctx_get_iatt(inode_t *inode, xlator_t *this, struct iatt *attr)
 {
     rda_inode_ctx_t *ctx_p = NULL;
-
-    if (!inode || !this || !attr)
-        goto out;
 
     LOCK(&inode->lock);
     {
@@ -292,8 +288,8 @@ rda_inode_ctx_get_iatt(inode_t *inode, xlator_t *this, struct iatt *attr)
     }
     UNLOCK(&inode->lock);
 
-out:
-    return;
+    if (ctx_p == NULL)
+        memset(attr, 0, sizeof(struct iatt));
 }
 
 /*
@@ -319,8 +315,6 @@ __rda_fill_readdirp(xlator_t *this, gf_dirent_t *entries, size_t request_size,
         dirent_size = gf_dirent_size(dirent->d_name);
         if (size + dirent_size > request_size)
             break;
-
-        memset(&tmp_stat, 0, sizeof(tmp_stat));
 
         if (dirent->inode && (!((strcmp(dirent->d_name, ".") == 0) ||
                                 (strcmp(dirent->d_name, "..") == 0)))) {
@@ -519,23 +513,22 @@ rda_fill_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             /* must preserve entry order */
             list_add_tail(&dirent->list, &ctx->entries.list);
             if (dirent->inode) {
-                /* If ctxp->stat is invalidated, don't update it
-                 * with dirent->d_stat as we don't have
-                 * generation number of the inode when readdirp
-                 * request was initiated. So, we pass 0 for
-                 * generation number
-                 */
-
-                generation = -1;
-                if (ctx->writes_during_prefetch) {
-                    memset(gfid, 0, sizeof(gfid));
-                    uuid_utoa_r(dirent->inode->gfid, gfid);
-                    if (dict_get(ctx->writes_during_prefetch, gfid))
-                        generation = 0;
-                }
-
                 if (!((strcmp(dirent->d_name, ".") == 0) ||
                       (strcmp(dirent->d_name, "..") == 0))) {
+                    /* If ctxp->stat is invalidated, don't update it
+                     * with dirent->d_stat as we don't have
+                     * generation number of the inode when readdirp
+                     * request was initiated. So, we pass 0 for
+                     * generation number
+                     */
+
+                    generation = -1;
+                    if (ctx->writes_during_prefetch) {
+                        uuid_utoa_r(dirent->inode->gfid, gfid);
+                        if (dict_get(ctx->writes_during_prefetch, gfid))
+                            generation = 0;
+                    }
+
                     rda_inode_ctx_update_iatts(dirent->inode, this,
                                                &dirent->d_stat, &dirent->d_stat,
                                                generation);

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.h
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.h
@@ -61,14 +61,14 @@ struct rda_fd_ctx {
     size_t cur_size;   /* current size of the preload */
     off_t next_offset; /* tail of the ctx */
     uint32_t state;
+    int op_errno;
     gf_lock_t lock;
-    gf_dirent_t entries;
     call_frame_t *fill_frame;
     call_stub_t *stub;
-    int op_errno;
     dict_t *xattrs; /* md-cache keys to be sent in readdirp() */
     dict_t *writes_during_prefetch;
     gf_atomic_t prefetching;
+    gf_dirent_t entries;
 };
 
 struct rda_local {


### PR DESCRIPTION
- Used a pointer to an iatt struct instead of a copy.
- Moved some code that was unconditionally used to be used conditionally.
- Removed a memset() to a guid that was just before a call to uuid_utoa_r()

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

