### PR TITLE
null dereference[name.c]

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -299,6 +299,8 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
                      "ip-%s port-%s",
                      host, service);
     }
+    if (!cache->next)
+        goto err;
 
     return 0;
 

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -281,6 +281,8 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
 
         *addr_info = cache->next;
     }
+    if (!*addr_info)
+        goto err;
 
     if (cache->next)
         cache->next = cache->next->ai_next;
@@ -299,8 +301,6 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
                      "ip-%s port-%s",
                      host, service);
     }
-    if (!cache->next)
-        goto err;
 
     return 0;
 
@@ -651,8 +651,7 @@ socket_client_get_remote_sockaddr(rpc_transport_t *this,
     /* Address-family is updated based on remote_host in
        af_inet_client_get_remote_sockaddr
     */
-    if (ret == -1)
-        goto err;
+
     if (*sa_family != sockaddr->sa_family) {
         *sa_family = sockaddr->sa_family;
     }

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -651,6 +651,8 @@ socket_client_get_remote_sockaddr(rpc_transport_t *this,
     /* Address-family is updated based on remote_host in
        af_inet_client_get_remote_sockaddr
     */
+    if (ret == -1)
+        goto err;
     if (*sa_family != sockaddr->sa_family) {
         *sa_family = sockaddr->sa_family;
     }


### PR DESCRIPTION
Issue : Access to field 'ai_addr' results in a dereference of a null pointer (loaded from variable 'addr_info')
Fix : addr_info is not set to a valid value when chache->next is null. So check in gf_resolve_ip6() and return relevant value of ret 
       after de-allocating unused memory.

**WORK IN PROGRESS**
Updates: #1060
Change-Id: Ia1c6e88f2fddab4ce815bf5423b6b6976f7cc90f

Signed-off-by : Harshita Shree [hshree@redhat.com]

