### PR TITLE
bit-rot: simplify and cleanup time management

### DIFF
--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -863,12 +863,6 @@ br_kickstart_scanner(struct gf_tw_timer_list *timer, void *data,
     return;
 }
 
-static uint32_t
-br_fsscan_calculate_delta(uint32_t times)
-{
-    return times;
-}
-
 #define BR_SCRUB_ONDEMAND (1)
 #define BR_SCRUB_MINUTE (60)
 #define BR_SCRUB_HOURLY (60 * 60)
@@ -877,29 +871,29 @@ br_fsscan_calculate_delta(uint32_t times)
 #define BR_SCRUB_BIWEEKLY (14 * 24 * 60 * 60)
 #define BR_SCRUB_MONTHLY (30 * 24 * 60 * 60)
 
-static unsigned int
+static time_t
 br_fsscan_calculate_timeout(scrub_freq_t freq)
 {
-    uint32_t timo = 0;
+    time_t timo = 0;
 
     switch (freq) {
         case BR_FSSCRUB_FREQ_MINUTE:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_MINUTE);
+            timo = BR_SCRUB_MINUTE;
             break;
         case BR_FSSCRUB_FREQ_HOURLY:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_HOURLY);
+            timo = BR_SCRUB_HOURLY;
             break;
         case BR_FSSCRUB_FREQ_DAILY:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_DAILY);
+            timo = BR_SCRUB_DAILY;
             break;
         case BR_FSSCRUB_FREQ_WEEKLY:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_WEEKLY);
+            timo = BR_SCRUB_WEEKLY;
             break;
         case BR_FSSCRUB_FREQ_BIWEEKLY:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_BIWEEKLY);
+            timo = BR_SCRUB_BIWEEKLY;
             break;
         case BR_FSSCRUB_FREQ_MONTHLY:
-            timo = br_fsscan_calculate_delta(BR_SCRUB_MONTHLY);
+            timo = BR_SCRUB_MONTHLY;
             break;
         default:
             timo = 0;
@@ -911,7 +905,7 @@ br_fsscan_calculate_timeout(scrub_freq_t freq)
 int32_t
 br_fsscan_schedule(xlator_t *this)
 {
-    uint32_t timo = 0;
+    time_t timo = 0;
     br_private_t *priv = NULL;
     char timestr[GF_TIMESTR_SIZE] = {
         0,
@@ -963,7 +957,7 @@ error_return:
 int32_t
 br_fsscan_activate(xlator_t *this)
 {
-    uint32_t timo = 0;
+    time_t timo = 0;
     char timestr[GF_TIMESTR_SIZE] = {
         0,
     };
@@ -1006,7 +1000,7 @@ int32_t
 br_fsscan_reschedule(xlator_t *this)
 {
     int32_t ret = 0;
-    uint32_t timo = 0;
+    time_t timo = 0;
     char timestr[GF_TIMESTR_SIZE] = {
         0,
     };
@@ -1057,7 +1051,7 @@ int32_t
 br_fsscan_ondemand(xlator_t *this)
 {
     int32_t ret = 0;
-    uint32_t timo = 0;
+    time_t timo = 0;
     char timestr[GF_TIMESTR_SIZE] = {
         0,
     };

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1330,8 +1330,6 @@ br_brick_connect(xlator_t *this, br_child_t *child)
     }
 
     memcpy(child->brick_path, stub->export, strlen(stub->export) + 1);
-    child->tv.tv_sec = ntohl(stub->timebuf[0]);
-    child->tv.tv_usec = ntohl(stub->timebuf[1]);
 
     ret = br_child_enaction(this, child, stub);
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot.h
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.h
@@ -87,8 +87,6 @@ struct br_child {
 
     struct mem_pool *timer_pool; /* timer-wheel's timer mem-pool */
 
-    struct timeval tv;
-
     struct br_scanfs fsscan; /* per subvolume FS scanner */
 
     gf_boolean_t active_scrubbing; /* Actively scrubbing or not */
@@ -144,7 +142,7 @@ struct br_monitor {
 
     xlator_t *this;
     /* scheduler */
-    uint32_t boot;
+    time_t boot;
 
     int32_t active_child_count; /* Number of children currently scrubbing */
     gf_boolean_t kick;          /* This variable tracks the scrubber is

--- a/xlators/features/bit-rot/src/stub/bit-rot-common.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-common.h
@@ -103,8 +103,8 @@ typedef struct br_isignature_out {
 
     unsigned long version; /* current signed version    */
 
-    uint32_t time[2]; /* time when the object
-                         got dirtied               */
+    unsigned long time[2]; /* time when the object
+                              got dirtied               */
 
     int8_t signaturetype; /* hash type                 */
     size_t signaturelen;  /* signature length          */
@@ -112,7 +112,7 @@ typedef struct br_isignature_out {
 } br_isignature_out_t;
 
 typedef struct br_stub_init {
-    uint32_t timebuf[2];
+    unsigned long timebuf[2];
     char export[PATH_MAX];
 } br_stub_init_t;
 
@@ -139,7 +139,7 @@ br_is_signature_type_valid(int8_t signaturetype)
 }
 
 static inline void
-br_set_default_ongoingversion(br_version_t *buf, uint32_t *tv)
+br_set_default_ongoingversion(br_version_t *buf, unsigned long *tv)
 {
     buf->ongoingversion = BITROT_DEFAULT_CURRENT_VERSION;
     buf->timebuf[0] = tv[0];
@@ -156,7 +156,8 @@ br_set_default_signature(br_signature_t *buf, size_t *size)
 }
 
 static inline void
-br_set_ongoingversion(br_version_t *buf, unsigned long version, uint32_t *tv)
+br_set_ongoingversion(br_version_t *buf, unsigned long version,
+                      unsigned long *tv)
 {
     buf->ongoingversion = version;
     buf->timebuf[0] = tv[0];

--- a/xlators/features/bit-rot/src/stub/bit-rot-object-version.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-object-version.h
@@ -16,7 +16,7 @@
  */
 typedef struct br_version {
     unsigned long ongoingversion;
-    uint32_t timebuf[2];
+    unsigned long timebuf[2];
 } br_version_t;
 
 typedef struct __attribute__((__packed__)) br_signature {

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.h
@@ -115,7 +115,7 @@ typedef struct br_stub_local {
 typedef struct br_stub_private {
     gf_boolean_t do_versioning;
 
-    uint32_t boot[2];
+    unsigned long boot[2];
     char export[PATH_MAX];
 
     pthread_mutex_t lock;


### PR DESCRIPTION
bit-rot: simplify and cleanup time management
    
Drop trivial `br_fsscan_calculate_delta()`, consistently use
`unsigned long` and `time_t` to represent time intervals here
and there, drop unused `tv` from `struct br_child`, adjust
related code.
    
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000