### PR TITLE
api: Fix return from `glfs_open()` to honour `O_DIRECTORY` flag

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -452,15 +452,23 @@ retry:
         goto out;
 
     if (IA_ISDIR(iatt.ia_type)) {
-        ret = -1;
-        errno = EISDIR;
-        goto out;
-    }
-
-    if (!IA_ISREG(iatt.ia_type)) {
-        ret = -1;
-        errno = EINVAL;
-        goto out;
+        if ((flags & (O_RDWR | O_WRONLY)) ||
+            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
+            ret = -1;
+            errno = EISDIR;
+            goto out;
+        }
+    } else {
+        if (flags & O_DIRECTORY) {
+            ret = -1;
+            errno = ENOTDIR;
+            goto out;
+        }
+        if (!IA_ISREG(iatt.ia_type)) {
+            ret = -1;
+            errno = EINVAL;
+            goto out;
+        }
     }
 
     if (glfd->fd) {


### PR DESCRIPTION
As a consumer of libgfapi, Samba used to differentiate[[source](https://git.samba.org/?p=samba.git;a=blob;f=source3/modules/vfs_glusterfs.c;h=bce73094c54a577d5ee39d26dbc43de8b5690d6a;hb=HEAD#l783)] between file and directory OPENs based on stat information(and thereby setting `O_DIRECTORY` flag) acquired prior to actual OPEN. Recent improvements in Samba took out the need for `O_DIRECTORY` in OPEN flags causing failure(with **EISDIR**) to connect to GlusterFS backed shares via libgfapi. Explanation from one such [change](https://git.samba.org/?p=samba.git;a=commit;h=2bbdaca8da8a0f4d4ff6bb5d4a98470db223b265) in Samba made me realize that _glfs_open()_ wasn't returning error codes in a proper fashion and according to [standards](https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html).

Changes from the current PR aims to implement proper handling of `O_DIRECTORY` flag inside _glfs_open()_. The presence of `O_DIRECTORY` flag is to ensure the file being opened is a directory.

Find more details from commit message.