### PR TITLE
Locks: Optimize the interrupt flow of POSIX locks

### DIFF
--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -95,6 +95,7 @@
 #define IO_THREADS_QUEUE_SIZE_KEY "io-thread-queue-size"
 
 #define GF_XATTR_CLRLK_CMD "glusterfs.clrlk"
+#define GF_XATTR_INTRLK_CMD "glusterfs.intrlk"
 #define GF_XATTR_PATHINFO_KEY "trusted.glusterfs.pathinfo"
 #define GF_XATTR_NODE_UUID_KEY "trusted.glusterfs.node-uuid"
 #define GF_XATTR_LIST_NODE_UUIDS_KEY "trusted.glusterfs.list-node-uuids"

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -1368,7 +1368,8 @@ afr_is_special_xattr(const char *name, fop_getxattr_cbk_t *cbk,
         } else {
             *cbk = afr_getxattr_pathinfo_cbk;
         }
-    } else if (!strncmp(name, GF_XATTR_CLRLK_CMD, SLEN(GF_XATTR_CLRLK_CMD))) {
+    } else if (!strncmp(name, GF_XATTR_CLRLK_CMD, SLEN(GF_XATTR_CLRLK_CMD)) ||
+               !strncmp(name, GF_XATTR_INTRLK_CMD, SLEN(GF_XATTR_INTRLK_CMD))) {
         if (is_fgetxattr) {
             *cbk = afr_fgetxattr_clrlk_cbk;
         } else {

--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -111,7 +111,8 @@ clrlk_parse_args(const char *cmd, clrlk_args *args)
     if (!opts)
         goto out;
 
-    if (sscanf(cmd, GF_XATTR_CLRLK_CMD ".%s", opts) < 1) {
+    if (sscanf(cmd, GF_XATTR_CLRLK_CMD ".%s", opts) < 1 &&
+        sscanf(cmd, GF_XATTR_INTRLK_CMD ".%s", opts) < 1) {
         ret = -1;
         goto out;
     }
@@ -147,7 +148,8 @@ out:
 
 int
 clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
-                    int *blkd, int *granted, int *op_errno)
+                    int *blkd, int *granted, int *op_errno, char *client_uid,
+                    pid_t client_pid, bool setlk_interrupt)
 {
     posix_lock_t *plock = NULL;
     posix_lock_t *tmp = NULL;
@@ -177,6 +179,13 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
                               plock->user_flock.l_start != ulock.l_start ||
                               plock->user_flock.l_len != ulock.l_len))
                 continue;
+
+            if (setlk_interrupt) {
+                if ((plock->client_pid != client_pid) ||
+                    (strcmp(plock->client_uid, client_uid) != 0)) {
+                    continue;
+                }
+            }
 
             list_del_init(&plock->list);
             if (plock->blocked) {

--- a/xlators/features/locks/src/clear.h
+++ b/xlators/features/locks/src/clear.h
@@ -59,7 +59,8 @@ clrlk_parse_args(const char *cmd, clrlk_args *args);
 
 int
 clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
-                    int *blkd, int *granted, int *op_errno);
+                    int *blkd, int *granted, int *op_errno, char *client_uid,
+                    pid_t client_pid, bool setlk_interrupt);
 int
 clrlk_clear_inodelk(xlator_t *this, pl_inode_t *pl_inode, pl_dom_list_t *dom,
                     clrlk_args *args, int *blkd, int *granted, int *op_errno);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -1233,13 +1233,15 @@ pl_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
-                  dict_t **dict, int32_t *op_errno)
+                  dict_t **dict, int32_t *op_errno, char *client_uid,
+                  pid_t client_pid)
 {
     int32_t bcount = 0;
     int32_t gcount = 0;
     char *key = NULL;
     char *lk_summary = NULL;
     pl_inode_t *pl_inode = NULL;
+    bool setlk_interrupt = false;
     clrlk_args args = {
         0,
     };
@@ -1272,8 +1274,13 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
                                                     &bcount, &gcount, op_errno);
             break;
         case CLRLK_POSIX:
+            if (!strncmp(name, GF_XATTR_INTRLK_CMD,
+                         SLEN(GF_XATTR_INTRLK_CMD))) {
+                setlk_interrupt = true;
+            }
             op_ret = clrlk_clear_posixlk(this, pl_inode, &args, &bcount,
-                                         &gcount, op_errno);
+                                         &gcount, op_errno, client_uid,
+                                         client_pid, setlk_interrupt);
             break;
         default:
             op_ret = -1;
@@ -1352,6 +1359,8 @@ pl_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
     int32_t op_errno = EINVAL;
     int32_t op_ret = -1;
     dict_t *dict = NULL;
+    char *client_uid = NULL;
+    pid_t client_pid = -1;
 
     if (!name)
         goto usual;
@@ -1359,8 +1368,19 @@ pl_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
     if (strncmp(name, GF_XATTR_CLRLK_CMD, SLEN(GF_XATTR_CLRLK_CMD)))
         goto usual;
 
-    op_ret = pl_getxattr_clrlk(this, name, loc->inode, &dict, &op_errno);
+    if (frame->root && frame->root->client) {
+        client_uid = frame->root->client->client_uid;
+        client_pid = frame->root->pid;
+    }
+    if (strncmp(name, GF_XATTR_INTRLK_CMD, SLEN(GF_XATTR_INTRLK_CMD)) == 0) {
+        if (!client_uid || client_pid < 0)
+            goto unwind;
+    }
 
+    op_ret = pl_getxattr_clrlk(this, name, loc->inode, &dict, &op_errno,
+                               client_uid, client_pid);
+
+unwind:
     STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict, xdata);
 
     if (dict)
@@ -1593,9 +1613,24 @@ pl_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 {
     int32_t op_ret = 0, op_errno = 0;
     dict_t *dict = NULL;
+    char *client_uid = NULL;
+    pid_t client_pid = -1;
 
     if (!name) {
         goto usual;
+    }
+
+    if (frame->root && frame->root->client) {
+        client_uid = frame->root->client->client_uid;
+        client_pid = frame->root->pid;
+    }
+
+    if (strncmp(name, GF_XATTR_INTRLK_CMD, SLEN(GF_XATTR_INTRLK_CMD)) == 0) {
+        if (!client_uid || client_pid < 0) {
+            op_ret = -1;
+            op_errno = EINVAL;
+            goto unwind;
+        }
     }
 
     if (strcmp(name, GF_XATTR_LOCKINFO_KEY) == 0) {
@@ -1616,8 +1651,11 @@ pl_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 
         goto unwind;
     } else if (strncmp(name, GF_XATTR_CLRLK_CMD, SLEN(GF_XATTR_CLRLK_CMD)) ==
-               0) {
-        op_ret = pl_getxattr_clrlk(this, name, fd->inode, &dict, &op_errno);
+                   0 ||
+               strncmp(name, GF_XATTR_INTRLK_CMD, SLEN(GF_XATTR_INTRLK_CMD)) ==
+                   0) {
+        op_ret = pl_getxattr_clrlk(this, name, fd->inode, &dict, &op_errno,
+                                   client_uid, client_pid);
 
         goto unwind;
     } else {

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -4828,7 +4828,7 @@ fuse_setlk_interrupt_handler(xlator_t *this, fuse_interrupt_record_t *fir)
     state = fir->data;
 
     ret = gf_asprintf(
-        &xattr_name, GF_XATTR_CLRLK_CMD ".tposix.kblocked.%hd,%jd-%jd",
+        &xattr_name, GF_XATTR_INTRLK_CMD ".tposix.kblocked.%hd,%jd-%jd",
         state->lk_lock.l_whence, state->lk_lock.l_start, state->lk_lock.l_len);
     if (ret == -1) {
         xattr_name = NULL;


### PR DESCRIPTION
Locks: Optimize the interrupt flow of POSIX locks

The bug has been merged into the branch "devel". https://github.com/gluster/glusterfs/pull/3266
So We backport this to branch "release-10".

Fixes: https://github.com/gluster/glusterfs/issues/3177

Signed-off-by:JamesWSWu [wu.shiwei@zte.com.cn](mailto:wu.shiwei@zte.com.cn)