### PR TITLE
glusterd: drop unused pointer to private data

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -1676,7 +1676,6 @@ __glusterd_handle_cli_uuid_get(rpcsvc_request_t *req)
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
     gf_cli_rsp rsp = {
         0,
     };
@@ -1691,9 +1690,6 @@ __glusterd_handle_cli_uuid_get(rpcsvc_request_t *req)
     };
 
     GF_ASSERT(req);
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
@@ -2851,7 +2847,6 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
         {0},
     };
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     xlator_t *this = THIS;
     gd1_mgmt_friend_update_rsp rsp = {
         {0},
@@ -2871,9 +2866,6 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
     int32_t op = 0;
 
     GF_ASSERT(req);
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &friend_req,
                          (xdrproc_t)xdr_gd1_mgmt_friend_update);

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -1571,10 +1571,6 @@ glusterd_op_stage_reset_volume(dict_t *dict, char **op_errstr)
     char *key_fixed = NULL;
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
 
@@ -7068,12 +7064,9 @@ glusterd_shd_select_brick_xlator(dict_t *dict, gf_xl_afr_op_t heal_op,
                                  int *hxlator_count, dict_t *rsp_dict)
 {
     int ret = -1;
-    glusterd_conf_t *priv = NULL;
     xlator_t *this = THIS;
     glusterd_svc_t *svc = NULL;
 
-    priv = this->private;
-    GF_ASSERT(priv);
     svc = &(volinfo->shd.svc);
 
     switch (heal_op) {
@@ -7149,7 +7142,6 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
 {
     int ret = -1;
     char *volname = NULL;
-    glusterd_conf_t *priv = NULL;
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
     char msg[2048] = {
@@ -7159,9 +7151,6 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
     gf_xl_afr_op_t heal_op = GF_SHD_OP_INVALID;
     int hxlator_count = 0;
     int index = 0;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -1126,13 +1126,10 @@ __glusterd_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *dict = NULL;
     char *peer_str = NULL;
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
     uuid_t *txn_id = NULL;
     call_frame_t *frame = NULL;
 
     GF_ASSERT(req);
-    priv = this->private;
-    GF_ASSERT(priv);
     GF_ASSERT(myframe);
 
     frame = myframe;
@@ -1266,7 +1263,6 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     dict_t *dict = NULL;
     char *peer_str = NULL;
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
     uuid_t *txn_id = NULL;
     glusterd_op_info_t txn_op_info = {
         GD_OP_STATE_DEFAULT,
@@ -1274,8 +1270,6 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
 
     GF_ASSERT(req);
-    priv = this->private;
-    GF_ASSERT(priv);
     GF_ASSERT(myframe);
 
     frame = myframe;
@@ -1435,7 +1429,6 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
     int port = 0;
     char *hostname = NULL;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     dict_t *dict = NULL;
 
     if (!frame || !data) {
@@ -1445,9 +1438,7 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     dict = data;
-    priv = this->private;
 
-    GF_ASSERT(priv);
     ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
@@ -1603,7 +1594,6 @@ glusterd_rpc_friend_remove(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = 0;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     glusterd_friend_sm_event_t *event = NULL;
 
     if (!frame || !data) {
@@ -1612,9 +1602,6 @@ glusterd_rpc_friend_remove(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     event = data;
-    priv = this->private;
-
-    GF_ASSERT(priv);
 
     RCU_READ_LOCK;
 
@@ -1652,13 +1639,9 @@ glusterd_rpc_friend_update(call_frame_t *frame, xlator_t *this, void *data)
         {0},
     };
     int ret = 0;
-    glusterd_conf_t *priv = NULL;
     dict_t *friends = NULL;
     call_frame_t *dummy_frame = NULL;
     glusterd_peerinfo_t *peerinfo = NULL;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     friends = data;
     if (!friends)
@@ -1701,13 +1684,9 @@ glusterd_cluster_lock(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     call_frame_t *dummy_frame = NULL;
 
     peerinfo = data;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     glusterd_get_uuid(&req.uuid);
 
@@ -1735,14 +1714,10 @@ glusterd_mgmt_v3_lock_peers(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     dict_t *dict = NULL;
     uuid_t *txn_id = NULL;
 
     dict = data;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
@@ -1811,14 +1786,10 @@ glusterd_mgmt_v3_unlock_peers(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     dict_t *dict = NULL;
     uuid_t *txn_id = NULL;
 
     dict = data;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
@@ -1888,12 +1859,9 @@ glusterd_cluster_unlock(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     call_frame_t *dummy_frame = NULL;
 
     peerinfo = data;
-    priv = this->private;
-    GF_ASSERT(priv);
 
     glusterd_get_uuid(&req.uuid);
 
@@ -1924,14 +1892,10 @@ glusterd_stage_op(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     dict_t *dict = NULL;
     uuid_t *txn_id = NULL;
 
     dict = data;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {
@@ -2000,13 +1964,10 @@ glusterd_commit_op(call_frame_t *frame, xlator_t *this, void *data)
     };
     int ret = -1;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     dict_t *dict = NULL;
     uuid_t *txn_id = NULL;
 
     dict = data;
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_ptr(dict, "peerinfo", VOID(&peerinfo));
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -4564,15 +4564,12 @@ glusterd_volinfo_copy_brickinfo(glusterd_volinfo_t *old_volinfo,
     glusterd_brickinfo_t *old_brickinfo = NULL;
     glusterd_brickinfo_t *new_ta_brickinfo = NULL;
     glusterd_brickinfo_t *old_ta_brickinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     int ret = 0;
     xlator_t *this = THIS;
     char abspath[PATH_MAX] = "";
 
     GF_ASSERT(new_volinfo);
     GF_ASSERT(old_volinfo);
-    priv = this->private;
-    GF_ASSERT(priv);
 
     cds_list_for_each_entry(new_brickinfo, &new_volinfo->bricks, brick_list)
     {
@@ -5205,14 +5202,11 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
     int i = 1;
     gf_boolean_t update = _gf_false;
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
     glusterd_friend_synctask_args_t *arg = NULL;
 
     GF_ASSERT(peer_data);
     GF_ASSERT(status);
 
-    priv = this->private;
-    GF_ASSERT(priv);
     ret = glusterd_import_global_opts(peer_data);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GLOBAL_OPT_IMPORT_FAIL,
@@ -7536,11 +7530,7 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
     int ret = -1;
     gf_boolean_t is_allocated = _gf_false;
     glusterd_peerinfo_t *peerinfo = NULL;
-    glusterd_conf_t *priv = NULL;
     xlator_t *this = THIS;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     GF_ASSERT(brick);
     GF_ASSERT(op_errstr);
@@ -12376,11 +12366,7 @@ glusterd_get_dst_brick_info(char **dst_brick, char *volname, char **op_errstr,
     char *c = NULL;
     char msg[2048] = "";
     xlator_t *this = THIS;
-    glusterd_conf_t *priv = NULL;
     int ret = 0;
-
-    priv = this->private;
-    GF_ASSERT(priv);
 
     ret = dict_get_strn(dict, "dst-brick", SLEN("dst-brick"), dst_brick);
 


### PR DESCRIPTION
Massively remove `glusterd_conf_t *` pointer where it's
actually used for `GF_ASSERT()` only since there is no
point in blindly checking the same pointer again and
again even in debug configuration.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000