### PR TITLE
glusterd: ensure friend events are always freed

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -216,9 +216,7 @@ out:
         }
         if (peer_ver)
             dict_unref(peer_ver);
-        if (event)
-            GF_FREE(event->peername);
-        GF_FREE(event);
+        glusterd_destroy_sm_event(event);
     }
 
     return ret;
@@ -301,9 +299,7 @@ out:
         if (ctx && ctx->hostname)
             GF_FREE(ctx->hostname);
         GF_FREE(ctx);
-        if (event)
-            GF_FREE(event->peername);
-        GF_FREE(event);
+        glusterd_destroy_sm_event(event);
     }
 
     return ret;
@@ -3854,6 +3850,8 @@ glusterd_probe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
             gf_uuid_copy(event->peerid, peerinfo->uuid);
 
             ret = glusterd_friend_sm_inject_event(event);
+            if (ret)
+                glusterd_destroy_sm_event(event);
             glusterd_xfer_cli_probe_resp(req, 0, GF_PROBE_SUCCESS, NULL,
                                          (char *)hoststr, port, dict);
         }
@@ -3943,6 +3941,8 @@ glusterd_deprobe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
 
 out:
     RCU_READ_UNLOCK;
+    if (ret)
+        glusterd_destroy_sm_event(event);
     return ret;
 }
 
@@ -6572,6 +6572,8 @@ glusterd_friend_remove_notify(glusterd_peerctx_t *peerctx, int32_t op_errno)
 
 out:
     RCU_READ_UNLOCK;
+    if (ret)
+        glusterd_destroy_sm_event(new_event);
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1918,11 +1918,13 @@ glusterd_event_connected_inject(glusterd_peerctx_t *peerctx)
 
     RCU_READ_UNLOCK;
 
-    if (ret)
+    if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_EVENT_INJECT_FAIL,
                "Unable to inject "
                "EVENT_CONNECTED ret = %d",
                ret);
+        glusterd_destroy_sm_event(event);
+    }
 
 out:
     gf_msg_debug("glusterd", 0, "returning %d", ret);

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -184,6 +184,18 @@ typedef struct glusterd_probe_ctx_ {
     int port;
     dict_t *dict;
 } glusterd_probe_ctx_t;
+
+static inline void
+glusterd_destroy_sm_event(glusterd_friend_sm_event_t *event)
+{
+    if (!event)
+        return;
+
+    if (event->peername)
+        GF_FREE(event->peername);
+    GF_FREE(event);
+}
+
 int
 glusterd_friend_sm_new_event(glusterd_friend_sm_event_type_t event_type,
                              glusterd_friend_sm_event_t **new_event);


### PR DESCRIPTION
Introduce `glusterd_destroy_sm_event()` and ensure that
all of `glusterd_friend_sm_event_t` events are freed on
all paths, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000