### PR TITLE
Upcall minor improvements

### DIFF
--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -449,12 +449,14 @@ up_invalidate_needed(dict_t *xattrs)
  *
  * Since sending notifications for cache_invalidation is a best effort,
  * any errors during the process are logged and ignored.
+ *
+ * The function should be called only if upcall is enabled
  */
 void
 upcall_cache_invalidate(call_frame_t *frame, xlator_t *this, client_t *client,
-                        inode_t *inode, uint32_t flags, struct iatt *stbuf,
-                        struct iatt *p_stbuf, struct iatt *oldp_stbuf,
-                        dict_t *xattr)
+                        inode_t *inode, const uint32_t flags,
+                        struct iatt *stbuf, struct iatt *p_stbuf,
+                        struct iatt *oldp_stbuf, dict_t *xattr)
 {
     upcall_client_t *up_client_entry = NULL;
     upcall_client_t *tmp = NULL;
@@ -462,9 +464,6 @@ upcall_cache_invalidate(call_frame_t *frame, xlator_t *this, client_t *client,
     gf_boolean_t found = _gf_false;
     time_t time_now;
     inode_t *linked_inode = NULL;
-
-    if (!is_upcall_enabled(this))
-        return;
 
     /* server-side generated fops like quota/marker will not have any
      * client associated with them. Ignore such fops.

--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -56,8 +56,9 @@ get_cache_invalidation_timeout(xlator_t *this)
 }
 
 static upcall_client_t *
-__add_upcall_client(client_t *client, upcall_inode_ctx_t *up_inode_ctx,
-                    time_t now, time_t timeout)
+__add_upcall_client(xlator_t *this, client_t *client,
+                    upcall_inode_ctx_t *up_inode_ctx, time_t now,
+                    time_t timeout)
 {
     upcall_client_t *up_client_entry = GF_MALLOC(
         sizeof(*up_client_entry), gf_upcall_mt_upcall_client_entry_t);
@@ -73,7 +74,7 @@ __add_upcall_client(client_t *client, upcall_inode_ctx_t *up_inode_ctx,
 
     list_add_tail(&up_client_entry->client_list, &up_inode_ctx->client_list);
 
-    gf_log(THIS->name, GF_LOG_DEBUG, "upcall_entry_t client added - %s",
+    gf_log(this->name, GF_LOG_DEBUG, "upcall_entry_t client added - %s",
            up_client_entry->client_uid);
 
     return up_client_entry;
@@ -549,7 +550,7 @@ upcall_cache_invalidate(call_frame_t *frame, xlator_t *this, client_t *client,
         }
 
         if (!found) {
-            up_client_entry = __add_upcall_client(client, up_inode_ctx,
+            up_client_entry = __add_upcall_client(this, client, up_inode_ctx,
                                                   time_now, timeout);
         }
     }
@@ -601,7 +602,7 @@ upcall_client_cache_invalidate(xlator_t *this, uuid_t gfid,
         up_req.data = &ca_req;
         up_req.event_type = GF_UPCALL_CACHE_INVALIDATION;
 
-        gf_log(THIS->name, GF_LOG_TRACE,
+        gf_log(this->name, GF_LOG_TRACE,
                "Cache invalidation notification sent to %s",
                up_client_entry->client_uid);
 

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -30,7 +30,6 @@ up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -41,9 +40,9 @@ up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(open, frame, op_ret, op_errno, fd, xdata);
@@ -83,8 +82,9 @@ up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
               dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
+
+    EXIT_IF_UPCALL_OFF(this, out);
 
     client = frame->root->client;
     local = frame->local;
@@ -92,9 +92,9 @@ up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_WRITE_FLAGS;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, postbuf,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_WRITE_FLAGS,
+                            postbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(writev, frame, op_ret, op_errno, prebuf, postbuf,
@@ -137,7 +137,6 @@ up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
              struct iobref *iobref, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -148,9 +147,9 @@ up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, stbuf,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            stbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(readv, frame, op_ret, op_errno, vector, count, stbuf,
@@ -190,7 +189,6 @@ up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -201,9 +199,9 @@ up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(lk, frame, op_ret, op_errno, lock, xdata);
@@ -242,7 +240,6 @@ up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                 dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -253,9 +250,9 @@ up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_WRITE_FLAGS;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, postbuf,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_WRITE_FLAGS,
+                            postbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(truncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -365,7 +362,6 @@ up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               struct iatt *postnewparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -376,20 +372,19 @@ up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = (UP_RENAME_FLAGS | UP_PARENT_DENTRY_FLAGS);
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, stbuf,
+
+    upcall_cache_invalidate(frame, this, client, local->inode,
+                            (UP_RENAME_FLAGS | UP_PARENT_DENTRY_FLAGS), stbuf,
                             postnewparent, postoldparent, NULL);
 
-    flags = UP_UPDATE_CLIENT;
     upcall_cache_invalidate(frame, this, client, local->rename_oldloc.parent,
-                            flags, postoldparent, NULL, NULL, NULL);
+                            UP_UPDATE_CLIENT, postoldparent, NULL, NULL, NULL);
 
     if (local->rename_oldloc.parent == local->loc.parent)
         goto out;
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.parent, flags,
-                            postnewparent, NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.parent,
+                            UP_UPDATE_CLIENT, postnewparent, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(rename, frame, op_ret, op_errno, stbuf, preoldparent,
@@ -433,7 +428,6 @@ up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
               dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -444,13 +438,13 @@ up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
+
+    upcall_cache_invalidate(frame, this, client, local->inode,
+                            (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS), NULL,
                             postparent, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.parent, flags,
-                            postparent, NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.parent,
+                            UP_UPDATE_CLIENT, postparent, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(unlink, frame, op_ret, op_errno, preparent, postparent,
@@ -491,7 +485,6 @@ up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -502,13 +495,13 @@ up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, stbuf,
+
+    upcall_cache_invalidate(frame, this, client, local->inode,
+                            (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS), stbuf,
                             postparent, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.parent, flags,
-                            postparent, NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.parent,
+                            UP_UPDATE_CLIENT, postparent, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(link, frame, op_ret, op_errno, inode, stbuf, preparent,
@@ -550,7 +543,6 @@ up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
              dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -562,13 +554,12 @@ up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         goto out;
     }
 
-    flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
+    upcall_cache_invalidate(frame, this, client, local->inode,
+                            (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS), NULL,
                             postparent, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.parent, flags,
-                            postparent, NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.parent,
+                            UP_UPDATE_CLIENT, postparent, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(rmdir, frame, op_ret, op_errno, preparent, postparent,
@@ -609,7 +600,6 @@ up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -622,13 +612,11 @@ up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     }
 
     /* invalidate parent's entry too */
-    flags = UP_TIMES;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags,
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_TIMES,
                             postparent, NULL, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.inode, flags, stbuf,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.inode,
+                            UP_UPDATE_CLIENT, stbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(mkdir, frame, op_ret, op_errno, inode, stbuf, preparent,
@@ -670,7 +658,6 @@ up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
               struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -685,13 +672,11 @@ up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     /* As its a new file create, no need of sending notification
      * However invalidate parent's entry and update that fact that the
      * client has accessed the newly created entry */
-    flags = UP_TIMES;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags,
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_TIMES,
                             postparent, NULL, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.inode, flags, stbuf,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.inode,
+                            UP_UPDATE_CLIENT, stbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(create, frame, op_ret, op_errno, fd, inode, stbuf,
@@ -734,7 +719,6 @@ up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
               struct iatt *postparent)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -745,9 +729,9 @@ up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, stbuf,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            stbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(lookup, frame, op_ret, op_errno, inode, stbuf, xattr,
@@ -786,7 +770,6 @@ up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -797,9 +780,9 @@ up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, buf, NULL,
-                            NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            buf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(stat, frame, op_ret, op_errno, buf, xdata);
@@ -888,7 +871,6 @@ up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
               int op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -899,9 +881,9 @@ up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(access, frame, op_ret, op_errno, xdata);
@@ -941,7 +923,6 @@ up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                 dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -952,9 +933,9 @@ up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, stbuf,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            stbuf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(readlink, frame, op_ret, op_errno, path, stbuf, xdata);
@@ -994,7 +975,6 @@ up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1007,13 +987,11 @@ up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
 
     /* invalidate parent's entry too */
-    flags = UP_TIMES;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags,
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_TIMES,
                             postparent, NULL, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.inode, flags, buf,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.inode,
+                            UP_UPDATE_CLIENT, buf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(mknod, frame, op_ret, op_errno, inode, buf, preparent,
@@ -1056,7 +1034,6 @@ up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1069,13 +1046,11 @@ up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* invalidate parent's entry too */
-    flags = UP_TIMES;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags,
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_TIMES,
                             postparent, NULL, NULL, NULL);
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->loc.inode, flags, buf,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->loc.inode,
+                            UP_UPDATE_CLIENT, buf, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(symlink, frame, op_ret, op_errno, inode, buf, preparent,
@@ -1116,7 +1091,6 @@ up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1127,9 +1101,9 @@ up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(opendir, frame, op_ret, op_errno, fd, xdata);
@@ -1168,7 +1142,6 @@ up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct statvfs *buf, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1179,9 +1152,9 @@ up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(statfs, frame, op_ret, op_errno, buf, xdata);
@@ -1220,7 +1193,6 @@ up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1231,9 +1203,9 @@ up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(readdir, frame, op_ret, op_errno, entries, xdata);
@@ -1273,7 +1245,6 @@ up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
     gf_dirent_t *entry = NULL;
 
@@ -1285,17 +1256,18 @@ up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
     list_for_each_entry(entry, &entries->list, list)
     {
         if (entry->inode == NULL) {
             continue;
         }
-        upcall_cache_invalidate(frame, this, client, entry->inode, flags,
-                                &entry->d_stat, NULL, NULL, NULL);
+        upcall_cache_invalidate(frame, this, client, entry->inode,
+                                UP_UPDATE_CLIENT, &entry->d_stat, NULL, NULL,
+                                NULL);
     }
 
 out:
@@ -1362,7 +1334,6 @@ up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1373,9 +1344,9 @@ up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_WRITE_FLAGS;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, post,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_WRITE_FLAGS,
+                            post, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(fallocate, frame, op_ret, op_errno, pre, post, xdata);
@@ -1416,7 +1387,6 @@ up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1427,9 +1397,9 @@ up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_WRITE_FLAGS;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, post,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_WRITE_FLAGS,
+                            post, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(discard, frame, op_ret, op_errno, pre, post, xdata);
@@ -1469,7 +1439,6 @@ up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1480,9 +1449,9 @@ up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_WRITE_FLAGS;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, post,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_WRITE_FLAGS,
+                            post, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(zerofill, frame, op_ret, op_errno, pre, post, xdata);
@@ -1521,7 +1490,6 @@ up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             int op_errno, off_t offset, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1532,9 +1500,9 @@ up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if ((op_ret < 0) || !local) {
         goto out;
     }
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(seek, frame, op_ret, op_errno, offset, xdata);
@@ -1887,7 +1855,6 @@ up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1899,9 +1866,8 @@ up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(fgetxattr, frame, op_ret, op_errno, dict, xdata);
@@ -1936,7 +1902,6 @@ up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     client_t *client = NULL;
-    uint32_t flags = 0;
     upcall_local_t *local = NULL;
 
     EXIT_IF_UPCALL_OFF(this, out);
@@ -1948,9 +1913,8 @@ up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    flags = UP_UPDATE_CLIENT;
-    upcall_cache_invalidate(frame, this, client, local->inode, flags, NULL,
-                            NULL, NULL, NULL);
+    upcall_cache_invalidate(frame, this, client, local->inode, UP_UPDATE_CLIENT,
+                            NULL, NULL, NULL, NULL);
 
 out:
     UPCALL_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, xdata);

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -2095,7 +2095,7 @@ mem_acct_init(xlator_t *this)
 }
 
 void
-upcall_local_wipe(xlator_t *this, upcall_local_t *local)
+upcall_local_wipe(upcall_local_t *local)
 {
     if (local) {
         inode_unref(local->inode);

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -25,6 +25,10 @@
 #include <glusterfs/defaults.h>
 #include "upcall-cache-invalidation.h"
 
+static upcall_local_t *
+upcall_local_init(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
+                  inode_t *inode, dict_t *xattr);
+
 static int32_t
 up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             int32_t op_errno, fd_t *fd, dict_t *xdata)
@@ -2105,17 +2109,16 @@ upcall_local_wipe(xlator_t *this, upcall_local_t *local)
     }
 }
 
-upcall_local_t *
+static upcall_local_t *
 upcall_local_init(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
                   inode_t *inode, dict_t *xattr)
 {
     upcall_local_t *local = NULL;
 
-    GF_VALIDATE_OR_GOTO("upcall", this, out);
     GF_VALIDATE_OR_GOTO(this->name, frame, out);
     GF_VALIDATE_OR_GOTO(this->name, inode, out);
 
-    local = mem_get0(THIS->local_pool);
+    local = mem_get0(this->local_pool);
 
     if (!local)
         goto out;

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -25,25 +25,21 @@
 #define UPCALL_STACK_UNWIND(fop, frame, params...)                             \
     do {                                                                       \
         upcall_local_t *__local = NULL;                                        \
-        xlator_t *__xl = NULL;                                                 \
         if (frame) {                                                           \
-            __xl = frame->this;                                                \
             __local = frame->local;                                            \
             frame->local = NULL;                                               \
         }                                                                      \
         STACK_UNWIND_STRICT(fop, frame, params);                               \
-        upcall_local_wipe(__xl, __local);                                      \
+        upcall_local_wipe(__local);                                            \
     } while (0)
 
 #define UPCALL_STACK_DESTROY(frame)                                            \
     do {                                                                       \
         upcall_local_t *__local = NULL;                                        \
-        xlator_t *__xl = NULL;                                                 \
-        __xl = frame->this;                                                    \
         __local = frame->local;                                                \
         frame->local = NULL;                                                   \
         STACK_DESTROY(frame->root);                                            \
-        upcall_local_wipe(__xl, __local);                                      \
+        upcall_local_wipe(__local);                                            \
     } while (0)
 
 struct _upcall_private {
@@ -94,7 +90,7 @@ struct upcall_local {
 typedef struct upcall_local upcall_local_t;
 
 void
-upcall_local_wipe(xlator_t *this, upcall_local_t *local);
+upcall_local_wipe(upcall_local_t *local);
 
 int
 upcall_cleanup_inode_ctx(xlator_t *this, inode_t *inode);

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -43,15 +43,15 @@
     } while (0)
 
 struct _upcall_private {
-    gf_boolean_t cache_invalidation_enabled;
     time_t cache_invalidation_timeout;
     struct list_head inode_ctx_list;
     gf_lock_t inode_ctx_lk;
-    gf_boolean_t reaper_init_done;
     pthread_t reaper_thr;
-    int32_t fini;
     dict_t *xattrs; /* list of xattrs registered by clients
                        for receiving invalidation */
+    int32_t fini;
+    gf_boolean_t cache_invalidation_enabled;
+    gf_boolean_t reaper_init_done;
 };
 typedef struct _upcall_private upcall_private_t;
 
@@ -71,8 +71,8 @@ struct _upcall_inode_ctx {
     struct list_head client_list;
     pthread_mutex_t client_list_lock; /* mutex for clients list
                                          of this upcall entry */
-    int destroy;
     uuid_t gfid; /* gfid of the entry */
+    int destroy;
 };
 typedef struct _upcall_inode_ctx upcall_inode_ctx_t;
 

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -95,9 +95,6 @@ typedef struct upcall_local upcall_local_t;
 
 void
 upcall_local_wipe(xlator_t *this, upcall_local_t *local);
-upcall_local_t *
-upcall_local_init(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
-                  inode_t *inode, dict_t *xattr);
 
 upcall_inode_ctx_t *
 upcall_inode_ctx_get(inode_t *inode, xlator_t *this);

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -96,8 +96,6 @@ typedef struct upcall_local upcall_local_t;
 void
 upcall_local_wipe(xlator_t *this, upcall_local_t *local);
 
-upcall_inode_ctx_t *
-upcall_inode_ctx_get(inode_t *inode, xlator_t *this);
 int
 upcall_cleanup_inode_ctx(xlator_t *this, inode_t *inode);
 

--- a/xlators/features/upcall/src/upcall.h
+++ b/xlators/features/upcall/src/upcall.h
@@ -71,7 +71,7 @@ struct _upcall_inode_ctx {
     struct list_head client_list;
     pthread_mutex_t client_list_lock; /* mutex for clients list
                                          of this upcall entry */
-    uuid_t gfid; /* gfid of the entry */
+    uuid_t gfid;                      /* gfid of the entry */
     int destroy;
 };
 typedef struct _upcall_inode_ctx upcall_inode_ctx_t;


### PR DESCRIPTION
- [x]  upcall-internal.c: upcall_client_cache_invalidate() should only be called with non null GFID
    
    There's no point in checking it in a loop and in other calls it was already checked,
    So extracted the check in upcall_cache_forget() outside the loop.
    
- [x] upcall: remove unused 'xl' in upcall_local_wipe() call.

- [x] upcall: improve upcall_inode_ctx_get()/set() functions
    
    - No need to get in the setter, since it is only called if get already failed.
    - Make them static.
    - set() should return the inode ctx.

- [x]  upcall-internal.c: change 'THIS' to 'this'
    
    In some places, we've used 'THIS' where 'this' was perfectly fine to use.

- [x]    upcall: minor upcall_local_init() improvements
   
    - Use 'this' instead of 'THIS'
    - Make it static function
    - No need to check for 'this', it's always called after EXIT_IF_UPCALL_OFF macro
    which is already using 'this'.

- [x]  upcall-internal.c: pass the timeout instead of fetching it over and over
    
    We've fetched the timeout (via a call to get_cache_invalidation_timeout() function)
    where we could have fetched it less often and pass it around.

- [x]   upcall: upcall_cache_invalidate() should not check if upcall is enabled
    
    It was already called only if upcall was enabled, in all places but one.
    Added that one (up_writev_cbk) as well and removed the check from
    upcall_cache_invalidate() which was useful in case where it is called in a loop,
    for example in up_readdirp_cbk()
    
    In addition, wherever it was called with a constant flag, used that constant.
