### PR TITLE
afr: check for parent gfid before calling afr_is_private_directory()

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -50,13 +50,8 @@ afr_quorum_errno(afr_private_t *priv)
 }
 
 gf_boolean_t
-afr_is_private_directory(afr_private_t *priv, uuid_t pargfid, const char *name,
-                         pid_t pid)
+afr_is_private_directory(afr_private_t *priv, const char *name, pid_t pid)
 {
-    if (!__is_root_gfid(pargfid)) {
-        return _gf_false;
-    }
-
     if (strcmp(name, GF_REPLICATE_TRASH_DIR) == 0) {
         /*For backward compatibility /.landfill is private*/
         return _gf_true;
@@ -4018,8 +4013,8 @@ afr_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
         return 0;
     }
 
-    if (afr_is_private_directory(this->private, loc->parent->gfid, loc->name,
-                                 frame->root->pid)) {
+    if (__is_root_gfid(loc->parent->gfid) &&
+        afr_is_private_directory(this->private, loc->name, frame->root->pid)) {
         op_errno = EPERM;
         goto out;
     }

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -184,8 +184,7 @@ afr_readdir_transform_entries(pid_t pid, xlator_t *this,
          * which we check once (above) for all entries
          */
         if (is_root_gfid) {
-            if (afr_is_private_directory(priv, fd->inode->gfid, entry->d_name,
-                                         pid)) {
+            if (afr_is_private_directory(priv, entry->d_name, pid)) {
                 continue;
             }
         }

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -770,8 +770,8 @@ afr_selfheal_entry_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     priv = this->private;
 
-    if (afr_is_private_directory(priv, fd->inode->gfid, name,
-                                 GF_CLIENT_PID_SELF_HEALD)) {
+    if (__is_root_gfid(fd->inode->gfid) &&
+        afr_is_private_directory(priv, name, GF_CLIENT_PID_SELF_HEALD)) {
         return 0;
     }
 

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1305,6 +1305,5 @@ afr_fill_success_replies(afr_local_t *local, afr_private_t *priv,
                          unsigned char *replies);
 
 gf_boolean_t
-afr_is_private_directory(afr_private_t *priv, uuid_t pargfid, const char *name,
-                         pid_t pid);
+afr_is_private_directory(afr_private_t *priv, const char *name, pid_t pid);
 #endif /* __AFR_H__ */


### PR DESCRIPTION
In continuation to c95027c2bd8f69e59b3f342be1786caee4ed85f2 (afr: readdir(p) improvemtns (#3150))
extracted the root gfid check from afr_is_private_directory() to ensure it's not done more than needed.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

