### PR TITLE
afr-inode-write.c: remove one lock/unlock cycle

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -279,7 +279,7 @@ afr_writev_handle_short_writes(call_frame_t *frame, xlator_t *this)
     }
 }
 
-static void
+static int
 afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
@@ -288,6 +288,7 @@ afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
     afr_local_t *local = frame->local;
     uint32_t open_fd_count = 0;
     uint32_t write_is_append = 0;
+    int call_count;
 
     LOCK(&frame->lock);
     {
@@ -311,7 +312,10 @@ afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
         }
     }
 unlock:
+    call_count = --local->call_count;
     UNLOCK(&frame->lock);
+
+    return call_count;
 }
 
 static void
@@ -338,19 +342,17 @@ afr_process_post_writev(call_frame_t *frame, xlator_t *this)
         local->inode_ctx->open_fd_count = local->open_fd_count;
 }
 
-int
+static int
 afr_writev_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     call_frame_t *fop_frame = NULL;
     int child_index = (long)cookie;
-    int call_count = -1;
+    int call_count;
 
-    afr_inode_write_fill(frame, this, child_index, op_ret, op_errno, prebuf,
-                         postbuf, xdata);
-
-    call_count = afr_frame_return(frame);
+    call_count = afr_inode_write_fill(frame, this, child_index, op_ret,
+                                      op_errno, prebuf, postbuf, xdata);
 
     if (call_count == 0) {
         afr_process_post_writev(frame, this);


### PR DESCRIPTION
Just like in __afr_inode_write_cbk(), in afr_writev_wind_cbk() we call
afr_inode_write_fill() which takes the frame lock, so while at it,
reduce the call count and return it to the caller (instead of a call to
afr_frame_return() which takes the lock as well)

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

