### PR TITLE
[reservelk.c] Remove double lock on pl_inode's mutex

### DIFF
--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -291,11 +291,8 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
         return;
     }
     INIT_LIST_HEAD(&granted);
-    pthread_mutex_lock(&pl_inode->mutex);
-    {
-        __grant_blocked_lock_calls(this, pl_inode, &granted);
-    }
-    pthread_mutex_unlock(&pl_inode->mutex);
+
+    __grant_blocked_lock_calls(this, pl_inode, &granted);
 
     list_for_each_entry_safe(lock, tmp, &granted, list)
     {


### PR DESCRIPTION
Lock on `pl_inode->mutex` is acquired when `__grant_blocked_lock_calls`
is called. So having a lock on this mutex before calling this function
may result in a deadlock. This patch removes the initial lock.

Note: If the previous behavior was intended, I would love to know how it used to work without resulting in a deadlock, will help me understand things better :)

Signed-off-by: black.dragon74 <nickk.2974@gmail.com>

Regards

