### PR TITLE
[inode.c] Don't fetch THIS unconditionally

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -577,7 +577,7 @@ __inode_ref(inode_t *inode, bool is_invalidate)
      * in inode table increases which is wrong. So just keep the ref
      * count as 1 always
      */
-    if (inode->ref && __is_root_gfid(inode->gfid))
+    if (__is_root_gfid(inode->gfid) && inode->ref)
         return inode;
 
     if (!inode->ref) {

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -531,8 +531,6 @@ __inode_unref(inode_t *inode, bool clear)
          */
         return inode;
 
-    this = THIS;
-
     if (clear && inode->in_invalidate_list) {
         inode->in_invalidate_list = false;
         inode->table->invalidate_size--;
@@ -541,6 +539,7 @@ __inode_unref(inode_t *inode, bool clear)
     GF_ASSERT(inode->ref);
 
     --inode->ref;
+    this = THIS;
 
     index = __inode_get_xl_index(inode, this);
     if (index >= 0) {
@@ -569,8 +568,6 @@ __inode_ref(inode_t *inode, bool is_invalidate)
 
     if (!inode)
         return NULL;
-
-    this = THIS;
 
     /*
      * Root inode should always be in active list of inode table. So unrefs
@@ -603,6 +600,7 @@ __inode_ref(inode_t *inode, bool is_invalidate)
     }
 
     inode->ref++;
+    this = THIS;
 
     index = __inode_get_xl_index(inode, this);
     if (index >= 0) {

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -577,7 +577,7 @@ __inode_ref(inode_t *inode, bool is_invalidate)
      * in inode table increases which is wrong. So just keep the ref
      * count as 1 always
      */
-    if (__is_root_gfid(inode->gfid) && inode->ref)
+    if (inode->ref && __is_root_gfid(inode->gfid))
         return inode;
 
     if (!inode->ref) {


### PR DESCRIPTION
In some cases we can skip fetching `THIS` as we return before
we consume its value. This patch optimizes such cases.

Signed-off-by: black.dragon74 <nickk.2974@gmail.com>

