### PR TITLE
Mounting with ipv6 hostname leads to failure

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -322,7 +322,8 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     uint16_t remote_port = GF_DEFAULT_SOCKET_LISTEN_PORT;
     struct addrinfo *addr_info = NULL;
     int32_t ret = 0;
-    struct in6_addr serveraddr;
+    struct in6_addr serveraddr_ipv6;
+    struct in_addr serveraddr_ipv4;
 
     remote_host_data = dict_get_sizen(options, "remote-host");
     if (remote_host_data == NULL) {
@@ -359,8 +360,12 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     /* Need to update transport-address family if address-family is not provided
        to command-line arguments
     */
-    if (inet_pton(AF_INET6, remote_host, &serveraddr)) {
+    if (inet_pton(AF_INET6, remote_host, &serveraddr_ipv6)) {
         sockaddr->sa_family = AF_INET6;
+    } else if (inet_pton(AF_INET, remote_host, &serveraddr_ipv4)) {
+        sockaddr->sa_family = AF_INET;
+    } else {
+        sockaddr->sa_family = AF_UNSPEC;
     }
 
     /* TODO: gf_resolve is a blocking call. kick in some


### PR DESCRIPTION
Defective code can be found in function
af_inet_client_get_remote_sockaddr :

if (inet_pton(AF_INET6, remote_host, &serveraddr_ipv6)) {
    sockaddr->sa_family  = AF_INET6;
}

The problem is, when a ipv6 hostname comes here, it fails
to pass the condition. Hence, the sa_family of this ipv6
hostname cannnot be correctly marked as AF_INET6, but
AF_INET.

it can be verified by following steps:
1. create volume in ipv6 (ip or hostname)
2. mount the volume using hostname
3. mount failed, since the hostname is incorrectly
   set to AF_INET as displayed in log file.

Fixes: #3329
Change-Id: Ibd1b9e71f2d48a205eef1ce3cebd7397ce26e94f
Signed-off-by: ChenJinhao <jinhaochen.cloud@gmail.com>

