### PR TITLE
rpc: avoid restarting the bail out timer after initiating shut down

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -105,12 +105,14 @@ call_bail(void *data)
     };
     char peerid[UNIX_PATH_MAX] = {0};
     gf_boolean_t need_unref = _gf_false;
+    glusterfs_ctx_t *ctx = NULL;
 
     GF_VALIDATE_OR_GOTO("client", data, out);
 
     clnt = data;
 
     conn = &clnt->conn;
+    ctx = clnt->ctx;
     pthread_mutex_lock(&conn->lock);
     {
         trans = conn->trans;
@@ -122,7 +124,7 @@ call_bail(void *data)
     pthread_mutex_unlock(&conn->lock);
     /*rpc_clnt_connection_cleanup will be unwinding all saved frames,
      * bailed or otherwise*/
-    if (!trans)
+    if (!trans || ctx->cleanup_started)
         goto out;
 
     gettimeofday(&current, NULL);
@@ -368,13 +370,15 @@ rpc_clnt_reconnect(void *conn_ptr)
     struct rpc_clnt *clnt = NULL;
     gf_boolean_t need_unref = _gf_false;
     gf_boolean_t canceled_unref = _gf_false;
+    glusterfs_ctx_t *ctx = NULL;
 
     conn = conn_ptr;
     clnt = conn->rpc_clnt;
+    ctx = clnt->ctx;
     pthread_mutex_lock(&conn->lock);
     {
         trans = conn->trans;
-        if (!trans)
+        if (!trans || ctx->cleanup_started)
             goto out_unlock;
 
         if (conn->reconnect) {


### PR DESCRIPTION
glfs_fini takes time (20s) and slows down qemu-img, the time
is taken by due to timer_thread behavior. The timer thread
reregister function unless the timer event has not been
removed from a list.To avoid the delay the even needs
to add only if cleanup has not started.In case if cleanup
has started there is no need to add the event again in
timer thread list.

> Fixes: #3334
> Change-Id: I179c63c656c2917de9eb2bb44664453a1b6fc471
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/3340)

Change-Id: I58e1ed875399f49bc93d69be5975f2559f3785e9
Updates: #3334
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

