### PR TITLE
[RFE] logging: new way of defining and using log messages

### DIFF
--- a/doc/developer-guide/logging-guidelines.md
+++ b/doc/developer-guide/logging-guidelines.md
@@ -231,8 +231,16 @@ to use:
 
 - Errors
 
+  For positive errors:
+
   ```c
   GLFS_ERROR(name)
+  ```
+
+  For negative errors:
+
+  ```c
+  GLFS_RESULT(name)
   ```
 
 - Strings

--- a/doc/developer-guide/logging-guidelines.md
+++ b/doc/developer-guide/logging-guidelines.md
@@ -1,131 +1,299 @@
-Guidelines on using the logging framework within a component
-============================================================
+# Guidelines on using the logging framework within a component
+
 Gluster library libglusterfs.so provides message logging abstractions that
 are intended to be used across all code/components within gluster.
 
 There could be potentially 2 major cases how the logging infrastructure is
 used,
-  - A new gluster service daemon or end point is created
-    - The service daemon infrastructure itself initlializes the logging
+
+- A new gluster service daemon or end point is created
+
+  - The service daemon infrastructure itself initlializes the logging
     infrastructure (i.e calling gf_log_init and related set functions)
-      - See, glusterfsd.c:logging_init
-    - Alternatively there could be a case where an end point service (say
+
+    - See, glusterfsd.c:logging_init
+
+  - Alternatively there could be a case where an end point service (say
     gfapi) may need to do the required initialization
-    - This document does not (yet?) cover guidelines for these cases. Best
+
+  - This document does not (yet?) cover guidelines for these cases. Best
     bet would be to look at code in glusterfsd.c:logging_init (or equivalent)
     in case a need arises and you reach this document.
-  - A new xlator or subcomponent is written as a part of the stack
-    - Primarily in this case, the consumer of the logging APIs would only
+
+- A new xlator or subcomponent is written as a part of the stack
+
+  - Primarily in this case, the consumer of the logging APIs would only
     invoke an API to *log* a particular message at a certain severity
-    - This document elaborates on this use of the message logging framework
+
+  - This document elaborates on this use of the message logging framework
     in this context
 
-There are 2 interfaces provided to log messages,
-1. The older gf_log* interface
-2. The newer gf_msg* interface
+There are 3 interfaces provided to log messages:
 
-1. Older _to_be_deprecated_ gf_log* interface
-  - Not much documentation is provided for this interface here, as these are
-  meant to be deprecated and all code should be moved to the newer gf_msg*
-  interface
+1. GF_LOG* structured message interface
 
-2. New gf_msg* interface
-  - The set of interfaces provided by gf_msg are,
-    - NOTE: It is best to consult logging.h for the latest interfaces, as
-    this document may get out of sync with the code
+   All new messages should be defined using this interface. More details
+   about it in the next section.
 
-    *gf_msg(dom, levl, errnum, msgid, fmt...)*
-      - Used predominantly to log a message above TRACE and DEBUG levels
-      - See further guidelines below
+2. gf_msg* interface
 
-    *gf_msg_debug(dom, errnum, fmt...)*
-    *gf_msg_trace(dom, errnum, fmt...)*
-      - Above are handy shortcuts for TRACE and DEBUG level messages
-      - See further guidelines below
+   This interface is deprecated now. New log messages should use the
+   new structured interface.
 
-    *gf_msg_callingfn(dom, levl, errnum, msgid, fmt...)*
-      - Useful function when a backtrace to detect calling routines that
-      reached this execution point needs to be logged in addition to the
-      message
-      - This is very handy for framework libraries or code, as there could
-      be many callers to the same, and the real failure would need the call
-      stack to determine who the caller actually was
-      - A good example is the dict interfaces using this function to log who
-      called, when a particular error/warning needs to be displayed
-      - See further guidelines below
+3. gf_log* interface
 
-    *gf_msg_plain(levl, fmt...)*
-    *gf_msg_plain_nomem(levl, msg)*
-    *gf_msg_backtrace_nomem*
-      - The above interfaces are provided to log messages without any typical
-      headers (like the time stamp, dom, errnum etc.). The primary users of
-      the above interfaces are, when printing the final graph, or printing
-      the configuration when a process is about dump core or abort, or
-      printing the backtrace when a process receives a critical signal
-      - These interfaces should not be used outside the scope of the users
-      above, unless you know what you are doing
+   This interface was deprecated long ago and it must not be used
+   anymore.
 
-    *gf_msg_nomem(dom, levl, size)*
-      - Very crisp messages, throwing out file, function, line numbers, in
-      addition to the passed in size
-      - These are used in the memory allocation abstractions interfaces in
-      gluster, when the allocation fails (hence a no-mem log message, so that
-      further allocation is not attempted by the logging infrastructure)
-      - If you are contemplating using these, then you know why and how
+## Structured log messages
 
-  - Guidelines for the various arguments to the interfaces
-    **dom**
-      - The domain from which this message appears, IOW for xlators it should
-      be the name of the xlator (as in this->name)
+This interface is designed to be easy to use, flexible and consistent.
 
-      - The intention of this string is to distinguish from which
-      component/xlator the message is being printed
+The main advantages are:
 
-      - This information can also be gleaned from the FILE:LINE:FUNCTION
-      information printed in the message anyway, but is retained to provide
-      backward compatability to the messages as seen by admins earlier
+- **Centralized message definition**
 
-    **levl**
-      - Consult logging.h:gf_loglevel_t for logging levels (they pretty much
-      map to syslog levels)
+  All messages are defined in a unique location. If a message text needs to be
+  updated, only one place has to be changed, even if the same log message is
+  used in many places.
 
-    **errnum**
-      - errno should be passed in here, if available, 0 otherwise. This auto
-      enables the logging infrastructure to print (man 3) strerror form of the
-      same at the end of the message in a consistent format
+- **Customizable list of additional data per message**
 
-      - If any message is already adding the strerror as a parameter to the
-      message, it is suggested/encouraged to remove the same and pass it as
-      errnum
+  Each message can contain a list of additional info that will be logged as
+  part of the message itself. This extra data is:
 
-      - The intention is that, if all messages did this using errnum and not
-      as a part of their own argument list, the output would look consistent
-      for the admin and cross component developers when reading logs
+  - **Declared once**
 
-    **msgid**
-      - This is a unique message ID per message (which now is more a message
-      ID per group of messages in the implementation)
+    It's defined as part of the centralized message definition itself
 
-      - Rules for generating this ID can be found in dht-messages.h (it used
-      to be template-common-messages.h, but that template is not updated,
-      this comment should be changed once that is done) and glfs-message-id.h
+  - **Typed**
 
-      - Every message that is *above* TRACE and DEBUG should get a message
-      ID, as this helps generating message catalogs that can help admins to
-      understand the context of messages better. Another intention is that
-      automated message parsers could detect a class of message IDs and send
-      out notifications on the same, rather than parse the message string
-      itself (which if it changes, the input to the parser has to change, etc.
-      and hence is better to retain message IDs)
+    Each value has a type that is checked by the C compiler at build time to
+    ensure correctness.
 
-      - Ok so if intention is not yet clear, look at journald MESSAGE ID
-      motivation, as that coupled with ident/dom above is expected to provide
-      us with similar advantages
+  - **Enforced**
 
-      - Bottomline: Every message gets its own ID, in case a message is
-      *not* DEBUG or TRACE and still is developer centric, a generic message
-      ID per component *maybe* assigned to the same to provide ease of use
-      of the API
+    Each extra data field needs to be specified when a message of that type
+    is logged. If the fields passed when a message is logged doesn't match the
+    definition, the compiler will generate an error. This way it's easy to
+    identify all places where a message has been used and update them.
 
-    **fmt**
-      - As in format argument of (man 3) printf
+- **Better uniformity in data type representation**
+
+  Each data types are represented in the same way in all messages, increasing
+  the consistency of the logs.
+
+- **Compile-time generation of messages**
+
+  The text and the extra data is formatted at compile time to reduce run time
+  cost.
+
+- **All argument preparation is done only if the message will be logged**
+
+  Data types that need some preprocessing to be logged, are not computed until
+  we are sure that the message needs to be logged based on the current log
+  level.
+
+- **Very easy to use**
+
+  Definition of messages and its utilization is quite simple. There are some
+  predefined types, but it's easy to create new data types if needed.
+
+- **Code auto-completion friendly**
+
+  Once a message is defined, logging it is very simple when an IDE with code
+  auto-completion is used. The code auto-completion will help to find the
+  name of the message and the list of arguments it needs.
+
+- **All extra overhead is optimally optimized by gcc/clang**
+
+  The additional code and structures required to make all this possible are
+  easily optimized by compilers, so resulting code is equivalent to directly
+  logging the message.
+
+### Definition of new messages
+
+#### Creating a new component
+
+If a new xlator or component is created that requires some messages, the first
+thing to do is to reserve a component ID in file glusterfs/glfs-message-id.h.
+
+This is done by adding a new `GLFS_MSGID_COMP()` entry at the end of the
+`enum _msgid_comp`. A unique name and a number of blocks to reserve must
+be specified (each block can contain up to 1000 messages).
+
+> Example:
+>
+> ```c
+>     GLFS_MSGID_COMP(EXAMPLE, 1),
+>     /* --- new segments for messages goes above this line --- */
+>
+>     GLFS_MSGID_END
+> ```
+
+Once created, a copy of glusterfs/template-component-messages.h can be used as
+a starting point for the messages of the new component. Check the comments of
+that file for more information, but basically you need to use the macro
+`GLFS_COMPONENT()` before starting defining the messages.
+
+> Example:
+>
+> ```c
+> GLFS_COMPONENT(EXAMPLE);
+> ```
+
+#### Creating new messages
+
+Each message is automatically assigned a unique sequential number and it
+should remain the same once created. This means that you must create new
+messages at the end of the file, after any other message. This way the newly
+created message will take the next free sequential id, without touching any
+previously assigned id.
+
+To define a message, the macro `GLFS_NEW()` must be used. It requires four
+mandatory arguments:
+
+1. The name of the component. This is the one created in the previous section.
+
+2. The name of the message. This is the name to use when you want to log the
+   message.
+
+3. The text associated to the message. This must be a fixed string without
+   any formatting.
+
+4. The number of extra data fields to include to the message.
+
+If there are extra data fields, for each field you must add field definition
+inside the macro.
+
+##### Field definitions
+
+Each field consists of five arguments, written between parenthesis:
+
+1. **Data type**
+
+   This is a regular C type that will be used to manipulate the data. It can
+   be anything valid.
+
+2. **Field name**
+
+   This is the name that will be used to reference the data and to show it in
+   the log message. It must be a valid C identifier.
+
+3. **Format string**
+
+   This is a string representing the way in which this data will be shown in
+   the log. It can be something as simple as '%u' or a bit more elaborated
+   like '%d (%s)', depending on how we want to show something.
+
+4. **Format data**
+
+   This must be a list of expressions to generate each of the arguments needed
+   for the format string. In most cases this will be just the name of the
+   field, but it could be something else if the data needs to be processed.
+
+5. **Preparation code**
+
+   This is optional. If present it must contain any additional variable
+   definition and code to prepare the format data.
+
+> Examples:
+>
+> ```c
+>     (uint32_t, value, "%u", (value))
+> ```
+>
+> ```c
+>     (int32_t, error, "%d (%s)", (error, strerror(error)))
+> ```
+>
+> ```c
+>     (uuid_t *, gfid, "%s", (gfid_str),
+>      char gfid_str[48]; uuid_unparse(*gfid, gfid_str))
+> ```
+
+##### Predefined data types
+
+Some macros are available to declare typical data types and make it easier
+to use:
+
+- Signed integers
+
+  ```c
+  GLFS_INT(name)
+  ```
+
+- Unsigned integers
+
+  ```c
+  GLFS_UINT(name)
+  ```
+
+- Errors
+
+  ```c
+  GLFS_ERROR(name)
+  ```
+
+- Strings
+
+  ```c
+  GLFS_STR(name)
+  ```
+
+- UUIDs
+
+  ```c
+  GLFS_UUID(name)
+  ```
+
+- Pointers
+
+  ```c
+  GLFS_PTR(name)
+  ```
+
+This is a full example that defines a new message using the previous macros:
+
+```c
+GLFS_NEW(EXAMPLE, MSG_TEST, "This is a test message", 3,
+    GLFS_UINT(number),
+    GLFS_STR(name),
+    GLFS_ERROR(error)
+)
+```
+
+This will generate a log message with the following format:
+
+```c
+"This is a test message <{number=%u}, {name='%s'}, {error=%d (%s)}>"
+```
+
+#### Logging messages
+
+Once a message is defined, it can be logged using the following macros:
+
+- `GF_LOG_C()`: log a critical message
+- `GF_LOG_E()`: log an error message
+- `GF_LOG_W()`: log a warning message
+- `GF_LOG_I()`: log an info message
+- `GF_LOG_D()`: log a debug message
+- `GF_LOG_T()`: log a trace message
+
+All macros receive an xlator (or `NULL` if none is required) and the message
+itself. The additional data of the message is passed after the message name
+between parenthesis.
+
+> Example:
+>
+> ```c
+>     GF_LOG_I(this, MSG_TEST(10, "something", ENOENT));
+> ```
+
+The resulting logging message would be similar to this:
+
+```c
+"This is a test message <{number=10}, {name='something'}, {error=2 (File not found)}>"
+```
+
+> Note: the xlator argument is used to get the name of the xlator if present.

--- a/doc/developer-guide/logging-guidelines.md
+++ b/doc/developer-guide/logging-guidelines.md
@@ -316,3 +316,49 @@ A similar example with a debug message:
 
 Note that if the field name matches the source of the data as in the case of
 the second field, the source argument can be omitted.
+
+## Migration from older interfaces
+
+Given the amount of existing messages, it's not feasible to migrate all of
+them at once, so a special macro is provided to allow incremental migration
+of existing log messages.
+
+1. Migrate header file
+
+   The first step is to update the header file where all message IDs are
+   defined.
+
+   - Initialize the component
+
+     You need to add the `GLFS_COMPONENT()` macro at the beginning with the
+     appropriate component name. This name can be found in the first argument
+     of the existing `GLFS_MSGID()` macro.
+
+   - Replace message definitions
+
+     All existing messages inside `GLFS_MSGID()` need to be converted to:
+
+     ```c
+     GLFS_MIG(component, id, "", 0)
+     ```
+
+     Where `component` is the name of the component used in `GLFS_COMPONENT()`,
+     and `id` is each of the existing IDs inside `GLFS_MSGID()`.
+
+     This step will use the new way of defining messages, but is compatible
+     with the old logging interface, so once this is done, the code should
+     compile fine.
+
+2. Migrate a message
+
+   It's possible to migrate the messages one by one without breaking anything.
+
+   For each message to migrate:
+
+   - Choose one message.
+   - Replace `GLFS_MIG` by `GLFS_NEW`.
+   - Add a meaningful message text as the third argument.
+   - Update the number of fields if necessary.
+   - Add the required field definition.
+   - Look for each instance of the log message in the code.
+   - Replace the existing log macro by one of the `GF_LOG_*()` macros.

--- a/doc/developer-guide/logging-guidelines.md
+++ b/doc/developer-guide/logging-guidelines.md
@@ -288,14 +288,14 @@ Once a message is defined, it can be logged using the following macros:
 - `GF_LOG_D()`: log a debug message
 - `GF_LOG_T()`: log a trace message
 
-All macros receive an xlator (or `NULL` if none is required) and the message
-itself. The additional data of the message is passed after the message name
+All macros receive a string, representing the domain of the log message, and
+the message itself. The additional data of the message is passed after the message name
 between parenthesis.
 
 > Example:
 >
 > ```c
->     GF_LOG_I(this, MSG_TEST(10, "something", ENOENT));
+>     GF_LOG_I(this->name, MSG_TEST(10, "something", ENOENT));
 > ```
 
 The resulting logging message would be similar to this:
@@ -303,5 +303,3 @@ The resulting logging message would be similar to this:
 ```c
 "This is a test message <{number=10}, {name='something'}, {error=2 (File not found)}>"
 ```
-
-> Note: the xlator argument is used to get the name of the xlator if present.

--- a/extras/create_new_xlator/new-xlator.c.tmpl
+++ b/extras/create_new_xlator/new-xlator.c.tmpl
@@ -136,16 +136,47 @@ enum gf_mdc_mem_types_ {
 
 #include <glusterfs/glfs-message-id.h>
 
-/* To add new message IDs, append new identifiers at the end of the list.
+/* First of all the new component needs to be declared at the end of
+ * enum _msgid_comp in glusterfs/glfs-message-id.h. Then the ID used
+ * needs to be referenced here to start defining messages associated
+ * with this component.
  *
- * Never remove a message ID. If it's not used anymore, you can rename it or
- * leave it as it is, but not delete it. This is to prevent reutilization of
- * IDs by other messages.
+ * More than one component can be defined, but its messages need to
+ * be defined sequentially. There can't be definitions of messages
+ * from different components interleaved. */
+
+/* Example:
  *
- * The component name must match one of the entries defined in
- * glfs-message-id.h.
+ *    GLFS_COMPONENT(COMPONENT);
  */
 
-GLFS_MSGID(@FOP_PREFIX@, @FOP_PREFIX@_MSG_NO_MEMORY);
+/* Add every new message at the end. The position of the message
+ * determines its ID, so adding the message at the beginning would
+ * change the IDs of all other messages. Also never remove one message
+ * once it has been present in at least one release. This would cause
+ * the same message id to be reused by another message.
+ *
+ * For new messages, use GLFS_NEW(). To deprecate a message, leave
+ * it as it is, but change GLFS_NEW by GLFS_OLD. To remove a message
+ * (i.e. the message cannot be used by the code), replace GLFS_OLD
+ * by GLFS_GONE. */
+
+// clang-format off
+
+/* Example:
+ *
+ *    GLFS_NEW(COMPONENT, MSGID, "Message text", 6 /* num fields */,
+ *        GLFS_INT(integer),
+ *        GLFS_UINT(number),
+ *        GLFS_STR(name),
+ *        GLFS_UUID(gfid),
+ *        GLFS_PTR(pointer),
+ *        GLFS_ERROR(error)
+ *    )
+ */
+
+/* Add new messages above this line. */
+
+// clang-format on
 
 #endif /* __@HFL_NAME@_H__ */

--- a/extras/create_new_xlator/new-xlator.c.tmpl
+++ b/extras/create_new_xlator/new-xlator.c.tmpl
@@ -165,13 +165,14 @@ enum gf_mdc_mem_types_ {
 
 /* Example:
  *
- *    GLFS_NEW(COMPONENT, MSGID, "Message text", 6 /* num fields */,
+ *    GLFS_NEW(COMPONENT, MSGID, "Message text", 7 /* num fields */,
  *        GLFS_INT(integer),
  *        GLFS_UINT(number),
  *        GLFS_STR(name),
  *        GLFS_UUID(gfid),
  *        GLFS_PTR(pointer),
- *        GLFS_ERROR(error)
+ *        GLFS_ERR(error),
+ *        GLFS_RES(result)
  *    )
  */
 

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -110,9 +110,9 @@
  * defined at a time. Calling this macro for another component before finishing
  * the definition of messages for the previous component will mess the message
  * ids. */
-#define GLFS_COMPONENT(_name) \
-    enum { \
-        GLFS_##_name##_COMP_BASE = GLFS_MSGID_COMP_##_name - __COUNTER__ - 1 \
+#define GLFS_COMPONENT(_name)                                                  \
+    enum {                                                                     \
+        GLFS_##_name##_COMP_BASE = GLFS_MSGID_COMP_##_name - __COUNTER__ - 1   \
     }
 
 /* Unpack arguments. */
@@ -121,38 +121,37 @@
 /* These macros apply a macro to a list of 0..9 arguments. It can be extended
  * if more arguments are required. */
 
-#define GLFS_APPLY_0(_macro,  _in)
+#define GLFS_APPLY_0(_macro, _in)
 
-#define GLFS_APPLY_1(_macro, _in, _f) \
-    _macro _f
+#define GLFS_APPLY_1(_macro, _in, _f) _macro _f
 
-#define GLFS_APPLY_2(_macro, _in, _f, _more) \
+#define GLFS_APPLY_2(_macro, _in, _f, _more)                                   \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_1(_macro, _in, _more)
 
-#define GLFS_APPLY_3(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_3(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_2(_macro, _in, _more)
 
-#define GLFS_APPLY_4(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_4(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_3(_macro, _in, _more)
 
-#define GLFS_APPLY_5(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_5(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_4(_macro, _in, _more)
 
-#define GLFS_APPLY_6(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_6(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_5(_macro, _in, _more)
 
-#define GLFS_APPLY_7(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_7(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_6(_macro, _in, _more)
 
-#define GLFS_APPLY_8(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_8(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_7(_macro, _in, _more)
 
-#define GLFS_APPLY_9(_macro, _in, _f, _more...) \
+#define GLFS_APPLY_9(_macro, _in, _f, _more...)                                \
     _macro _f GLFS_EXPAND _in GLFS_APPLY_8(_macro, _in, _more)
 
 /* Apply a macro to a variable number of fields. */
-#define GLFS_APPLY(_macro, _in, _num, _fields...) \
-    GLFS_APPLY_##_num(_macro, _in, ## _fields)
+#define GLFS_APPLY(_macro, _in, _num, _fields...)                              \
+    GLFS_APPLY_##_num(_macro, _in, ##_fields)
 
 /* Build a declaration for a structure from a field. */
 #define GLFS_FIELD(_type, _name, _extra...) _type _name;
@@ -167,110 +166,102 @@
 #define GLFS_ARG(_type, _name, _extra...) _type _name
 
 /* Initialize a variable from a field in a structure. */
-#define GLFS_VAR(_type, _name, _fmt, _data, _extra...) \
-    _type _name = _info->_name; _extra
+#define GLFS_VAR(_type, _name, _fmt, _data, _extra...)                         \
+    _type _name = _info->_name;                                                \
+    _extra
 
 /* Extract the data from a field. */
 #define GLFS_DATA(_type, _name, _fmt, _data, _extra...) , GLFS_EXPAND _data
 
 /* Generate the fields of the structre. */
-#define GLFS_FIELDS(_num, _fields...) \
-    GLFS_APPLY(GLFS_FIELD, (), _num, ## _fields)
+#define GLFS_FIELDS(_num, _fields...)                                          \
+    GLFS_APPLY(GLFS_FIELD, (), _num, ##_fields)
 
 /* Generate a list of the names of all fields. */
-#define GLFS_NAMES(_num, _fields...) \
-    GLFS_APPLY(GLFS_NAME, (), _num, ## _fields)
+#define GLFS_NAMES(_num, _fields...) GLFS_APPLY(GLFS_NAME, (), _num, ##_fields)
 
 /* Generate a format string for all fields. */
-#define GLFS_FMTS(_num, _fields...) \
-    GLFS_APPLY(GLFS_FMT, (", "), _num, ## _fields)
+#define GLFS_FMTS(_num, _fields...)                                            \
+    GLFS_APPLY(GLFS_FMT, (", "), _num, ##_fields)
 
 /* Generate the function call argument declaration for all fields. */
-#define GLFS_ARGS(_num, _fields...) \
-    GLFS_APPLY(GLFS_ARG, (,), _num, ## _fields)
+#define GLFS_ARGS(_num, _fields...) GLFS_APPLY(GLFS_ARG, (, ), _num, ##_fields)
 
 /* Generate the list of variables for all fields. */
-#define GLFS_VARS(_num, _fields...) \
-    GLFS_APPLY(GLFS_VAR, (), _num, ## _fields)
+#define GLFS_VARS(_num, _fields...) GLFS_APPLY(GLFS_VAR, (), _num, ##_fields)
 
 /* Generate the list of values from all fields. */
-#define GLFS_DATAS(_num, _fields...) \
-    GLFS_APPLY(GLFS_DATA, (), _num, ## _fields)
+#define GLFS_DATAS(_num, _fields...) GLFS_APPLY(GLFS_DATA, (), _num, ##_fields)
 
 /* Create the structure for a message. */
-#define GLFS_STRUCT(_name, _num, _fields...) \
-    struct _glfs_##_name { \
-        void (*_process)(const char *, const char *, const char *, uint32_t, \
-                         uint32_t, struct _glfs_##_name *); \
-        GLFS_FIELDS(_num, ## _fields) \
+#define GLFS_STRUCT(_name, _num, _fields...)                                   \
+    struct _glfs_##_name {                                                     \
+        void (*_process)(const char *, const char *, const char *, uint32_t,   \
+                         uint32_t, struct _glfs_##_name *);                    \
+        GLFS_FIELDS(_num, ##_fields)                                           \
     }
 
 /* Create the processing function for a message. */
-#define GLFS_PROCESS(_mod, _name, _msg, _num, _fields...) \
-    enum { _name##_ID = GLFS_##_mod##_COMP_BASE + __COUNTER__ }; \
-    _Static_assert((int)_name##_ID <= (int)GLFS_MSGID_COMP_##_mod##_END, \
-                   "Too many messages allocated for component " #_mod); \
-    extern inline __attribute__((__always_inline__)) void \
-    _glfs_process_##_name(const char *_dom, const char *_file, \
-                          const char *_func, uint32_t _line, uint32_t _level, \
-                          struct _glfs_##_name *_info) \
-    { \
-        GLFS_VARS(_num, ## _fields) \
-        _gf_log(_dom, _file, _func, _line, _level, "[MSGID:%u] " _msg " <" \
-                GLFS_FMTS(_num, ## _fields) ">", _name##_ID \
-                GLFS_DATAS(_num, ## _fields)); \
+#define GLFS_PROCESS(_mod, _name, _msg, _num, _fields...)                      \
+    enum { _name##_ID = GLFS_##_mod##_COMP_BASE + __COUNTER__ };               \
+    _Static_assert((int)_name##_ID <= (int)GLFS_MSGID_COMP_##_mod##_END,       \
+                   "Too many messages allocated for component " #_mod);        \
+    extern inline                                                              \
+        __attribute__((__always_inline__)) void _glfs_process_##_name(         \
+            const char *_dom, const char *_file, const char *_func,            \
+            uint32_t _line, uint32_t _level, struct _glfs_##_name *_info)      \
+    {                                                                          \
+        GLFS_VARS(_num, ##_fields)                                             \
+        _gf_log(_dom, _file, _func, _line, _level,                             \
+                "[MSGID:%u] " _msg " <" GLFS_FMTS(_num, ##_fields) ">",        \
+                _name##_ID GLFS_DATAS(_num, ##_fields));                       \
     }
 
 /* Create the data capture function for a message. */
-#define GLFS_CREATE(_name, _attr, _num, _fields...) \
-    extern inline __attribute__((__always_inline__, __warn_unused_result__)) \
-    _attr struct _glfs_##_name _name(GLFS_ARGS(_num, ## _fields)) \
-    { \
-        return (struct _glfs_##_name){ \
-            _glfs_process_##_name GLFS_NAMES(_num, ## _fields) \
-        }; \
+#define GLFS_CREATE(_name, _attr, _num, _fields...)                            \
+    extern inline __attribute__((__always_inline__, __warn_unused_result__))   \
+    _attr struct _glfs_##_name _name(GLFS_ARGS(_num, ##_fields))               \
+    {                                                                          \
+        return (struct _glfs_##_name){                                         \
+            _glfs_process_##_name GLFS_NAMES(_num, ##_fields)};                \
     }
 
 /* Create a new message. */
-#define GLFS_NEW(_mod, _name, _msg, _num, _fields...) \
-    GLFS_STRUCT(_name, _num, ## _fields); \
-    GLFS_PROCESS(_mod, _name, _msg, _num, ## _fields) \
-    GLFS_CREATE(_name,, _num, ## _fields)
+#define GLFS_NEW(_mod, _name, _msg, _num, _fields...)                          \
+    GLFS_STRUCT(_name, _num, ##_fields);                                       \
+    GLFS_PROCESS(_mod, _name, _msg, _num, ##_fields)                           \
+    GLFS_CREATE(_name, , _num, ##_fields)
 
 /* Create a deprecated message. */
-#define GLFS_OLD(_mod, _name, _msg, _num, _fields...) \
-    GLFS_STRUCT(_name, _num, ## _fields); \
-    GLFS_PROCESS(_mod, _name, _msg, _num, ## _fields) \
-    GLFS_CREATE(_name, __attribute__((__deprecated__)), _num, ## _fields)
+#define GLFS_OLD(_mod, _name, _msg, _num, _fields...)                          \
+    GLFS_STRUCT(_name, _num, ##_fields);                                       \
+    GLFS_PROCESS(_mod, _name, _msg, _num, ##_fields)                           \
+    GLFS_CREATE(_name, __attribute__((__deprecated__)), _num, ##_fields)
 
 /* Create a deleted message. */
-#define GLFS_GONE(_mod, _name, _msg, _num, _fields...) \
+#define GLFS_GONE(_mod, _name, _msg, _num, _fields...)                         \
     enum { _name##_ID_GONE = GLFS_##_mod##_COMP_BASE + __COUNTER__ };
 
 /* Helper to create an unsigned integer field. */
-#define GLFS_UINT(_name) \
-    (uint32_t, _name, "%" PRIu32, (_name))
+#define GLFS_UINT(_name) (uint32_t, _name, "%" PRIu32, (_name))
 
 /* Helper to create a signed integer field. */
-#define GLFS_INT(_name) \
-    (int32_t, _name, "%" PRId32, (_name))
+#define GLFS_INT(_name) (int32_t, _name, "%" PRId32, (_name))
 
 /* Helper to create an error field. */
-#define GLFS_ERROR(_name) \
+#define GLFS_ERROR(_name)                                                      \
     (int32_t, _name, "%" PRId32 " (%s)", (-_name, strerror(-_name)))
 
 /* Helper to create a string field. */
-#define GLFS_STR(_name) \
-    (const char *, _name, "'%s'", (_name))
+#define GLFS_STR(_name) (const char *, _name, "'%s'", (_name))
 
 /* Helper to create a gfid field. */
-#define GLFS_GFID(_name) \
-    (uuid_t *, _name, "%s", (*_name##_buff), \
-    char _name##_buff[48]; uuid_unparse(*_name, _name##_buff))
+#define GLFS_GFID(_name)                                                       \
+    (uuid_t *, _name, "%s", (*_name##_buff), char _name##_buff[48];            \
+     uuid_unparse(*_name, _name##_buff))
 
 /* Helper to create a pointer field. */
-#define GLFS_PTR(_name) \
-    (void *, _name, "%p", (_name))
+#define GLFS_PTR(_name) (void *, _name, "%p", (_name))
 
 /* Per module message segments allocated */
 /* NOTE: For any new module add to the end the modules */

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -232,7 +232,8 @@
 /* Create the data capture function for a message. */
 #define GLFS_CREATE(_name, _attr, _num, _fields...)                            \
     static inline __attribute__((__always_inline__, __warn_unused_result__))   \
-    _attr struct _glfs_##_name _name(GLFS_ARGS(_num, ##_fields))               \
+    _attr struct _glfs_##_name                                                 \
+    _name(GLFS_ARGS(_num, ##_fields))                                          \
     {                                                                          \
         return (struct _glfs_##_name){                                         \
             _glfs_process_##_name GLFS_NAMES(_num, ##_fields)};                \

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -220,7 +220,8 @@
 /* Create the data capture function for a message. */
 #define GLFS_CREATE(_name, _attr, _num, _fields...)                            \
     extern inline __attribute__((__always_inline__, __warn_unused_result__))   \
-    _attr struct _glfs_##_name _name(GLFS_ARGS(_num, ##_fields))               \
+    _attr struct _glfs_##_name                                                 \
+    _name(GLFS_ARGS(_num, ##_fields))                                          \
     {                                                                          \
         return (struct _glfs_##_name){                                         \
             _glfs_process_##_name GLFS_NAMES(_num, ##_fields)};                \

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -206,7 +206,7 @@
     enum { _name##_ID = GLFS_##_mod##_COMP_BASE + __COUNTER__ };               \
     _Static_assert((int)_name##_ID <= (int)GLFS_MSGID_COMP_##_mod##_END,       \
                    "Too many messages allocated for component " #_mod);        \
-    extern inline                                                              \
+    static inline                                                              \
         __attribute__((__always_inline__)) void _glfs_process_##_name(         \
             const char *_dom, const char *_file, const char *_func,            \
             uint32_t _line, uint32_t _level, struct _glfs_##_name *_info)      \
@@ -219,7 +219,7 @@
 
 /* Create the data capture function for a message. */
 #define GLFS_CREATE(_name, _attr, _num, _fields...)                            \
-    extern inline __attribute__((__always_inline__, __warn_unused_result__))   \
+    static inline __attribute__((__always_inline__, __warn_unused_result__))   \
     _attr struct _glfs_##_name                                                 \
     _name(GLFS_ARGS(_num, ##_fields))                                          \
     {                                                                          \

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -203,8 +203,8 @@
 
 /* Create the processing function for a message. */
 #define GLFS_PROCESS(_mod, _name, _msg, _num, _fields...)                      \
-    enum { _name##_ID = GLFS_##_mod##_COMP_BASE + __COUNTER__ };               \
-    _Static_assert((int)_name##_ID <= (int)GLFS_MSGID_COMP_##_mod##_END,       \
+    enum { _glfs_##_name = GLFS_##_mod##_COMP_BASE + __COUNTER__ };            \
+    _Static_assert((int)_glfs_##_name <= (int)GLFS_MSGID_COMP_##_mod##_END,    \
                    "Too many messages allocated for component " #_mod);        \
     static inline                                                              \
         __attribute__((__always_inline__)) void _glfs_process_##_name(         \
@@ -214,7 +214,7 @@
         GLFS_VARS(_num, ##_fields)                                             \
         _gf_log(_dom, _file, _func, _line, _level,                             \
                 "[MSGID:%u] " _msg " <" GLFS_FMTS(_num, ##_fields) ">",        \
-                _name##_ID GLFS_DATAS(_num, ##_fields));                       \
+                _glfs_##_name GLFS_DATAS(_num, ##_fields));                    \
     }
 
 /* Create the data capture function for a message. */

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -129,25 +129,25 @@
     _macro _f GLFS_EXPAND _in GLFS_APPLY_1(_macro, _in, _more)
 
 #define GLFS_APPLY_3(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_2(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_2(_macro, _in, ##_more)
 
 #define GLFS_APPLY_4(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_3(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_3(_macro, _in, ##_more)
 
 #define GLFS_APPLY_5(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_4(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_4(_macro, _in, ##_more)
 
 #define GLFS_APPLY_6(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_5(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_5(_macro, _in, ##_more)
 
 #define GLFS_APPLY_7(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_6(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_6(_macro, _in, ##_more)
 
 #define GLFS_APPLY_8(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_7(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_7(_macro, _in, ##_more)
 
 #define GLFS_APPLY_9(_macro, _in, _f, _more...)                                \
-    _macro _f GLFS_EXPAND _in GLFS_APPLY_8(_macro, _in, ## _more)
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_8(_macro, _in, ##_more)
 
 /* Apply a macro to a variable number of fields. */
 #define GLFS_APPLY(_macro, _in, _num, _fields...)                              \
@@ -187,8 +187,7 @@
     GLFS_APPLY(GLFS_FIELD, (), _num, ##_fields)
 
 /* Generate a list of the names of all fields. */
-#define GLFS_NAMES(_num, _fields...)                                           \
-    GLFS_APPLY(GLFS_NAME, (), _num, ##_fields)
+#define GLFS_NAMES(_num, _fields...) GLFS_APPLY(GLFS_NAME, (), _num, ##_fields)
 
 /* Generate a format string for all fields. */
 #define GLFS_FMTS(_num, _fields...)                                            \
@@ -233,8 +232,7 @@
 /* Create the data capture function for a message. */
 #define GLFS_CREATE(_name, _attr, _num, _fields...)                            \
     static inline __attribute__((__always_inline__, __warn_unused_result__))   \
-    _attr struct _glfs_##_name                                                 \
-    _name(GLFS_ARGS(_num, ##_fields))                                          \
+    _attr struct _glfs_##_name _name(GLFS_ARGS(_num, ##_fields))               \
     {                                                                          \
         return (struct _glfs_##_name){                                         \
             _glfs_process_##_name GLFS_NAMES(_num, ##_fields)};                \
@@ -244,16 +242,16 @@
     do {                                                                       \
         GLFS_COPIES(_num, ##_fields)                                           \
         _gf_log(_dom, __FILE__, __FUNCTION__, __LINE__, GF_LOG_DEBUG,          \
-                "[MSGID:DBG] " _msg " <" GLFS_FMTS(_num, ##_fields) ">"        \
-                GLFS_DATAS(_num, ##_fields));                                  \
+                "[MSGID:DBG] " _msg " <" GLFS_FMTS(                            \
+                    _num, ##_fields) ">" GLFS_DATAS(_num, ##_fields));         \
     } while (0)
 
 #define GLFS_TRACE(_dom, _msg, _num, _fields...)                               \
     do {                                                                       \
         GLFS_COPIES(_num, ##_fields)                                           \
         _gf_log(_dom, __FILE__, __FUNCTION__, __LINE__, GF_LOG_TRACE,          \
-                "[MSGID:TRC] " _msg " <" GLFS_FMTS(_num, ##_fields) ">"        \
-                GLFS_NAMES(_num, ##_fields));                                  \
+                "[MSGID:TRC] " _msg " <" GLFS_FMTS(                            \
+                    _num, ##_fields) ">" GLFS_NAMES(_num, ##_fields));         \
     } while (0)
 
 /* Create a new message. */
@@ -278,40 +276,40 @@
 
 /* Map a field name to its source. If source is not present, use the name */
 #define GLFS_MAP1(_dummy, _src, _data...) _src
-#define GLFS_MAP(_name, _src...) GLFS_MAP1(, ## _src, _name)
+#define GLFS_MAP(_name, _src...) GLFS_MAP1(, ##_src, _name)
 
 /* Helper to create an unsigned integer field. */
 #define GLFS_UINT(_name, _src...)                                              \
-    (uint32_t, _name, GLFS_MAP(_name, ## _src), "%" PRIu32, (GLFS_GET(_name)))
+    (uint32_t, _name, GLFS_MAP(_name, ##_src), "%" PRIu32, (GLFS_GET(_name)))
 
 /* Helper to create a signed integer field. */
 #define GLFS_INT(_name, _src...)                                               \
-    (int32_t, _name, GLFS_MAP(_name, ## _src), "%" PRId32, (GLFS_GET(_name)))
+    (int32_t, _name, GLFS_MAP(_name, ##_src), "%" PRId32, (GLFS_GET(_name)))
 
 /* Helper to create an error field. */
 #define GLFS_ERR(_name, _src...)                                               \
-    (int32_t, _name, GLFS_MAP(_name, ## _src), "%" PRId32 " (%s)",             \
+    (int32_t, _name, GLFS_MAP(_name, ##_src), "%" PRId32 " (%s)",              \
      (GLFS_GET(_name), strerror(GLFS_GET(_name))))
 
 /* Helper to create an error field where the error code is encoded in a
  * negative number. */
 #define GLFS_RES(_name, _src...)                                               \
-    (int32_t, _name, GLFS_MAP(_name, ## _src), "%" PRId32 " (%s)",             \
+    (int32_t, _name, GLFS_MAP(_name, ##_src), "%" PRId32 " (%s)",              \
      (-GLFS_GET(_name), strerror(-GLFS_GET(_name))))
 
 /* Helper to create a string field. */
 #define GLFS_STR(_name, _src...)                                               \
-    (const char *, _name, GLFS_MAP(_name, ## _src), "'%s'", (GLFS_GET(_name)))
+    (const char *, _name, GLFS_MAP(_name, ##_src), "'%s'", (GLFS_GET(_name)))
 
 /* Helper to create a gfid field. */
 #define GLFS_UUID(_name, _src...)                                              \
-    (const uuid_t *, _name, GLFS_MAP(_name, ## _src), "%s",                    \
+    (const uuid_t *, _name, GLFS_MAP(_name, ##_src), "%s",                     \
      (*GLFS_GET(_name##_buff)), char GLFS_GET(_name##_buff)[48];               \
      uuid_unparse(*GLFS_GET(_name), GLFS_GET(_name##_buff)))
 
 /* Helper to create a pointer field. */
 #define GLFS_PTR(_name, _src...)                                               \
-    (void *, _name, GLFS_MAP(_name, ## _src), "%p", (GLFS_GET(_name)))
+    (void *, _name, GLFS_MAP(_name, ##_src), "%p", (GLFS_GET(_name)))
 
 /* Per module message segments allocated */
 /* NOTE: For any new module add to the end the modules */

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -268,13 +268,17 @@
     GLFS_PROCESS(_mod, _name, _msg, _num, ##_fields)                           \
     GLFS_CREATE(_name, __attribute__((__deprecated__)), _num, ##_fields)
 
-/* Map a field name to its source. If source is not present, use the name */
-#define GLFS_MAP1(_dummy, _src, _data...) _src
-#define GLFS_MAP(_name, _src...) GLFS_MAP1(, ## _src, _name)
-
 /* Create a deleted message. */
 #define GLFS_GONE(_mod, _name, _msg, _num, _fields...)                         \
     enum { _name##_ID_GONE = GLFS_##_mod##_COMP_BASE + __COUNTER__ };
+
+/* Create a new message compatible with the old interface. */
+#define GLFS_MIG(_mod, _name, _msg, _num, _fields...)                          \
+    enum { _name = GLFS_##_mod##_COMP_BASE + __COUNTER__ };
+
+/* Map a field name to its source. If source is not present, use the name */
+#define GLFS_MAP1(_dummy, _src, _data...) _src
+#define GLFS_MAP(_name, _src...) GLFS_MAP1(, ## _src, _name)
 
 /* Helper to create an unsigned integer field. */
 #define GLFS_UINT(_name, _src...)                                              \

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -257,7 +257,7 @@
 #define GLFS_STR(_name) (const char *, _name, "'%s'", (_name))
 
 /* Helper to create a gfid field. */
-#define GLFS_GFID(_name)                                                       \
+#define GLFS_UUID(_name)                                                       \
     (uuid_t *, _name, "%s", (*_name##_buff), char _name##_buff[48];            \
      uuid_unparse(*_name, _name##_buff))
 

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -251,6 +251,11 @@
 
 /* Helper to create an error field. */
 #define GLFS_ERROR(_name)                                                      \
+    (int32_t, _name, "%" PRId32 " (%s)", (_name, strerror(_name)))
+
+/* Helper to create an error field where the error code is encoded in a
+ * negative number. */
+#define GLFS_RESULT(_name)                                                     \
     (int32_t, _name, "%" PRId32 " (%s)", (-_name, strerror(-_name)))
 
 /* Helper to create a string field. */

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -16,7 +16,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <pthread.h>
-#include "glusterfs/list.h"
+
+#include <glusterfs/list.h>
 
 #ifdef GF_DARWIN_HOST_OS
 #define GF_PRI_FSBLK "u"
@@ -341,28 +342,21 @@ _gf_smsg(const char *domain, const char *file, const char *function,
 
 /* Logging macro for messages created by GLFS_NEW(). It uses the same logic as
  * gf_log_get_loglevel() but inline and without requiring THIS. */
-#define GF_LOG(_xl, _lvl, _data)                                               \
+#define GF_LOG(_name, _lvl, _data)                                             \
     do {                                                                       \
-        xlator_t *__log_xl = (_xl);                                            \
-        const char *__log_name = "";                                           \
-        uint32_t __log_level = GF_LOG_INFO;                                    \
-        if ((__log_xl != NULL) && (__log_xl->ctx != NULL)) {                   \
-            __log_name = __log_xl->name;                                       \
-            __log_level = __log_xl->ctx->log.loglevel;                         \
-        }                                                                      \
-        if (__log_level >= (_lvl)) {                                           \
+        if (global_ctx->log.loglevel >= (_lvl)) {                              \
             typeof(_data) __log_data = _data;                                  \
-            __log_data._process(__log_name, __FILE__, __FUNCTION__, __LINE__,  \
-                                _lvl, &__log_data);                            \
+            __log_data._process(_name, __FILE__, __FUNCTION__, __LINE__, _lvl, \
+                                &__log_data);                                  \
         }                                                                      \
     } while (0)
 
 /* Shortcut macros for different log levels. */
-#define GF_LOC_C(_xl, _data) GF_LOG(_xl, GF_LOG_CRITICAL, _data)
-#define GF_LOG_E(_xl, _data) GF_LOG(_xl, GF_LOG_ERROR, _data)
-#define GF_LOG_W(_xl, _data) GF_LOG(_xl, GF_LOG_WARNING, _data)
-#define GF_LOG_I(_xl, _data) GF_LOG(_xl, GF_LOG_INFO, _data)
-#define GF_LOG_D(_xl, _data) GF_LOG(_xl, GF_LOG_DEBUG, _data)
-#define GF_LOG_T(_xl, _data) GF_LOG(_xl, GF_LOG_TRACE, _data)
+#define GF_LOC_C(_name, _data) GF_LOG(_name, GF_LOG_CRITICAL, _data)
+#define GF_LOG_E(_name, _data) GF_LOG(_name, GF_LOG_ERROR, _data)
+#define GF_LOG_W(_name, _data) GF_LOG(_name, GF_LOG_WARNING, _data)
+#define GF_LOG_I(_name, _data) GF_LOG(_name, GF_LOG_INFO, _data)
+#define GF_LOG_D(_name, _data) GF_LOG(_name, GF_LOG_DEBUG, _data)
+#define GF_LOG_T(_name, _data) GF_LOG(_name, GF_LOG_TRACE, _data)
 
 #endif /* __LOGGING_H__ */

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -339,4 +339,30 @@ _gf_smsg(const char *domain, const char *file, const char *function,
                  msgid, msgid##_STR, ##event);                                 \
     } while (0)
 
+/* Logging macro for messages created by GLFS_NEW(). It uses the same logic as
+ * gf_log_get_loglevel() but inline and without requiring THIS. */
+#define GF_LOG(_xl, _lvl, _data) \
+    do { \
+        xlator_t *__log_xl = (_xl); \
+        const char *__log_name = ""; \
+        uint32_t __log_level = GF_LOG_INFO; \
+        if ((__log_xl != NULL) && (__log_xl->ctx != NULL)) { \
+            __log_name = __log_xl->name; \
+            __log_level = __log_xl->ctx->log.loglevel; \
+        } \
+        if (__log_level >= (_lvl)) { \
+            typeof(_data) __log_data = _data; \
+            __log_data._process(__log_name, __FILE__, __FUNCTION__, __LINE__, \
+                                _lvl, &__log_data); \
+        } \
+    } while (0)
+
+/* Shortcut macros for different log levels. */
+#define GF_LOC_C(_xl, _data) GF_LOG(_xl, GF_LOG_CRITICAL, _data)
+#define GF_LOG_E(_xl, _data) GF_LOG(_xl, GF_LOG_ERROR, _data)
+#define GF_LOG_W(_xl, _data) GF_LOG(_xl, GF_LOG_WARNING, _data)
+#define GF_LOG_I(_xl, _data) GF_LOG(_xl, GF_LOG_INFO, _data)
+#define GF_LOG_D(_xl, _data) GF_LOG(_xl, GF_LOG_DEBUG, _data)
+#define GF_LOG_T(_xl, _data) GF_LOG(_xl, GF_LOG_TRACE, _data)
+
 #endif /* __LOGGING_H__ */

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -356,7 +356,19 @@ _gf_smsg(const char *domain, const char *file, const char *function,
 #define GF_LOG_E(_name, _data) GF_LOG(_name, GF_LOG_ERROR, _data)
 #define GF_LOG_W(_name, _data) GF_LOG(_name, GF_LOG_WARNING, _data)
 #define GF_LOG_I(_name, _data) GF_LOG(_name, GF_LOG_INFO, _data)
-#define GF_LOG_D(_name, _data) GF_LOG(_name, GF_LOG_DEBUG, _data)
-#define GF_LOG_T(_name, _data) GF_LOG(_name, GF_LOG_TRACE, _data)
+
+#define GF_LOG_D(_name, _msg, _num, _fields...)                                \
+    do {                                                                       \
+        if (global_ctx->log.loglevel >= GF_LOG_DEBUG) {                              \
+            GLFS_DEBUG(_name, _msg, _num, ## _fields);                         \
+        }                                                                      \
+    } while (0)
+
+#define GF_LOG_T(_name, _msg, _num, _fields...)                                \
+    do {                                                                       \
+        if (global_ctx->log.loglevel >= GF_LOG_TRACE) {                              \
+            GLFS_TRACE(_name, _msg, _num, ## _fields);                         \
+        }                                                                      \
+    } while (0)
 
 #endif /* __LOGGING_H__ */

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -341,20 +341,20 @@ _gf_smsg(const char *domain, const char *file, const char *function,
 
 /* Logging macro for messages created by GLFS_NEW(). It uses the same logic as
  * gf_log_get_loglevel() but inline and without requiring THIS. */
-#define GF_LOG(_xl, _lvl, _data) \
-    do { \
-        xlator_t *__log_xl = (_xl); \
-        const char *__log_name = ""; \
-        uint32_t __log_level = GF_LOG_INFO; \
-        if ((__log_xl != NULL) && (__log_xl->ctx != NULL)) { \
-            __log_name = __log_xl->name; \
-            __log_level = __log_xl->ctx->log.loglevel; \
-        } \
-        if (__log_level >= (_lvl)) { \
-            typeof(_data) __log_data = _data; \
-            __log_data._process(__log_name, __FILE__, __FUNCTION__, __LINE__, \
-                                _lvl, &__log_data); \
-        } \
+#define GF_LOG(_xl, _lvl, _data)                                               \
+    do {                                                                       \
+        xlator_t *__log_xl = (_xl);                                            \
+        const char *__log_name = "";                                           \
+        uint32_t __log_level = GF_LOG_INFO;                                    \
+        if ((__log_xl != NULL) && (__log_xl->ctx != NULL)) {                   \
+            __log_name = __log_xl->name;                                       \
+            __log_level = __log_xl->ctx->log.loglevel;                         \
+        }                                                                      \
+        if (__log_level >= (_lvl)) {                                           \
+            typeof(_data) __log_data = _data;                                  \
+            __log_data._process(__log_name, __FILE__, __FUNCTION__, __LINE__,  \
+                                _lvl, &__log_data);                            \
+        }                                                                      \
     } while (0)
 
 /* Shortcut macros for different log levels. */

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -359,15 +359,15 @@ _gf_smsg(const char *domain, const char *file, const char *function,
 
 #define GF_LOG_D(_name, _msg, _num, _fields...)                                \
     do {                                                                       \
-        if (global_ctx->log.loglevel >= GF_LOG_DEBUG) {                              \
-            GLFS_DEBUG(_name, _msg, _num, ## _fields);                         \
+        if (global_ctx->log.loglevel >= GF_LOG_DEBUG) {                        \
+            GLFS_DEBUG(_name, _msg, _num, ##_fields);                          \
         }                                                                      \
     } while (0)
 
 #define GF_LOG_T(_name, _msg, _num, _fields...)                                \
     do {                                                                       \
-        if (global_ctx->log.loglevel >= GF_LOG_TRACE) {                              \
-            GLFS_TRACE(_name, _msg, _num, ## _fields);                         \
+        if (global_ctx->log.loglevel >= GF_LOG_TRACE) {                        \
+            GLFS_TRACE(_name, _msg, _num, ##_fields);                          \
         }                                                                      \
     } while (0)
 

--- a/libglusterfs/src/glusterfs/template-component-messages.h
+++ b/libglusterfs/src/glusterfs/template-component-messages.h
@@ -48,7 +48,8 @@
  *        GLFS_STR(name),
  *        GLFS_UUID(gfid),
  *        GLFS_PTR(pointer),
- *        GLFS_ERROR(error)
+ *        GLFS_ERR(error),
+ *        GLFS_RES(result)
  *    )
  */
 

--- a/libglusterfs/src/glusterfs/template-component-messages.h
+++ b/libglusterfs/src/glusterfs/template-component-messages.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013 Red Hat, Inc. <http://www.redhat.com>
+ Copyright (c) 2013-2022 Red Hat, Inc. <https://www.redhat.com>
  This file is part of GlusterFS.
 
  This file is licensed to you under your choice of the GNU Lesser
@@ -13,16 +13,47 @@
 
 #include "glusterfs/glfs-message-id.h"
 
-/* To add new message IDs, append new identifiers at the end of the list.
+/* First of all the new component needs to be declared at the end of
+ * enum _msgid_comp in glusterfs/glfs-message-id.h. Then the ID used
+ * needs to be referenced here to start defining messages associated
+ * with this component.
  *
- * Never remove a message ID. If it's not used anymore, you can rename it or
- * leave it as it is, but not delete it. This is to prevent reutilization of
- * IDs by other messages.
+ * More than one component can be defined, but its messages need to
+ * be defined sequentially. There can't be definitions of messages
+ * from different components interleaved. */
+
+/* Example:
  *
- * The component name must match one of the entries defined in
- * glfs-message-id.h.
+ *    GLFS_COMPONENT(COMPONENT);
  */
 
-GLFS_MSGID(component, message id, message id, ...);
+/* Add every new message at the end. The position of the message
+ * determines its ID, so adding the message at the beginning would
+ * change the IDs of all other messages. Also never remove one message
+ * once it has been present in at least one release. This would cause
+ * the same message id to be reused by another message.
+ *
+ * For new messages, use GLFS_NEW(). To deprecate a message, leave
+ * it as it is, but change GLFS_NEW by GLFS_OLD. To remove a message
+ * (i.e. the message cannot be used by the code), replace GLFS_OLD
+ * by GLFS_GONE. */
 
-#endif /* !_component_MESSAGES_H_ */
+// clang-format off
+
+/* Example:
+ *
+ *    GLFS_NEW(_COMPONENT, MSGID, "Message text", <num fields>
+ *        GLFS_INT(integer),
+ *        GLFS_UINT(number),
+ *        GLFS_STR(name),
+ *        GLFS_UUID(gfid),
+ *        GLFS_PTR(pointer),
+ *        GLFS_ERROR(error)
+ *    )
+ */
+
+/* Add new messages above this line. */
+
+// clang-format on
+
+#endif /* _component_MESSAGES_H_ */

--- a/xlators/features/quiesce/src/quiesce-messages.h
+++ b/xlators/features/quiesce/src/quiesce-messages.h
@@ -23,6 +23,8 @@
  * glfs-message-id.h.
  */
 
+// clang-format off
+
 GLFS_COMPONENT(QUIESCE);
 
 GLFS_NEW(QUIESCE, QUIESCE_MSG_INVAL_HOST, "Invalid internet address", 1,
@@ -33,5 +35,7 @@ GLFS_NEW(QUIESCE, QUIESCE_MSG_FAILOVER_FAILED, "Failed to initiate failover", 2,
     GLFS_STR(host),
     GLFS_ERROR(error)
 )
+
+// clang-format on
 
 #endif /* __NL_CACHE_MESSAGES_H__ */

--- a/xlators/features/quiesce/src/quiesce-messages.h
+++ b/xlators/features/quiesce/src/quiesce-messages.h
@@ -33,7 +33,7 @@ GLFS_NEW(QUIESCE, QUIESCE_MSG_INVAL_HOST, "Invalid internet address", 1,
 
 GLFS_NEW(QUIESCE, QUIESCE_MSG_FAILOVER_FAILED, "Failed to initiate failover", 2,
     GLFS_STR(host),
-    GLFS_ERROR(error)
+    GLFS_ERR(error)
 )
 
 // clang-format on

--- a/xlators/features/quiesce/src/quiesce-messages.h
+++ b/xlators/features/quiesce/src/quiesce-messages.h
@@ -23,6 +23,15 @@
  * glfs-message-id.h.
  */
 
-GLFS_MSGID(QUIESCE, QUIESCE_MSG_INVAL_HOST, QUIESCE_MSG_FAILOVER_FAILED);
+GLFS_COMPONENT(QUIESCE);
+
+GLFS_NEW(QUIESCE, QUIESCE_MSG_INVAL_HOST, "Invalid internet address", 1,
+    GLFS_STR(address)
+)
+
+GLFS_NEW(QUIESCE, QUIESCE_MSG_FAILOVER_FAILED, "Failed to initiate failover", 2,
+    GLFS_STR(host),
+    GLFS_ERROR(error)
+)
 
 #endif /* __NL_CACHE_MESSAGES_H__ */

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -174,16 +174,15 @@ __gf_quiesce_perform_failover(xlator_t *this)
                         &priv->failover_list, list) {
                 failover_host->tried = 0;
         }*/
-        gf_msg_debug(this->name, 0,
-                     "all the failover hosts have "
-                     "been tried and looks like didn't succeed");
+        GF_LOG_D(this->name, "All the failover hosts have been tried and looks "
+                             "like didn't succeed", 0);
         ret = -1;
         goto out;
     }
 
     frame = create_frame(this, this->ctx->pool);
     if (!frame) {
-        gf_msg_debug(this->name, 0, "failed to create the frame");
+        GF_LOG_D(this->name, "Failed to create the frame", 0);
         ret = -1;
         goto out;
     }

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -174,8 +174,10 @@ __gf_quiesce_perform_failover(xlator_t *this)
                         &priv->failover_list, list) {
                 failover_host->tried = 0;
         }*/
-        GF_LOG_D(this->name, "All the failover hosts have been tried and looks "
-                             "like didn't succeed", 0);
+        GF_LOG_D(this->name,
+                 "All the failover hosts have been tried and looks like "
+                 "didn't succeed",
+                 0);
         ret = -1;
         goto out;
     }

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -96,7 +96,7 @@ gf_quiesce_populate_failover_hosts(xlator_t *this, quiesce_priv_t *priv,
 
         while (addr_tok) {
             if (!valid_internet_address(addr_tok, _gf_true, _gf_false)) {
-                GF_LOG_I(this, QUIESCE_MSG_INVAL_HOST(addr_tok));
+                GF_LOG_I(this->name, QUIESCE_MSG_INVAL_HOST(addr_tok));
                 continue;
             }
             failover_host = GF_CALLOC(1, sizeof(*failover_host),
@@ -127,7 +127,7 @@ gf_quiesce_failover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
          * just abort the failover attempts without retrying with other
          * hosts.
          */
-        GF_LOG_I(this, QUIESCE_MSG_FAILOVER_FAILED(cookie, op_errno));
+        GF_LOG_I(this->name, QUIESCE_MSG_FAILOVER_FAILED(cookie, op_errno));
     }
 
     GF_FREE(cookie);

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -96,10 +96,7 @@ gf_quiesce_populate_failover_hosts(xlator_t *this, quiesce_priv_t *priv,
 
         while (addr_tok) {
             if (!valid_internet_address(addr_tok, _gf_true, _gf_false)) {
-                gf_msg(this->name, GF_LOG_INFO, 0, QUIESCE_MSG_INVAL_HOST,
-                       "Specified "
-                       "invalid internet address:%s",
-                       addr_tok);
+                GF_LOG_I(this, QUIESCE_MSG_INVAL_HOST(addr_tok));
                 continue;
             }
             failover_host = GF_CALLOC(1, sizeof(*failover_host),
@@ -130,8 +127,7 @@ gf_quiesce_failover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
          * just abort the failover attempts without retrying with other
          * hosts.
          */
-        gf_msg(this->name, GF_LOG_INFO, op_errno, QUIESCE_MSG_FAILOVER_FAILED,
-               "Initiating failover to host:%s failed:", (char *)cookie);
+        GF_LOG_I(this, QUIESCE_MSG_FAILOVER_FAILED(cookie, op_errno));
     }
 
     GF_FREE(cookie);


### PR DESCRIPTION
Messages from quiesce xlator have been migrated to the new format as an
example.

This new approach has several advantages:

  - Centralized message definition
  - Customizable list of additional data per message
  - Typed message arguments to enforce correctness
  - Consistency between different instances of the same message
  - Better uniformity in data type representation
  - Compile-time generation of messages
  - Easily modify the message and update all references
  - All argument preparation is done only if the message will be logged
  - Very easy to use
  - Code auto-completion friendly
  - All extra overhead is optimally optimized by gcc/clang

The main drawback is that it makes heavy use of some macros, which is
considered a bad practice sometimes, and it uses specific gcc/clang
extensions, but we are already using them in other places.

To create a new message:

    GLFS_NEW(_comp, _name, _msg, _num, _fields...)

To deprecate an existing message:

    GLFS_OLD(_comp, _name, _msg, _num, _fields...)

To permanently remove a message (but keep its ID reserved):

    GLFS_GONE(_comp, _name, _msg, _num, _fields...)

To be able to mix messages using old and new interfaces, the messages
using the old interface can be defined this way:

    GLFS_MIG(_comp, _name, _msg, _num, _fields...)

Each field is a list composed of the following elements:

    (_type, _name, _source, _format, (_values) [, _extra])

 - _type   is the data type of the field (int32_t, const char *, ...)
 - _name   is the name of the field (it will also appear in the log
           string)
 - _source is the origin of the data
 - _format is the C format string to represent the field
 - _values is a list of values used by _format (generally it's only
           _name)
 - _extra  is an optional extra code to prepare the representation of
           the field (check GLFS_UUID() for an example)

There are some predefined macros for common data types.

Example:

Message definition:

    GLFS_NEW(LIBGLUSTERFS, LG_MSG_EXAMPLE, "Example message", 3,
        GLFS_UINT(number),
        GLFS_ERR(error),
        GLFS_STR(name)
    )

Message invocation:

    GF_LOG_I("test", LG_MSG_EXAMPLE(3, -2, "test"));

This will generate a message like this:

    "Example message ({number=3}, {error=2 (File not found)}, {name='test'})"

Debug and trace messages are defined directly in the logging place:

    GF_LOG_D("test", "Debug message", 3,
        GLFS_UINT(number, 3),
        GLFS_ERR(error, errno),
        GLFS_STR(name, this->name)
    );

Change-Id: I8f4bd7b9b90f649a52fe29a62222101eeccf0c68
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

