### PR TITLE
socket: more cleanups once again

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.h
+++ b/rpc/rpc-transport/socket/src/socket.h
@@ -163,7 +163,6 @@ struct gf_sock_incoming_frag {
 struct gf_sock_incoming {
     char *proghdr_base_addr;
     struct iobuf *iobuf;
-    size_t iobuf_size;
     struct gf_sock_incoming_frag frag;
     struct iovec vector[2];
     struct iovec payload_vector;
@@ -208,9 +207,6 @@ typedef struct {
      */
     int ssl_error_required;
     int ssl_session_id;
-
-    GF_REF_DECL; /* refcount to keep track of socket_poller
-                    threads */
     struct {
         pthread_mutex_t lock;
         pthread_cond_t cond;
@@ -220,9 +216,7 @@ typedef struct {
     int32_t idx;
     int32_t gen;
     uint32_t backlog;
-    SSL_METHOD *ssl_meth;
     SSL_CTX *ssl_ctx;
-    BIO *ssl_sbio;
     SSL *ssl_ssl;
     char *ssl_own_cert;
     char *ssl_private_key;


### PR DESCRIPTION
Drop unused `GF_REF_DECL` and convert `ssl_meth` and `ssl_sbio`
of `socket_private_t` / `iobuf_size` of `struct gf_sock_incoming`
to local variables, omit trivial `socket_proto_state_machine()`
wrapper, adjust related code and simplify `__socket_reset_priv()`
to `__socket_reset_incoming()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000