### PR TITLE
make functions static/remove redundant checks [afr]

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -102,13 +102,13 @@ afr_fill_success_replies(afr_local_t *local, afr_private_t *priv,
 int
 afr_fav_child_reset_sink_xattrs(void *opaque);
 
-int
+static int
 afr_fav_child_reset_sink_xattrs_cbk(int ret, call_frame_t *frame, void *opaque);
 
 static void
 afr_discover_done(call_frame_t *frame, xlator_t *this);
 
-int
+static int
 afr_dom_lock_acquire_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                          int op_ret, int op_errno, dict_t *xdata)
 {
@@ -132,7 +132,7 @@ afr_dom_lock_acquire_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_dom_lock_acquire(call_frame_t *frame)
 {
     afr_local_t *local = NULL;
@@ -194,7 +194,7 @@ blocking_lock:
     return 0;
 }
 
-int
+static int
 afr_dom_lock_release_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                          int op_ret, int op_errno, dict_t *xdata)
 {
@@ -369,7 +369,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
                   dict_t *xdata)
@@ -389,7 +389,7 @@ afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
@@ -729,7 +729,7 @@ afr_copy_frame(call_frame_t *base)
 }
 
 /* Check if an entry or inode could be undergoing a transaction. */
-gf_boolean_t
+static gf_boolean_t
 afr_is_possibly_under_txn(afr_transaction_type type, afr_local_t *local,
                           xlator_t *this)
 {
@@ -865,7 +865,7 @@ out:
  *                                to be called to recalculate the bitmaps.
  */
 
-int
+static int
 __afr_set_in_flight_sb_status(xlator_t *this, afr_local_t *local,
                               inode_t *inode)
 {
@@ -1025,7 +1025,7 @@ afr_set_in_flight_sb_status(xlator_t *this, call_frame_t *frame, inode_t *inode)
     return ret;
 }
 
-int
+static int
 __afr_inode_read_subvol_get_small(inode_t *inode, xlator_t *this,
                                   unsigned char *data, unsigned char *metadata,
                                   int *event_p)
@@ -1063,7 +1063,7 @@ __afr_inode_read_subvol_get_small(inode_t *inode, xlator_t *this,
     return ret;
 }
 
-int
+static int
 __afr_inode_read_subvol_set_small(inode_t *inode, xlator_t *this,
                                   unsigned char *data, unsigned char *metadata,
                                   int event)
@@ -1118,7 +1118,7 @@ __afr_inode_read_subvol_get(inode_t *inode, xlator_t *this, unsigned char *data,
     return ret;
 }
 
-int
+static int
 __afr_inode_split_brain_choice_get(inode_t *inode, xlator_t *this,
                                    int *spb_choice)
 {
@@ -1151,7 +1151,7 @@ __afr_inode_read_subvol_set(inode_t *inode, xlator_t *this, unsigned char *data,
     return ret;
 }
 
-int
+static int
 __afr_inode_split_brain_choice_set(inode_t *inode, xlator_t *this,
                                    int spb_choice)
 {
@@ -1413,7 +1413,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_set_split_brain_choice_cbk(void *data)
 {
     inode_t *inode = data;
@@ -1572,7 +1572,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
                  afr_transaction_type type)
 {
@@ -1596,7 +1596,7 @@ afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
     return 0;
 }
 
-int
+static int
 afr_accuse_smallfiles(xlator_t *this, struct afr_reply *replies,
                       unsigned char *data_accused)
 {
@@ -1628,7 +1628,7 @@ afr_accuse_smallfiles(xlator_t *this, struct afr_reply *replies,
     return 0;
 }
 
-int
+static int
 afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
                    unsigned char *data_accused, unsigned char *metadata_accused,
                    unsigned char *data_readable,
@@ -1743,7 +1743,7 @@ afr_replies_interpret(call_frame_t *frame, xlator_t *this, inode_t *inode,
     return ret;
 }
 
-int
+static int
 afr_refresh_selfheal_done(int ret, call_frame_t *heal, void *opaque)
 {
     if (heal)
@@ -1751,7 +1751,7 @@ afr_refresh_selfheal_done(int ret, call_frame_t *heal, void *opaque)
     return 0;
 }
 
-int
+static int
 afr_inode_refresh_err(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1774,7 +1774,7 @@ ret:
     return err;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_selfheal_enabled(const xlator_t *this)
 {
     const afr_private_t *priv = this->private;
@@ -1783,7 +1783,7 @@ afr_selfheal_enabled(const xlator_t *this)
            priv->entry_self_heal;
 }
 
-int
+static int
 afr_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
 {
     call_frame_t *heal_frame = NULL;
@@ -1847,7 +1847,7 @@ refresh_done:
     return 0;
 }
 
-int
+static int
 afr_inode_refresh_done(call_frame_t *frame, xlator_t *this, int error)
 {
     call_frame_t *heal_frame = NULL;
@@ -1907,7 +1907,7 @@ refresh_done:
     return 0;
 }
 
-void
+static void
 afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                              int op_ret, int op_errno, struct iatt *buf,
                              dict_t *xdata, struct iatt *par)
@@ -1949,7 +1949,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 }
 
-int
+static int
 afr_inode_refresh_subvol_with_lookup_cbk(call_frame_t *frame, void *cookie,
                                          xlator_t *this, int op_ret,
                                          int op_errno, inode_t *inode,
@@ -1961,7 +1961,7 @@ afr_inode_refresh_subvol_with_lookup_cbk(call_frame_t *frame, void *cookie,
     return 0;
 }
 
-int
+static int
 afr_inode_refresh_subvol_with_lookup(call_frame_t *frame, xlator_t *this, int i,
                                      inode_t *inode, uuid_t gfid, dict_t *xdata)
 {
@@ -1998,7 +1998,7 @@ afr_inode_refresh_subvol_with_fstat_cbk(call_frame_t *frame, void *cookie,
     return 0;
 }
 
-int
+static int
 afr_inode_refresh_subvol_with_fstat(call_frame_t *frame, xlator_t *this, int i,
                                     dict_t *xdata)
 {
@@ -2014,7 +2014,7 @@ afr_inode_refresh_subvol_with_fstat(call_frame_t *frame, xlator_t *this, int i,
     return 0;
 }
 
-int
+static int
 afr_inode_refresh_do(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2164,7 +2164,7 @@ afr_xattr_req_prepare(xlator_t *this, dict_t *xattr_req)
     return ret;
 }
 
-int
+static int
 afr_lookup_xattr_req_prepare(afr_local_t *local, xlator_t *this,
                              dict_t *xattr_req, loc_t *loc)
 {
@@ -2212,7 +2212,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_least_pending_reads_child(afr_private_t *priv, unsigned char *readable)
 {
     int i = 0;
@@ -2278,7 +2278,7 @@ afr_least_latency_times_pending_reads_child(afr_private_t *priv,
     return child;
 }
 
-int
+static int
 afr_hash_child(afr_read_subvol_args_t *args, afr_private_t *priv,
                unsigned char *readable)
 {
@@ -2379,7 +2379,7 @@ afr_inode_read_subvol_type_get(inode_t *inode, xlator_t *this,
         return afr_inode_read_subvol_get(inode, this, readable, 0, event_p);
 }
 
-void
+static void
 afr_readables_intersect_get(inode_t *inode, xlator_t *this, int *event,
                             unsigned char *intersection)
 {
@@ -2850,7 +2850,7 @@ afr_get_parent_read_subvol(xlator_t *this, inode_t *parent,
     return par_read_subvol_iter;
 }
 
-int
+static int
 afr_read_subvol_decide(inode_t *inode, xlator_t *this,
                        afr_read_subvol_args_t *args, unsigned char *readable)
 {
@@ -3236,7 +3236,7 @@ afr_attempt_local_discovery(xlator_t *this, int32_t child_index)
                       GF_XATTR_PATHINFO_KEY, NULL);
 }
 
-int
+static int
 afr_lookup_sh_metadata_wrap(void *opaque)
 {
     call_frame_t *frame = opaque;
@@ -3470,7 +3470,7 @@ unwind:
     return 0;
 }
 
-int
+static int
 afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -3925,7 +3925,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_lookup_do(call_frame_t *frame, xlator_t *this, int err)
 {
     int ret = 0;
@@ -4247,7 +4247,7 @@ afr_flush_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     return 0;
 }
 
-afr_local_t *
+static afr_local_t *
 afr_wakeup_same_fd_delayed_op(xlator_t *this, afr_lock_t *lock, fd_t *fd)
 {
     afr_local_t *local = NULL;
@@ -4269,7 +4269,7 @@ afr_wakeup_same_fd_delayed_op(xlator_t *this, afr_lock_t *lock, fd_t *fd)
     return local;
 }
 
-void
+static void
 afr_delayed_changelog_wake_resume(xlator_t *this, inode_t *inode,
                                   call_stub_t *stub)
 {
@@ -4481,7 +4481,7 @@ afr_fop_lock_wind(call_frame_t *frame, xlator_t *this, int child_index,
     }
 }
 
-void
+static void
 afr_fop_lock_proceed(call_frame_t *frame)
 {
     afr_local_t *local = NULL;
@@ -4628,7 +4628,7 @@ out:
     return 0;
 }
 
-int32_t
+static int32_t
 afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
 {
     int i = 0;
@@ -5868,7 +5868,7 @@ find_best_down_child(xlator_t *this)
     return best_child;
 }
 
-int
+static int
 find_worst_up_child(xlator_t *this)
 {
     afr_private_t *priv = NULL;
@@ -5893,7 +5893,7 @@ find_worst_up_child(xlator_t *this)
     return worst_child;
 }
 
-void
+static void
 __afr_handle_ping_event(xlator_t *this, xlator_t *child_xlator, const int idx,
                         int64_t halo_max_latency_msec, int32_t *event,
                         int64_t child_latency_msec)
@@ -5972,7 +5972,7 @@ afr_get_halo_latency(xlator_t *this)
     return halo_max_latency_msec;
 }
 
-void
+static void
 __afr_handle_child_up_event(xlator_t *this, xlator_t *child_xlator,
                             const int idx, int64_t child_latency_msec,
                             int32_t *event, int32_t *call_psh,
@@ -6873,7 +6873,7 @@ afr_update_heal_status(xlator_t *this, struct afr_reply *replies,
 }
 
 /*return EIO, EAGAIN or pending*/
-int
+static int
 afr_lockless_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
                      inode_t **inode, gf_boolean_t *entry_selfheal,
                      gf_boolean_t *data_selfheal,
@@ -7368,7 +7368,7 @@ afr_get_need_heal(afr_private_t *priv)
     return need_heal;
 }
 
-int
+static int
 afr_fav_child_reset_sink_xattrs_cbk(int ret, call_frame_t *heal_frame,
                                     void *opaque)
 {

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -21,7 +21,7 @@
 #include <glusterfs/compat.h>
 #include "afr-transaction.h"
 
-int32_t
+static int32_t
 afr_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {

--- a/xlators/cluster/afr/src/afr-dir-write.c
+++ b/xlators/cluster/afr/src/afr-dir-write.c
@@ -23,7 +23,7 @@
 
 #include "afr-transaction.h"
 
-void
+static void
 afr_mark_entry_pending_changelog(call_frame_t *frame, xlator_t *this);
 
 static int
@@ -246,7 +246,7 @@ __afr_dir_write_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_mark_new_entry_changelog_cbk(call_frame_t *frame, void *cookie,
                                  xlator_t *this, int op_ret, int op_errno,
                                  dict_t *xattr, dict_t *xdata)
@@ -333,7 +333,7 @@ out:
     return;
 }
 
-void
+static void
 afr_mark_entry_pending_changelog(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -379,7 +379,7 @@ afr_mark_entry_pending_changelog(call_frame_t *frame, xlator_t *this)
 
 /* {{{ create */
 
-int
+static int
 afr_create_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -399,7 +399,7 @@ afr_create_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_create_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
@@ -409,7 +409,7 @@ afr_create_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_create_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -496,7 +496,7 @@ out:
 
 /* {{{ mknod */
 
-int
+static int
 afr_mknod_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -515,7 +515,7 @@ afr_mknod_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_mknod_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    int32_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
@@ -525,7 +525,7 @@ afr_mknod_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_mknod_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -604,7 +604,7 @@ out:
 
 /* {{{ mkdir */
 
-int
+static int
 afr_mkdir_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -623,7 +623,7 @@ afr_mkdir_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_mkdir_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    int32_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
@@ -633,7 +633,7 @@ afr_mkdir_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_mkdir_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -718,7 +718,7 @@ out:
 
 /* {{{ link */
 
-int
+static int
 afr_link_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -737,7 +737,7 @@ afr_link_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_link_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
@@ -747,7 +747,7 @@ afr_link_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_link_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -825,7 +825,7 @@ out:
 
 /* {{{ symlink */
 
-int
+static int
 afr_symlink_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -844,7 +844,7 @@ afr_symlink_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_symlink_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int32_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *buf, struct iatt *preparent,
@@ -854,7 +854,7 @@ afr_symlink_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_symlink_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -933,7 +933,7 @@ out:
 
 /* {{{ rename */
 
-int
+static int
 afr_rename_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -953,7 +953,7 @@ afr_rename_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_rename_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
@@ -965,7 +965,7 @@ afr_rename_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                postnewparent, xdata);
 }
 
-int
+static int
 afr_rename_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1052,7 +1052,7 @@ out:
 
 /* {{{ unlink */
 
-int
+static int
 afr_unlink_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *main_frame = NULL;
@@ -1070,7 +1070,7 @@ afr_unlink_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_unlink_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
@@ -1079,7 +1079,7 @@ afr_unlink_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_unlink_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1173,7 +1173,7 @@ afr_rmdir_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_rmdir_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
@@ -1182,7 +1182,7 @@ afr_rmdir_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                preparent, postparent, NULL, NULL, xdata);
 }
 
-int
+static int
 afr_rmdir_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -111,7 +111,7 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
 
 /* {{{ access */
 
-int
+static int
 afr_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                int op_errno, dict_t *xdata)
 {
@@ -132,7 +132,7 @@ afr_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     return 0;
 }
 
-int
+static int
 afr_access_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_private_t *priv = NULL;
@@ -184,7 +184,7 @@ out:
 
 /* {{{ stat */
 
-int
+static int
 afr_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
              int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
@@ -205,7 +205,7 @@ afr_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     return 0;
 }
 
-int
+static int
 afr_stat_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_private_t *priv = NULL;
@@ -253,7 +253,7 @@ out:
 
 /* {{{ fstat */
 
-int
+static int
 afr_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
@@ -274,7 +274,7 @@ afr_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     return 0;
 }
 
-int
+static int
 afr_fstat_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_private_t *priv = NULL;
@@ -325,7 +325,7 @@ out:
 
 /* {{{ readlink */
 
-int
+static int
 afr_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  int32_t op_ret, int32_t op_errno, const char *buf,
                  struct iatt *sbuf, dict_t *xdata)
@@ -346,7 +346,7 @@ afr_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_readlink_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -404,7 +404,7 @@ struct _xattr_key {
     struct list_head list;
 };
 
-int
+static int
 __gather_xattr_keys(dict_t *dict, char *key, data_t *value, void *data)
 {
     struct list_head *list = data;
@@ -455,7 +455,7 @@ afr_getxattr_ignorable_errnos(int32_t op_errno)
 
     return _gf_false;
 }
-int
+static int
 afr_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
@@ -479,7 +479,7 @@ afr_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_getxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -501,7 +501,7 @@ afr_getxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
     return 0;
 }
 
-int32_t
+static int32_t
 afr_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
                     dict_t *xdata)
 
@@ -510,7 +510,7 @@ afr_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
     return 0;
 }
 
-int32_t
+static int32_t
 afr_fgetxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                         int32_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
@@ -597,7 +597,7 @@ unlock:
     return ret;
 }
 
-int32_t
+static int32_t
 afr_getxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
@@ -689,7 +689,7 @@ unlock:
 /**
  * node-uuid cbk uses next child querying mechanism
  */
-int32_t
+static int32_t
 afr_getxattr_node_uuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            int32_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
@@ -737,7 +737,7 @@ unwind:
 /**
  * list-node-uuids cbk returns the list of node_uuids for the subvolume.
  */
-int32_t
+static int32_t
 afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
                                  xlator_t *this, int32_t op_ret,
                                  int32_t op_errno, dict_t *dict, dict_t *xdata)
@@ -835,7 +835,7 @@ unlock:
     return ret;
 }
 
-int32_t
+static int32_t
 afr_getxattr_quota_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                             int32_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata)
@@ -912,16 +912,12 @@ afr_update_local_dicts(call_frame_t *frame, dict_t *dict, dict_t *xdata)
         UNLOCK(&frame->lock);
     }
 
-    if (dict != NULL) {
-        if (dict_copy(dict, local->dict) == NULL) {
-            goto done;
-        }
+    if (dict_copy(dict, local->dict) == NULL) {
+        goto done;
     }
 
-    if (xdata != NULL) {
-        if (dict_copy(xdata, local->xdata_rsp) == NULL) {
-            goto done;
-        }
+    if (dict_copy(xdata, local->xdata_rsp) == NULL) {
+        goto done;
     }
 
     ret = 0;
@@ -1043,7 +1039,7 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int32_t
+static int32_t
 afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            int32_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
@@ -1167,7 +1163,7 @@ out:
     return ret;
 }
 
-int32_t
+static int32_t
 afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                           int32_t op_ret, int32_t op_errno, dict_t *dict,
                           dict_t *xdata)
@@ -1302,7 +1298,7 @@ afr_aggregate_stime_xattr(dict_t *this, char *key, data_t *value, void *data)
     return ret;
 }
 
-int32_t
+static int32_t
 afr_common_getxattr_stime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                               int32_t op_ret, int32_t op_errno, dict_t *dict,
                               dict_t *xdata)
@@ -1426,7 +1422,7 @@ afr_getxattr_all_subvols(xlator_t *this, call_frame_t *frame, const char *name,
     return;
 }
 
-int
+static int
 afr_marker_populate_args(call_frame_t *frame, int type, int *gauge,
                          xlator_t **subvols)
 {
@@ -1582,7 +1578,7 @@ out:
 
 /* {{{ fgetxattr */
 
-int32_t
+static int32_t
 afr_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
@@ -1606,7 +1602,7 @@ afr_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_fgetxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1710,7 +1706,7 @@ out:
 
 /* {{{ readv */
 
-int
+static int
 afr_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct iovec *vector, int32_t count,
               struct iatt *buf, struct iobref *iobref, dict_t *xdata)
@@ -1732,7 +1728,7 @@ afr_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     return 0;
 }
 
-int
+static int
 afr_readv_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1789,7 +1785,7 @@ out:
 
 /* {{{ seek */
 
-int
+static int
 afr_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
              int32_t op_errno, off_t offset, dict_t *xdata)
 {
@@ -1809,7 +1805,7 @@ afr_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     return 0;
 }
 
-int
+static int
 afr_seek_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -912,12 +912,16 @@ afr_update_local_dicts(call_frame_t *frame, dict_t *dict, dict_t *xdata)
         UNLOCK(&frame->lock);
     }
 
-    if (dict_copy(dict, local->dict) == NULL) {
-        goto done;
+    if (dict != NULL) {
+        if (dict_copy(dict, local->dict) == NULL) {
+            goto done;
+        }
     }
 
-    if (dict_copy(xdata, local->xdata_rsp) == NULL) {
-        goto done;
+    if (xdata != NULL) {
+        if (dict_copy(xdata, local->xdata_rsp) == NULL) {
+            goto done;
+        }
     }
 
     ret = 0;

--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -240,7 +240,7 @@ afr_writev_unwind(call_frame_t *frame, xlator_t *this)
                      &local->cont.inode_wfop.postbuf, local->xdata_rsp);
 }
 
-int
+static int
 afr_transaction_writev_unwind(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *fop_frame = NULL;
@@ -338,7 +338,7 @@ afr_process_post_writev(call_frame_t *frame, xlator_t *this)
         local->inode_ctx->open_fd_count = local->open_fd_count;
 }
 
-int
+static int
 afr_writev_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
@@ -420,7 +420,7 @@ afr_writev_wind(call_frame_t *frame, xlator_t *this, int subvol)
     return 0;
 }
 
-int
+static int
 afr_do_writev(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *transaction_frame = NULL;
@@ -554,7 +554,7 @@ out:
 
 /* {{{ truncate */
 
-int
+static int
 afr_truncate_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -572,7 +572,7 @@ afr_truncate_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_truncate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
@@ -588,7 +588,7 @@ afr_truncate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_truncate_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -667,7 +667,7 @@ out:
 
 /* {{{ ftruncate */
 
-int
+static int
 afr_ftruncate_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -685,7 +685,7 @@ afr_ftruncate_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_ftruncate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
@@ -701,7 +701,7 @@ afr_ftruncate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_ftruncate_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -782,7 +782,7 @@ out:
 
 /* {{{ setattr */
 
-int
+static int
 afr_setattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -800,7 +800,7 @@ afr_setattr_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_setattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int op_ret, int op_errno, struct iatt *preop,
                      struct iatt *postop, dict_t *xdata)
@@ -809,7 +809,7 @@ afr_setattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postop, NULL, xdata);
 }
 
-int
+static int
 afr_setattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -884,7 +884,7 @@ out:
 
 /* {{{ fsetattr */
 
-int
+static int
 afr_fsetattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -902,7 +902,7 @@ afr_fsetattr_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_fsetattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                       int32_t op_ret, int32_t op_errno, struct iatt *preop,
                       struct iatt *postop, dict_t *xdata)
@@ -911,7 +911,7 @@ afr_fsetattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postop, NULL, xdata);
 }
 
-int
+static int
 afr_fsetattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -989,7 +989,7 @@ out:
 
 /* {{{ setxattr */
 
-int
+static int
 afr_setxattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1006,7 +1006,7 @@ afr_setxattr_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_setxattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
 {
@@ -1014,7 +1014,7 @@ afr_setxattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  NULL, NULL, xdata);
 }
 
-int
+static int
 afr_setxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1031,7 +1031,7 @@ afr_setxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
     return 0;
 }
 
-int
+static int
 afr_emptyb_set_pending_changelog_cbk(call_frame_t *frame, void *cookie,
                                      xlator_t *this, int op_ret, int op_errno,
                                      dict_t *xattr, dict_t *xdata)
@@ -1064,7 +1064,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_emptyb_set_pending_changelog(call_frame_t *frame, xlator_t *this,
                                  unsigned char *locked_nodes)
 {
@@ -1175,7 +1175,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_brick_args_cleanup(void *opaque)
 {
     afr_empty_brick_args_t *data = NULL;
@@ -1185,14 +1185,14 @@ afr_brick_args_cleanup(void *opaque)
     GF_FREE(data);
 }
 
-int
+static int
 _afr_handle_empty_brick_cbk(int ret, call_frame_t *frame, void *opaque)
 {
     afr_brick_args_cleanup(opaque);
     return 0;
 }
 
-int
+static int
 _afr_handle_empty_brick(void *opaque)
 {
     afr_local_t *local = NULL;
@@ -1268,7 +1268,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_split_brain_resolve_do(call_frame_t *frame, xlator_t *this, loc_t *loc,
                            char *data)
 {
@@ -1318,7 +1318,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_get_split_brain_child_index(xlator_t *this, void *value, size_t len)
 {
     int spb_child_index = -1;
@@ -1338,7 +1338,7 @@ afr_get_split_brain_child_index(xlator_t *this, void *value, size_t len)
     return spb_child_index;
 }
 
-int
+static int
 afr_can_set_split_brain_choice(void *opaque)
 {
     afr_spbc_timeout_t *data = opaque;
@@ -1361,7 +1361,7 @@ afr_can_set_split_brain_choice(void *opaque)
     return ret;
 }
 
-int
+static int
 afr_handle_split_brain_commands(xlator_t *this, call_frame_t *frame, loc_t *loc,
                                 dict_t *dict)
 {
@@ -1452,7 +1452,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_handle_spb_choice_timeout(xlator_t *this, call_frame_t *frame, dict_t *dict)
 {
     int ret = -1;
@@ -1471,7 +1471,7 @@ afr_handle_spb_choice_timeout(xlator_t *this, call_frame_t *frame, dict_t *dict)
     return ret;
 }
 
-int
+static int
 afr_handle_empty_brick(xlator_t *this, call_frame_t *frame, loc_t *loc,
                        dict_t *dict)
 {
@@ -1626,7 +1626,7 @@ out:
 
 /* {{{ fsetxattr */
 
-int
+static int
 afr_fsetxattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1643,7 +1643,7 @@ afr_fsetxattr_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_fsetxattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
 {
@@ -1651,7 +1651,7 @@ afr_fsetxattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  NULL, NULL, xdata);
 }
 
-int
+static int
 afr_fsetxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1734,7 +1734,7 @@ out:
 
 /* {{{ removexattr */
 
-int
+static int
 afr_removexattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1759,7 +1759,7 @@ afr_removexattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  NULL, NULL, xdata);
 }
 
-int
+static int
 afr_removexattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1836,7 +1836,7 @@ out:
 }
 
 /* ffremovexattr */
-int
+static int
 afr_fremovexattr_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1853,7 +1853,7 @@ afr_fremovexattr_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_fremovexattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                           int32_t op_ret, int32_t op_errno, dict_t *xdata)
 {
@@ -1861,7 +1861,7 @@ afr_fremovexattr_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  NULL, NULL, xdata);
 }
 
-int
+static int
 afr_fremovexattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -1938,7 +1938,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_fallocate_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1956,7 +1956,7 @@ afr_fallocate_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_fallocate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
@@ -1965,7 +1965,7 @@ afr_fallocate_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_fallocate_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -2048,7 +2048,7 @@ out:
 
 /* {{{ discard */
 
-int
+static int
 afr_discard_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2066,7 +2066,7 @@ afr_discard_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_discard_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
@@ -2075,7 +2075,7 @@ afr_discard_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_discard_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -2155,7 +2155,7 @@ out:
 
 /* {{{ zerofill */
 
-int
+static int
 afr_zerofill_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2173,7 +2173,7 @@ afr_zerofill_unwind(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_zerofill_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
@@ -2182,7 +2182,7 @@ afr_zerofill_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_zerofill_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -2262,7 +2262,7 @@ out:
 
 /* }}} */
 
-int32_t
+static int32_t
 afr_xattrop_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int32_t op_ret, int32_t op_errno, dict_t *xattr,
                      dict_t *xdata)
@@ -2271,7 +2271,7 @@ afr_xattrop_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  NULL, xattr, xdata);
 }
 
-int
+static int
 afr_xattrop_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;
@@ -2288,7 +2288,7 @@ afr_xattrop_wind(call_frame_t *frame, xlator_t *this, int subvol)
     return 0;
 }
 
-int
+static int
 afr_xattrop_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2451,7 +2451,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_fsync_unwind(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2479,7 +2479,7 @@ afr_fsync_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                  postbuf, NULL, xdata);
 }
 
-int
+static int
 afr_fsync_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = NULL;

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -17,7 +17,7 @@
 #define LOCKED_YES 0x1   /* for DATA, METADATA, ENTRY and higher_path */
 #define LOCKED_LOWER 0x2 /* for lower path */
 
-void
+static void
 afr_lockee_cleanup(afr_lockee_t *lockee)
 {
     if (lockee->fd) {
@@ -73,7 +73,7 @@ afr_entry_lockee_cmp(const void *l1, const void *l2)
         return 1;
 }
 
-int
+static int
 afr_lock_blocking(call_frame_t *frame, xlator_t *this, int child_index);
 
 void
@@ -85,7 +85,7 @@ afr_set_lk_owner(call_frame_t *frame, xlator_t *this, void *lk_owner)
     set_lk_owner_from_ptr(&frame->root->lk_owner, lk_owner);
 }
 
-int32_t
+static int32_t
 internal_lock_count(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -192,7 +192,7 @@ initialize_internal_lock_variables(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_lockee_locked_nodes_count(afr_internal_lock_t *int_lock)
 {
     int call_count = 0;
@@ -303,7 +303,7 @@ afr_unlock_common_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return ret;
 }
 
-void
+static void
 afr_internal_lock_wind(call_frame_t *frame,
                        int32_t (*cbk)(call_frame_t *, void *, xlator_t *,
                                       int32_t, int32_t, dict_t *),
@@ -521,7 +521,7 @@ is_blocking_locks_count_sufficient(call_frame_t *frame, xlator_t *this)
     return ret;
 }
 
-int
+static int
 afr_lock_blocking(call_frame_t *frame, xlator_t *this, int cookie)
 {
     afr_internal_lock_t *int_lock = NULL;

--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -23,7 +23,7 @@
 #include "afr-self-heal.h"
 #include "protocol-common.h"
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_fd_fixable(fd_t *fd)
 {
     if (!fd || !fd->inode)
@@ -36,7 +36,7 @@ afr_is_fd_fixable(fd_t *fd)
     return _gf_true;
 }
 
-int
+static int
 afr_open_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
@@ -48,7 +48,7 @@ afr_open_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
              int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
@@ -96,7 +96,7 @@ afr_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     return 0;
 }
 
-int
+static int
 afr_open_continue(call_frame_t *frame, xlator_t *this, int err)
 {
     afr_local_t *local = NULL;
@@ -192,7 +192,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_openfd_fix_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                         int32_t op_ret, int32_t op_errno, fd_t *fd,
                         dict_t *xdata)
@@ -436,7 +436,7 @@ afr_is_reopen_allowed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-void
+static void
 afr_is_reopen_allowed(xlator_t *this, call_frame_t *frame)
 {
     afr_private_t *priv = NULL;

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -44,7 +44,7 @@ afr_read_txn_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local->readfn(frame, this, subvol);
 }
 
-int
+static int
 afr_read_txn_next_subvol(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -230,7 +230,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
 {
     call_frame_t *ta_frame = NULL;
@@ -263,7 +263,7 @@ out:
     afr_read_txn_wind(frame, this, -1);
 }
 
-int
+static int
 afr_read_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
 {
     afr_private_t *priv = NULL;
@@ -340,7 +340,7 @@ afr_read_txn_continue(call_frame_t *frame, xlator_t *this, int subvol)
    the same frame
 */
 
-void
+static void
 afr_read_txn_wipe(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -152,7 +152,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_gfid_sbrain_source_from_src_brick(xlator_t *this, struct afr_reply *replies,
                                       char *src_brick)
 {
@@ -169,7 +169,7 @@ afr_gfid_sbrain_source_from_src_brick(xlator_t *this, struct afr_reply *replies,
     return -1;
 }
 
-int
+static int
 afr_selfheal_gfid_mismatch_by_majority(struct afr_reply *replies,
                                        int child_count)
 {
@@ -194,7 +194,7 @@ afr_selfheal_gfid_mismatch_by_majority(struct afr_reply *replies,
     return -1;
 }
 
-int
+static int
 afr_gfid_sbrain_source_from_bigger_file(struct afr_reply *replies,
                                         int child_count)
 {
@@ -215,7 +215,7 @@ afr_gfid_sbrain_source_from_bigger_file(struct afr_reply *replies,
     return src;
 }
 
-int
+static int
 afr_gfid_sbrain_source_from_latest_mtime(struct afr_reply *replies,
                                          int child_count)
 {
@@ -406,7 +406,7 @@ out:
     return 0;
 }
 
-int
+static int
 afr_selfheal_post_op_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                          int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
 {
@@ -454,7 +454,7 @@ afr_selfheal_post_op(call_frame_t *frame, xlator_t *this, inode_t *inode,
     return ret;
 }
 
-int
+static int
 afr_check_stale_error(struct afr_reply *replies, afr_private_t *priv)
 {
     int i = 0;
@@ -522,7 +522,7 @@ afr_selfheal_restore_time(call_frame_t *frame, xlator_t *this, inode_t *inode,
     return 0;
 }
 
-dict_t *
+static dict_t *
 afr_selfheal_output_xattr(xlator_t *this, gf_boolean_t is_full_crawl,
                           afr_transaction_type type, int *output_dirty,
                           int **output_matrix, int subvol,
@@ -728,7 +728,7 @@ afr_replies_copy(struct afr_reply *dst, struct afr_reply *src, int count)
     }
 }
 
-int
+static int
 afr_selfheal_fill_dirty(xlator_t *this, int *dirty, int subvol, int idx,
                         dict_t *xdata)
 {
@@ -1061,7 +1061,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_sh_fav_by_majority(xlator_t *this, struct afr_reply *replies,
                        inode_t *inode)
 {
@@ -1261,7 +1261,7 @@ afr_sh_get_fav_by_policy(xlator_t *this, struct afr_reply *replies,
     return fav_child;
 }
 
-int
+static int
 afr_mark_split_brain_source_sinks_by_policy(
     call_frame_t *frame, xlator_t *this, inode_t *inode, unsigned char *sources,
     unsigned char *sinks, unsigned char *healed_sinks, unsigned char *locked_on,
@@ -1525,7 +1525,7 @@ afr_get_quorum_count(afr_private_t *priv)
     }
 }
 
-void
+static void
 afr_selfheal_post_op_failure_accounting(afr_private_t *priv, char *accused,
                                         unsigned char *sources,
                                         unsigned char *locked_on)
@@ -2254,19 +2254,19 @@ afr_selfheal_unentrylk(call_frame_t *frame, xlator_t *this, inode_t *inode,
     return 0;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_data_set(xlator_t *this, dict_t *xdata)
 {
     return afr_is_pending_set(this, xdata, AFR_DATA_TRANSACTION);
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_metadata_set(xlator_t *this, dict_t *xdata)
 {
     return afr_is_pending_set(this, xdata, AFR_METADATA_TRANSACTION);
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_entry_set(xlator_t *this, dict_t *xdata)
 {
     return afr_is_pending_set(this, xdata, AFR_ENTRY_TRANSACTION);
@@ -2649,7 +2649,7 @@ none:
     return NULL;
 }
 
-int
+static int
 afr_refresh_selfheal_wrap(void *opaque)
 {
     call_frame_t *heal_frame = opaque;
@@ -2660,7 +2660,7 @@ afr_refresh_selfheal_wrap(void *opaque)
     return ret;
 }
 
-int
+static int
 afr_refresh_heal_done(int ret, call_frame_t *frame, void *opaque)
 {
     call_frame_t *heal_frame = opaque;

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -428,7 +428,7 @@ __afr_selfheal_truncate_sinks(call_frame_t *frame, xlator_t *this, fd_t *fd,
     return 0;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_has_source_witnesses(xlator_t *this, unsigned char *sources,
                          uint64_t *witness)
 {
@@ -780,7 +780,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_selfheal_data_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            int32_t op_ret, int32_t op_errno, fd_t *fd,
                            dict_t *xdata)

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -15,7 +15,7 @@
 #include <glusterfs/syncop-utils.h>
 #include <glusterfs/events.h>
 
-int
+static int
 afr_selfheal_entry_anon_inode(xlator_t *this, inode_t *dir, const char *name,
                               inode_t *inode, int child,
                               struct afr_reply *replies,

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -21,14 +21,14 @@ _afr_ignorable_key_match(dict_t *d, char *k, data_t *val, void *mdata)
     return afr_is_xattr_ignorable(k);
 }
 
-void
+static void
 afr_delete_ignorable_xattrs(dict_t *xattr)
 {
     dict_foreach_match(xattr, _afr_ignorable_key_match, NULL,
                        dict_remove_foreach_fn, NULL);
 }
 
-int
+static int
 __afr_selfheal_metadata_do(call_frame_t *frame, xlator_t *this, inode_t *inode,
                            int source, unsigned char *healed_sinks,
                            struct afr_reply *locked_replies)

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -13,7 +13,7 @@
 #include "afr-self-heal.h"
 #include "afr-messages.h"
 
-int
+static int
 __afr_selfheal_assign_gfid(xlator_t *this, inode_t *parent, uuid_t pargfid,
                            const char *bname, inode_t *inode,
                            struct afr_reply *replies, void *gfid,
@@ -54,7 +54,7 @@ out:
     return ret;
 }
 
-int
+static int
 __afr_selfheal_name_impunge(call_frame_t *frame, xlator_t *this,
                             inode_t *parent, uuid_t pargfid, const char *bname,
                             inode_t *inode, struct afr_reply *replies,
@@ -93,7 +93,7 @@ __afr_selfheal_name_impunge(call_frame_t *frame, xlator_t *this,
     return ret;
 }
 
-int
+static int
 __afr_selfheal_name_expunge(xlator_t *this, inode_t *parent, uuid_t pargfid,
                             const char *bname, inode_t *inode,
                             struct afr_reply *replies)
@@ -298,7 +298,7 @@ out:
     return source_is_empty;
 }
 
-int
+static int
 __afr_selfheal_name_do(call_frame_t *frame, xlator_t *this, inode_t *parent,
                        uuid_t pargfid, const char *bname, inode_t *inode,
                        unsigned char *sources, unsigned char *sinks,
@@ -364,7 +364,7 @@ __afr_selfheal_name_do(call_frame_t *frame, xlator_t *this, inode_t *parent,
     return ret;
 }
 
-int
+static int
 __afr_selfheal_name_finalize_source(xlator_t *this, unsigned char *sources,
                                     unsigned char *healed_sinks,
                                     unsigned char *locked_on, uint64_t *witness)
@@ -395,7 +395,7 @@ __afr_selfheal_name_finalize_source(xlator_t *this, unsigned char *sources,
     return source;
 }
 
-int
+static int
 __afr_selfheal_name_prepare(call_frame_t *frame, xlator_t *this,
                             inode_t *parent, uuid_t pargfid,
                             unsigned char *locked_on, unsigned char *sources,
@@ -448,7 +448,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_selfheal_name_do(call_frame_t *frame, xlator_t *this, inode_t *parent,
                      uuid_t pargfid, const char *bname, void *gfid_req,
                      dict_t *req, dict_t *rsp)
@@ -522,7 +522,7 @@ unlock:
     return ret;
 }
 
-int
+static int
 afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
                                    inode_t *parent, uuid_t pargfid,
                                    const char *bname, gf_boolean_t *need_heal)

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -35,7 +35,7 @@
 #define NTH_FULL_HEALER(this, n)                                               \
     &((((afr_private_t *)this->private))->shd.full_healers[n])
 
-char *
+static char *
 afr_subvol_name(xlator_t *this, int subvol)
 {
     afr_private_t *priv = NULL;
@@ -47,13 +47,13 @@ afr_subvol_name(xlator_t *this, int subvol)
     return priv->children[subvol]->name;
 }
 
-void
+static void
 afr_destroy_crawl_event_data(void *data)
 {
     return;
 }
 
-void
+static void
 afr_destroy_shd_event_data(void *data)
 {
     shd_event_t *shd_event = data;
@@ -65,7 +65,7 @@ afr_destroy_shd_event_data(void *data)
     return;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_shd_is_subvol_local(xlator_t *this, int subvol)
 {
     afr_private_t *priv = NULL;
@@ -81,7 +81,7 @@ afr_shd_is_subvol_local(xlator_t *this, int subvol)
     return is_local;
 }
 
-int
+static int
 __afr_shd_healer_wait(struct subvol_healer *healer)
 {
     afr_private_t *priv = NULL;
@@ -110,7 +110,7 @@ disabled_loop:
     return ret;
 }
 
-int
+static int
 afr_shd_healer_wait(struct subvol_healer *healer)
 {
     int ret = 0;
@@ -124,7 +124,7 @@ afr_shd_healer_wait(struct subvol_healer *healer)
     return ret;
 }
 
-gf_boolean_t
+static gf_boolean_t
 safe_break(struct subvol_healer *healer)
 {
     gf_boolean_t ret = _gf_false;
@@ -143,7 +143,7 @@ unlock:
     return ret;
 }
 
-inode_t *
+static inode_t *
 afr_shd_inode_find(xlator_t *this, xlator_t *subvol, uuid_t gfid)
 {
     int ret = 0;
@@ -182,7 +182,7 @@ out:
     return inode;
 }
 
-inode_t *
+static inode_t *
 afr_shd_index_inode(xlator_t *this, xlator_t *subvol, char *vgfid)
 {
     loc_t rootloc = {
@@ -241,7 +241,7 @@ afr_shd_entry_purge(xlator_t *subvol, inode_t *inode, char *name,
     return ret;
 }
 
-void
+static void
 afr_shd_zero_xattrop(xlator_t *this, uuid_t gfid)
 {
     call_frame_t *frame = NULL;
@@ -288,7 +288,7 @@ out:
     return;
 }
 
-int
+static int
 afr_shd_selfheal_name(struct subvol_healer *healer, int child, uuid_t parent,
                       const char *bname)
 {
@@ -299,7 +299,7 @@ afr_shd_selfheal_name(struct subvol_healer *healer, int child, uuid_t parent,
     return ret;
 }
 
-int
+static int
 afr_shd_selfheal(struct subvol_healer *healer, int child, uuid_t gfid)
 {
     int ret = 0;
@@ -359,7 +359,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_shd_sweep_prepare(struct subvol_healer *healer)
 {
     crawl_event_t *event = NULL;
@@ -375,7 +375,7 @@ afr_shd_sweep_prepare(struct subvol_healer *healer)
     _mask_cancellation();
 }
 
-void
+static void
 afr_shd_sweep_done(struct subvol_healer *healer)
 {
     crawl_event_t *event = NULL;
@@ -436,7 +436,7 @@ afr_shd_index_heal(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     return 0;
 }
 
-int
+static int
 afr_shd_index_sweep(struct subvol_healer *healer, char *vgfid)
 {
     loc_t loc = {0};
@@ -487,7 +487,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_shd_index_sweep_all(struct subvol_healer *healer)
 {
     int ret = 0;
@@ -514,7 +514,7 @@ out:
         return count;
 }
 
-int
+static int
 afr_shd_full_heal(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
                   void *data)
 {
@@ -539,7 +539,7 @@ afr_shd_full_heal(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     return 0;
 }
 
-int
+static int
 afr_shd_full_sweep(struct subvol_healer *healer, inode_t *inode)
 {
     afr_private_t *priv = NULL;
@@ -551,7 +551,7 @@ afr_shd_full_sweep(struct subvol_healer *healer, inode_t *inode)
                       GF_CLIENT_PID_SELF_HEALD, healer, afr_shd_full_heal);
 }
 
-int
+static int
 afr_shd_fill_ta_loc(xlator_t *this, loc_t *loc)
 {
     afr_private_t *priv = NULL;
@@ -591,7 +591,7 @@ out:
     return ret;
 }
 
-int
+static int
 _afr_shd_ta_get_xattrs(xlator_t *this, loc_t *loc, dict_t **xdata)
 {
     afr_private_t *priv = NULL;
@@ -631,7 +631,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_shd_ta_get_xattrs(xlator_t *this, loc_t *loc, struct subvol_healer *healer,
                       dict_t **xdata)
 {
@@ -664,7 +664,7 @@ out:
         healer->rerun = 1;
 }
 
-int
+static int
 afr_shd_ta_unset_xattrs(xlator_t *this, loc_t *loc, dict_t **xdata, int healer)
 {
     afr_private_t *priv = NULL;
@@ -747,7 +747,7 @@ out:
     return ret;
 }
 
-void
+static void
 afr_shd_ta_check_and_unset_xattrs(xlator_t *this, loc_t *loc,
                                   struct subvol_healer *healer,
                                   dict_t *pre_crawl_xdata)
@@ -784,7 +784,7 @@ unref:
         afr_ta_post_op_unlock(this, loc);
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_bricks_available_for_heal(afr_private_t *priv)
 {
     int up_children = 0;
@@ -1090,7 +1090,7 @@ afr_shd_index_healer(void *data)
     return NULL;
 }
 
-void *
+static void *
 afr_shd_full_healer(void *data)
 {
     struct subvol_healer *healer = NULL;
@@ -1132,7 +1132,7 @@ afr_shd_full_healer(void *data)
     return NULL;
 }
 
-int
+static int
 afr_shd_healer_init(xlator_t *this, struct subvol_healer *healer)
 {
     int ret = 0;
@@ -1153,7 +1153,7 @@ out:
     return ret;
 }
 
-int
+static int
 afr_shd_healer_spawn(xlator_t *this, struct subvol_healer *healer,
                      void *(threadfn)(void *))
 {
@@ -1179,21 +1179,21 @@ unlock:
     return ret;
 }
 
-int
+static int
 afr_shd_full_healer_spawn(xlator_t *this, int subvol)
 {
     return afr_shd_healer_spawn(this, NTH_FULL_HEALER(this, subvol),
                                 afr_shd_full_healer);
 }
 
-int
+static int
 afr_shd_index_healer_spawn(xlator_t *this, int subvol)
 {
     return afr_shd_healer_spawn(this, NTH_INDEX_HEALER(this, subvol),
                                 afr_shd_index_healer);
 }
 
-int
+static int
 afr_shd_dict_add_crawl_event(xlator_t *this, dict_t *output,
                              crawl_event_t *crawl_event)
 {
@@ -1411,7 +1411,7 @@ afr_selfheal_childup(xlator_t *this, afr_private_t *priv)
     return;
 }
 
-int
+static int
 afr_shd_get_index_count(xlator_t *this, int i, uint64_t *count)
 {
     afr_private_t *priv = NULL;

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -34,27 +34,27 @@ afr_post_op_handle_failure(call_frame_t *frame, xlator_t *this, int op_errno);
 static int
 afr_internal_lock_finish(call_frame_t *frame, xlator_t *this);
 
-void
+static void
 __afr_transaction_wake_shared(afr_local_t *local, struct list_head *shared);
 
-void
+static void
 afr_changelog_post_op_do(call_frame_t *frame, xlator_t *this);
 
-int
+static int
 afr_changelog_post_op_safe(call_frame_t *frame, xlator_t *this);
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_pre_op_uninherit(call_frame_t *frame, xlator_t *this);
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_pre_op_update(call_frame_t *frame, xlator_t *this);
 
-int
+static int
 afr_changelog_call_count(afr_transaction_type type,
                          unsigned char *pre_op_subvols,
                          unsigned char *failed_subvols,
                          unsigned int child_count);
-int
+static int
 afr_changelog_do(call_frame_t *frame, xlator_t *this, dict_t *xattr,
                  afr_changelog_resume_t changelog_resume,
                  afr_xattrop_type_t op);
@@ -246,7 +246,7 @@ afr_needs_changelog_update(afr_local_t *local)
     return _gf_false;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_has_quorum(afr_local_t *local, xlator_t *this)
 {
     afr_private_t *priv = NULL;
@@ -269,7 +269,7 @@ afr_changelog_has_quorum(afr_local_t *local, xlator_t *this)
     return _gf_false;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_write_subvol_valid(call_frame_t *frame, xlator_t *this)
 {
     int i = 0;
@@ -341,7 +341,7 @@ afr_transaction_fop(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_transaction_done(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -488,7 +488,7 @@ __mark_all_success(call_frame_t *frame, xlator_t *this)
     }
 }
 
-void
+static void
 afr_compute_pre_op_sources(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -528,7 +528,7 @@ afr_compute_pre_op_sources(call_frame_t *frame, xlator_t *this)
                 local->transaction.pre_op_sources[j] = 0;
 }
 
-void
+static void
 afr_txn_arbitrate_fop(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -557,7 +557,7 @@ afr_txn_arbitrate_fop(call_frame_t *frame, xlator_t *this)
     return;
 }
 
-int
+static int
 afr_transaction_perform_fop(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -726,7 +726,7 @@ afr_ta_process_onwireq(afr_ta_fop_state_t fop_state, xlator_t *this)
     }
 }
 
-int
+static int
 afr_changelog_post_op_done(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -781,7 +781,7 @@ afr_locked_nodes_get(afr_transaction_type type, afr_internal_lock_t *int_lock)
     return int_lock->lockee[0].locked_nodes;
 }
 
-int
+static int
 afr_changelog_call_count(afr_transaction_type type,
                          unsigned char *pre_op_subvols,
                          unsigned char *failed_subvols,
@@ -828,7 +828,7 @@ afr_txn_nothing_failed(call_frame_t *frame, xlator_t *this)
     return _gf_true;
 }
 
-void
+static void
 afr_handle_symmetric_errors(call_frame_t *frame, xlator_t *this)
 {
     if (afr_is_symmetric_error(frame, this))
@@ -923,7 +923,7 @@ afr_has_fop_cbk_quorum(call_frame_t *frame)
     return afr_has_quorum(success, this, NULL);
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_need_dirty_marking(call_frame_t *frame, xlator_t *this)
 {
     afr_private_t *priv = this->private;
@@ -949,7 +949,7 @@ afr_need_dirty_marking(call_frame_t *frame, xlator_t *this)
     return need_dirty;
 }
 
-void
+static void
 afr_handle_quorum(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1085,7 +1085,7 @@ afr_ta_post_op_done(int ret, call_frame_t *frame, void *opaque)
     return 0;
 }
 
-int **
+static int **
 afr_set_changelog_xattr(afr_private_t *priv, unsigned char *pending,
                         dict_t *xattr, afr_local_t *local)
 {
@@ -1376,7 +1376,7 @@ afr_handle_failure_using_thin_arbiter(call_frame_t *frame, xlator_t *this)
     afr_ta_decide_post_op_state(frame, this);
 }
 
-void
+static void
 afr_changelog_post_op_do(call_frame_t *frame, xlator_t *this)
 {
     afr_private_t *priv = this->private;
@@ -1487,7 +1487,7 @@ afr_changelog_post_op_now(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_pre_op_uninherit(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1552,7 +1552,7 @@ unlock:
     return ret;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_pre_op_inherit(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1598,7 +1598,7 @@ unlock:
     return ret;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_changelog_pre_op_update(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -1652,7 +1652,7 @@ unlock:
     return ret;
 }
 
-int
+static int
 afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                   int op_errno, dict_t *xattr, dict_t *xdata)
 {
@@ -1680,7 +1680,7 @@ afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     return 0;
 }
 
-void
+static void
 afr_changelog_populate_xdata(call_frame_t *frame, afr_xattrop_type_t op,
                              dict_t **xdata, dict_t **newloc_xdata)
 {
@@ -1776,7 +1776,7 @@ out:
     return;
 }
 
-int
+static int
 afr_changelog_prepare(xlator_t *this, call_frame_t *frame, int *call_count,
                       afr_changelog_resume_t changelog_resume,
                       afr_xattrop_type_t op, dict_t **xdata,
@@ -1804,7 +1804,7 @@ afr_changelog_prepare(xlator_t *this, call_frame_t *frame, int *call_count,
     return 0;
 }
 
-int
+static int
 afr_changelog_do(call_frame_t *frame, xlator_t *this, dict_t *xattr,
                  afr_changelog_resume_t changelog_resume, afr_xattrop_type_t op)
 {
@@ -2027,7 +2027,7 @@ err:
     return 0;
 }
 
-int
+static int
 afr_post_nonblocking_lock_cbk(call_frame_t *frame, xlator_t *this)
 {
     afr_internal_lock_t *int_lock = NULL;
@@ -2052,7 +2052,7 @@ afr_post_nonblocking_lock_cbk(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_set_transaction_flock(xlator_t *this, afr_local_t *local,
                           afr_lockee_t *lockee)
 {
@@ -2194,7 +2194,7 @@ afr_copy_inodelk_vars(afr_internal_lock_t *dst, afr_internal_lock_t *src,
            priv->child_count * sizeof(*dl->locked_nodes));
 }
 
-void
+static void
 __afr_transaction_wake_shared(afr_local_t *local, struct list_head *shared)
 {
     gf_boolean_t conflict = _gf_false;
@@ -2231,7 +2231,7 @@ afr_lock_resume_shared(struct list_head *list)
     }
 }
 
-int
+static int
 afr_internal_lock_finish(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = frame->local;
@@ -2257,7 +2257,7 @@ afr_internal_lock_finish(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_are_conflicting_ops_waiting(afr_local_t *local, xlator_t *this)
 {
     afr_lock_t *lock = NULL;
@@ -2284,7 +2284,7 @@ afr_are_conflicting_ops_waiting(afr_local_t *local, xlator_t *this)
     return _gf_false;
 }
 
-gf_boolean_t
+static gf_boolean_t
 afr_is_delayed_changelog_post_op_needed(call_frame_t *frame, xlator_t *this,
                                         int delay)
 {
@@ -2394,7 +2394,7 @@ afr_fd_has_witnessed_unstable_write(xlator_t *this, inode_t *inode)
     return witness;
 }
 
-int
+static int
 afr_changelog_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                         int op_ret, int op_errno, struct iatt *pre,
                         struct iatt *post, dict_t *xdata)
@@ -2427,7 +2427,7 @@ afr_changelog_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int
+static int
 afr_changelog_fsync(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2473,7 +2473,7 @@ afr_changelog_fsync(call_frame_t *frame, xlator_t *this)
     return 0;
 }
 
-int
+static int
 afr_changelog_post_op_safe(call_frame_t *frame, xlator_t *this)
 {
     afr_local_t *local = NULL;
@@ -2654,7 +2654,7 @@ __need_previous_lock_unlocked(afr_local_t *local)
     return _gf_false;
 }
 
-void
+static void
 __afr_eager_lock_handle(afr_local_t *local, gf_boolean_t *take_lock,
                         gf_boolean_t *do_pre_op, afr_local_t **timer_local)
 {
@@ -2725,7 +2725,7 @@ out:
     return;
 }
 
-void
+static void
 afr_transaction_start(afr_local_t *local, xlator_t *this)
 {
     afr_private_t *priv = NULL;
@@ -2764,7 +2764,7 @@ lock_phase:
         afr_delayed_changelog_wake_up_cbk(timer_local);
 }
 
-int
+static int
 afr_write_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
 {
     afr_local_t *local = frame->local;
@@ -2782,7 +2782,7 @@ fail:
     return 0;
 }
 
-int
+static int
 afr_transaction_lockee_init(call_frame_t *frame)
 {
     afr_local_t *local = frame->local;

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -61,7 +61,7 @@ mem_acct_init(xlator_t *this)
     return ret;
 }
 
-int
+static int
 xlator_subvolume_index(xlator_t *this, xlator_t *subvol)
 {
     int index = -1;
@@ -107,7 +107,7 @@ fix_quorum_options(xlator_t *this, afr_private_t *priv, char *qtype,
     }
 }
 
-int
+static int
 afr_set_favorite_child_policy(afr_private_t *priv, char *policy)
 {
     int index = -1;
@@ -135,7 +135,7 @@ set_data_self_heal_algorithm(afr_private_t *priv, char *algo)
     }
 }
 
-void
+static void
 afr_handle_anon_inode_options(afr_private_t *priv, dict_t *options)
 {
     char *volfile_id_str = NULL;
@@ -664,7 +664,7 @@ init(xlator_t *this)
 out:
     return ret;
 }
-void
+static void
 afr_destroy_healer_object(xlator_t *this, struct subvol_healer *healer)
 {
     int ret = -1;
@@ -687,7 +687,7 @@ afr_destroy_healer_object(xlator_t *this, struct subvol_healer *healer)
     pthread_mutex_destroy(&healer->mutex);
 }
 
-void
+static void
 afr_selfheal_daemon_fini(xlator_t *this)
 {
     struct subvol_healer *healer = NULL;


### PR DESCRIPTION
Made relevant functions static in afr component to improve code readability and performance.
Also removed redundant null checks 

Reference to issue #2967 
Change-Id: I96172331f1aa0ff2d65ea2a876303ec799bf5144

Signed-off-by: Harshita Shree hshree@redhat.com

