### PR TITLE
server:Optimize server_process_event_upcall code path

### DIFF
--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1408,6 +1408,7 @@ server_process_event_upcall(xlator_t *this, void *data)
         {0},
     };
     xdrproc_t xdrproc;
+    gf_boolean_t xprt_found = _gf_false;
 
     GF_VALIDATE_OR_GOTO(this->name, data, out);
 
@@ -1485,21 +1486,26 @@ server_process_event_upcall(xlator_t *this, void *data)
             if (!client || strcmp(client->client_uid, client_uid))
                 continue;
 
-            ret = rpcsvc_request_submit(conf->rpc, xprt, &server_cbk_prog,
-                                        cbk_procnum, up_req, this->ctx,
-                                        xdrproc);
-            if (ret < 0) {
-                gf_msg_debug(this->name, 0,
-                             "Failed to send "
-                             "upcall to client:%s upcall "
-                             "event:%d",
-                             client_uid, upcall_data->event_type);
-            }
+            xprt_found = _gf_true;
+            rpc_transport_ref(xprt);
             break;
         }
     }
     pthread_mutex_unlock(&conf->mutex);
-    ret = 0;
+
+    if (xprt_found) {
+        ret = rpcsvc_request_submit(conf->rpc, xprt, &server_cbk_prog,
+                                    cbk_procnum, up_req, this->ctx, xdrproc);
+        rpc_transport_unref(xprt);
+        if (ret < 0) {
+            gf_msg_debug(this->name, 0,
+                         "Failed to send "
+                         "upcall to client:%s upcall "
+                         "event:%d",
+                         client_uid, upcall_data->event_type);
+        }
+    }
+
 out:
     GF_FREE((gf_c_req.xdata).xdata_val);
     GF_FREE((gf_recall_lease.xdata).xdata_val);


### PR DESCRIPTION
The function server_process_event_upcall handles upcall event and send a
notification to client. To send a notification to client it has taken
a lock to access xprt and the lock has not released until the event has not
been sent to the client, It means at a time it will not able to process
more than one notification it has lock contention while a brick process is trying
to send more than one upcall event notification.

Solution: Instead of sending an event under critical section take a reference
          on the xprt.
Fixes: #3321
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: Ibaab1626ab6e0c318df77e8efe528e71f3802517

