### PR TITLE
dht: Synchronize layout_(ref|unref) during layout_(get|set) in dht code

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -3016,6 +3016,8 @@ dht_should_lookup_everywhere(xlator_t *this, dht_conf_t *conf, loc_t *loc)
                 (parent_layout->commit_hash == conf->vol_commit_hash)) {
                 lookup_everywhere = _gf_false;
             }
+            if (!ret)
+                dht_layout_unref(parent_layout);
         }
         goto out;
     } else {
@@ -3027,6 +3029,8 @@ dht_should_lookup_everywhere(xlator_t *this, dht_conf_t *conf, loc_t *loc)
                     (!parent_layout->search_unhashed)) {
                     lookup_everywhere = _gf_false;
                 }
+                if (!ret)
+                    dht_layout_unref(parent_layout);
             } else {
                 lookup_everywhere = _gf_false;
             }
@@ -11181,18 +11185,26 @@ dht_inode_ctx_layout_get(inode_t *inode, xlator_t *this, dht_layout_t **layout)
 {
     dht_inode_ctx_t *ctx = NULL;
     int ret = -1;
+    uint64_t ctx_int = 0;
 
     ret = dht_inode_ctx_get(inode, this, &ctx);
 
-    if (!ret && ctx) {
-        if (ctx->layout) {
-            if (layout)
-                *layout = ctx->layout;
-            ret = 0;
-        } else {
-            ret = -1;
+    LOCK(&inode->lock);
+    {
+        ret = __inode_ctx_get(inode, this, &ctx_int);
+        if (!ret) {
+            ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
+            if (ctx && ctx->layout) {
+                if (layout) {
+                    *layout = ctx->layout;
+                    dht_layout_ref(ctx->layout);
+                }
+            } else {
+                ret = -1;
+            }
         }
     }
+    UNLOCK(&inode->lock);
 
     return ret;
 }

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -532,7 +532,6 @@ struct dht_conf {
     int32_t refresh_interval;
     gf_lock_t subvolume_lock;
     time_t last_stat_fetch;
-    gf_lock_t layout_lock;
     dict_t *leaf_to_subvol;
     void *private; /* Can be used by wrapper xlators over
                       dht */
@@ -870,7 +869,7 @@ dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout);
 void
 dht_layout_unref(xlator_t *this, dht_layout_t *layout);
 dht_layout_t *
-dht_layout_ref(xlator_t *this, dht_layout_t *layout);
+dht_layout_ref(dht_layout_t *layout);
 int
 dht_layout_index_for_subvol(dht_layout_t *layout, xlator_t *subvol);
 xlator_t *

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -307,7 +307,7 @@ dht_free_disk_available_subvol(xlator_t *this, xlator_t *subvol,
             goto out;
         }
     } else {
-        layout = dht_layout_ref(this, local->layout);
+        layout = dht_layout_ref(local->layout);
     }
 
     LOCK(&conf->subvolume_lock);

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -1792,18 +1792,40 @@ dht_inode_ctx_layout_set(inode_t *inode, xlator_t *this,
 {
     dht_inode_ctx_t *ctx = NULL;
     int ret = -1;
+    uint64_t ctx_int = 0;
+    dht_layout_t *old_layout = NULL;
 
-    ret = dht_inode_ctx_get(inode, this, &ctx);
-    if (!ret && ctx) {
-        ctx->layout = layout_int;
-    } else {
-        ctx = GF_CALLOC(1, sizeof(*ctx), gf_dht_mt_inode_ctx_t);
-        if (!ctx)
-            return ret;
-        ctx->layout = layout_int;
+    LOCK(&inode->lock);
+    {
+        ret = __inode_ctx_get(inode, this, &ctx_int);
+        if (!ret) {
+            ctx = (dht_inode_ctx_t *)(uintptr_t)ctx_int;
+            if (ctx) {
+                old_layout = ctx->layout;
+                ctx->layout = layout_int;
+            }
+        }
+
+        if (!ctx) {
+            ctx = GF_CALLOC(1, sizeof(*ctx), gf_dht_mt_inode_ctx_t);
+            if (ctx) {
+                ctx->layout = layout_int;
+                ctx_int = (long)ctx;
+                ret = __inode_ctx_set0(inode, this, &ctx_int);
+                if (ret)
+                    GF_FREE(ctx);
+            } else {
+                ret = -1;
+            }
+        }
+        if (!ret && layout_int)
+            dht_layout_ref(ctx->layout);
     }
+    UNLOCK(&inode->lock);
 
     ret = dht_inode_ctx_set(inode, this, ctx);
+    if (old_layout)
+        dht_layout_unref(old_layout);
 
     return ret;
 }

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -56,12 +56,9 @@ dht_layout_t *
 dht_layout_get(xlator_t *this, inode_t *inode)
 {
     dht_layout_t *layout = NULL;
-    int ret = 0;
 
-    ret = dht_inode_ctx_layout_get(inode, this, &layout);
-    if ((!ret) && layout) {
-        GF_ATOMIC_INC(layout->ref);
-    }
+    dht_inode_ctx_layout_get(inode, this, &layout);
+
     return layout;
 }
 
@@ -69,28 +66,13 @@ int
 dht_layout_set(xlator_t *this, inode_t *inode, dht_layout_t *layout)
 {
     dht_conf_t *conf = NULL;
-    int oldret = -1;
     int ret = -1;
-    dht_layout_t *old_layout;
 
     conf = this->private;
     if (!conf || !layout)
         goto out;
 
-    LOCK(&conf->layout_lock);
-    {
-        oldret = dht_inode_ctx_layout_get(inode, this, &old_layout);
-        if (layout)
-            GF_ATOMIC_INC(layout->ref);
-        ret = dht_inode_ctx_layout_set(inode, this, layout);
-    }
-    UNLOCK(&conf->layout_lock);
-
-    if (!oldret) {
-        dht_layout_unref(this, old_layout);
-    }
-    if (ret)
-        GF_ATOMIC_DEC(layout->ref);
+    ret = dht_inode_ctx_layout_set(inode, this, layout);
 
 out:
     return ret;
@@ -111,9 +93,9 @@ dht_layout_unref(xlator_t *this, dht_layout_t *layout)
 }
 
 dht_layout_t *
-dht_layout_ref(xlator_t *this, dht_layout_t *layout)
+dht_layout_ref(dht_layout_t *layout)
 {
-    if (layout->preset || !this->private)
+    if (layout->preset)
         return layout;
 
     GF_ATOMIC_INC(layout->ref);
@@ -780,14 +762,7 @@ dht_layout_preset(xlator_t *this, xlator_t *subvol, inode_t *inode)
     gf_msg_debug(this->name, 0, "file = %s, subvol = %s",
                  uuid_utoa(inode->gfid), subvol ? subvol->name : "<nil>");
 
-    LOCK(&conf->layout_lock);
-    {
-        dht_inode_ctx_layout_set(inode, this, layout);
-    }
-
-    UNLOCK(&conf->layout_lock);
-
-    ret = 0;
+    ret = dht_inode_ctx_layout_set(inode, this, layout);
 out:
     return ret;
 }

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -544,8 +544,8 @@ dht_selfheal_layout_lock(call_frame_t *frame, dht_layout_t *layout,
     local->selfheal.should_heal = should_heal;
 
     tmp = local->selfheal.layout;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
-    dht_layout_unref(frame->this, tmp);
+    local->selfheal.layout = dht_layout_ref(layout);
+    dht_layout_unref(tmp);
 
     if (!newdir) {
         count = conf->subvolume_cnt;
@@ -1908,7 +1908,7 @@ dht_selfheal_new_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     inode_unref(inode);
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     dht_layout_sort_volname(layout);
     dht_selfheal_layout_new_directory(frame, &local->loc, layout);
@@ -1937,7 +1937,7 @@ dht_fix_directory_layout(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     local = frame->local;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     /* No layout sorting required here */
     tmp_layout = dht_fix_layout_of_directory(frame, &local->loc, layout);
@@ -1968,7 +1968,7 @@ dht_selfheal_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     this = frame->this;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     if (local->need_attrheal) {
         if (__is_root_gfid(local->stbuf.ia_gfid)) {
@@ -2073,7 +2073,7 @@ dht_selfheal_restore(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     local = frame->local;
 
     local->selfheal.dir_cbk = dir_cbk;
-    local->selfheal.layout = dht_layout_ref(frame->this, layout);
+    local->selfheal.layout = dht_layout_ref(layout);
 
     ret = dht_selfheal_dir_mkdir(frame, loc, layout, 1);
 

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -169,6 +169,8 @@ dht_inodectx_dump(xlator_t *this, inode_t *inode)
     gf_proc_dump_add_section("xlator.cluster.dht.%s.inode", this->name);
     dht_layout_dump(layout, "layout");
 
+    if (!ret)
+        dht_layout_unref(layout);
 out:
     return ret;
 }
@@ -637,7 +639,6 @@ dht_init(xlator_t *this)
     }
 
     LOCK_INIT(&conf->subvolume_lock);
-    LOCK_INIT(&conf->layout_lock);
     LOCK_INIT(&conf->lock);
     synclock_init(&conf->link_lock, SYNC_LOCK_DEFAULT);
 


### PR DESCRIPTION
Currently dht_layout(ref|unref) is happening after increase/decreate
atomic counter. There is some race condition during new layout has been
changed at the same time old layout is using in other thread.Due to this
a client process is getting crashed.

Solution: Remove layout->ref_lock and use inode->lock to synchronize
layout.

Fixes: #3262
Change-Id: I55952484bd651176f818b9cab54274f37dbca1a6
Signed-off-by: Mohit Agrawal moagrawa@redhat.com

