### PR TITLE
centos8: tests timed out 

### DIFF
--- a/tests/basic/afr/tarissue.t
+++ b/tests/basic/afr/tarissue.t
@@ -3,7 +3,7 @@
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 TESTS_EXPECTED_IN_LOOP=10

--- a/tests/basic/all_squash.t
+++ b/tests/basic/all_squash.t
@@ -2,7 +2,7 @@
 . $(dirname $0)/../include.rc
 . $(dirname $0)/../volume.rc
 . $(dirname $0)/../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 cleanup;

--- a/tests/basic/mount.t
+++ b/tests/basic/mount.t
@@ -2,7 +2,7 @@
 
 . $(dirname $0)/../include.rc
 . $(dirname $0)/../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 cleanup;

--- a/tests/basic/namespace.t
+++ b/tests/basic/namespace.t
@@ -3,7 +3,7 @@
 . $(dirname $0)/../include.rc
 . $(dirname $0)/../volume.rc
 . $(dirname $0)/../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 # These hashes are a result of calling SuperFastHash

--- a/tests/bugs/distribute/bug-1125824.t
+++ b/tests/bugs/distribute/bug-1125824.t
@@ -3,7 +3,7 @@
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 create_files () {

--- a/tests/bugs/distribute/bug-1190734.t
+++ b/tests/bugs/distribute/bug-1190734.t
@@ -3,7 +3,7 @@
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 BRICK_COUNT=3

--- a/tests/bugs/snapshot/bug-1166197.t
+++ b/tests/bugs/snapshot/bug-1166197.t
@@ -4,7 +4,7 @@
 . $(dirname $0)/../../snapshot.rc
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../nfs.rc
-
+SCRIPT_TIMEOUT=500
 #G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST
 
 cleanup;


### PR DESCRIPTION
These issues are getting timed out in 
build environment and not reproducible on softserve centos8

Issue: #3306 
Change-Id: I971fc3591767f4e9802f02073e0bda8714af9c8e
Signed-off-by: Preet Bhatia [pbhatia@redhat.com](mailto:pbhatia@redhat.com)