### PR TITLE
marker, libxlator: use long values for time management

### DIFF
--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -623,7 +623,7 @@ marker_start_setxattr(call_frame_t *frame, xlator_t *this)
     GF_UUID_ASSERT(local->loc.gfid);
 
     ret = dict_set_static_bin(dict, priv->marker_xattr, (void *)local->timebuf,
-                              8);
+                              sizeof(local->timebuf));
     if (ret) {
         gf_log(this->name, GF_LOG_WARNING, "failed to set marker xattr (%s)",
                local->loc.path);
@@ -650,8 +650,8 @@ marker_gettimeofday(marker_local_t *local)
 
     gettimeofday(&tv, NULL);
 
-    local->timebuf[0] = htonl(tv.tv_sec);
-    local->timebuf[1] = htonl(tv.tv_usec);
+    local->timebuf[0] = gf_host_time_to_net_time(tv.tv_sec);
+    local->timebuf[1] = gf_host_time_to_net_time(tv.tv_usec);
 
     return;
 }

--- a/xlators/features/marker/src/marker.h
+++ b/xlators/features/marker/src/marker.h
@@ -84,7 +84,7 @@ enum {
     } while (0)
 
 struct marker_local {
-    uint32_t timebuf[2];
+    unsigned long timebuf[2];
     pid_t pid;
     loc_t loc;
     loc_t parent_loc;

--- a/xlators/lib/src/libxlator.h
+++ b/xlators/lib/src/libxlator.h
@@ -105,8 +105,8 @@ struct marker_str {
     struct volume_mark *volmark;
     data_t *data;
 
-    uint32_t host_timebuf[2];
-    uint32_t net_timebuf[2];
+    unsigned long host_timebuf[2];
+    unsigned long net_timebuf[2];
     int32_t call_count;
     int gauge[MCNT_MAX];
     int count[MCNT_MAX];
@@ -142,5 +142,35 @@ gf_get_min_stime(xlator_t *this, dict_t *dst, char *key, data_t *value);
 
 int
 gf_get_max_stime(xlator_t *this, dict_t *dst, char *key, data_t *value);
+
+/* These assumes that the network byte order is big endian for sure. */
+
+static inline unsigned long
+gf_net_time_to_host_time(unsigned long t)
+{
+#if __BYTE_ORDER == __BIG_ENDIAN
+    return t;
+#else /* __LITTLE_ENDIAN */
+#if defined(__LP64__)
+    return be64toh(t);
+#else /* assume 32-bit system */
+    return be32toh(t);
+#endif /* __LP64__ */
+#endif /* __BYTE_ORDER */
+}
+
+static inline unsigned long
+gf_host_time_to_net_time(unsigned long t)
+{
+#if __BYTE_ORDER == __BIG_ENDIAN
+    return t;
+#else /* __LITTLE_ENDIAN */
+#if defined(__LP64__)
+    return htobe64(t);
+#else /* assume 32-bit system */
+    return htobe32(t);
+#endif /* __LP64__ */
+#endif /* __BYTE_ORDER */
+}
 
 #endif /* !_LIBXLATOR_H */


### PR DESCRIPTION
Consistently use `unsigned long` to manage time values, add convenient
`gf_net_time_to_host_time()` and `gf_host_time_to_net_time()` to control
byte order where needed, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000