### PR TITLE
meta.c/.h: meta_lookup() and other small improvements

### DIFF
--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -126,7 +126,7 @@ meta_default_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         return default_readv_failure_cbk(frame, ENODATA);
 
     if (!meta_fd->size)
-        meta_file_fill(this, fd);
+        meta_file_fill(this, meta_fd, fd);
 
     iobuf = iobuf_get2(this->ctx->iobuf_pool, size);
     if (!iobuf)
@@ -400,7 +400,7 @@ meta_default_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     if (!meta_fd)
         goto err;
 
-    meta_dir_fill(this, fd);
+    meta_dir_fill(this, meta_fd, ops, fd);
 
     fixed_dirents = ops->fixed_dirents;
     fixed_size = fixed_dirents_len(fixed_dirents);

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -63,7 +63,7 @@ meta_default_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
     struct iatt iatt = {};
 
-    meta_iatt_fill(&iatt, fd->inode, fd->inode->ia_type);
+    meta_iatt_fill(this, &iatt, fd->inode, fd->inode->ia_type);
 
     META_STACK_UNWIND(fstat, frame, 0, 0, &iatt, xdata);
 
@@ -256,7 +256,7 @@ meta_default_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ops->link_fill(this, loc->inode, strfd);
 
-    meta_iatt_fill(&iatt, loc->inode, IA_IFLNK);
+    meta_iatt_fill(this, &iatt, loc->inode, IA_IFLNK);
 
     if (strfd->data) {
         len = strlen(strfd->data);
@@ -282,7 +282,7 @@ meta_default_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd,
 {
     struct iatt iatt = {};
 
-    meta_iatt_fill(&iatt, fd->inode, IA_IFREG);
+    meta_iatt_fill(this, &iatt, fd->inode, IA_IFREG);
 
     META_STACK_UNWIND(ftruncate, frame, 0, 0, &iatt, &iatt, xdata);
 
@@ -468,7 +468,7 @@ meta_default_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     struct iatt iatt = {};
 
-    meta_iatt_fill(&iatt, loc->inode, IA_IFREG);
+    meta_iatt_fill(this, &iatt, loc->inode, IA_IFREG);
 
     META_STACK_UNWIND(truncate, frame, 0, 0, &iatt, &iatt, xdata);
 
@@ -481,7 +481,7 @@ meta_default_stat(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     struct iatt iatt = {};
 
-    meta_iatt_fill(&iatt, loc->inode, loc->inode->ia_type);
+    meta_iatt_fill(this, &iatt, loc->inode, loc->inode->ia_type);
 
     META_STACK_UNWIND(stat, frame, 0, 0, &iatt, xdata);
 
@@ -527,7 +527,7 @@ hook:
 
         dirent->hook(frame, this, loc, xdata);
 
-        meta_iatt_fill(&iatt, loc->inode, dirent->type);
+        meta_iatt_fill(this, &iatt, loc->inode, dirent->type);
 
         META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
                           &parent);

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -129,7 +129,7 @@ meta_ctx_set(inode_t *inode, xlator_t *this, void *ctx)
 }
 
 void
-meta_local_cleanup(meta_local_t *local, xlator_t *this)
+meta_local_cleanup(meta_local_t *local)
 {
     if (!local)
         return;

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -291,7 +291,6 @@ int
 meta_dir_fill(xlator_t *this, meta_fd_t *meta_fd, struct meta_ops *ops,
               fd_t *fd)
 {
-    struct meta_ops *ops = NULL;
     struct meta_dirent *dp = NULL;
     int ret = 0;
 

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -252,16 +252,11 @@ meta_inode_discover(call_frame_t *frame, xlator_t *this, loc_t *loc,
 }
 
 int
-meta_file_fill(xlator_t *this, fd_t *fd)
+meta_file_fill(xlator_t *this, meta_fd_t *meta_fd, fd_t *fd)
 {
-    meta_fd_t *meta_fd = NULL;
     strfd_t *strfd = NULL;
     struct meta_ops *ops = NULL;
     int ret = 0;
-
-    meta_fd = meta_fd_get(fd, this);
-    if (!meta_fd)
-        return -1;
 
     if (meta_fd->data)
         return meta_fd->size;
@@ -292,23 +287,15 @@ meta_file_fill(xlator_t *this, fd_t *fd)
 }
 
 int
-meta_dir_fill(xlator_t *this, fd_t *fd)
+meta_dir_fill(xlator_t *this, meta_fd_t *meta_fd, struct meta_ops *ops,
+              fd_t *fd)
 {
-    meta_fd_t *meta_fd = NULL;
     struct meta_ops *ops = NULL;
     struct meta_dirent *dp = NULL;
     int ret = 0;
 
-    meta_fd = meta_fd_get(fd, this);
-    if (!meta_fd)
-        return -1;
-
     if (meta_fd->dirents)
         return meta_fd->size;
-
-    ops = meta_ops_get(fd->inode, this);
-    if (!ops)
-        return -1;
 
     if (ops->dir_fill)
         ret = ops->dir_fill(this, fd->inode, &dp);

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -217,18 +217,23 @@ default_meta_iatt_fill(struct iatt *iatt, inode_t *inode, ia_type_t type,
 }
 
 void
-meta_iatt_fill(struct iatt *iatt, inode_t *inode, ia_type_t type)
+meta_iatt_fill(xlator_t *this, struct iatt *iatt, inode_t *inode,
+               ia_type_t type)
 {
     struct meta_ops *ops = NULL;
+    xlator_t *xl = this;
 
-    ops = meta_ops_get(inode, THIS);
+    if (xl == NULL)
+        xl = THIS;
+
+    ops = meta_ops_get(inode, xl);
     if (!ops)
         return;
 
     if (!ops->iatt_fill)
         default_meta_iatt_fill(iatt, inode, type, !!ops->file_write);
     else
-        ops->iatt_fill(THIS, inode, iatt);
+        ops->iatt_fill(xl, inode, iatt);
     return;
 }
 
@@ -239,7 +244,7 @@ meta_inode_discover(call_frame_t *frame, xlator_t *this, loc_t *loc,
     struct iatt iatt = {};
     struct iatt postparent = {};
 
-    meta_iatt_fill(&iatt, loc->inode, loc->inode->ia_type);
+    meta_iatt_fill(this, &iatt, loc->inode, loc->inode->ia_type);
 
     META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
                       &postparent);

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -175,9 +175,10 @@ meta_direct_io_mode(dict_t *xdata, call_frame_t *frame)
 static void
 meta_uuid_copy(uuid_t dst, uuid_t src)
 {
-    gf_uuid_copy(dst, src);
-    if (gf_uuid_is_null(dst))
+    if (gf_uuid_is_null(src))
         gf_uuid_generate(dst);
+    else
+        gf_uuid_copy(dst, src);
 }
 
 static void

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -141,7 +141,7 @@ meta_local_cleanup(meta_local_t *local)
     return;
 }
 
-meta_local_t *
+static meta_local_t *
 meta_local(call_frame_t *frame)
 {
     meta_local_t *local = NULL;

--- a/xlators/meta/src/meta.c
+++ b/xlators/meta/src/meta.c
@@ -30,7 +30,7 @@ meta_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
         meta_root_dir_hook(frame, this, loc, xdata);
 
-        meta_iatt_fill(&iatt, loc->inode, IA_IFDIR);
+        meta_iatt_fill(this, &iatt, loc->inode, IA_IFDIR);
         gf_uuid_copy(iatt.ia_gfid, priv->meta_root_gfid);
 
         META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,

--- a/xlators/meta/src/meta.c
+++ b/xlators/meta/src/meta.c
@@ -16,19 +16,22 @@
 
 #include "meta-hooks.h"
 
-int
+static int
 meta_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
     inode_t *inode = NULL;
+    meta_priv_t *priv = this->private;
 
-    if (META_HOOK(loc) || IS_META_ROOT_GFID(loc->gfid)) {
+    if ((loc->name && !strcmp(loc->name, priv->meta_dir_name) &&
+         __is_root_gfid(loc->pargfid)) ||
+        !gf_uuid_compare(loc->gfid, priv->meta_root_gfid)) {
         struct iatt iatt = {};
         struct iatt parent = {};
 
         meta_root_dir_hook(frame, this, loc, xdata);
 
         meta_iatt_fill(&iatt, loc->inode, IA_IFDIR);
-        gf_uuid_parse(META_ROOT_GFID, iatt.ia_gfid);
+        gf_uuid_copy(iatt.ia_gfid, priv->meta_root_gfid);
 
         META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
                           &parent);
@@ -211,17 +214,18 @@ init(xlator_t *this)
     meta_priv_t *priv = NULL;
     int ret = -1;
 
-    priv = GF_CALLOC(sizeof(*priv), 1, gf_meta_mt_priv_t);
+    priv = GF_MALLOC(sizeof(meta_priv_t), gf_meta_mt_priv_t);
     if (!priv)
         return ret;
 
-    GF_OPTION_INIT("meta-dir-name", priv->meta_dir_name, str, out);
+    GF_OPTION_INIT("meta-dir-name", priv->meta_dir_name, str, err);
+
+    gf_uuid_parse(META_ROOT_GFID, priv->meta_root_gfid);
 
     this->private = priv;
-    ret = 0;
-out:
-    if (ret)
-        GF_FREE(priv);
+    return 0;
+err:
+    GF_FREE(priv);
 
     return ret;
 }

--- a/xlators/meta/src/meta.h
+++ b/xlators/meta/src/meta.h
@@ -122,10 +122,11 @@ meta_local_t *
 meta_local(call_frame_t *frame);
 
 int
-meta_file_fill(xlator_t *this, fd_t *fd);
+meta_file_fill(xlator_t *this, meta_fd_t *meta_fd, fd_t *fd);
 
 int
-meta_dir_fill(xlator_t *this, fd_t *fd);
+meta_dir_fill(xlator_t *this, meta_fd_t *meta_fd, struct meta_ops *ops,
+              fd_t *fd);
 
 int
 fixed_dirents_len(struct meta_dirent *dirents);

--- a/xlators/meta/src/meta.h
+++ b/xlators/meta/src/meta.h
@@ -80,7 +80,8 @@ typedef struct {
     while (0)
 
 void
-meta_iatt_fill(struct iatt *iatt, inode_t *inode, ia_type_t type);
+meta_iatt_fill(xlator_t *this, struct iatt *iatt, inode_t *inode,
+               ia_type_t type);
 
 int
 meta_inode_discover(call_frame_t *frame, xlator_t *this, loc_t *loc,

--- a/xlators/meta/src/meta.h
+++ b/xlators/meta/src/meta.h
@@ -59,15 +59,13 @@ typedef struct {
 #define META_STACK_UNWIND(fop, frame, params...)                               \
     do {                                                                       \
         meta_local_t *__local = NULL;                                          \
-        xlator_t *__this = NULL;                                               \
         if (frame) {                                                           \
             __local = frame->local;                                            \
-            __this = frame->this;                                              \
             frame->local = NULL;                                               \
         }                                                                      \
         STACK_UNWIND_STRICT(fop, frame, params);                               \
         if (__local) {                                                         \
-            meta_local_cleanup(__local, __this);                               \
+            meta_local_cleanup(__local);                                       \
         }                                                                      \
     } while (0)
 
@@ -105,7 +103,7 @@ void *
 meta_ctx_get(inode_t *inode, xlator_t *this);
 
 void
-meta_local_cleanup(meta_local_t *local, xlator_t *this);
+meta_local_cleanup(meta_local_t *local);
 
 struct xlator_fops *
 meta_defaults_init(struct xlator_fops *fops);

--- a/xlators/meta/src/meta.h
+++ b/xlators/meta/src/meta.h
@@ -16,8 +16,6 @@
 
 #define META_ROOT_GFID "ba926388-bb9c-4eec-ad60-79dba4cc083a"
 
-#define IS_META_ROOT_GFID(g) (strcmp(uuid_utoa(g), META_ROOT_GFID) == 0)
-
 typedef int (*meta_hook_t)(call_frame_t *frame, xlator_t *this, loc_t *loc,
                            dict_t *xdata);
 
@@ -27,6 +25,7 @@ typedef struct {
 
 typedef struct {
     char *meta_dir_name;
+    unsigned char meta_root_gfid[GF_UUID_BUF_SIZE];
 } meta_priv_t;
 
 struct meta_dirent {
@@ -56,12 +55,6 @@ typedef struct {
 } meta_fd_t;
 
 #define COUNT(arr) (sizeof(arr) / sizeof(arr[0]))
-
-#define META_HOOK(loc)                                                         \
-    (__is_root_gfid(loc->pargfid) &&                                           \
-     !strcmp(loc->name, META_PRIV(THIS)->meta_dir_name))
-
-#define META_PRIV(t) ((meta_priv_t *)(t->private))
 
 #define META_STACK_UNWIND(fop, frame, params...)                               \
     do {                                                                       \

--- a/xlators/meta/src/meta.h
+++ b/xlators/meta/src/meta.h
@@ -118,9 +118,6 @@ meta_fd_release(fd_t *fd, xlator_t *this);
 dict_t *
 meta_direct_io_mode(dict_t *xdata, call_frame_t *frame);
 
-meta_local_t *
-meta_local(call_frame_t *frame);
-
 int
 meta_file_fill(xlator_t *this, meta_fd_t *meta_fd, fd_t *fd);
 


### PR DESCRIPTION
The meta_lookup() function would use two macros:
META_HOOK - which would call THIS to fetch this->private
IS_META_ROOT_GFID - which did a strcmp() to the result of a uuid_utoa() function.

Simplified by saving the result of the uuid_utoa() in the private struct, doing the comparison directly, and without the call to 'THIS'.
In turn, re-used that result to copy that UUID instead of parsing it (again).

Found out you can skip most of this if 'loc->name' is null, so added it as well.

Updates: #3359
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

