### PR TITLE
loc_gfid and loc_pargfid should not unconditionally clear the gfid

### DIFF
--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -1072,34 +1072,30 @@ void
 loc_gfid(loc_t *loc, uuid_t gfid)
 {
     if (!gfid)
-        goto out;
-    gf_uuid_clear(gfid);
-
-    if (!loc)
-        goto out;
+        return;
+    else if (!loc)
+        gf_uuid_clear(gfid);
     else if (!gf_uuid_is_null(loc->gfid))
         gf_uuid_copy(gfid, loc->gfid);
     else if (loc->inode && (!gf_uuid_is_null(loc->inode->gfid)))
         gf_uuid_copy(gfid, loc->inode->gfid);
-out:
-    return;
+    else
+        gf_uuid_clear(gfid);
 }
 
 void
 loc_pargfid(loc_t *loc, uuid_t gfid)
 {
     if (!gfid)
-        goto out;
-    gf_uuid_clear(gfid);
-
-    if (!loc)
-        goto out;
+        return;
+    else if (!loc)
+        gf_uuid_clear(gfid);
     else if (!gf_uuid_is_null(loc->pargfid))
         gf_uuid_copy(gfid, loc->pargfid);
     else if (loc->parent && (!gf_uuid_is_null(loc->parent->gfid)))
         gf_uuid_copy(gfid, loc->parent->gfid);
-out:
-    return;
+    else
+        gf_uuid_clear(gfid);
 }
 
 char *

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -455,7 +455,7 @@ fuse_loc_fill(loc_t *loc, fuse_state_t *state, ino_t ino, ino_t par,
     inode_t *parent = NULL;
     int32_t ret = -1;
     char *path = NULL;
-    uuid_t null_gfid = {
+    static uuid_t null_gfid = {
         0,
     };
 


### PR DESCRIPTION
There is no reason to unconditionally clear the gfid, if we'll copy content into it later.