### PR TITLE
glusterd-snapd-svc.c: fix for compile warning

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -31,11 +31,6 @@ glusterd_svc_build_snapd_logdir(char *logdir, char *volname, size_t len)
     snprintf(logdir, len, "%s/snaps/%s", priv->logdir, volname);
 }
 
-static int
-glusterd_svc_build_snapd_logfile(char *logfile, char *logdir, size_t len)
-{
-    return snprintf(logfile, len, "%s/snapd.log", logdir);
-}
 
 void
 glusterd_snapdsvc_build(glusterd_svc_t *svc)
@@ -111,7 +106,7 @@ glusterd_snapdsvc_init(void *data)
                "Unable to create logdir %s", logdir);
         goto out;
     }
-    len = glusterd_svc_build_snapd_logfile(logfile, logdir, sizeof(logfile));
+    len = snprintf(logfile, sizeof(logfile), "%s/snapd.log", logdir);
     if ((len < 0) || (len >= sizeof(logfile))) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_COPY_FAIL, NULL);
         ret = -1;

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -31,10 +31,10 @@ glusterd_svc_build_snapd_logdir(char *logdir, char *volname, size_t len)
     snprintf(logdir, len, "%s/snaps/%s", priv->logdir, volname);
 }
 
-static void
+static int
 glusterd_svc_build_snapd_logfile(char *logfile, char *logdir, size_t len)
 {
-    snprintf(logfile, len, "%s/snapd.log", logdir);
+    return snprintf(logfile, len, "%s/snapd.log", logdir);
 }
 
 void
@@ -111,7 +111,12 @@ glusterd_snapdsvc_init(void *data)
                "Unable to create logdir %s", logdir);
         goto out;
     }
-    glusterd_svc_build_snapd_logfile(logfile, logdir, sizeof(logfile));
+    len = glusterd_svc_build_snapd_logfile(logfile, logdir, sizeof(logfile));
+    if ((len < 0) || (len >= sizeof(logfile))) {
+        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_COPY_FAIL, NULL);
+        ret = -1;
+        goto out;
+    }
     len = snprintf(volfileid, sizeof(volfileid), "snapd/%s", volinfo->volname);
     if ((len < 0) || (len >= sizeof(volfileid))) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_COPY_FAIL, NULL);


### PR DESCRIPTION
Warning:
```
glusterd-snapd-svc.c:37:5: note: ‘snprintf’ output between 11 and 4106 bytes into a destination of size 4096
     snprintf(logfile, len, "%s/snapd.log", logdir);
```
Description: As both logfile and logdir having same size so this warning arises so added 
extra check for this warning

Updates : #1000 
Change-Id: I05d5905c192936d3f52f8813f94baac929159914
Signed-off-by: Preet Bhatia [pbhatia@redhat.com](mailto:pbhatia@redhat.com)