### PR TITLE
dht: do not print uuid in binary form

### DIFF
--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -1196,8 +1196,8 @@ dht_protect_namespace(call_frame_t *frame, loc_t *loc, xlator_t *subvol,
     ret = dht_build_parent_loc(this, &parent, loc, &op_errno);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_LOC_FAILED,
-                "gfid=%s", loc->gfid, "name=%s", loc->name, "path=%s",
-                loc->path, NULL);
+                "gfid=%s", uuid_utoa(loc->gfid), "name=%s", loc->name,
+                "path=%s", loc->path, NULL);
         goto out;
     }
     gf_uuid_unparse(parent.gfid, pgfid);

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -1341,7 +1341,8 @@ dht_selfheal_dir_mkdir(call_frame_t *frame, loc_t *loc, dht_layout_t *layout,
                 if (ret) {
                     gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                             DHT_MSG_DIR_XATTR_HEAL_FAILED, "path=%s",
-                            local->loc.path, "gfid=%s", local->gfid, NULL);
+                            local->loc.path, "gfid=%s", uuid_utoa(local->gfid),
+                            NULL);
                 }
             } else {
                 if (!gf_uuid_is_null(local->gfid))
@@ -1352,8 +1353,8 @@ dht_selfheal_dir_mkdir(call_frame_t *frame, loc_t *loc, dht_layout_t *layout,
                     return 0;
 
                 gf_smsg(this->name, GF_LOG_INFO, 0, DHT_MSG_SET_XATTR_FAILED,
-                        "path=%s", local->loc.path, "gfid=%s", local->gfid,
-                        NULL);
+                        "path=%s", local->loc.path, "gfid=%s",
+                        uuid_utoa(local->gfid), NULL);
             }
         }
         dht_selfheal_dir_setattr(frame, loc, &local->stbuf, 0xffffffff, layout);


### PR DESCRIPTION
Fix `dht_protect_namespace()` and `dht_selfheal_dir_mkdir()`
by using `uuid_utoa()` to avoid printing uuid in binary form.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000