### PR TITLE
graph.c: fix for compile warning

### DIFF
--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -1509,7 +1509,7 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
     ret = fill_uuid(parent_graph->graph_uuid, 128, parent_graph->dob);
     if (ret < 0) {
         gf_msg("glusterfs", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
-               "%s (%s) set type failed", name, type);
+               "%s (%s) fill uuid failed", name, type);
         goto out;
     }
     parent_graph->id = ctx->graph_id++;

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -528,13 +528,14 @@ glusterfs_graph_unknown_options(glusterfs_graph_t *graph)
     return 0;
 }
 
-static void
+static int
 fill_uuid(char *uuid, int size, struct timeval tv)
 {
     char now_str[GF_TIMESTR_SIZE];
 
     gf_time_fmt_tv(now_str, sizeof now_str, &tv, gf_timefmt_dirent);
-    snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(), now_str);
+    return snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(),
+                    now_str);
 }
 
 static int
@@ -662,8 +663,12 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     /* XXX: DOB setting */
     gettimeofday(&graph->dob, NULL);
 
-    fill_uuid(graph->graph_uuid, sizeof(graph->graph_uuid), graph->dob);
-
+    ret = fill_uuid(graph->graph_uuid, sizeof(graph->graph_uuid), graph->dob);
+    if ((ret < 0) || (ret >= sizeof(graph->graph_uuid))) {
+        gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
+               "glusterfs fill uuid failed");
+        return -1;
+    }
     graph->id = ctx->graph_id++;
 
     /* XXX: --xlator-option additions */
@@ -1498,7 +1503,12 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
     ixl = NULL;
 
     gettimeofday(&parent_graph->dob, NULL);
-    fill_uuid(parent_graph->graph_uuid, 128, parent_graph->dob);
+    ret = fill_uuid(parent_graph->graph_uuid, 128, parent_graph->dob);
+    if ((ret < 0) || (ret >= 128)) {
+        gf_msg("glusterfs", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
+               "%s (%s) set type failed", name, type);
+        goto out;
+    }
     parent_graph->id = ctx->graph_id++;
     ret = 0;
 out:

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -532,10 +532,13 @@ static int
 fill_uuid(char *uuid, int size, struct timeval tv)
 {
     char now_str[GF_TIMESTR_SIZE];
-
+    int32_t ret = 0;
     gf_time_fmt_tv(now_str, sizeof now_str, &tv, gf_timefmt_dirent);
-    return snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(),
-                    now_str);
+    ret = snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(), now_str);
+    if (ret >= size) {
+        ret = -1;
+    }
+    return ret;
 }
 
 static int
@@ -664,7 +667,7 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     gettimeofday(&graph->dob, NULL);
 
     ret = fill_uuid(graph->graph_uuid, sizeof(graph->graph_uuid), graph->dob);
-    if ((ret < 0) || (ret >= sizeof(graph->graph_uuid))) {
+    if (ret < 0) {
         gf_msg("graph", GF_LOG_ERROR, 0, LG_MSG_GRAPH_ERROR,
                "glusterfs fill uuid failed");
         return -1;
@@ -1504,7 +1507,7 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
 
     gettimeofday(&parent_graph->dob, NULL);
     ret = fill_uuid(parent_graph->graph_uuid, 128, parent_graph->dob);
-    if ((ret < 0) || (ret >= 128)) {
+    if (ret < 0) {
         gf_msg("glusterfs", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
                "%s (%s) set type failed", name, type);
         goto out;


### PR DESCRIPTION
Warning:
```
graph.c: In function ‘fill_uuid.constprop’:
graph.c:537:33: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 125 [-Wformat-truncation=]
     snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(), now_str);
                                 ^~                               ~~~~~~~
graph.c:537:5: note: ‘snprintf’ output 4 or more bytes (assuming 259) into a destination of size 128
     snprintf(uuid, size, "%s-%d-%s", gf_gethostname(), getpid(), now_str);

```
Description: Warning arises as destination buffer having less size 
so added extra check to remove this warning


Updates: #1000 
Change-Id: I78d6df65e2b34891cfc6d36d814f25390a279977
Signed-off-by: Preet Bhatia [pbhatia@redhat.com](mailto:pbhatia@redhat.com)