### PR TITLE
fix compile warning[glusterd-store]

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4345,7 +4345,7 @@ glusterd_store_uuid_peerpath_set(glusterd_peerinfo_t *peerinfo, char *peerfpath,
 {
     char peerdir[PATH_MAX];
     char str[50] = {0};
-    int ret = -1;
+    int32_t ret = -1;
 
     GF_ASSERT(peerinfo);
     GF_ASSERT(peerfpath);
@@ -4391,8 +4391,9 @@ glusterd_store_peerinfo_uuid_shandle_create(glusterd_peerinfo_t *peerinfo)
     char peerfpath[PATH_MAX];
     int32_t ret = -1;
 
-    if (glusterd_store_uuid_peerpath_set(peerinfo, peerfpath,
-                                         sizeof(peerfpath)) < 0)
+    ret = glusterd_store_uuid_peerpath_set(peerinfo, peerfpath,
+                                           sizeof(peerfpath));
+    if (ret)
         return ret;
 
     ret = gf_store_handle_create_on_absence(&peerinfo->shandle, peerfpath);

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4339,12 +4339,13 @@ glusterd_store_create_peer_dir()
     return ret;
 }
 
-static void
+static int
 glusterd_store_uuid_peerpath_set(glusterd_peerinfo_t *peerinfo, char *peerfpath,
                                  size_t len)
 {
     char peerdir[PATH_MAX];
     char str[50] = {0};
+    int ret = -1;
 
     GF_ASSERT(peerinfo);
     GF_ASSERT(peerfpath);
@@ -4352,7 +4353,10 @@ glusterd_store_uuid_peerpath_set(glusterd_peerinfo_t *peerinfo, char *peerfpath,
 
     glusterd_store_peerinfo_dirpath_set(peerdir, sizeof(peerdir));
     gf_uuid_unparse(peerinfo->uuid, str);
-    snprintf(peerfpath, len, "%s/%s", peerdir, str);
+    ret = snprintf(peerfpath, len, "%s/%s", peerdir, str);
+    if (ret < 0 || ret >= len)
+        return -1;
+    return 0;
 }
 
 static void
@@ -4387,7 +4391,10 @@ glusterd_store_peerinfo_uuid_shandle_create(glusterd_peerinfo_t *peerinfo)
     char peerfpath[PATH_MAX];
     int32_t ret = -1;
 
-    glusterd_store_uuid_peerpath_set(peerinfo, peerfpath, sizeof(peerfpath));
+    if (glusterd_store_uuid_peerpath_set(peerinfo, peerfpath,
+                                         sizeof(peerfpath)) < 0)
+        return ret;
+
     ret = gf_store_handle_create_on_absence(&peerinfo->shandle, peerfpath);
     return ret;
 }


### PR DESCRIPTION
Warning:

`glusterd-store.c:4355:36: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
 4355 |     snprintf(peerfpath, len, "%s/%s", peerdir, str);
      |                                    ^
glusterd-store.c:4355:5: note: ‘snprintf’ output 2 or more bytes (assuming 4097) into a destination of size 4096
 4355 |     snprintf(peerfpath, len, "%s/%s", peerdir, str);
`

Description: Added check for overflowing warning.
Updates : #1000 
Change-Id: I7b7b95ab3a71d7cf6b7d2143fea81b819e3b34d8

Signed-off-by: Harshita Shree hshree@redhat.com