### PR TITLE
glusterd, libglusterfs, api: use arrays for host and peer names

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -1216,7 +1216,6 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
     }
 
     GF_FREE(ctx->statedump_path);
-    FREE(ctx->hostname);
     FREE(ctx);
 
     return ret;

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -4176,11 +4176,8 @@ glusterfs_compute_sha256(const unsigned char *content, size_t size,
     return 0;
 }
 
-/* * Safe wrapper function for strncpy.
- * This wrapper makes sure that when there is no null byte among the first n in
- * source srting for strncpy function call, the string placed in dest will be
- * null-terminated.
- */
+/* This wrapper is intended to make sure that 'dest' is null-terminated
+   even if there is no null byte among the bytes copied from 'src'. */
 
 char *
 gf_strncpy(char *dest, const char *src, const size_t dest_size)

--- a/libglusterfs/src/ctx.c
+++ b/libglusterfs/src/ctx.c
@@ -17,7 +17,6 @@ glusterfs_ctx_t *global_ctx = NULL;
 glusterfs_ctx_t *
 glusterfs_ctx_new()
 {
-    long namelen = 0;
     glusterfs_ctx_t *ctx = NULL;
 
     /* no GF_CALLOC here, gf_acct_mem_set_enable is not
@@ -50,17 +49,7 @@ glusterfs_ctx_new()
     GF_ATOMIC_INIT(ctx->stats.total_pairs_used, 0);
     GF_ATOMIC_INIT(ctx->stats.total_dicts_used, 0);
 
-    namelen = sysconf(_SC_HOST_NAME_MAX);
-    if (namelen < 0)
-        namelen = _POSIX_HOST_NAME_MAX;
-    ctx->hostname = MALLOC(namelen + 1);
-    if (!ctx->hostname) {
-        FREE(ctx);
-        ctx = NULL;
-        goto out;
-    }
-    if (gethostname(ctx->hostname, namelen + 1)) {
-        FREE(ctx->hostname);
+    if (gethostname(ctx->hostname, sizeof(ctx->hostname))) {
         FREE(ctx);
         ctx = NULL;
         goto out;

--- a/libglusterfs/src/glusterfs/compat.h
+++ b/libglusterfs/src/glusterfs/compat.h
@@ -505,6 +505,25 @@ dirname_r(char *path);
 #pragma GCC poison system mkostemp popen
 #endif
 
+/* New code should use GF_HOST_NAME_MAX. An existing
+   code is likely to migrate to use it as well. */
+
+#if defined(_POSIX_HOST_NAME_MAX)
+/* Mandated by SUSv2. */
+#define GF_HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#elif defined(HOST_NAME_MAX)
+/* Mandated by POSIX.1 */
+#define GF_HOST_NAME_MAX HOST_NAME_MAX
+#elif defined(MAXNAMLEN)
+/* BSD-specific name for what POSIX calls NAME_MAX. */
+#define GF_HOST_NAME_MAX MAXNAMLEN
+#elif defined(NAME_MAX)
+/* Try something generic. */
+#define GF_HOST_NAME_MAX NAME_MAX
+#else /* none of the above */
+#error "Unable to determine maximum host name length"
+#endif /* maximum host name length */
+
 int
 gf_umount_lazy(char *xlname, char *path, int rmdir);
 

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -63,7 +63,6 @@
 #define O_PATH 010000000 /* from asm-generic/fcntl.h */
 #endif
 
-
 #ifndef EBADFD
 /* Mac OS X does not have EBADFD */
 #define EBADFD EBADF
@@ -762,7 +761,7 @@ struct _glusterfs_ctx {
 
     gf_boolean_t cleanup_starting;
     gf_boolean_t destroy_ctx;
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     char volume_id[GF_UUID_BUF_SIZE]; /* Used only in protocol/client */
 };
 typedef struct _glusterfs_ctx glusterfs_ctx_t;

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1905,12 +1905,13 @@ glusterd_event_connected_inject(glusterd_peerctx_t *peerctx)
         GF_FREE(ctx);
         goto out;
     }
-    ctx->hostname = gf_strdup(peerinfo->hostname);
+
+    gf_strncpy(ctx->hostname, peerinfo->hostname, sizeof(ctx->hostname));
     ctx->port = peerinfo->port;
     ctx->req = peerctx->args.req;
     ctx->dict = peerctx->args.dict;
 
-    event->peername = gf_strdup(peerinfo->hostname);
+    gf_strncpy(event->peername, peerinfo->hostname, sizeof(event->peername));
     gf_uuid_copy(event->peerid, peerinfo->uuid);
     event->ctx = ctx;
 

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -48,12 +48,6 @@ gf_boolean_t
 glusterd_are_vol_all_peers_up(glusterd_volinfo_t *volinfo,
                               struct cds_list_head *peers, char **down_peerstr);
 
-int32_t
-glusterd_peer_hostname_new(const char *hostname,
-                           glusterd_peer_hostname_t **name);
-void
-glusterd_peer_hostname_free(glusterd_peer_hostname_t *name);
-
 gf_boolean_t
 gd_peer_has_address(glusterd_peerinfo_t *peerinfo, const char *address);
 

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -322,7 +322,8 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
         /* Injecting EVENT_NEW_NAME to send update */
         ret = glusterd_friend_sm_new_event(GD_FRIEND_EVENT_NEW_NAME, &event);
         if (!ret) {
-            event->peername = gf_strdup(peerinfo->hostname);
+            gf_strncpy(event->peername, peerinfo->hostname,
+                       sizeof(event->peername));
             gf_uuid_copy(event->peerid, peerinfo->uuid);
 
             ret = glusterd_friend_sm_inject_event(event);
@@ -388,7 +389,7 @@ cont:
         goto out;
     }
 
-    event->peername = gf_strdup(peerinfo->hostname);
+    gf_strncpy(event->peername, peerinfo->hostname, sizeof(event->peername));
     gf_uuid_copy(event->peerid, peerinfo->uuid);
 
     event->ctx = ((call_frame_t *)myframe)->local;
@@ -496,10 +497,11 @@ __glusterd_friend_add_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     gf_uuid_copy(ev_ctx->uuid, rsp.uuid);
-    ev_ctx->hostname = gf_strdup(rsp.hostname);
+    gf_strncpy(ev_ctx->hostname, rsp.hostname, sizeof(ev_ctx->hostname));
 
-    event->peername = gf_strdup(peerinfo->hostname);
+    gf_strncpy(event->peername, peerinfo->hostname, sizeof(event->peername));
     gf_uuid_copy(event->peerid, peerinfo->uuid);
+
     event->ctx = ev_ctx;
     ret = glusterd_friend_sm_inject_event(event);
 
@@ -604,7 +606,8 @@ inject:
                "Unable to get event");
         goto unlock;
     }
-    event->peername = gf_strdup(peerinfo->hostname);
+
+    gf_strncpy(event->peername, peerinfo->hostname, sizeof(event->peername));
     gf_uuid_copy(event->peerid, peerinfo->uuid);
 
     ret = glusterd_friend_sm_inject_event(event);

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -43,7 +43,7 @@ typedef enum glusterd_friend_sm_state_ {
 } glusterd_friend_sm_state_t;
 
 typedef struct glusterd_peer_hostname_ {
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     struct cds_list_head hostname_list;
 } glusterd_peer_hostname_t;
 
@@ -65,11 +65,10 @@ typedef struct glusterd_sm_tr_log_ {
 
 struct glusterd_peerinfo_ {
     uuid_t uuid;
-    char uuid_str[50]; /* Retrieve this using
-                        * gd_peer_uuid_str ()
-                        */
+    /* Retrieve this using gd_peer_uuid_str(). */
+    char uuid_str[GF_UUID_BUF_SIZE];
     glusterd_friend_sm_state_t state;
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     struct cds_list_head hostnames;
     int port;
     struct cds_list_head uuid_list;
@@ -113,7 +112,7 @@ typedef struct glusterd_peer_ctx_args_ {
 typedef struct glusterd_peer_ctx_ {
     glusterd_peerctx_args_t args;
     uuid_t peerid;
-    char *peername;
+    char peername[GF_HOST_NAME_MAX + 1];
     uint32_t peerinfo_gen;
     char *errstr;
 } glusterd_peerctx_t;
@@ -144,7 +143,7 @@ typedef enum glusterd_friend_update_op_ {
 struct glusterd_friend_sm_event_ {
     struct cds_list_head list;
     uuid_t peerid;
-    char *peername;
+    char peername[GF_HOST_NAME_MAX + 1];
     void *ctx;
     glusterd_friend_sm_event_type_t event;
 };
@@ -160,7 +159,7 @@ typedef struct glusterd_sm_ {
 
 typedef struct glusterd_friend_req_ctx_ {
     uuid_t uuid;
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     rpcsvc_request_t *req;
     int port;
     dict_t *vols;
@@ -169,12 +168,12 @@ typedef struct glusterd_friend_req_ctx_ {
 
 typedef struct glusterd_friend_update_ctx_ {
     uuid_t uuid;
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     int op;
 } glusterd_friend_update_ctx_t;
 
 typedef struct glusterd_probe_ctx_ {
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     rpcsvc_request_t *req;
     int port;
     dict_t *dict;

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4693,7 +4693,8 @@ glusterd_store_retrieve_peers(xlator_t *this)
          */
         address = cds_list_entry(peerinfo->hostnames.next,
                                  glusterd_peer_hostname_t, hostname_list);
-        peerinfo->hostname = gf_strdup(address->hostname);
+        gf_strncpy(peerinfo->hostname, address->hostname,
+                   sizeof(peerinfo->hostname));
 
         ret = glusterd_friend_add_from_peerinfo(peerinfo, 1, NULL);
         if (ret)

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -112,7 +112,7 @@ typedef struct glusterd_dict_ctx_ {
 } glusterd_dict_ctx_t;
 
 typedef struct glusterd_hostname_ {
-    char *hostname;
+    char hostname[GF_HOST_NAME_MAX + 1];
     struct list_head hostname_list;
 } glusterd_hostname_t;
 

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1459,7 +1459,6 @@ glusterd_destroy_hostname_list(struct list_head *hostname_list_head)
                              hostname_list)
     {
         list_del_init(&hostname_obj->hostname_list);
-        GF_FREE(hostname_obj->hostname);
         GF_FREE(hostname_obj);
     }
 }

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -262,7 +262,7 @@ struct glusterd_brickinfo {
     glusterd_brick_proc_t *brick_proc; /* Information regarding mux bricks */
     struct cds_list_head mux_bricks; /* List to store the bricks in brick_proc*/
     uint32_t fs_share_count;
-    char hostname[NAME_MAX];
+    char hostname[GF_HOST_NAME_MAX + 1];
     char path[VALID_GLUSTERD_PATHMAX];
     char real_path[VALID_GLUSTERD_PATHMAX];
     char device_path[VALID_GLUSTERD_PATHMAX];


### PR DESCRIPTION
Introduce `GF_HOST_NAME_MAX` and use fixed-size arrays to manage
host and peer names in `glusterfs_ctx_t` and through `glusterd`
code. This follows the convention to use `PATH_MAX`-sized arrays to
manage file names and eliminates a lot of runtime checks whether
functions like `gf_strdup()` has failed to allocate memory.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000