### PR TITLE
Multiple files: reduce padding in structures

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1085,10 +1085,6 @@ parse_opts(int key, char *arg, struct argp_state *state)
 
             break;
 
-        case ARGP_GLOBAL_TIMER_WHEEL:
-            cmd_args->global_timer_wheel = 1;
-            break;
-
         case ARGP_GID_TIMEOUT_KEY:
             if (!gf_string2int(arg, &cmd_args->gid_timeout)) {
                 cmd_args->gid_timeout_set = _gf_true;

--- a/libglusterfs/src/glusterfs/circ-buff.h
+++ b/libglusterfs/src/glusterfs/circ-buff.h
@@ -25,18 +25,16 @@ typedef struct _circular_buffer circular_buffer_t;
 
 struct _buffer {
     unsigned int w_index;
+    int used_len; /* indicates the amount of circular buffer used. */
     size_t size_buffer;
-    gf_boolean_t use_once;
-    /* This variable is assigned the proper value at the time of initing */
-    /* the buffer. It indicates, whether the buffer should be used once */
-    /*  it becomes full. */
-
-    int used_len;
-    /* indicates the amount of circular buffer used. */
 
     circular_buffer_t **cb;
     void (*destroy_buffer_data)(void *data);
     pthread_mutex_t lock;
+    /* This variable is assigned the proper value at the time of initing */
+    /* the buffer. It indicates, whether the buffer should be used once */
+    /*  it becomes full. */
+    gf_boolean_t use_once;
 };
 
 typedef struct _buffer buffer_t;

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -42,6 +42,7 @@ typedef struct _client {
     xlator_t *bound_xl;
     xlator_t *this;
     int tbl_index;
+    int32_t opversion;
     char *client_uid;
     char *client_name;
     struct {
@@ -56,7 +57,6 @@ typedef struct _client {
     char *subdir_mount;
     inode_t *subdir_inode;
     uuid_t subdir_gfid;
-    int32_t opversion;
     /* Variable to save fd_count for detach brick */
     gf_atomic_t fd_cnt;
 } client_t;
@@ -71,9 +71,9 @@ typedef struct client_table_entry cliententry_t;
 
 struct clienttable {
     unsigned int max_clients;
+    int first_free;
     gf_lock_t lock;
     cliententry_t *cliententries;
-    int first_free;
     client_t *local;
 };
 typedef struct clienttable clienttable_t;

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -39,22 +39,24 @@ struct _inode_table {
     char *name;             /* name of the inode table, just for gf_log() */
     inode_t *root;          /* root directory inode, with number 1 */
     xlator_t *xl;           /* xlator to be called to do purge */
-    uint32_t lru_limit;     /* maximum LRU cache size */
     struct list_head *inode_hash; /* buckets for inode hash table */
     struct list_head *name_hash;  /* buckets for dentry hash table */
     struct list_head active; /* list of inodes currently active (in an fop) */
     uint32_t active_size;    /* count of inodes in active list */
+    uint32_t lru_limit;      /* maximum LRU cache size */
     struct list_head lru;    /* list of inodes recently used.
                                 lru.next most recent */
     uint32_t lru_size;       /* count of inodes in lru list  */
-    struct list_head purge;  /* list of inodes to be purged soon */
     uint32_t purge_size;     /* count of inodes in purge list */
+    struct list_head purge;  /* list of inodes to be purged soon */
 
     struct mem_pool *inode_pool;  /* memory pool for inodes */
     struct mem_pool *dentry_pool; /* memory pool for dentrys */
     struct mem_pool *fd_mem_pool; /* memory pool for fd_t */
     int ctxcount;                 /* number of slots in inode->ctx */
 
+    uint32_t root_id; /* Save the xlator id at the time of inode table
+                         creation */
     /* This is required for 'invalidation' when 'nlookup' would be used,
        specially in case of fuse-bridge */
     int32_t (*invalidator_fn)(xlator_t *, inode_t *);
@@ -62,8 +64,6 @@ struct _inode_table {
     struct list_head invalidate; /* inodes which are in invalidation queue */
     uint32_t invalidate_size;    /* count of inodes in invalidation list */
     uint32_t root_level; /* Save the xlator level at the time of inode table
-                            creation */
-    uint32_t root_id;    /* Save the xlator id at the time of inode table
                             creation */
     /* flag to indicate whether the cleanup of the inode
        table started or not */

--- a/libglusterfs/src/glusterfs/options.h
+++ b/libglusterfs/src/glusterfs/options.h
@@ -102,6 +102,13 @@ typedef struct volume_options {
     char *key[ZR_VOLUME_MAX_NUM_KEY];
     /* different key, same meaning */
     volume_option_type_t type;
+
+    /* Required for int options where only the min value
+     * is given and is 0. This will cause validation not to
+     * happen
+     */
+    opt_validate_type_t validate;
+
     double min; /* 0 means no range */
     double max; /* 0 means no range */
     char *value[ZR_OPTION_MAX_ARRAY_SIZE];
@@ -109,11 +116,6 @@ typedef struct volume_options {
        the value from this array */
     char *default_value;
     char *description; /* about the key */
-    /* Required for int options where only the min value
-     * is given and is 0. This will cause validation not to
-     * happen
-     */
-    opt_validate_type_t validate;
 
     /* The op-version at which this option was introduced.
      * This is an array to support options that get backported to supported

--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -98,6 +98,7 @@ struct _call_stack {
     uint16_t ngrps;
     int8_t type;
     uint32_t groups_small[SMALL_GROUP_COUNT];
+    int32_t op;
     uint32_t *groups_large;
     uint32_t *groups;
     glusterfs_ctx_t *ctx;
@@ -105,7 +106,6 @@ struct _call_stack {
     struct list_head myframes; /* List of call_frame_t that go
                                   to make the call stack */
 
-    int32_t op;
     struct timespec tv;
     xlator_t *err_xl;
     int32_t error;

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -96,9 +96,9 @@ struct synctask {
 
     pthread_mutex_t mutex; /* for synchronous spawning of synctask */
     pthread_cond_t cond;
-    int done;
 
     struct list_head waitq; /* can wait only "once" at a time */
+    int done;
 };
 
 struct syncproc {
@@ -142,10 +142,10 @@ struct syncenv {
     int procmin;
     int procmax;
 
-    size_t stacksize;
-
     int destroy; /* FLAG to mark syncenv is in destroy mode
                     so that no more synctasks are accepted*/
+
+    size_t stacksize;
 };
 
 typedef enum { LOCK_NULL = 0, LOCK_TASK, LOCK_THREAD } lock_type_t;
@@ -204,11 +204,11 @@ struct syncargs {
     dict_t *xattr;
     struct statvfs statvfs_buf;
     struct iovec *vector;
-    int count;
     struct iobref *iobref;
     char *buffer;
     dict_t *xdata;
     struct gf_flock flock;
+    int count;
     struct gf_lease lease;
     dict_t *dict_out;
 
@@ -238,8 +238,8 @@ struct syncopctx {
     gid_t gid;
     int grpsize;
     int ngrps;
-    gid_t *groups;
     pid_t pid;
+    gid_t *groups;
     gf_lkowner_t lk_owner;
 };
 

--- a/rpc/rpc-lib/src/rpc-clnt.h
+++ b/rpc/rpc-lib/src/rpc-clnt.h
@@ -123,9 +123,9 @@ typedef struct rpc_auth_data {
 
 struct rpc_clnt_config {
     time_t rpc_timeout;
-    int remote_port;
     char *remote_host;
     time_t ping_timeout;
+    int remote_port;
 };
 
 #define rpc_auth_flavour(au) ((au).flavour)
@@ -146,10 +146,10 @@ struct rpc_clnt_connection {
     uint64_t msgcnt;
     uint64_t cleanup_gen;
     char *name;
-    int32_t ping_started;
     time_t frame_timeout;
     time_t ping_timeout;
     rpc_clnt_status_t status;
+    int32_t ping_started;
 };
 typedef struct rpc_clnt_connection rpc_clnt_connection_t;
 
@@ -157,13 +157,13 @@ struct rpc_req {
     rpc_clnt_connection_t *conn;
     struct iovec rsp[2];
     int rspcnt;
+    uint32_t xid;
     struct iobref *rsp_iobref;
     rpc_clnt_prog_t *prog;
     rpc_auth_data_t verf;
     fop_cbk_fn_t cbkfn;
     int procnum;
     int rpc_status;
-    uint32_t xid;
 };
 
 typedef struct rpc_clnt {

--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -116,6 +116,11 @@ struct rpcsvc_request {
 
     gf_lkowner_t lk_owner;
 
+    /* The identifier for the call from client.
+     * Needed to pair the reply with the call.
+     */
+    uint32_t xid;
+
     /* Might want to move this to AUTH_UNIX specific state since this array
      * is not available for every authentication scheme.
      */
@@ -188,20 +193,15 @@ struct rpcsvc_request {
        the one we should consider for time */
     struct timespec ctime;
 
-    /* The identifier for the call from client.
-     * Needed to pair the reply with the call.
+    /* If latency measurement is enabled, marks the request handling
+     * start time.
      */
-    uint32_t xid;
+    struct timespec begin;
 
     /* Execute this request's actor function in ownthread of program?*/
     gf_boolean_t ownthread;
 
     gf_boolean_t synctask;
-
-    /* If latency measurement is enabled, marks the request handling
-     * start time.
-     */
-    struct timespec begin;
 };
 
 #define rpcsvc_request_program(req) ((rpcsvc_program_t *)((req)->prog))

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -154,8 +154,8 @@ struct afr_nfsd {
 
 typedef struct _afr_lk_heal_info {
     fd_t *fd;
-    int32_t cmd;
     struct gf_flock flock;
+    int32_t cmd;
     dict_t *xdata_req;
     unsigned char *locked_nodes;
     struct list_head pos;
@@ -262,6 +262,8 @@ typedef struct _afr_private {
     afr_self_heald_t shd;
     struct afr_nfsd nfsd;
 
+    gf_boolean_t use_anon_inode;
+
     uint32_t halo_max_latency_msec;
     uint32_t halo_max_replicas;
     uint32_t halo_min_replicas;
@@ -270,7 +272,6 @@ typedef struct _afr_private {
     gf_boolean_t esh_granular;
     gf_boolean_t consistent_io;
     gf_boolean_t data_self_heal; /* on/off */
-    gf_boolean_t use_anon_inode;
 
     /*For lock healing.*/
     struct list_head saved_locks;

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -106,8 +106,8 @@ typedef struct dht_layout dht_layout_t;
 struct dht_stat_time {
     uint64_t atime;
     uint32_t atime_nsec;
-    uint64_t ctime;
     uint32_t ctime_nsec;
+    uint64_t ctime;
     uint64_t mtime;
     uint32_t mtime_nsec;
 };
@@ -345,6 +345,8 @@ struct dht_local {
     off_t queue_offset;
     int32_t queue;
 
+    int32_t mds_heal_fresh_lookup;
+
     /* inodelks during filerename for backward compatibility */
     dht_lock_t **rename_inodelk_backward_compatible;
 
@@ -359,7 +361,6 @@ struct dht_local {
     int rename_inodelk_bc_count;
     /* This is use only for directory operation */
     int32_t valid;
-    int32_t mds_heal_fresh_lookup;
     short lock_type;
     char need_selfheal;
     char need_xattr_heal;

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -157,18 +157,19 @@ struct ios_conf {
     gf_boolean_t dump_fd_stats;
     gf_boolean_t count_fop_hits;
     gf_boolean_t measure_latency;
+    gf_boolean_t dump_thread_should_die;
+    gf_boolean_t dump_thread_running;
     struct ios_stat_head list[IOS_STATS_TYPE_MAX];
     struct ios_stat_head thru_list[IOS_STATS_THRU_MAX];
     int32_t ios_dump_interval;
     pthread_t dump_thread;
-    gf_boolean_t dump_thread_should_die;
-    gf_boolean_t dump_thread_running;
     gf_lock_t ios_sampling_lock;
     int32_t ios_sample_interval;
     int32_t ios_sample_buf_size;
     ios_sample_buf_t *ios_sample_buf;
     struct dnscache *dnscache;
     int32_t ios_dnscache_ttl_sec;
+    ios_dump_type_t dump_format;
     /*
      * What we really need here is just a unique value to keep files
      * created by this instance distinct from those created by any other.
@@ -181,7 +182,6 @@ struct ios_conf {
      * all of the cases where "xlator_name" is used as a *variable* name.
      */
     char *unique_id;
-    ios_dump_type_t dump_format;
 };
 
 struct ios_fd {

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -211,10 +211,10 @@ typedef struct shard_unlink_thread {
     pthread_mutex_t mutex;
     pthread_cond_t cond;
     pthread_t thread;
+    xlator_t *this;
     gf_boolean_t running;
     gf_boolean_t rerun;
     gf_boolean_t stop;
-    xlator_t *this;
 } shard_unlink_thread_t;
 
 typedef struct shard_priv {
@@ -224,8 +224,8 @@ typedef struct shard_priv {
     inode_t *dot_shard_inode;
     inode_t *dot_shard_rm_inode;
     gf_lock_t lock;
-    int inode_count;
     struct list_head ilist_head;
+    int inode_count;
     uint32_t deletion_rate;
     shard_bg_deletion_state_t bg_del_state;
     gf_boolean_t first_lookup_done;
@@ -279,6 +279,7 @@ typedef struct shard_local {
     uint64_t block_size;
     uint64_t dst_block_size;
     int32_t datasync;
+    glusterfs_fop_t fop;
     off_t offset;
     size_t total_size;
     size_t written_size;
@@ -296,7 +297,6 @@ typedef struct shard_local {
     dict_t *xattr_req;
     dict_t *xattr_rsp;
     inode_t **inode_list;
-    glusterfs_fop_t fop;
     struct iatt prebuf;
     struct iatt postbuf;
     struct iatt preoldparent;
@@ -309,6 +309,11 @@ typedef struct shard_local {
     gf_dirent_t entries_head;
     gf_boolean_t is_set_fsid;
     gf_boolean_t list_inited;
+    gf_boolean_t first_lookup_done;
+    gf_boolean_t lookup_shards_barriered;
+    gf_boolean_t unlink_shards_barriered;
+    gf_boolean_t resolve_not;
+    gf_boolean_t cleanup_required;
     shard_post_fop_handler_t handler;
     shard_post_lookup_shards_fop_handler_t pls_fop_handler;
     shard_post_resolve_fop_handler_t post_res_handler;
@@ -317,37 +322,32 @@ typedef struct shard_local {
     shard_inodelk_t int_inodelk;
     shard_entrylk_t int_entrylk;
     inode_t *resolver_base_inode;
-    gf_boolean_t first_lookup_done;
     syncbarrier_t barrier;
-    gf_boolean_t lookup_shards_barriered;
-    gf_boolean_t unlink_shards_barriered;
-    gf_boolean_t resolve_not;
     loc_t newloc;
     call_frame_t *main_frame;
     call_frame_t *inodelk_frame;
     call_frame_t *entrylk_frame;
-    uint32_t deletion_rate;
-    gf_boolean_t cleanup_required;
-    uuid_t base_gfid;
     char *name;
+    uint32_t deletion_rate;
+    uuid_t base_gfid;
 } shard_local_t;
 
 typedef struct shard_inode_ctx {
     uint64_t block_size; /* The block size with which this inode is
                             sharded */
     struct iatt stat;
-    gf_boolean_t refresh;
     /* The following members of inode ctx will be applicable only to the
      * individual shards' ctx and never the base file ctx.
      */
     struct list_head ilist;
     uuid_t base_gfid;
     int block_num;
+    gf_boolean_t refresh;
     gf_boolean_t refreshed;
     struct list_head to_fsync_list;
     int fsync_needed;
-    inode_t *inode;
     int fsync_count;
+    inode_t *inode;
     inode_t *base_inode;
 } shard_inode_ctx_t;
 

--- a/xlators/lib/src/libxlator.h
+++ b/xlators/lib/src/libxlator.h
@@ -111,10 +111,10 @@ struct marker_str {
     int gauge[MCNT_MAX];
     int count[MCNT_MAX];
 
+    uint8_t retval;
     xlator_specf_unwind_t xl_specf_unwind;
     void *xl_local;
     char *vol_uuid;
-    uint8_t retval;
 };
 
 typedef struct marker_str xl_marker_local_t;

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -71,23 +71,23 @@ struct glusterd_peerinfo_ {
     glusterd_friend_sm_state_t state;
     char *hostname;
     struct cds_list_head hostnames;
+    int connected;
     int port;
     struct cds_list_head uuid_list;
     struct rpc_clnt *rpc;
     rpc_clnt_prog_t *mgmt;
     rpc_clnt_prog_t *peer;
     rpc_clnt_prog_t *mgmt_v3;
-    int connected;
     gf_store_handle_t *shandle;
     glusterd_sm_tr_log_t sm_log;
-    gf_boolean_t quorum_action;
     gd_quorum_contrib_t quorum_contrib;
-    gf_boolean_t locked;
-    gf_boolean_t detaching;
+    uint32_t generation;
     /* Members required for proper cleanup using RCU */
     gd_rcu_head rcu_head;
     pthread_mutex_t delete_lock;
-    uint32_t generation;
+    gf_boolean_t locked;
+    gf_boolean_t detaching;
+    gf_boolean_t quorum_action;
 };
 
 typedef struct glusterd_peerinfo_ glusterd_peerinfo_t;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -238,8 +238,8 @@ struct glusterd_brickinfo {
     struct rpc_clnt *rpc;
     int decommissioned;
     gf_brick_status_t status;
-    int32_t snap_status;
     struct glusterd_snap_ops *snap;
+    int32_t snap_status;
     /*
      * The group is used to identify which bricks are part of the same
      * replica set during brick-volfile generation, so that JBR volfiles
@@ -253,11 +253,11 @@ struct glusterd_brickinfo {
 
     /* Below are used for handling the case of multiple bricks sharing
        the backend filesystem */
+    uint32_t fs_share_count;
     uint64_t statfs_fsid;
     pthread_mutex_t restart_mutex;
     glusterd_brick_proc_t *brick_proc; /* Information regarding mux bricks */
     struct cds_list_head mux_bricks; /* List to store the bricks in brick_proc*/
-    uint32_t fs_share_count;
     char hostname[NAME_MAX];
     char path[VALID_GLUSTERD_PATHMAX];
     char real_path[VALID_GLUSTERD_PATHMAX];
@@ -277,9 +277,9 @@ typedef int (*defrag_cbk_fn_t)(glusterd_volinfo_t *volinfo,
 struct glusterd_defrag_info_ {
     int refcnt;
     gf_lock_t lock;
-    gf_boolean_t connected;
     struct rpc_clnt *rpc;
     defrag_cbk_fn_t cbk_fn;
+    gf_boolean_t connected;
 };
 
 typedef struct glusterd_defrag_info_ glusterd_defrag_info_t;

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -68,14 +68,14 @@ struct mdc_conf {
     gf_boolean_t cache_samba_metadata;
     gf_boolean_t mdc_invalidation;
     gf_boolean_t global_invalidation;
+    gf_boolean_t cache_statfs;
+    gf_atomic_uint32_t generation;
 
     time_t last_child_down;
     gf_lock_t lock;
     struct mdc_statistics mdc_counter;
-    gf_boolean_t cache_statfs;
     struct mdc_statfs_cache statfs_cache;
     char *mdc_xattr_str;
-    gf_atomic_uint32_t generation;
 };
 
 struct mdc_local;
@@ -99,6 +99,10 @@ struct md_cache {
     uint32_t md_nlink;
     uint32_t md_uid;
     uint32_t md_gid;
+    gf_boolean_t need_lookup;
+    gf_boolean_t valid;
+    gf_boolean_t gen_rollover;
+    gf_boolean_t invalidation_rollover;
     uint32_t md_atime_nsec;
     uint32_t md_mtime_nsec;
     uint32_t md_ctime_nsec;
@@ -113,10 +117,6 @@ struct md_cache {
     char *linkname;
     time_t ia_time;
     time_t xa_time;
-    gf_boolean_t need_lookup;
-    gf_boolean_t valid;
-    gf_boolean_t gen_rollover;
-    gf_boolean_t invalidation_rollover;
     gf_lock_t lock;
 };
 

--- a/xlators/performance/read-ahead/src/read-ahead.h
+++ b/xlators/performance/read-ahead/src/read-ahead.h
@@ -33,12 +33,13 @@ struct ra_fill {
     off_t offset;
     size_t size;
     struct iovec *vector;
-    int32_t count;
     struct iobref *iobref;
+    int32_t count;
 };
 
 struct ra_local {
     mode_t mode;
+    int32_t wait_count;
     struct ra_fill fill;
     off_t offset;
     size_t size;
@@ -47,7 +48,6 @@ struct ra_local {
     off_t pending_offset;
     size_t pending_size;
     fd_t *fd;
-    int32_t wait_count;
     pthread_mutex_t local_lock;
 };
 
@@ -58,13 +58,13 @@ struct ra_page {
     char dirty;    /* Internal request, not from user. */
     char poisoned; /* Pending read invalidated by write. */
     char ready;
-    struct iovec *vector;
+    char stale;
     int32_t count;
+    struct iovec *vector;
     off_t offset;
     size_t size;
     struct ra_waitq *waitq;
     struct iobref *iobref;
-    char stale;
 };
 
 struct ra_file {
@@ -73,11 +73,11 @@ struct ra_file {
     struct ra_conf *conf;
     fd_t *fd;
     int disabled;
+    int32_t refcount;
     size_t expected;
     struct ra_page pages;
     off_t offset;
     size_t size;
-    int32_t refcount;
     pthread_mutex_t file_lock;
     struct iatt stbuf;
     uint64_t page_size;
@@ -87,9 +87,9 @@ struct ra_file {
 struct ra_conf {
     uint64_t page_size;
     uint32_t page_count;
+    gf_boolean_t force_atime_update;
     void *cache_block;
     struct ra_file files;
-    gf_boolean_t force_atime_update;
     pthread_mutex_t conf_lock;
 };
 

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -149,18 +149,16 @@ typedef struct wb_request {
     int op_ret;
     int op_errno;
 
-    int32_t refcount;
     wb_inode_t *wb_inode;
     glusterfs_fop_t fop;
     gf_lkowner_t lk_owner;
     pid_t client_pid;
+    int32_t refcount;
     struct iobref *iobref;
     uint64_t gen; /* inode liability state at the time of
                      request arrival */
 
     fd_t *fd;
-    int wind_count; /* number of sync-attempts. Only
-                       for debug purposes */
     struct {
         size_t size; /* 0 size == till infinity */
         off_t off;
@@ -177,6 +175,8 @@ typedef struct wb_request {
      */
     uint64_t unique;
     uuid_t gfid;
+    int wind_count; /* number of sync-attempts. Only
+                       for debug purposes */
 } wb_request_t;
 
 typedef struct wb_conf {

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -123,6 +123,7 @@ struct _server_state {
     struct iatt stbuf;
     int valid;
 
+    int32_t flags;
     /*
      * this fd is used in all the fd based operations PLUS
      * as a source fd in copy_file_range
@@ -130,7 +131,6 @@ struct _server_state {
     fd_t *fd;
     fd_t *fd_out; /* destination fd in copy_file_range */
     dict_t *params;
-    int32_t flags;
     struct iovec payload_vector[MAX_IOVEC];
     int payload_count;
     struct iobref *iobref;
@@ -157,7 +157,6 @@ struct _server_state {
     dict_t *dict;
     struct gf_flock flock;
     const char *volume;
-    gf_seek_what_t what;
 
     dict_t *xdata;
     mode_t umask;
@@ -166,6 +165,8 @@ struct _server_state {
 
     struct iovec rsp_vector[MAX_IOVEC];
     int rsp_count;
+
+    gf_seek_what_t what;
 
     /* subdir mount */
     client_t *client;

--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -56,8 +56,8 @@ struct posix_aio_cb {
     struct iobref *iobref;
     struct iatt prebuf;
     int _fd;
-    fd_t *fd;
     int op;
+    fd_t *fd;
     off_t offset;
 };
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -176,9 +176,8 @@ struct posix_fd {
     DIR *dir;              /* handle returned by the kernel */
     off_t dir_eof;         /* offset at dir EOF */
     struct list_head list; /* to add to the janitor list */
-    int odirect;
     xlator_t *xl;
-    char _pad[4]; /* manual padding */
+    int odirect;
 };
 
 struct posix_diskxl {


### PR DESCRIPTION
Examples:
struct gf_log_handle_
        /* size: 208, cachelines: 4, members: 22 */
        /* sum members: 194, holes: 2, sum holes: 8 */
        /* padding: 6 */
        /* last cacheline: 16 bytes */
After:
        /* size: 200, cachelines: 4, members: 22 */
        /* padding: 6 */
        /* last cacheline: 8 bytes */

struct clienttable {
        /* size: 72, cachelines: 2, members: 5 */
        /* sum members: 64, holes: 2, sum holes: 8 */
        /* last cacheline: 8 bytes */
After:
        /* size: 64, cachelines: 1, members: 5 */

struct gf_flock {
       /* size: 1056, cachelines: 17, members: 6 */
        /* sum members: 1052, holes: 1, sum holes: 4 */
        /* last cacheline: 32 bytes */
After:
        /* size: 1056, cachelines: 17, members: 6 */
        /* padding: 4 */
        /* last cacheline: 32 bytes */

struct _call_stack
        /* size: 1864, cachelines: 30, members: 25 */
        /* sum members: 1851, holes: 4, sum holes: 13 */
        /* last cacheline: 8 bytes */
After:
        /* size: 1856, cachelines: 29, members: 25 */
        /* sum members: 1851, holes: 1, sum holes: 5 */

struct _buffer {
        /* size: 80, cachelines: 2, members: 7 */
        /* sum members: 73, holes: 2, sum holes: 7 */
        /* last cacheline: 16 bytes */
After:
        /* size: 80, cachelines: 2, members: 7 */
        /* padding: 7 */
        /* last cacheline: 16 bytes */

struct _inode_table {
        /* size: 256, cachelines: 4, members: 26 */
        /* sum members: 233, holes: 5, sum holes: 20 */
        /* padding: 3 */
After:
        /* size: 240, cachelines: 4, members: 26 */
        /* padding: 7 */
        /* last cacheline: 48 bytes */

struct _fd {
        /* size: 120, cachelines: 2, members: 10 */
        /* sum members: 105, holes: 2, sum holes: 8 */
        /* padding: 7 */
        /* last cacheline: 56 bytes */
After:
        /* size: 112, cachelines: 2, members: 10 */
        /* padding: 7 */
        /* last cacheline: 48 bytes */

struct _client {
      /* size: 200, cachelines: 4, members: 14 */
        /* sum members: 192, holes: 2, sum holes: 8 */
        /* last cacheline: 8 bytes */
After:
       /* size: 192, cachelines: 3, members: 14 */

struct rpc_req {
        /* size: 496, cachelines: 8, members: 10 */
        /* sum members: 488, holes: 1, sum holes: 4 */
        /* padding: 4 */
        /* last cacheline: 48 bytes */
After:
        /* size: 488, cachelines: 8, members: 10 */
        /* last cacheline: 40 bytes */

struct syncenv {
        /* size: 16032, cachelines: 251, members: 12 */
        /* sum members: 16024, holes: 1, sum holes: 4 */
        /* padding: 4 */
        /* last cacheline: 32 bytes */
After:
        /* size: 16024, cachelines: 251, members: 12 */
        /* last cacheline: 24 bytes */

struct glusterd_brickinfo {
        /* size: 25968, cachelines: 406, members: 30 */
        /* sum members: 25953, holes: 2, sum holes: 8 */
        /* padding: 7 */
        /* last cacheline: 48 bytes */
After:
        /* size: 25960, cachelines: 406, members: 30 */
        /* sum members: 25953, holes: 1, sum holes: 4 */
        /* padding: 3 */
        /* last cacheline: 40 bytes */

struct ios_conf {
        /* size: 6792, cachelines: 107, members: 21 */
        /* sum members: 6769, holes: 4, sum holes: 19 */
        /* padding: 4 */
        /* last cacheline: 8 bytes */
After:
        /* size: 6776, cachelines: 106, members: 21 */
        /* sum members: 6769, holes: 2, sum holes: 7 */
        /* last cacheline: 56 bytes */

struct posix_aio_cb {
        /* size: 272, cachelines: 5, members: 9 */
        /* sum members: 264, holes: 2, sum holes: 8 */
        /* last cacheline: 16 bytes */
After:
        /* size: 264, cachelines: 5, members: 9 */
        /* last cacheline: 8 bytes */

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

