### PR TITLE
O_PATH support over protocol

### DIFF
--- a/rpc/xdr/src/glusterfs3.h
+++ b/rpc/xdr/src/glusterfs3.h
@@ -49,6 +49,10 @@
 
 #define GF_O_FMODE_EXEC 040
 
+/* refer 2717 */
+#define GF_O_PATH 010000000
+
+
 #define XLATE_BIT(from, to, bit)                                               \
     do {                                                                       \
         if (from & bit)                                                        \
@@ -118,6 +122,9 @@ gf_flags_from_flags(uint32_t flags)
 #endif
     XLATE_BIT(flags, gf_flags, O_LARGEFILE);
     XLATE_BIT(flags, gf_flags, O_FMODE_EXEC);
+#ifdef O_PATH
+    XLATE_BIT(flags, gf_flags, O_PATH);
+#endif
 
     return gf_flags;
 }
@@ -149,6 +156,9 @@ gf_flags_to_flags(uint32_t gf_flags)
 #endif
     UNXLATE_BIT(gf_flags, flags, O_LARGEFILE);
     UNXLATE_BIT(gf_flags, flags, O_FMODE_EXEC);
+#ifdef O_PATH
+    UNXLATE_BIT(gf_flags, flags, O_PATH);
+#endif
 
     return flags;
 }


### PR DESCRIPTION
This doesn't break XDR as the flag is passed as 32bit number.
But the support for O_PATH will come only when both the client
and server have this code in it to translate the number (32bit) over the wire.

Change-Id: I057eefe4bb0f93f27cd844268ffca21254bd7fbf
Signed-off-by: Amar Tumballi <amar@kadalu.io>

Updates: #2717 