### PR TITLE
clang issue: Dereference of undefined pointer value

### DIFF
--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -518,7 +518,7 @@ static int32_t
 ob_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
           mode_t mode, mode_t umask, fd_t *fd, dict_t *xdata)
 {
-    ob_inode_t *ob_inode;
+    ob_inode_t *ob_inode = NULL;
     call_stub_t *stub;
     fd_t *first_fd;
     ob_state_t state;
@@ -551,13 +551,13 @@ ob_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     /* In case of failure we need to decrement the number of open files because
      * ob_fdclose() won't be called. */
-
-    LOCK(&fd->inode->lock);
-    {
-        ob_inode->open_count--;
+    if (ob_inode != NULL) {
+        LOCK(&fd->inode->lock);
+        {
+            ob_inode->open_count--;
+        }
+        UNLOCK(&fd->inode->lock);
     }
-    UNLOCK(&fd->inode->lock);
-
     gf_smsg(this->name, GF_LOG_ERROR, -state, OPEN_BEHIND_MSG_FAILED, "fop=%s",
             "create", "path=%s", loc->path, NULL);
 


### PR DESCRIPTION
Issue: Access to field 'open_count' results in a dereference of 
an undefined pointer value (loaded from variable 'ob_inode')
[clang-scan-build-issue](https://build.gluster.org/job/clang-scan/lastBuild/clangScanBuildBugs/) 

Fix: First initialized ob_inode and then check for ob_inode if it is NULL 

Updates: #1060 
Change-Id: I26e5873e2a73613fcce127f3da81751121f55b79
Signed-off-by: Preet Bhatia [pbhatia@redhat.com](mailto:pbhatia@redhat.com)