### PR TITLE
gcc-warning[glfs.c]

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -487,6 +487,8 @@ glfs_free_xlator_options(cmd_args_t *cmd_args)
     xlator_cmdline_option_t *xo = NULL;
     xlator_cmdline_option_t *tmp_xo = NULL;
 
+    GF_VALIDATE_OR_GOTO(THIS->name, cmd_args, out);
+
     list_for_each_entry_safe(xo, tmp_xo, &cmd_args->xlator_options, cmd_args)
     {
         list_del_init(&xo->cmd_args);
@@ -495,6 +497,9 @@ glfs_free_xlator_options(cmd_args_t *cmd_args)
         GF_FREE(xo->value);
         GF_FREE(xo);
     }
+
+out:
+    return;
 }
 
 GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_setfsuid, 3.4.2)

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -487,9 +487,6 @@ glfs_free_xlator_options(cmd_args_t *cmd_args)
     xlator_cmdline_option_t *xo = NULL;
     xlator_cmdline_option_t *tmp_xo = NULL;
 
-    if (!(&cmd_args->xlator_options))
-        return;
-
     list_for_each_entry_safe(xo, tmp_xo, &cmd_args->xlator_options, cmd_args)
     {
         list_del_init(&xo->cmd_args);

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -487,7 +487,7 @@ glfs_free_xlator_options(cmd_args_t *cmd_args)
     xlator_cmdline_option_t *xo = NULL;
     xlator_cmdline_option_t *tmp_xo = NULL;
 
-    if (!&(cmd_args->xlator_options))
+    if (!(&cmd_args->xlator_options))
         return;
 
     list_for_each_entry_safe(xo, tmp_xo, &cmd_args->xlator_options, cmd_args)


### PR DESCRIPTION
In reference to issue: #3388 
`glfs.c: In function ‘glfs_free_xlator_options’:
glfs.c:490:9: warning: the comparison will always evaluate as ‘true’ for the address of ‘xlator_options’ will never be NULL [-Waddress]
  490 |     if (!&(cmd_args->xlator_options))`

Revised the check on (&cmd_args->xlator-options)
Fixes: #3388 
Change-Id: Id20554ffff976c10474c755205d3b478f829c3e1
Signed-off-by: Harshita Shree hshree@redhat.com

