### PR TITLE
[ec] Use regular iovec object in place of array of len 1

### DIFF
--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -1148,7 +1148,7 @@ out:
 int32_t
 ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
 {
-    struct iovec vector[1];
+    struct iovec vector;
     ec_cbk_data_t *ans = NULL;
     struct iobref *iobref = NULL;
     void *ptr;
@@ -1199,8 +1199,8 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
             goto out;
         }
 
-        vector[0].iov_base = ptr + fop->head;
-        vector[0].iov_len = size - fop->head;
+        vector.iov_base = ptr + fop->head;
+        vector.iov_len = size - fop->head;
 
         max = fop->offset * ec->fragments + size;
         if (max > cbk->iatt[0].ia_size) {
@@ -1212,7 +1212,7 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
         }
         size -= fop->head;
         if (size > max) {
-            vector[0].iov_len -= size - max;
+            vector.iov_len -= size - max;
             size = max;
         }
 
@@ -1223,7 +1223,7 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
         cbk->buffers = iobref;
 
         GF_FREE(cbk->vector);
-        cbk->vector = iov_dup(vector, 1);
+        cbk->vector = iov_dup(&vector, 1);
         if (cbk->vector == NULL) {
             return -ENOMEM;
         }

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -2108,17 +2108,17 @@ ec_wind_writev(ec_t *ec, ec_fop_data_t *fop, int32_t idx)
 {
     ec_trace("WIND", fop, "idx=%d", idx);
 
-    struct iovec vector[1];
+    struct iovec vector;
     size_t size;
 
     size = fop->vector[1].iov_len;
 
-    vector[0].iov_base = fop->vector[1].iov_base + idx * size;
-    vector[0].iov_len = size;
+    vector.iov_base = fop->vector[1].iov_base + idx * size;
+    vector.iov_len = size;
 
     STACK_WIND_COOKIE(fop->frame, ec_writev_cbk, (void *)(uintptr_t)idx,
                       ec->xl_list[idx], ec->xl_list[idx]->fops->writev, fop->fd,
-                      vector, 1, fop->offset / ec->fragments, fop->uint32,
+                      &vector, 1, fop->offset / ec->fragments, fop->uint32,
                       fop->buffers, fop->xdata);
 }
 


### PR DESCRIPTION
Memory is allocated on the stack in both the cases and I saw no reason
for using an array other than the struct ptr being passed to `WIND` and `dup`
functions. We can achieve the same by using `&` at such places.

Signed-off-by: black-dragon74 <niryadav@redhat.com>

