### PR TITLE
simplify function calls[afr-common]

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -2411,8 +2411,7 @@ afr_read_subvol_get(inode_t *inode, xlator_t *this, int *subvol_p,
 }
 
 static void
-afr_local_transaction_cleanup(afr_local_t *local,
-                              const unsigned int child_count)
+afr_local_transaction_cleanup(afr_local_t *local, unsigned int child_count)
 {
     int i = 0;
 

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -731,15 +731,12 @@ afr_copy_frame(call_frame_t *base)
 /* Check if an entry or inode could be undergoing a transaction. */
 static gf_boolean_t
 afr_is_possibly_under_txn(afr_transaction_type type, afr_local_t *local,
-                          xlator_t *this)
+                          unsigned int child_count)
 {
     int i = 0;
     int tmp = 0;
-    afr_private_t *priv = NULL;
     GF_UNUSED char *key = NULL;
     int keylen = 0;
-
-    priv = this->private;
 
     if (type == AFR_ENTRY_TRANSACTION) {
         key = GLUSTERFS_PARENT_ENTRYLK;
@@ -751,7 +748,7 @@ afr_is_possibly_under_txn(afr_transaction_type type, afr_local_t *local,
         key = GLUSTERFS_INODELK_COUNT;
         keylen = SLEN(GLUSTERFS_INODELK_COUNT);
     }
-    for (i = 0; i < priv->child_count; i++) {
+    for (i = 0; i < child_count; i++) {
         if (!local->replies[i].xdata)
             continue;
         if (dict_get_int32n(local->replies[i].xdata, key, keylen, &tmp) == 0)
@@ -1554,16 +1551,13 @@ out:
 }
 
 static int
-afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
+afr_accused_fill(afr_private_t *priv, dict_t *xdata, unsigned char *accused,
                  afr_transaction_type type)
 {
-    afr_private_t *priv = NULL;
     int i = 0;
     int idx = afr_index_for_transaction_type(type);
     void *pending_raw = NULL;
     int ret = 0;
-
-    priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
         ret = dict_get_ptr(xdata, priv->pending_key[i], &pending_raw);
@@ -1578,14 +1572,11 @@ afr_accused_fill(xlator_t *this, dict_t *xdata, unsigned char *accused,
 }
 
 static int
-afr_accuse_smallfiles(xlator_t *this, struct afr_reply *replies,
+afr_accuse_smallfiles(afr_private_t *priv, struct afr_reply *replies,
                       unsigned char *data_accused)
 {
     int i = 0;
-    afr_private_t *priv = NULL;
     uint64_t maxsize = 0;
-
-    priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
         if (replies[i].valid && replies[i].xdata &&
@@ -1653,11 +1644,11 @@ afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
 
         if (!xdata)
             continue; /* mkdir_cbk sends NULL xdata_rsp. */
-        afr_accused_fill(this, xdata, data_accused,
+        afr_accused_fill(priv, xdata, data_accused,
                          (ia_type == IA_IFDIR) ? AFR_ENTRY_TRANSACTION
                                                : AFR_DATA_TRANSACTION);
 
-        afr_accused_fill(this, xdata, metadata_accused,
+        afr_accused_fill(priv, xdata, metadata_accused,
                          AFR_METADATA_TRANSACTION);
     }
 
@@ -1667,8 +1658,9 @@ afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
          * ia_sizes obtained in post-refresh replies may
          * mismatch due to a race between inode-refresh and
          * ongoing writes, causing spurious heal launches*/
-        !afr_is_possibly_under_txn(AFR_DATA_TRANSACTION, local, this)) {
-        afr_accuse_smallfiles(this, replies, data_accused);
+        !afr_is_possibly_under_txn(AFR_DATA_TRANSACTION, local,
+                                   priv->child_count)) {
+        afr_accuse_smallfiles(priv, replies, data_accused);
     }
 
     for (i = 0; i < priv->child_count; i++) {
@@ -2419,12 +2411,9 @@ afr_read_subvol_get(inode_t *inode, xlator_t *this, int *subvol_p,
 }
 
 static void
-afr_local_transaction_cleanup(afr_local_t *local, xlator_t *this)
+afr_local_transaction_cleanup(afr_local_t *local, afr_private_t *priv)
 {
-    afr_private_t *priv = NULL;
     int i = 0;
-
-    priv = this->private;
 
     afr_matrix_cleanup(local->pending, priv->child_count);
 
@@ -2587,12 +2576,11 @@ afr_local_cleanup(afr_local_t *local, xlator_t *this)
 
     if (!local)
         return;
+    priv = this->private;
 
     syncbarrier_destroy(&local->barrier);
 
-    afr_local_transaction_cleanup(local, this);
-
-    priv = this->private;
+    afr_local_transaction_cleanup(local, priv);
 
     loc_wipe(&local->loc);
     loc_wipe(&local->newloc);
@@ -2948,7 +2936,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
     parent = local->loc.parent;
 
     locked_entry = afr_is_possibly_under_txn(AFR_ENTRY_TRANSACTION, local,
-                                             this);
+                                             priv->child_count);
 
     readable = alloca0(priv->child_count);
     success_replies = alloca0(priv->child_count);
@@ -5346,7 +5334,7 @@ out:
     return 0;
 }
 
-int32_t
+static int32_t
 afr_lease_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
                      dict_t *xdata)
@@ -5732,9 +5720,8 @@ __afr_get_up_children_count(afr_private_t *priv)
 }
 
 static int
-__get_heard_from_all_status(xlator_t *this)
+__get_heard_from_all_status(afr_private_t *priv)
 {
-    afr_private_t *priv = this->private;
     int i;
 
     for (i = 0; i < priv->child_count; i++) {
@@ -5755,7 +5742,7 @@ __afr_transform_event_from_state(xlator_t *this)
     int up_children = 0;
     afr_private_t *priv = this->private;
 
-    if (__get_heard_from_all_status(this))
+    if (__get_heard_from_all_status(priv))
         /* have_heard_from_all. Let afr_notify() do the propagation. */
         return GF_EVENT_MAXVAL;
 
@@ -6318,7 +6305,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
     if (event == GF_EVENT_TRANSLATOR_OP) {
         LOCK(&priv->lock);
         {
-            had_heard_from_all = __get_heard_from_all_status(this);
+            had_heard_from_all = __get_heard_from_all_status(priv);
         }
         UNLOCK(&priv->lock);
 
@@ -6338,7 +6325,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
 
     LOCK(&priv->lock);
     {
-        had_heard_from_all = __get_heard_from_all_status(this);
+        had_heard_from_all = __get_heard_from_all_status(priv);
         switch (event) {
             case GF_EVENT_PARENT_UP:
                 __afr_launch_notify_timer(this, priv);
@@ -6383,7 +6370,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
                 propagate = 1;
                 break;
         }
-        have_heard_from_all = __get_heard_from_all_status(this);
+        have_heard_from_all = __get_heard_from_all_status(priv);
         if (!had_heard_from_all && have_heard_from_all) {
             if (priv->timer) {
                 gf_timer_call_cancel(this->ctx, priv->timer);


### PR DESCRIPTION
Follow up patch for #3348 which simplifies afr function calls .
For instance using replacing xlator_t * with afr_private_t * where needed.

Change-Id: Iaa7b692ed479c8a2bdf7943a6ca1932457a83c99
Signed-off-by : Harshita Shree hshree@redhat.com