### PR TITLE
build: mention GNU Emacs and Global tags as ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ config.*
 configure
 cscope.*
 tags
+TAGS
+ID
+GPATH
+GRTAGS
+GTAGS
+GSYMS
 depcomp
 INSTALL
 install-sh


### PR DESCRIPTION
Add TAGS (generated by `etags` and used by GNU Emacs) and
ID / GPATH / GRTAGS / GTAGS / GSYMS (generated by GNU Global)
entries to `.gitignore`. Note the same set of generated files
is cleaned by `distclean-tags` target from `Makefile.in`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

