### PR TITLE
Fix for compile warnings[glusterd-utils.c]

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -7706,11 +7706,11 @@ out:
 
     if (*in_use) {
         if (path && curdir && !strcmp(path, curdir)) {
-            ret = snprintf(msg, sizeof(msg),
-                           "%s is already part of a "
-                           "volume",
-                           path);
-            if (ret < 0 || ret >= sizeof(msg)) {
+            int z = snprintf(msg, sizeof(msg),
+                             "%s is already part of a "
+                             "volume",
+                             path);
+            if (z < 0 || z >= sizeof(msg)) {
                 snprintf(msg, sizeof(msg), "path too big");
                 ret = -1;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -7706,10 +7706,14 @@ out:
 
     if (*in_use) {
         if (path && curdir && !strcmp(path, curdir)) {
-            snprintf(msg, sizeof(msg),
-                     "%s is already part of a "
-                     "volume",
-                     path);
+            ret = snprintf(msg, sizeof(msg),
+                           "%s is already part of a "
+                           "volume",
+                           path);
+            if (ret < 0 || ret >= sizeof(msg)) {
+                snprintf(msg, sizeof(msg), "path too big");
+                ret = -1;
+            }
         } else {
             snprintf(msg, sizeof(msg),
                      "parent directory %s is "
@@ -7740,12 +7744,17 @@ glusterd_check_and_set_brick_xattr(char *host, char *path, uuid_t uuid,
     /* Check for xattr support in backend fs */
     ret = sys_lsetxattr(path, "trusted.glusterfs.test", "working", 8, 0);
     if (ret == -1) {
-        snprintf(msg, sizeof(msg),
-                 "Glusterfs is not"
-                 " supported on brick: %s:%s.\nSetting"
-                 " extended attributes failed, reason:"
-                 " %s.",
-                 host, path, strerror(errno));
+        ret = snprintf(msg, sizeof(msg),
+                       "Glusterfs is not"
+                       " supported on brick: %s:%s.\nSetting"
+                       " extended attributes failed, reason:"
+                       " %s.",
+                       host, path, strerror(errno));
+        if (ret < 0 || ret >= sizeof(msg)) {
+            snprintf(msg, sizeof(msg), "path too big");
+            ret = -1;
+            goto out;
+        }
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_SET_XATTR_BRICK_FAIL,
                 "Host=%s, Path=%s", host, path, NULL);
         goto out;


### PR DESCRIPTION
Warnings:
```
glusterd-utils.c:7709:13: note: ‘snprintf’ output between 29 and 3804 bytes into a destination of size 2048
             snprintf(msg, sizeof(msg),

glusterd-utils.c:7743:9: note: ‘snprintf’ output 86 or more bytes (assuming 4115) into a destination of size 2048
         snprintf(msg, sizeof(msg),
```

Warning arises as msg is having smaller size
so added extra check to remove warning

Updates: #1000
Change-Id: I65692d0a5ed39a06068519d49ca0eb11e15286a2
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

