### PR TITLE
dht: handle defrag pattern list properly

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -427,9 +427,9 @@ typedef enum gf_defrag_status_t gf_defrag_status_t;
 typedef struct gf_defrag_pattern_list gf_defrag_pattern_list_t;
 
 struct gf_defrag_pattern_list {
-    char path_pattern[256];
+    struct list_head list;
+    char *path_pattern;
     uint64_t size;
-    gf_defrag_pattern_list_t *next;
 };
 
 struct dht_container {
@@ -477,7 +477,7 @@ struct gf_defrag_info_ {
     time_t start_time;
     uint32_t new_commit_hash;
     gf_defrag_status_t defrag_status;
-    gf_defrag_pattern_list_t *defrag_pattern;
+    struct list_head defrag_pattern;
 
     pthread_cond_t parallel_migration_cond;
     pthread_mutex_t dfq_mutex;

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2490,13 +2490,12 @@ gf_defrag_pattern_match(gf_defrag_info_t *defrag, char *name, uint64_t size)
 
     GF_VALIDATE_OR_GOTO("dht", defrag, out);
 
-    trav = defrag->defrag_pattern;
-    while (trav) {
+    list_for_each_entry(trav, &defrag->defrag_pattern, list)
+    {
         if (!fnmatch(trav->path_pattern, name, FNM_NOESCAPE)) {
             match = _gf_true;
             break;
         }
-        trav = trav->next;
     }
 
     if ((match == _gf_true) && (size >= trav->size))
@@ -2696,7 +2695,7 @@ gf_defrag_migrate_single_file(void *opaque)
         gettimeofday(&start, NULL);
     }
 
-    if (defrag->defrag_pattern &&
+    if (!list_empty(&defrag->defrag_pattern) &&
         (gf_defrag_pattern_match(defrag, entry->d_name,
                                  entry->d_stat.ia_size) == _gf_false)) {
         gf_log(this->name, GF_LOG_ERROR, "pattern_match failed");
@@ -3170,7 +3169,7 @@ gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
 
         defrag->num_files_lookedup++;
 
-        if (defrag->defrag_pattern &&
+        if (!list_empty(&defrag->defrag_pattern) &&
             (gf_defrag_pattern_match(defrag, df_entry->d_name,
                                      df_entry->d_stat.ia_size) == _gf_false)) {
             defrag->size_processed += df_entry->d_stat.ia_size;

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -533,7 +533,6 @@ gf_defrag_pattern_list_fill(xlator_t *this, gf_defrag_info_t *defrag,
     char *num = NULL;
     char *pattern_str = NULL;
     char *pattern = NULL;
-    gf_defrag_pattern_list_t *temp_list = NULL;
     gf_defrag_pattern_list_t *pattern_list = NULL;
 
     if (!this || !defrag || !data)
@@ -551,6 +550,7 @@ gf_defrag_pattern_list_fill(xlator_t *this, gf_defrag_info_t *defrag,
         if (!pattern_list) {
             goto out;
         }
+        INIT_LIST_HEAD(&pattern_list->list);
         pattern = strtok_r(dup_str, ":", &tmp_str1);
         num = strtok_r(NULL, ":", &tmp_str1);
         if (!pattern)
@@ -566,21 +566,10 @@ gf_defrag_pattern_list_fill(xlator_t *this, gf_defrag_info_t *defrag,
                    num);
             goto out;
         }
-        memcpy(pattern_list->path_pattern, pattern, strlen(dup_str));
-
-        if (!defrag->defrag_pattern)
-            temp_list = NULL;
-        else
-            temp_list = defrag->defrag_pattern;
-
-        pattern_list->next = temp_list;
-
-        defrag->defrag_pattern = pattern_list;
+        pattern_list->path_pattern = pattern;
+        list_add_tail(&pattern_list->list, &defrag->defrag_pattern);
         pattern_list = NULL;
-
-        GF_FREE(dup_str);
         dup_str = NULL;
-
         pattern_str = strtok_r(NULL, ",", &tmp_str);
     }
 
@@ -664,6 +653,7 @@ dht_init(xlator_t *this)
         GF_VALIDATE_OR_GOTO(this->name, defrag, err);
 
         LOCK_INIT(&defrag->lock);
+        INIT_LIST_HEAD(&defrag->defrag_pattern);
 
         defrag->is_exiting = 0;
 


### PR DESCRIPTION
Fix possible `memcpy(to, from, strlen(from))`-alike
buffer overrun, use common list manipulation code to
maintain pattern list and construct it in expected
(not reversed) order, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000