### PR TITLE
Use flexible array members

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -58,7 +58,7 @@ struct mem_acct_rec {
 struct mem_acct {
     uint32_t num_types;
     gf_atomic_t refcnt;
-    struct mem_acct_rec rec[0];
+    struct mem_acct_rec rec[];
 };
 
 struct mem_header {
@@ -297,7 +297,7 @@ typedef struct per_thread_pool_list {
      * in the implementation code so we just make it a single-element array
      * here.
      */
-    per_thread_pool_t pools[1];
+    per_thread_pool_t pools[];
 } per_thread_pool_list_t;
 
 /* actual pool structure, shared between different mem_pools */

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -628,16 +628,6 @@ struct dht_dfoffset_ctx {
 };
 typedef struct dht_dfoffset_ctx dht_dfoffset_ctx_t;
 
-struct dht_disk_layout {
-    uint32_t cnt;
-    uint32_t type;
-    struct {
-        uint32_t start;
-        uint32_t stop;
-    } list[];
-};
-typedef struct dht_disk_layout dht_disk_layout_t;
-
 typedef enum {
     GF_DHT_MIGRATE_DATA,
     GF_DHT_MIGRATE_DATA_EVEN_IF_LINK_EXISTS,

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -634,7 +634,7 @@ struct dht_disk_layout {
     struct {
         uint32_t start;
         uint32_t stop;
-    } list[1];
+    } list[];
 };
 typedef struct dht_disk_layout dht_disk_layout_t;
 

--- a/xlators/features/changelog/lib/src/gf-changelog-helpers.h
+++ b/xlators/features/changelog/lib/src/gf-changelog-helpers.h
@@ -78,7 +78,7 @@ struct gf_event {
 
     struct list_head list;
 
-    struct iovec iov[0];
+    struct iovec iov[];
 };
 #define GF_EVENT_CALLOC_SIZE(cnt, len)                                         \
     (sizeof(struct gf_event) + (cnt * sizeof(struct iovec)) + len)


### PR DESCRIPTION
for dynamically sized trailing elements in a structure. See [here](https://www.kernel.org/doc/html/v5.16/process/deprecated.html#zero-length-and-one-element-arrays) for more information on this.

Closes: #3366

Signed-off-by: black-dragon74 <niryadav@redhat.com>

