### PR TITLE
[changelog-rpc-common] Fix use after free

### DIFF
--- a/xlators/features/changelog/src/changelog-rpc-common.c
+++ b/xlators/features/changelog/src/changelog-rpc-common.c
@@ -78,7 +78,8 @@ changelog_rpc_client_init(xlator_t *this, void *cbkdata, char *sockfile,
 dealloc_rpc_clnt:
     rpc_clnt_unref(rpc);
 dealloc_dict:
-    dict_unref(options);
+    if (options)
+        dict_unref(options);
 error_return:
     return NULL;
 }


### PR DESCRIPTION
The earlier code was fine too but would lead to flooding of log messages.
Call `dict_unref` only when `options` dict is not NULL.

CID: #1487689
Updates: #1060

Signed-off-by: black-dragon74 <niryadav@redhat.com>

