### PR TITLE
[Clang]: Uninitialized argument value

### DIFF
--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -121,8 +121,8 @@ typedef struct ob_inode {
 
 #define OB_POST_FD(_fop, _xl, _frame, _fd, _trigger, _args...)                 \
     do {                                                                       \
-        ob_inode_t *__ob_inode;                                                \
-        fd_t *__first_fd;                                                      \
+        ob_inode_t *__ob_inode = NULL;                                         \
+        fd_t *__first_fd = NULL;                                               \
         ob_state_t __ob_state = ob_open_and_resume_fd(                         \
             _xl, _fd, 0, true, _trigger, &__ob_inode, &__first_fd);            \
         switch (__ob_state) {                                                  \


### PR DESCRIPTION
Issue: 2nd function call argument is an uninitialized value

Fix:Warning arises due to __ob_inode and __first_fd not
initialized so initializes it with NULL

Updates: #1060
Change-Id: If290291f96710d3e41434905ef03ec2ae3fc4a85
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

