### PR TITLE
marker.c: lookup - skip dict ref/unref if marker version is not valid

### DIFF
--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -2978,10 +2978,10 @@ marker_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
         goto check_feature;
 
     xattr_req = xattr_req ? dict_ref(xattr_req) : dict_new();
-    if (xattr_req)
-        unref = _gf_true;
-    else
+    if (!xattr_req) {
         goto err;
+    }
+    unref = _gf_true;
 
     ret = marker_key_replace_with_ver(this, xattr_req);
     if (ret < 0)

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -2975,7 +2975,7 @@ marker_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
     priv = this->private;
 
     if (priv->version <= 0)
-        goto check_feature;
+        goto wind;
 
     xattr_req = xattr_req ? dict_ref(xattr_req) : dict_new();
     if (!xattr_req) {
@@ -2987,7 +2987,6 @@ marker_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
     if (ret < 0)
         goto err;
 
-check_feature:
     if (priv->feature_enabled == 0)
         goto wind;
 


### PR DESCRIPTION
There's no point in doing a dict_ref() (or creating a new dictionary) and then eventually
unref (or deleting) if version <= 0, since no work will be done anyway.

(Could the feature be enabled without a version?)

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

