### PR TITLE
xlator_t: remove inconsistent alignment attribute

### DIFF
--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -802,7 +802,7 @@ struct _xlator {
         gf_atomic_t total_fop_cbk;
         gf_atomic_t interval_fop_cbk;
         gf_latency_t latencies;
-    } stats[GF_FOP_MAXVALUE] __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
+    } stats[GF_FOP_MAXVALUE];
 
     /* Misc */
     eh_t *history; /* event history context */


### PR DESCRIPTION
The 'stats' array inside 'xlator_t' was explicitly aligned to 128 bytes
(CAA_CACHE_LINE_SIZE = 128). Since this is a structure definition, it
caused the whole structure to be considered aligned to 128. That's not
problematic by itself as long as we really allocate the memory blocks
for 'xlator_t' objects at addresses multiple of 128 bytes, because the
compiler may use this fact to generate aligned access instructions
which are faster than unaligned ones.

Since we are not really allocating 'xlator_t' objects at that alignment,
the assumption that the compiler does is wrong, causing a crash.

Fixes: #3417
Change-Id: I33b5021035aae24f0b5ea14e255873da79fc0625
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>