### PR TITLE
io-threads: Use gf_thread_pool to avoid lock contention

### DIFF
--- a/libglusterfs/src/async.c
+++ b/libglusterfs/src/async.c
@@ -629,7 +629,7 @@ gf_async_init(glusterfs_ctx_t *ctx)
 
     gf_async_cleanup();
 
-    if (!ctx->cmd_args.global_threading ||
+    if ((!ctx->cmd_args.global_threading && (!ctx->async_thread))||
         (ctx->process_mode == GF_GLUSTERD_PROCESS)) {
         return 0;
     }
@@ -704,7 +704,10 @@ gf_async_init(glusterfs_ctx_t *ctx)
         gf_async_fatal(-ENOMEM, "No worker thread has started");
     }
 
-    gf_async_ctrl.enabled = true;
+    if (!ctx->async_thread) {
+        gf_log("MY_LOG", GF_LOG_INFO, "Set ctr.enabled to true");
+        gf_async_ctrl.enabled = true;
+    }
 
     ret = 0;
 

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -14,6 +14,7 @@
 #include "glusterfs/defaults.h"
 #include "glusterfs/default-args.h"
 #include "glusterfs/list.h"
+#include "glusterfs/async.h"
 
 typedef struct _call_stub {
     struct list_head list;
@@ -134,6 +135,7 @@ typedef struct _call_stub {
     uint32_t wind;
     default_args_t args;
     default_args_cbk_t args_cbk;
+    gf_async_t async;
 } call_stub_t;
 
 call_stub_t *

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -757,6 +757,7 @@ struct _glusterfs_ctx {
 
     gf_boolean_t cleanup_starting;
     gf_boolean_t destroy_ctx;
+    gf_boolean_t async_thread;
     char *hostname;
     char volume_id[GF_UUID_BUF_SIZE]; /* Used only in protocol/client */
 };

--- a/xlators/performance/io-threads/src/io-threads.h
+++ b/xlators/performance/io-threads/src/io-threads.h
@@ -14,6 +14,7 @@
 #include <glusterfs/compat-errno.h>
 #include <glusterfs/dict.h>
 #include <glusterfs/list.h>
+#include <glusterfs/async.h>
 #include <stdlib.h>
 #include "iot-mem-types.h"
 #include <semaphore.h>


### PR DESCRIPTION
The patch is not ready for review.

Fixes: #3424
Change-Id: Id2a09ec0f71fb33495136a555f303cf79deb5291
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

