### PR TITLE
dht: move defrag total size counter into defrag info

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -465,6 +465,7 @@ struct gf_defrag_info_ {
     uint64_t skipped;
     uint64_t num_dirs_processed;
     uint64_t size_processed;
+    uint64_t total_size;
     gf_lock_t lock;
     pthread_t th;
     struct rpc_clnt *rpc;


### PR DESCRIPTION
Drop unused `g_totalfiles` global variable and move total size
counter into `struct gf_defrag_info_`, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

