### PR TITLE
Converted CALLOC to MALLOC

### DIFF
--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -294,7 +294,7 @@ _run_dir_scan_task(call_frame_t *frame, xlator_t *subvol, loc_t *parent,
     int ret = 0;
     struct syncop_dir_scan_data *scan_data = NULL;
 
-    scan_data = GF_CALLOC(1, sizeof(struct syncop_dir_scan_data),
+    scan_data = GF_MALLOC(sizeof(struct syncop_dir_scan_data),
                           gf_common_mt_scan_data);
     if (!scan_data) {
         ret = -ENOMEM;

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -304,12 +304,12 @@ _run_dir_scan_task(call_frame_t *frame, xlator_t *subvol, loc_t *parent,
     scan_data->subvol = subvol;
     scan_data->parent = parent;
     scan_data->data = data;
-    scan_data->mut = mut;
+    scan_data->q = q;
+    scan_data->entry = entry;
     scan_data->cond = cond;
+    scan_data->mut = mut;
     scan_data->fn = fn;
     scan_data->jobs_running = jobs_running;
-    scan_data->entry = entry;
-    scan_data->q = q;
     scan_data->qlen = qlen;
     scan_data->retval = retval;
 

--- a/libglusterfs/src/throttle-tbf.c
+++ b/libglusterfs/src/throttle-tbf.c
@@ -43,7 +43,7 @@ tbf_init_throttle(unsigned long tokens_required)
 {
     tbf_throttle_t *throttle = NULL;
 
-    throttle = GF_CALLOC(1, sizeof(*throttle), gf_common_mt_tbf_throttle_t);
+    throttle = GF_MALLOC(sizeof(*throttle), gf_common_mt_tbf_throttle_t);
     if (!throttle)
         return NULL;
 
@@ -175,7 +175,7 @@ tbf_init(tbf_opspec_t *tbfspec, unsigned int count)
     tbf_t *tbf = NULL;
     tbf_opspec_t *opspec = NULL;
 
-    tbf = GF_CALLOC(1, TBF_ALLOC_SIZE, gf_common_mt_tbf_t);
+    tbf = GF_MALLOC(TBF_ALLOC_SIZE, gf_common_mt_tbf_t);
     if (!tbf)
         goto error_return;
 

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -33,7 +33,7 @@ __allocate_domain(const char *volume)
 {
     pl_dom_list_t *dom = NULL;
 
-    dom = GF_CALLOC(1, sizeof(*dom), gf_locks_mt_pl_dom_list_t);
+    dom = GF_MALLOC(sizeof(*dom), gf_locks_mt_pl_dom_list_t);
     if (!dom)
         goto out;
 

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -210,7 +210,7 @@ store_eliminate_path(char *str, trash_elim_path **eliminate)
 
     component = strtok_r(str, ",", &strtokptr);
     while (component) {
-        trav = GF_CALLOC(1, sizeof(*trav), gf_trash_mt_trash_elim_path);
+        trav = GF_MALLOC(sizeof(*trav), gf_trash_mt_trash_elim_path);
         if (!trav) {
             ret = ENOMEM;
             goto out;


### PR DESCRIPTION
Converted calloc to malloc as we
already initialized all fields after allocation

Updates: #1000
Change-Id: I3e250fb016f6ea7e949983fcb8e98f1018dbad05
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

