### PR TITLE
server: miscellaneous cleanups

### DIFF
--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -119,22 +119,6 @@ server_decode_groups(call_frame_t *frame, rpcsvc_request_t *req)
 }
 
 void
-server_loc_wipe(loc_t *loc)
-{
-    if (loc->parent) {
-        inode_unref(loc->parent);
-        loc->parent = NULL;
-    }
-
-    if (loc->inode) {
-        inode_unref(loc->inode);
-        loc->inode = NULL;
-    }
-
-    GF_FREE((void *)loc->path);
-}
-
-void
 server_resolve_wipe(server_resolve_t *resolve)
 {
     GF_FREE((void *)resolve->path);
@@ -176,8 +160,8 @@ free_state(server_state_t *state)
 
     GF_FREE((void *)state->name);
 
-    server_loc_wipe(&state->loc);
-    server_loc_wipe(&state->loc2);
+    loc_wipe(&state->loc);
+    loc_wipe(&state->loc2);
 
     server_resolve_wipe(&state->resolve);
     server_resolve_wipe(&state->resolve2);

--- a/xlators/protocol/server/src/server-helpers.h
+++ b/xlators/protocol/server/src/server-helpers.h
@@ -15,25 +15,8 @@
 
 #define CALL_STATE(frame) ((server_state_t *)frame->root->state)
 
-#define XPRT_FROM_FRAME(frame) ((rpc_transport_t *)CALL_STATE(frame)->xprt)
-
-#define SERVER_CONF(frame)                                                     \
-    ((server_conf_t *)XPRT_FROM_FRAME(frame)->this->private)
-
-#define XPRT_FROM_XLATOR(this) ((((server_conf_t *)this->private))->listen)
-
-#define INODE_LRU_LIMIT(this)                                                  \
-    (((server_conf_t *)(this->private))->config.inode_lru_limit)
-
-#define IS_ROOT_INODE(inode) (inode == inode->table->root)
-
-#define IS_NOT_ROOT(pathlen) ((pathlen > 2) ? 1 : 0)
-
 void
 free_state(server_state_t *state);
-
-void
-server_loc_wipe(loc_t *loc);
 
 void
 server_print_request(call_frame_t *frame);

--- a/xlators/protocol/server/src/server-mem-types.h
+++ b/xlators/protocol/server/src/server-mem-types.h
@@ -17,10 +17,8 @@ enum gf_server_mem_types_ {
     gf_server_mt_server_conf_t = gf_common_mt_end + 1,
     gf_server_mt_state_t,
     gf_server_mt_dirent_rsp_t,
-    gf_server_mt_rsp_buf_t,
     gf_server_mt_setvolume_rsp_t,
     gf_server_mt_lock_mig_t,
-    gf_server_mt_compound_rsp_t,
     gf_server_mt_child_status,
     gf_server_mt_end,
 };

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -27,16 +27,7 @@
         ret = RPCSVC_ACTOR_ERROR;                                              \
     } while (0)
 
-extern void
-set_resolve_gfid(client_t *client, uuid_t resolve_gfid, char *on_wire_gfid);
-extern int
-_gf_server_log_setxattr_failure(dict_t *d, char *k, data_t *v, void *tmp);
-extern int
-rpc_receive_common(rpcsvc_request_t *req, call_frame_t **fr,
-                   server_state_t **st, ssize_t *xdrlen, void *args,
-                   void *xdrfn, glusterfs_fop_t fop);
-
-int
+static int
 _gf_server_log_setxattr_failure(dict_t *d, char *k, data_t *v, void *tmp)
 {
     server_state_t *state = NULL;
@@ -67,7 +58,7 @@ forget_inode_if_no_dentry(inode_t *inode)
     return;
 }
 
-void
+static void
 set_resolve_gfid(client_t *client, uuid_t resolve_gfid, char *on_wire_gfid)
 {
     if (client->subdir_mount && __is_root_gfid((unsigned char *)on_wire_gfid)) {
@@ -78,7 +69,7 @@ set_resolve_gfid(client_t *client, uuid_t resolve_gfid, char *on_wire_gfid)
     }
 }
 
-int
+static int
 rpc_receive_common(rpcsvc_request_t *req, call_frame_t **fr,
                    server_state_t **st, ssize_t *xdrlen, void *args,
                    void *xdrfn, glusterfs_fop_t fop)


### PR DESCRIPTION
Drop unused macros, memory types, and useless prototypes,
make functions `static` where appropriate, prefer generic
`loc_wipe()` over (removed) `server_loc_wipe()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000