### PR TITLE
glusterd: use binary uuid to avoid extra conversions

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -320,7 +320,7 @@ static int
 gf_cli_output_peer_status(dict_t *dict, int count)
 {
     int ret = -1;
-    char *uuid_buf = NULL;
+    uuid_t uuid;
     char *hostname_buf = NULL;
     int32_t i = 1;
     char key[256] = {
@@ -335,8 +335,8 @@ gf_cli_output_peer_status(dict_t *dict, int count)
     cli_out("Number of Peers: %d", count);
     i = 1;
     while (i <= count) {
-        keylen = snprintf(key, sizeof(key), "friend%d.uuid", i);
-        ret = dict_get_strn(dict, key, keylen, &uuid_buf);
+        keylen = snprintf(key, sizeof(key), GF_FRIEND_UUID_KEY, i);
+        ret = dict_get_gfuuid(dict, key, &uuid);
         if (ret)
             goto out;
 
@@ -360,7 +360,7 @@ gf_cli_output_peer_status(dict_t *dict, int count)
             goto out;
 
         cli_out("\nHostname: %s\nUuid: %s\nState: %s (%s)", hostname_buf,
-                uuid_buf, state, connected_str);
+                uuid_utoa(uuid), state, connected_str);
 
         keylen = snprintf(key, sizeof(key), "friend%d.hostname_count", i);
         ret = dict_get_int32n(dict, key, keylen, &hostname_count);
@@ -387,7 +387,9 @@ static int
 gf_cli_output_pool_list(dict_t *dict, int count)
 {
     int ret = -1;
-    char *uuid_buf = NULL;
+    uuid_t uuid = {
+        0,
+    };
     char *hostname_buf = NULL;
     int32_t hostname_len = 8; /*min len 8 chars*/
     int32_t i = 1;
@@ -418,8 +420,8 @@ gf_cli_output_pool_list(dict_t *dict, int count)
 
     i = 1;
     while (i <= count) {
-        keylen = snprintf(key, sizeof(key), "friend%d.uuid", i);
-        ret = dict_get_strn(dict, key, keylen, &uuid_buf);
+        keylen = snprintf(key, sizeof(key), GF_FRIEND_UUID_KEY, i);
+        ret = dict_get_gfuuid(dict, key, &uuid);
         if (ret)
             goto out;
 
@@ -437,7 +439,7 @@ gf_cli_output_pool_list(dict_t *dict, int count)
         else
             connected_str = "Disconnected";
 
-        cli_out("%s\t%-*s\t%s ", uuid_buf, hostname_len, hostname_buf,
+        cli_out("%s\t%-*s\t%s ", uuid_utoa(uuid), hostname_len, hostname_buf,
                 connected_str);
         i++;
     }
@@ -9210,6 +9212,9 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
     char key[64] = ""; /* keyprefix is ""status.snap0" */
     int i = 0;
     int volcount = 0;
+    uuid_t uuid = {
+        0,
+    };
     char *get_buffer = NULL;
 
     GF_ASSERT(dict);
@@ -9227,17 +9232,17 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
     }
     cli_out("\nSnap Name : %s", get_buffer);
 
-    ret = snprintf(key, sizeof(key), "%s.uuid", keyprefix);
+    ret = snprintf(key, sizeof(key), GF_UUID_KEY, keyprefix);
     if (ret < 0) {
         goto out;
     }
 
-    ret = dict_get_str(dict, key, &get_buffer);
+    ret = dict_get_gfuuid(dict, key, &uuid);
     if (ret) {
         gf_log("cli", GF_LOG_ERROR, "Unable to get snap UUID");
         goto out;
     }
-    cli_out("Snap UUID : %s", get_buffer);
+    cli_out("Snap UUID : %s", uuid_utoa(uuid));
 
     ret = snprintf(key, sizeof(key), "%s.volcount", keyprefix);
     if (ret < 0) {

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -2424,7 +2424,9 @@ cli_xml_output_vol_info(cli_local_t *local, dict_t *dict)
     int count = 0;
     char *volname = NULL;
     char *volume_id = NULL;
-    char *uuid = NULL;
+    uuid_t uuid = {
+        0,
+    };
     int type = 0;
     int status = 0;
     int brick_count = 0;
@@ -2576,12 +2578,12 @@ cli_xml_output_vol_info(cli_local_t *local, dict_t *dict)
             ret = xmlTextWriterStartElement(local->writer, (xmlChar *)"brick");
             XML_RET_CHECK_AND_GOTO(ret, out);
 
-            snprintf(key, sizeof(key), "volume%d.brick%d.uuid", i, j);
-            ret = dict_get_str(dict, key, &uuid);
+            snprintf(key, sizeof(key), GF_VOLUME_BRICK_UUID_KEY, i, j);
+            ret = dict_get_gfuuid(dict, key, &uuid);
             if (ret)
                 goto out;
             ret = xmlTextWriterWriteFormatAttribute(
-                local->writer, (xmlChar *)"uuid", "%s", uuid);
+                local->writer, (xmlChar *)"uuid", "%s", uuid_utoa(uuid));
             XML_RET_CHECK_AND_GOTO(ret, out);
 
             snprintf(key, sizeof(key), "volume%d.brick%d", i, j);
@@ -2798,7 +2800,9 @@ cli_xml_output_peer_status(dict_t *dict, int op_ret, int op_errno,
     xmlTextWriterPtr writer = NULL;
     xmlDocPtr doc = NULL;
     int count = 0;
-    char *uuid = NULL;
+    uuid_t uuid = {
+        0,
+    };
     char *hostname = NULL;
     int connected = 0;
     int state_id = 0;
@@ -2833,13 +2837,13 @@ cli_xml_output_peer_status(dict_t *dict, int op_ret, int op_errno,
         ret = xmlTextWriterStartElement(writer, (xmlChar *)"peer");
         XML_RET_CHECK_AND_GOTO(ret, out);
 
-        snprintf(key, sizeof(key), "friend%d.uuid", i);
-        ret = dict_get_str(dict, key, &uuid);
+        snprintf(key, sizeof(key), GF_FRIEND_UUID_KEY, i);
+        ret = dict_get_gfuuid(dict, key, &uuid);
         if (ret)
             goto out;
 
         ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"uuid", "%s",
-                                              uuid);
+                                              uuid_utoa(uuid));
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         snprintf(key, sizeof(key), "friend%d.hostname", i);
@@ -2920,7 +2924,9 @@ cli_xml_output_vol_rebalance_status(xmlTextWriterPtr writer, dict_t *dict,
     int ret = -1;
     int count = 0;
     char *node_name = NULL;
-    char *node_uuid = NULL;
+    uuid_t uuid = {
+        0,
+    };
     uint64_t files = 0;
     uint64_t size = 0;
     uint64_t lookups = 0;
@@ -2979,12 +2985,12 @@ cli_xml_output_vol_rebalance_status(xmlTextWriterPtr writer, dict_t *dict,
                                               "%s", node_name);
         XML_RET_CHECK_AND_GOTO(ret, out);
 
-        snprintf(key, sizeof(key), "node-uuid-%d", i);
-        ret = dict_get_str(dict, key, &node_uuid);
+        snprintf(key, sizeof(key), GF_NODE_UUID_KEY, i);
+        ret = dict_get_gfuuid(dict, key, &uuid);
         if (ret)
             goto out;
         ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"id", "%s",
-                                              node_uuid);
+                                              uuid_utoa(uuid));
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         snprintf(key, sizeof(key), "files-%d", i);
@@ -4624,6 +4630,9 @@ cli_xml_snapshot_status_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     int volcount = 0;
     int i = 0;
     char *buffer = NULL;
+    uuid_t uuid = {
+        0,
+    };
     char key[PATH_MAX] = "";
 
     GF_ASSERT(writer);
@@ -4646,16 +4655,16 @@ cli_xml_snapshot_status_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
                                           buffer);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
-    snprintf(key, sizeof(key), "%s.uuid", keyprefix);
+    snprintf(key, sizeof(key), GF_UUID_KEY, keyprefix);
 
-    ret = dict_get_str(dict, key, &buffer);
+    ret = dict_get_gfuuid(dict, key, &uuid);
     if (ret) {
         gf_log("cli", GF_LOG_ERROR, "Unable to get snap UUID");
         goto out;
     }
 
     ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"uuid", "%s",
-                                          buffer);
+                                          uuid_utoa(uuid));
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     snprintf(key, sizeof(key), "%s.volcount", keyprefix);

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -63,7 +63,6 @@
 #define O_PATH 010000000 /* from asm-generic/fcntl.h */
 #endif
 
-
 #ifndef EBADFD
 /* Mac OS X does not have EBADFD */
 #define EBADFD EBADF
@@ -455,6 +454,12 @@ fop_enum_to_pri_string(glusterfs_fop_t fop);
 
 /* key value which quick read uses to get small files in lookup cbk */
 #define GF_CONTENT_KEY "glusterfs.content"
+
+/* Used both in glusterd and cli. */
+#define GF_VOLUME_BRICK_UUID_KEY "volume%d.brick%d.uuid"
+#define GF_FRIEND_UUID_KEY "friend%d.uuid"
+#define GF_NODE_UUID_KEY "node%d.uuid"
+#define GF_UUID_KEY "%s.uuid"
 
 struct _xlator_cmdline_option {
     struct list_head cmd_args;

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -38,9 +38,6 @@ glusterd_chk_peers_connected_befriended(uuid_t skip_uuid);
 char *
 glusterd_uuid_to_hostname(uuid_t uuid);
 
-char *
-gd_peer_uuid_str(glusterd_peerinfo_t *peerinfo);
-
 gf_boolean_t
 glusterd_are_all_peers_up();
 

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -65,9 +65,6 @@ typedef struct glusterd_sm_tr_log_ {
 
 struct glusterd_peerinfo_ {
     uuid_t uuid;
-    char uuid_str[50]; /* Retrieve this using
-                        * gd_peer_uuid_str ()
-                        */
     glusterd_friend_sm_state_t state;
     char *hostname;
     struct cds_list_head hostnames;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -7159,20 +7159,14 @@ glusterd_get_each_snap_object_status(char **op_errstr, dict_t *rsp_dict,
 
     temp = NULL;
 
-    keylen = snprintf(key, sizeof(key), "%s.uuid", keyprefix);
+    keylen = snprintf(key, sizeof(key), GF_UUID_KEY, keyprefix);
     if (keylen < 0) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_COPY_FAIL, NULL);
         ret = -1;
         goto out;
     }
 
-    temp = gf_strdup(uuid_utoa(snap->snap_id));
-    if (temp == NULL) {
-        ret = -1;
-        goto out;
-    }
-
-    ret = dict_set_dynstrn(rsp_dict, key, keylen, temp);
+    ret = dict_set_gfuuid(rsp_dict, key, snap->snap_id, true);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save "

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -424,8 +424,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     char *last_scrub_time = NULL;
     char *scrub_time = NULL;
     char *volname = NULL;
-    char *node_uuid = NULL;
-    char *node_uuid_str = NULL;
+    uuid_t node_uuid;
     char *bitd_log = NULL;
     char *scrub_log = NULL;
     char *scrub_freq = NULL;
@@ -471,13 +470,11 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count in dictonary");
 
-    keylen = snprintf(key, sizeof(key), "node-uuid-%d", src_count);
-    ret = dict_get_strn(rsp_dict, key, keylen, &node_uuid);
+    snprintf(key, sizeof(key), GF_NODE_UUID_KEY, src_count);
+    ret = dict_get_gfuuid(rsp_dict, key, &node_uuid);
     if (!ret) {
-        node_uuid_str = gf_strdup(node_uuid);
-        keylen = snprintf(key, sizeof(key), "node-uuid-%d",
-                          src_count + dst_count);
-        ret = dict_set_dynstrn(aggr, key, keylen, node_uuid_str);
+        snprintf(key, sizeof(key), GF_NODE_UUID_KEY, src_count + dst_count);
+        ret = dict_set_gfuuid(aggr, key, node_uuid, true);
         if (ret) {
             gf_msg_debug(this->name, 0, "failed to set node-uuid");
         }


### PR DESCRIPTION
Prefer binary representation of UUID in peer, friend and snapshot
management code, which is expected to simplify the things and avoid
extra UUID conversions between text and binary representations
within `glusterd`. This comes with a presumably less critical overhead
of doing a few more conversions on client side, which is needed for
printing different objects' status in both textual and XML form.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000