### PR TITLE
WIP: libglusterfs, rpc, bit-rot, glusterd: dict API tweaks

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -2422,7 +2422,8 @@ err:
 }
 
 int
-dict_set_dynstr_with_alloc(dict_t *this, char *key, const char *str)
+dict_set_dynstrn_with_alloc(dict_t *this, char *key, const int keylen,
+                            const char *str)
 {
     char *alloc_str = gf_strdup(str);
     int ret = -1;
@@ -2430,7 +2431,7 @@ dict_set_dynstr_with_alloc(dict_t *this, char *key, const char *str)
     if (!alloc_str)
         return ret;
 
-    ret = dict_set_dynstr(this, key, alloc_str);
+    ret = dict_set_dynstrn(this, key, keylen, alloc_str);
     if (ret == -EINVAL)
         GF_FREE(alloc_str);
 

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -367,7 +367,15 @@ dict_set_dynstr(dict_t *this, char *key, char *str);
 GF_MUST_CHECK int
 dict_set_dynstrn(dict_t *this, char *key, const int keylen, char *str);
 GF_MUST_CHECK int
-dict_set_dynstr_with_alloc(dict_t *this, char *key, const char *str);
+dict_set_dynstrn_with_alloc(dict_t *this, char *key, const int keylen,
+                            const char *str);
+
+static inline int
+dict_set_dynstr_with_alloc(dict_t *this, char *key, const char *str)
+{
+    return dict_set_dynstrn_with_alloc(this, key, strlen(key), str);
+}
+
 GF_MUST_CHECK int
 dict_add_dynstr_with_alloc(dict_t *this, char *key, char *str);
 GF_MUST_CHECK int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -408,7 +408,7 @@ dict_set_double
 dict_set_dynptr
 dict_set_dynstr
 dict_set_dynstrn
-dict_set_dynstr_with_alloc
+dict_set_dynstrn_with_alloc
 dict_set_gfuuid
 dict_set_iatt
 dict_set_mdata

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -2533,6 +2533,7 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
     xlator_list_t *volentry = NULL;
     char *srchkey = NULL;
     char *keyval = NULL;
+    int keylen = -1;
     int ret = -1;
 
     if ((!svc) || (!svc->options) || (!options))
@@ -2546,9 +2547,9 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
     /* Reconfigure the volume specific rpc-auth.addr allow part */
     volentry = xlator->children;
     while (volentry) {
-        ret = gf_asprintf(&srchkey, "rpc-auth.addr.%s.allow",
-                          volentry->xlator->name);
-        if (ret == -1) {
+        keylen = gf_asprintf(&srchkey, "rpc-auth.addr.%s.allow",
+                             volentry->xlator->name);
+        if (keylen == -1) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
             return (-1);
         }
@@ -2564,7 +2565,8 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
          */
         dict_del(svc->options, srchkey);
         if (!dict_get_str(options, srchkey, &keyval)) {
-            ret = dict_set_dynstr_with_alloc(svc->options, srchkey, keyval);
+            ret = dict_set_dynstrn_with_alloc(svc->options, srchkey, keylen,
+                                              keyval);
             if (ret < 0) {
                 gf_log(GF_RPCSVC, GF_LOG_ERROR, "dict_set_str error");
                 GF_FREE(srchkey);
@@ -2579,9 +2581,9 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
     /* Reconfigure the volume specific rpc-auth.addr reject part */
     volentry = xlator->children;
     while (volentry) {
-        ret = gf_asprintf(&srchkey, "rpc-auth.addr.%s.reject",
-                          volentry->xlator->name);
-        if (ret == -1) {
+        keylen = gf_asprintf(&srchkey, "rpc-auth.addr.%s.reject",
+                             volentry->xlator->name);
+        if (keylen == -1) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
             return (-1);
         }
@@ -2596,7 +2598,8 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
          */
         dict_del(svc->options, srchkey);
         if (!dict_get_str(options, srchkey, &keyval)) {
-            ret = dict_set_dynstr_with_alloc(svc->options, srchkey, keyval);
+            ret = dict_set_dynstrn_with_alloc(svc->options, srchkey, keylen,
+                                              keyval);
             if (ret < 0) {
                 gf_log(GF_RPCSVC, GF_LOG_ERROR, "dict_set_str error");
                 GF_FREE(srchkey);

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -1635,6 +1635,7 @@ br_read_bad_object_dir(xlator_t *this, br_child_t *child, fd_t *fd,
     char key[32] = {
         0,
     };
+    int keylen = -1;
     dict_t *out_dict = NULL;
 
     INIT_LIST_HEAD(&entries.list);
@@ -1648,14 +1649,14 @@ br_read_bad_object_dir(xlator_t *this, br_child_t *child, fd_t *fd,
         {
             offset = entry->d_off;
 
-            snprintf(key, sizeof(key), "quarantine-%d", count);
+            keylen = snprintf(key, sizeof(key), "quarantine-%d", count);
 
             /*
              * ignore the dict_set errors for now. The intention is
              * to get as many bad objects as possible instead of
              * erroring out at the first failure.
              */
-            ret = dict_set_dynstr_with_alloc(dict, key, entry->d_name);
+            ret = dict_set_dynstrn_with_alloc(dict, key, keylen, entry->d_name);
             if (!ret)
                 count++;
 
@@ -1785,9 +1786,9 @@ br_collect_bad_objects_of_child(xlator_t *this, br_child_t *child, dict_t *dict,
         if ((len < 0) || (len >= PATH_MAX)) {
             continue;
         }
-        snprintf(main_key, sizeof(main_key), "quarantine-%d", tmp_count);
 
-        ret = dict_set_dynstr_with_alloc(dict, main_key, tmp);
+        len = snprintf(main_key, sizeof(main_key), "quarantine-%d", tmp_count);
+        ret = dict_set_dynstrn_with_alloc(dict, main_key, len, tmp);
         if (!ret)
             tmp_count++;
         path = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1593,9 +1593,9 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                     goto out;
                 }
 
-                snprintf(key, sizeof(key), "brick%d.mount_dir", i + 1);
-                ret = dict_set_dynstr_with_alloc(rsp_dict, key,
-                                                 brickinfo->mount_dir);
+                len = snprintf(key, sizeof(key), "brick%d.mount_dir", i + 1);
+                ret = dict_set_dynstrn_with_alloc(rsp_dict, key, len,
+                                                  brickinfo->mount_dir);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, -ret,
                            GD_MSG_DICT_SET_FAILED, "Failed to set %s", key);

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -2308,9 +2308,9 @@ glusterd_sm_tr_log_transition_add_to_dict(dict_t *dict,
     if (ret)
         goto out;
 
-    snprintf(key, sizeof(key), "log%d-time", count);
+    keylen = snprintf(key, sizeof(key), "log%d-time", count);
     gf_time_fmt_FT(timestr, sizeof timestr, log->transitions[i].time);
-    ret = dict_set_dynstr_with_alloc(dict, key, timestr);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, timestr);
     if (ret)
         goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -609,11 +609,13 @@ glusterd_mgmt_v3_lock(const char *name, uuid_t uuid, uint32_t *op_errno,
 
 #ifdef DEBUG
     char *bt = NULL;
+    int keylen = -1;
 
     /* Saving the backtrace into the pre-allocated buffer, ctx->btbuf*/
     if ((bt = gf_backtrace_save(NULL))) {
-        snprintf(key, sizeof(key), "debug.last-success-bt-%s", key_dup);
-        ret = dict_set_dynstr_with_alloc(priv->mgmt_v3_lock, key, bt);
+        keylen = snprintf(key, sizeof(key), "debug.last-success-bt-%s",
+                          key_dup);
+        ret = dict_set_dynstrn_with_alloc(priv->mgmt_v3_lock, key, keylen, bt);
         if (ret)
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to save "

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -676,6 +676,7 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
                       const char *prefix)
 {
     int ret = -1;
+    int keylen = -1;
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;
     char key[100] = {
@@ -691,8 +692,9 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (prefix != NULL), out);
 
-    snprintf(key, sizeof(key), "%s.uuid", prefix);
-    ret = dict_set_dynstr_with_alloc(dict, key, uuid_utoa(friend->uuid));
+    keylen = snprintf(key, sizeof(key), "%s.uuid", prefix);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                      uuid_utoa(friend->uuid));
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set key %s in dict", key);
@@ -702,10 +704,10 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
     /* Setting the first hostname from the list with this key for backward
      * compatibility
      */
-    snprintf(key, sizeof(key), "%s.hostname", prefix);
+    keylen = snprintf(key, sizeof(key), "%s.hostname", prefix);
     address = cds_list_entry(&friend->hostnames, glusterd_peer_hostname_t,
                              hostname_list);
-    ret = dict_set_dynstr_with_alloc(dict, key, address->hostname);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, address->hostname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set key %s in dict", key);
@@ -723,8 +725,8 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
     {
         GF_VALIDATE_OR_GOTO(this->name, (address != NULL), out);
 
-        snprintf(key, sizeof(key), "%s.hostname%d", prefix, count);
-        ret = dict_set_dynstr_with_alloc(dict, key, address->hostname);
+        keylen = snprintf(key, sizeof(key), "%s.hostname%d", prefix, count);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen, address->hostname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set key %s in dict", key);
@@ -732,8 +734,8 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
         }
         count++;
     }
-    ret = snprintf(key, sizeof(key), "%s.address-count", prefix);
-    ret = dict_set_int32n(dict, key, ret, count);
+    keylen = snprintf(key, sizeof(key), "%s.address-count", prefix);
+    ret = dict_set_int32n(dict, key, keylen, count);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set key %s in dict", key);
@@ -884,6 +886,7 @@ gd_add_peer_hostnames_to_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
                               const char *prefix)
 {
     int ret = -1;
+    int keylen = -1;
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;
     char key[64] = {
@@ -906,8 +909,8 @@ gd_add_peer_hostnames_to_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
 
     cds_list_for_each_entry(addr, &peerinfo->hostnames, hostname_list)
     {
-        snprintf(key, sizeof(key), "%s.hostname%d", prefix, count);
-        ret = dict_set_dynstr_with_alloc(dict, key, addr->hostname);
+        keylen = snprintf(key, sizeof(key), "%s.hostname%d", prefix, count);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen, addr->hostname);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
@@ -916,8 +919,8 @@ gd_add_peer_hostnames_to_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
         count++;
     }
 
-    ret = snprintf(key, sizeof(key), "%s.hostname_count", prefix);
-    ret = dict_set_int32n(dict, key, ret, count);
+    keylen = snprintf(key, sizeof(key), "%s.hostname_count", prefix);
+    ret = dict_set_int32n(dict, key, keylen, count);
 
 out:
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -614,6 +614,7 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
                                 glusterd_volinfo_t *volinfo)
 {
     int ret = -1;
+    int keylen = -1;
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;
     char key[256] = {
@@ -632,9 +633,9 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
         goto out;
     }
 
-    snprintf(key, sizeof(key), "%s.restored_from_snap", prefix);
-    ret = dict_set_dynstr_with_alloc(dict, key,
-                                     uuid_utoa(volinfo->restored_from_snap));
+    keylen = snprintf(key, sizeof(key), "%s.restored_from_snap", prefix);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                      uuid_utoa(volinfo->restored_from_snap));
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Unable to set %s for volume"
@@ -644,9 +645,10 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
     }
 
     if (strlen(volinfo->restored_from_snapname_id) > 0) {
-        snprintf(key, sizeof(key), "%s.restored_from_snapname_id", prefix);
-        ret = dict_set_dynstr_with_alloc(dict, key,
-                                         volinfo->restored_from_snapname_id);
+        keylen = snprintf(key, sizeof(key), "%s.restored_from_snapname_id",
+                          prefix);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          volinfo->restored_from_snapname_id);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set %s for volume"
@@ -657,9 +659,10 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
     }
 
     if (strlen(volinfo->restored_from_snapname) > 0) {
-        snprintf(key, sizeof(key), "%s.restored_from_snapname", prefix);
-        ret = dict_set_dynstr_with_alloc(dict, key,
-                                         volinfo->restored_from_snapname);
+        keylen = snprintf(key, sizeof(key), "%s.restored_from_snapname",
+                          prefix);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          volinfo->restored_from_snapname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set %s for volume"
@@ -670,8 +673,9 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
     }
 
     if (strlen(volinfo->parent_volname) > 0) {
-        snprintf(key, sizeof(key), "%s.parent_volname", prefix);
-        ret = dict_set_dynstr_with_alloc(dict, key, volinfo->parent_volname);
+        keylen = snprintf(key, sizeof(key), "%s.parent_volname", prefix);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          volinfo->parent_volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set %s "
@@ -701,8 +705,9 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
     }
 
     if (strlen(volinfo->snap_plugin) > 0) {
-        snprintf(key, sizeof(key), "%s.snap_plugin", prefix);
-        ret = dict_set_dynstr_with_alloc(dict, key, volinfo->snap_plugin);
+        keylen = snprintf(key, sizeof(key), "%s.snap_plugin", prefix);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          volinfo->snap_plugin);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set %s "
@@ -723,6 +728,7 @@ glusterd_add_missed_snaps_to_export_dict(dict_t *peer_data)
     char value[PATH_MAX] = "";
     int32_t missed_snap_count = 0;
     int32_t ret = -1;
+    int keylen = -1;
     glusterd_conf_t *priv = NULL;
     glusterd_missed_snap_info *missed_snapinfo = NULL;
     glusterd_snap_op_t *snap_opinfo = NULL;
@@ -740,15 +746,16 @@ glusterd_add_missed_snaps_to_export_dict(dict_t *peer_data)
         cds_list_for_each_entry(snap_opinfo, &missed_snapinfo->snap_ops,
                                 snap_ops_list)
         {
-            snprintf(name_buf, sizeof(name_buf), "missed_snaps_%d",
-                     missed_snap_count);
+            keylen = snprintf(name_buf, sizeof(name_buf), "missed_snaps_%d",
+                              missed_snap_count);
             snprintf(value, sizeof(value), "%s:%s=%s:%d:%s:%d:%d",
                      missed_snapinfo->node_uuid, missed_snapinfo->snap_uuid,
                      snap_opinfo->snap_vol_id, snap_opinfo->brick_num,
                      snap_opinfo->brick_path, snap_opinfo->op,
                      snap_opinfo->status);
 
-            ret = dict_set_dynstr_with_alloc(peer_data, name_buf, value);
+            ret = dict_set_dynstrn_with_alloc(peer_data, name_buf, keylen,
+                                              value);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Unable to set %s", name_buf);
@@ -777,6 +784,7 @@ glusterd_add_snap_to_dict(glusterd_snap_t *snap, dict_t *peer_data,
     char buf[64] = "";
     char prefix[32] = "";
     int32_t ret = -1;
+    int keylen = -1;
     int32_t volcount = 0;
     glusterd_volinfo_t *volinfo = NULL;
     glusterd_brickinfo_t *brickinfo = NULL;
@@ -838,16 +846,17 @@ glusterd_add_snap_to_dict(glusterd_snap_t *snap, dict_t *peer_data,
         goto out;
     }
 
-    snprintf(buf, sizeof(buf), "%s.snapname", prefix);
-    ret = dict_set_dynstr_with_alloc(peer_data, buf, snap->snapname);
+    keylen = snprintf(buf, sizeof(buf), "%s.snapname", prefix);
+    ret = dict_set_dynstrn_with_alloc(peer_data, buf, keylen, snap->snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Unable to set snapname for snap %s", snap->snapname);
         goto out;
     }
 
-    snprintf(buf, sizeof(buf), "%s.snap_id", prefix);
-    ret = dict_set_dynstr_with_alloc(peer_data, buf, uuid_utoa(snap->snap_id));
+    keylen = snprintf(buf, sizeof(buf), "%s.snap_id", prefix);
+    ret = dict_set_dynstrn_with_alloc(peer_data, buf, keylen,
+                                      uuid_utoa(snap->snap_id));
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Unable to set snap_id for snap %s", snap->snapname);
@@ -855,8 +864,9 @@ glusterd_add_snap_to_dict(glusterd_snap_t *snap, dict_t *peer_data,
     }
 
     if (snap->description) {
-        snprintf(buf, sizeof(buf), "%s.description", prefix);
-        ret = dict_set_dynstr_with_alloc(peer_data, buf, snap->description);
+        keylen = snprintf(buf, sizeof(buf), "%s.description", prefix);
+        ret = dict_set_dynstrn_with_alloc(peer_data, buf, keylen,
+                                          snap->description);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set description for snap %s", snap->snapname);

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -1425,7 +1425,7 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
             continue;
         }
 
-        ret = dict_set_dynstr_with_alloc(dst, key, value);
+        ret = dict_set_dynstrn_with_alloc(dst, key, keylen, value);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
@@ -1453,9 +1453,10 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
                 goto out;
             }
 
-            snprintf(key, sizeof(key), "vol%" PRId64 ".brickdir%" PRId64, i + 1,
-                     brick_order);
-            ret = dict_set_dynstr_with_alloc(dst, key, snap_brick_dir);
+            keylen = snprintf(key, sizeof(key),
+                              "vol%" PRId64 ".brickdir%" PRId64, i + 1,
+                              brick_order);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, snap_brick_dir);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set %s", key);
@@ -1471,9 +1472,9 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
                 continue;
             }
 
-            snprintf(key, sizeof(key), "vol%" PRId64 ".fstype%" PRId64, i + 1,
-                     brick_order);
-            ret = dict_set_dynstr_with_alloc(dst, key, value);
+            keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".fstype%" PRId64,
+                              i + 1, brick_order);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, value);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set %s", key);
@@ -1489,9 +1490,10 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
                 continue;
             }
 
-            snprintf(key, sizeof(key), "vol%" PRId64 ".snap_type%" PRId64,
-                     i + 1, brick_order);
-            ret = dict_set_dynstr_with_alloc(dst, key, value);
+            keylen = snprintf(key, sizeof(key),
+                              "vol%" PRId64 ".snap_type%" PRId64, i + 1,
+                              brick_order);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, value);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set %s", key);
@@ -1507,9 +1509,10 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
                 continue;
             }
 
-            snprintf(key, sizeof(key), "vol%" PRId64 ".mnt_opts%" PRId64, i + 1,
-                     brick_order);
-            ret = dict_set_dynstr_with_alloc(dst, key, value);
+            keylen = snprintf(key, sizeof(key),
+                              "vol%" PRId64 ".mnt_opts%" PRId64, i + 1,
+                              brick_order);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, value);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set %s", key);
@@ -1525,10 +1528,10 @@ glusterd_snap_create_clone_pre_val_use_rsp_dict(dict_t *dst, dict_t *src)
                 goto out;
             }
 
-            snprintf(key, sizeof(key),
-                     "vol%" PRId64 ".brick_snapdevice%" PRId64, i + 1,
-                     brick_order);
-            ret = dict_set_dynstr_with_alloc(dst, key, snap_device);
+            keylen = snprintf(key, sizeof(key),
+                              "vol%" PRId64 ".brick_snapdevice%" PRId64, i + 1,
+                              brick_order);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, snap_device);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set %s", key);
@@ -1611,7 +1614,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                 ret = 0;
                 continue;
             }
-            ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to set %s", key);
                 goto out;
@@ -1640,7 +1643,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                        "Failed to get %s", key);
                 goto out;
             }
-            ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to set %s", key);
                 goto out;
@@ -1653,7 +1656,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to get %s", key);
             } else {
-                ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+                ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
                 if (ret) {
                     gf_msg_debug(this->name, 0, "Failed to set %s", key);
                     goto out;
@@ -1667,7 +1670,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                        "Failed to get %s", key);
                 goto out;
             }
-            ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to set %s", key);
                 goto out;
@@ -1681,7 +1684,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                        "Failed to get %s", key);
                 goto out;
             }
-            ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to set %s", key);
                 goto out;
@@ -1695,7 +1698,7 @@ glusterd_snap_restore_use_rsp_dict(dict_t *dst, dict_t *src)
                        "Failed to get %s", key);
                 goto out;
             }
-            ret = dict_set_dynstr_with_alloc(dst, key, strvalue);
+            ret = dict_set_dynstrn_with_alloc(dst, key, keylen, strvalue);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to set %s", key);
                 goto out;
@@ -1813,6 +1816,7 @@ glusterd_snap_create_clone_common_prevalidate(
     char key[128] = "";
     int ret = -1;
     int64_t i = 1;
+    int keylen = -1;
     int64_t brick_order = 0;
     int64_t brick_count = 0;
     xlator_t *this = THIS;
@@ -1883,8 +1887,9 @@ glusterd_snap_create_clone_common_prevalidate(
             goto out;
         }
 
-        snprintf(key, sizeof(key), "vol%" PRId64 ".snap_plugin", i);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, brickinfo->snap->name);
+        keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".snap_plugin", i);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                          brickinfo->snap->name);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
@@ -1893,9 +1898,10 @@ glusterd_snap_create_clone_common_prevalidate(
 
         snprintf(device, sizeof(device), "%s_%" PRId64, snap_volname,
                  brick_order);
-        snprintf(key, sizeof(key), "vol%" PRId64 ".brick_snapdevice%" PRId64, i,
-                 brick_count);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, device);
+        keylen = snprintf(key, sizeof(key),
+                          "vol%" PRId64 ".brick_snapdevice%" PRId64, i,
+                          brick_count);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen, device);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
@@ -1910,36 +1916,40 @@ glusterd_snap_create_clone_common_prevalidate(
                    brickinfo->path);
         }
 
-        snprintf(key, sizeof(key), "vol%" PRId64 ".fstype%" PRId64, i,
-                 brick_count);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, brickinfo->fstype);
+        keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".fstype%" PRId64, i,
+                          brick_count);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                          brickinfo->fstype);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
             goto out;
         }
 
-        snprintf(key, sizeof(key), "vol%" PRId64 ".snap_type%" PRId64, i,
-                 brick_count);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, brickinfo->snap_type);
+        keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".snap_type%" PRId64,
+                          i, brick_count);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                          brickinfo->snap_type);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
             goto out;
         }
 
-        snprintf(key, sizeof(key), "vol%" PRId64 ".mnt_opts%" PRId64, i,
-                 brick_count);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, brickinfo->mnt_opts);
+        keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".mnt_opts%" PRId64,
+                          i, brick_count);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                          brickinfo->mnt_opts);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
             goto out;
         }
 
-        snprintf(key, sizeof(key), "vol%" PRId64 ".brickdir%" PRId64, i,
-                 brick_count);
-        ret = dict_set_dynstr_with_alloc(rsp_dict, key, brickinfo->mount_dir);
+        keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".brickdir%" PRId64,
+                          i, brick_count);
+        ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                          brickinfo->mount_dir);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
@@ -3486,6 +3496,7 @@ int
 glusterd_snapshot_get_vol_snapnames(dict_t *dict, glusterd_volinfo_t *volinfo)
 {
     int ret = -1;
+    int keylen = -1;
     int snapcount = 0;
     char *snapname = NULL;
     char key[32] = "";
@@ -3500,10 +3511,9 @@ glusterd_snapshot_get_vol_snapnames(dict_t *dict, glusterd_volinfo_t *volinfo)
                                  snapvol_list)
     {
         snapcount++;
-        snprintf(key, sizeof(key), "snapname%d", snapcount);
-
-        ret = dict_set_dynstr_with_alloc(dict, key,
-                                         snap_vol->snapshot->snapname);
+        keylen = snprintf(key, sizeof(key), "snapname%d", snapcount);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          snap_vol->snapshot->snapname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to "
@@ -3757,8 +3767,8 @@ glusterd_handle_snapshot_create(rpcsvc_request_t *req, glusterd_op_t op,
             goto out;
         }
         GLUSTERD_GET_UUID_NOHYPHEN(snap_volname, *uuid_ptr);
-        snprintf(key, sizeof(key), "snap-volname%d", i);
-        ret = dict_set_dynstr_with_alloc(dict, key, snap_volname);
+        keylen = snprintf(key, sizeof(key), "snap-volname%d", i);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen, snap_volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set snap volname");
@@ -3944,8 +3954,8 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
         GF_FREE(uuid_ptr);
         goto out;
     }
-    snprintf(key, sizeof(key), "clone-volname%d", i);
-    ret = dict_set_dynstr_with_alloc(dict, key, snap_volname);
+    keylen = snprintf(key, sizeof(key), "clone-volname%d", i);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, snap_volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Unable to set snap volname");
@@ -4189,6 +4199,7 @@ glusterd_add_missed_snaps_to_dict(dict_t *rsp_dict,
     char name_buf[PATH_MAX] = "";
     int32_t missed_snap_count = -1;
     int32_t ret = -1;
+    int keylen = -1;
     xlator_t *this = THIS;
     int32_t len = 0;
 
@@ -4222,8 +4233,10 @@ glusterd_add_missed_snaps_to_dict(dict_t *rsp_dict,
     }
 
     /* Setting the missed_snap_entry in the rsp_dict */
-    snprintf(name_buf, sizeof(name_buf), "missed_snaps_%d", missed_snap_count);
-    ret = dict_set_dynstr_with_alloc(rsp_dict, name_buf, missed_snap_entry);
+    keylen = snprintf(name_buf, sizeof(name_buf), "missed_snaps_%d",
+                      missed_snap_count);
+    ret = dict_set_dynstrn_with_alloc(rsp_dict, name_buf, keylen,
+                                      missed_snap_entry);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set missed_snap_entry (%s) "
@@ -4349,13 +4362,14 @@ glusterd_add_brick_to_snap_volume(dict_t *dict, dict_t *rsp_dict,
     GF_ASSERT(snap_vol);
     GF_ASSERT(original_brickinfo);
 
-    snprintf(key, sizeof(key), "vol%" PRId64 ".origin_path%d", volcount,
-             brick_count);
+    keylen = snprintf(key, sizeof(key), "vol%" PRId64 ".origin_path%d",
+                      volcount, brick_count);
     if (clone)
-        ret = dict_set_dynstr_with_alloc(dict, key,
-                                         original_brickinfo->origin_path);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          original_brickinfo->origin_path);
     else
-        ret = dict_set_dynstr_with_alloc(dict, key, original_brickinfo->path);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          original_brickinfo->path);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
@@ -5288,7 +5302,7 @@ glusterd_handle_snapshot_delete_all(dict_t *dict)
             goto out;
         }
 
-        ret = dict_set_dynstr_with_alloc(dict, key, snap->snapname);
+        ret = dict_set_dynstrn_with_alloc(dict, key, ret, snap->snapname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Could not save "
@@ -9431,6 +9445,7 @@ glusterd_snapshot_get_volnames_uuids(dict_t *dict, char *volname,
     glusterd_volinfo_t *tmp_vol = NULL;
     xlator_t *this = THIS;
     int op_errno = 0;
+    int keylen = -1;
 
     GF_ASSERT(volname);
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, dict, out, op_errno, EINVAL);
@@ -9455,9 +9470,9 @@ glusterd_snapshot_get_volnames_uuids(dict_t *dict, char *volname,
         snapcount++;
 
         /* Set Snap Name */
-        snprintf(key, sizeof(key), "snapname.%d", snapcount);
-        ret = dict_set_dynstr_with_alloc(dict, key,
-                                         snap_vol->snapshot->snapname);
+        keylen = snprintf(key, sizeof(key), "snapname.%d", snapcount);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          snap_vol->snapshot->snapname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set "
@@ -9466,9 +9481,9 @@ glusterd_snapshot_get_volnames_uuids(dict_t *dict, char *volname,
         }
 
         /* Set Snap ID */
-        snprintf(key, sizeof(key), "snap-id.%d", snapcount);
-        ret = dict_set_dynstr_with_alloc(
-            dict, key, uuid_utoa(snap_vol->snapshot->snap_id));
+        keylen = snprintf(key, sizeof(key), "snap-id.%d", snapcount);
+        ret = dict_set_dynstrn_with_alloc(
+            dict, key, keylen, uuid_utoa(snap_vol->snapshot->snap_id));
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set "
@@ -9477,8 +9492,8 @@ glusterd_snapshot_get_volnames_uuids(dict_t *dict, char *volname,
         }
 
         /* Snap Volname which is used to activate the snap vol */
-        snprintf(key, sizeof(key), "snap-volname.%d", snapcount);
-        ret = dict_set_dynstr_with_alloc(dict, key, snap_vol->volname);
+        keylen = snprintf(key, sizeof(key), "snap-volname.%d", snapcount);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen, snap_vol->volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set "

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -562,9 +562,10 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
                               src_count);
             ret = dict_get_strn(rsp_dict, key, keylen, &bad_gfid_str);
             if (!ret) {
-                snprintf(key, sizeof(key), "quarantine-%d-%d", j,
-                         src_count + dst_count);
-                ret = dict_set_dynstr_with_alloc(aggr, key, bad_gfid_str);
+                keylen = snprintf(key, sizeof(key), "quarantine-%d-%d", j,
+                                  src_count + dst_count);
+                ret = dict_set_dynstrn_with_alloc(aggr, key, keylen,
+                                                  bad_gfid_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Failed to"

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3012,8 +3012,9 @@ glusterd_add_volume_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
         if (ret)
             goto out;
 
-        snprintf(key, sizeof(key), "%s.brick%d.uuid", pfx, i);
-        ret = dict_set_dynstr_with_alloc(dict, key, uuid_utoa(brickinfo->uuid));
+        keylen = snprintf(key, sizeof(key), "%s.brick%d.uuid", pfx, i);
+        ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                          uuid_utoa(brickinfo->uuid));
         if (ret)
             goto out;
 
@@ -3053,9 +3054,9 @@ glusterd_add_volume_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
             if (ret)
                 goto out;
 
-            snprintf(key, sizeof(key), "%s.ta-brick%d.uuid", pfx, i);
-            ret = dict_set_dynstr_with_alloc(dict, key,
-                                             uuid_utoa(ta_brickinfo->uuid));
+            keylen = snprintf(key, sizeof(key), "%s.ta-brick%d.uuid", pfx, i);
+            ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                              uuid_utoa(ta_brickinfo->uuid));
             if (ret)
                 goto out;
 
@@ -3106,6 +3107,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
     xlator_t *this = THIS;
     char type = 0;
     float version = 0.0f;
+    int keylen = -1;
 
     GF_ASSERT(prefix);
 
@@ -3139,8 +3141,9 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
             goto out;
         }
 
-        snprintf(key, sizeof(key) - 1, "%s.gfid%d", key_prefix, gfid_idx);
-        ret = dict_set_dynstr_with_alloc(load, key, uuid_utoa(buf));
+        keylen = snprintf(key, sizeof(key) - 1, "%s.gfid%d", key_prefix,
+                          gfid_idx);
+        ret = dict_set_dynstrn_with_alloc(load, key, keylen, uuid_utoa(buf));
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=%s", key, NULL);
@@ -6678,6 +6681,7 @@ _local_gsyncd_start(dict_t *this, char *key, data_t *value, void *data)
     gf_boolean_t is_template_in_use = _gf_false;
     gf_boolean_t is_paused = _gf_false;
     char key1[1024] = "";
+    int keylen = 0;
     xlator_t *this1 = THIS;
 
     priv = this1->private;
@@ -6762,7 +6766,8 @@ _local_gsyncd_start(dict_t *this, char *key, data_t *value, void *data)
     }
 
     /* Form key1 which is "<user@><secondary_host>::<secondaryvol>" */
-    snprintf(key1, sizeof(key1), "%s::%s", secondary_url, secondary_vol);
+    keylen = snprintf(key1, sizeof(key1), "%s::%s", secondary_url,
+                      secondary_vol);
 
     /* Looks for the last status, to find if the session was running
      * when the node went down. If the session was just created or
@@ -6789,8 +6794,8 @@ _local_gsyncd_start(dict_t *this, char *key, data_t *value, void *data)
                              NULL, _gf_true);
     } else {
         /* Add secondary to the dict indicating geo-rep session is running*/
-        ret = dict_set_dynstr_with_alloc(volinfo->gsync_active_secondaries,
-                                         key1, "running");
+        ret = dict_set_dynstrn_with_alloc(volinfo->gsync_active_secondaries,
+                                          key1, keylen, "running");
         if (ret) {
             gf_msg(this1->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Unable to set key:%s"
@@ -7008,9 +7013,10 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     struct fs_info *fs = NULL;
     static dict_t *cached_fs = NULL;
     xlator_t *this = THIS;
+    int keylen = -1;
 
-    ret = snprintf(key, sizeof(key), "brick%d.device", count);
-    ret = dict_get_strn(dict, key, ret, &device);
+    keylen = snprintf(key, sizeof(key), "brick%d.device", count);
+    ret = dict_get_strn(dict, key, keylen, &device);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", key, NULL);
@@ -7114,9 +7120,8 @@ glusterd_add_inode_size_to_dict(dict_t *dict, int count)
     }
 
 cached:
-    snprintf(key, sizeof(key), "brick%d.inode_size", count);
-
-    ret = dict_set_dynstr_with_alloc(dict, key, cur_word);
+    keylen = snprintf(key, sizeof(key), "brick%d.inode_size", count);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, cur_word);
 
 out:
     if (ret)
@@ -7170,6 +7175,7 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
                                  int count)
 {
     int ret = -1;
+    int keylen = -1;
     char key[64] = "";
     char buff[PATH_MAX] = "";
     char base_key[32] = "";
@@ -7197,9 +7203,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
     }
 
     /* get device file */
-    snprintf(key, sizeof(key), "%s.device", base_key);
-
-    ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_fsname);
+    keylen = snprintf(key, sizeof(key), "%s.device", base_key);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, entry->mnt_fsname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", key, NULL);
@@ -7207,9 +7212,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
     }
 
     /* fs type */
-    snprintf(key, sizeof(key), "%s.fs_name", base_key);
-
-    ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_type);
+    keylen = snprintf(key, sizeof(key), "%s.fs_name", base_key);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, entry->mnt_type);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", key, NULL);
@@ -7217,9 +7221,8 @@ glusterd_add_brick_mount_details(glusterd_brickinfo_t *brickinfo, dict_t *dict,
     }
 
     /* mount options */
-    snprintf(key, sizeof(key), "%s.mnt_options", base_key);
-
-    ret = dict_set_dynstr_with_alloc(dict, key, entry->mnt_opts);
+    keylen = snprintf(key, sizeof(key), "%s.mnt_options", base_key);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen, entry->mnt_opts);
 
 out:
     if (mnt_pt)
@@ -7402,8 +7405,9 @@ glusterd_add_brick_to_dict(glusterd_volinfo_t *volinfo,
         goto out;
 
     /* add peer uuid */
-    snprintf(key, sizeof(key), "%s.peerid", base_key);
-    ret = dict_set_dynstr_with_alloc(dict, key, uuid_utoa(brickinfo->uuid));
+    keylen = snprintf(key, sizeof(key), "%s.peerid", base_key);
+    ret = dict_set_dynstrn_with_alloc(dict, key, keylen,
+                                      uuid_utoa(brickinfo->uuid));
     if (ret) {
         goto out;
     }
@@ -9180,7 +9184,7 @@ glusterd_aggr_brick_mount_dirs(dict_t *aggr, dict_t *rsp_dict)
             continue;
         }
 
-        ret = dict_set_dynstr_with_alloc(aggr, key, brick_mount_dir);
+        ret = dict_set_dynstrn_with_alloc(aggr, key, keylen, brick_mount_dir);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s", key);
@@ -9815,8 +9819,8 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
 
     snprintf(buf, sizeof(buf), "%s", uuid_utoa(MY_UUID));
 
-    snprintf(key, sizeof(key), "node-uuid-%d", i);
-    ret = dict_set_dynstr_with_alloc(aggr, key, buf);
+    keylen = snprintf(key, sizeof(key), "node-uuid-%d", i);
+    ret = dict_set_dynstrn_with_alloc(aggr, key, keylen, buf);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "failed to set node-uuid");
@@ -9958,8 +9962,9 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
             keylen = snprintf(key, sizeof(key), "quarantine-%d", j);
             ret = dict_get_strn(rsp_dict, key, keylen, &bad_gfid_str);
             if (!ret) {
-                snprintf(key, sizeof(key), "quarantine-%d-%d", j, i);
-                ret = dict_set_dynstr_with_alloc(aggr, key, bad_gfid_str);
+                keylen = snprintf(key, sizeof(key), "quarantine-%d-%d", j, i);
+                ret = dict_set_dynstrn_with_alloc(aggr, key, keylen,
+                                                  bad_gfid_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Failed to"
@@ -11503,8 +11508,8 @@ glusterd_get_global_max_op_version(rpcsvc_request_t *req, dict_t *ctx,
         goto out;
     }
 
-    sprintf(dict_key, "value%d", count);
-    ret = dict_set_dynstr_with_alloc(ctx, dict_key, def_val);
+    keylen = sprintf(dict_key, "value%d", count);
+    ret = dict_set_dynstrn_with_alloc(ctx, dict_key, keylen, def_val);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set %s for key %s in dictionary", def_val,
@@ -11533,6 +11538,7 @@ glusterd_get_global_options_for_all_vols(rpcsvc_request_t *req, dict_t *ctx,
     char err_str[PATH_MAX] = "";
     char *allvolopt = NULL;
     int32_t i = 0;
+    int keylen = -1;
     gf_boolean_t exists = _gf_false;
     gf_boolean_t need_free = _gf_false;
 
@@ -11603,16 +11609,16 @@ glusterd_get_global_options_for_all_vols(rpcsvc_request_t *req, dict_t *ctx,
         }
 
         count++;
-        ret = sprintf(dict_key, "key%d", count);
-        ret = dict_set_strn(ctx, dict_key, ret, allvolopt);
+        keylen = snprintf(dict_key, sizeof(dict_key), "key%d", count);
+        ret = dict_set_strn(ctx, dict_key, keylen, allvolopt);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s in dictionary", allvolopt);
             goto out;
         }
 
-        sprintf(dict_key, "value%d", count);
-        ret = dict_set_dynstr_with_alloc(ctx, dict_key, def_val);
+        keylen = snprintf(dict_key, sizeof(dict_key), "value%d", count);
+        ret = dict_set_dynstrn_with_alloc(ctx, dict_key, keylen, def_val);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set %s for key %s in dictionary", def_val,
@@ -11741,14 +11747,15 @@ glusterd_get_default_val_for_volopt(dict_t *ctx, gf_boolean_t all_opts,
                    vme->key);
             goto out;
         }
-        sprintf(dict_key, "value%d", count);
+        keylen = sprintf(dict_key, "value%d", count);
         if (get_value_vme) {  // the value was never changed  - DEFAULT is used
             gf_asprintf(&def_val_str, "%s (DEFAULT)", def_val);
-            ret = dict_set_dynstr_with_alloc(ctx, dict_key, def_val_str);
+            ret = dict_set_dynstrn_with_alloc(ctx, dict_key, keylen,
+                                              def_val_str);
             GF_FREE(def_val_str);
             def_val_str = NULL;
         } else
-            ret = dict_set_dynstr_with_alloc(ctx, dict_key, def_val);
+            ret = dict_set_dynstrn_with_alloc(ctx, dict_key, keylen, def_val);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to "

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -906,6 +906,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
     int32_t local_brick_count = 0;
     int32_t i = 0;
     int32_t type = 0;
+    int keylen = -1;
     int32_t replica_count = 0;
     int32_t disperse_count = 0;
     char *brick = NULL;
@@ -1104,9 +1105,9 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
                     goto out;
                 }
 
-                snprintf(key, sizeof(key), "brick%d.mount_dir", i);
-                ret = dict_set_dynstr_with_alloc(rsp_dict, key,
-                                                 brick_info->mount_dir);
+                keylen = snprintf(key, sizeof(key), "brick%d.mount_dir", i);
+                ret = dict_set_dynstrn_with_alloc(rsp_dict, key, keylen,
+                                                  brick_info->mount_dir);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                            "Failed to set %s", key);
@@ -1382,9 +1383,10 @@ glusterd_op_stage_start_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                     goto out;
                 }
 
-                snprintf(key, sizeof(key), "brick%d.mount_dir", brick_count);
-                ret = dict_set_dynstr_with_alloc(rsp_dict, key,
-                                                 brickinfo->mount_dir);
+                len = snprintf(key, sizeof(key), "brick%d.mount_dir",
+                               brick_count);
+                ret = dict_set_dynstrn_with_alloc(rsp_dict, key, len,
+                                                  brickinfo->mount_dir);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                            "Failed to set %s", key);


### PR DESCRIPTION
This patch tries to bring up the following small but hopefully
useful tweaks:

1. Help the compiler to optimize the case:
```
dict_set_dynstr_with_alloc(dict, [compile-time constant], val);
```
by exposing a call to `strlen([compile-time-constant])` to an
inline function.

2. Fix the following suboptimal code fragments:
```
snprintf(key, sizeof(key), [format-string], args);
dict_set_dynstr_with_alloc(dict, key, val);
```
This code is suboptimal because the length of `key` is calculated
at least twice: first time in `snprintf()`, where the final key
length is returned from, and second time in `dict_set_dynstr()`
called from `dict_set_dynstr_with_alloc()`. To avoid this (and
adjust all of the cases to follow the common convention), code
similar to the above should use `dict_set_dynstrn_with_alloc()`:
```
keylen = snprintf(key, sizeof(key), [format-string], args);
dict_set_dynstrn_with_alloc(dict, key, keylen, val);
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000