### PR TITLE
Clang:Uninitialized argument value [open-behind]

### DIFF
--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -143,8 +143,8 @@ typedef struct ob_inode {
 
 #define OB_POST_FLUSH(_xl, _frame, _fd, _args...)                              \
     do {                                                                       \
-        ob_inode_t *__ob_inode;                                                \
-        fd_t *__first_fd;                                                      \
+        ob_inode_t *__ob_inode = NULL;                                         \
+        fd_t *__first_fd = NULL;                                               \
         ob_state_t __ob_state = ob_open_and_resume_fd(                         \
             _xl, _fd, 0, true, false, &__ob_inode, &__first_fd);               \
         switch (__ob_state) {                                                  \
@@ -447,7 +447,7 @@ ob_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags, fd_t *fd,
     ob_inode_t *ob_inode = NULL;
     call_frame_t *open_frame;
     call_stub_t *stub;
-    fd_t *first_fd;
+    fd_t *first_fd = NULL;
     ob_state_t state;
 
     state = ob_open_behind(this, fd, flags, &ob_inode, &first_fd);
@@ -520,7 +520,7 @@ ob_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 {
     ob_inode_t *ob_inode = NULL;
     call_stub_t *stub;
-    fd_t *first_fd;
+    fd_t *first_fd = NULL;
     ob_state_t state;
 
     /* Create requests are never delayed. We always send them synchronously. */


### PR DESCRIPTION
Issue: 2nd function call argument is an uninitialized value
       3rd function call argument is an uninitialized value

Fix: Warning arises due to __ob_inode and __first_fd not
initialized so initializes it with NULL at various positions 

Updates: #1060
Change-Id: I527f9baaf4594391876097a801b5060316b6bfe3
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

