### PR TITLE
Clang-null dereference fix[syncop.c]

### DIFF
--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -1570,6 +1570,8 @@ syncop_readdir(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
         0,
     };
 
+    INIT_LIST_HEAD(&args.entries.list);
+
     SYNCOP(subvol, (&args), syncop_readdir_cbk, subvol->fops->readdir, fd, size,
            off, xdata_in);
 


### PR DESCRIPTION
Since args.entries.list is not initialized "prev" stores a null pointer which results in null de-reference as below in __list_splice() which is called by list_splice_init().
`(list->prev)->next` 

Updates: #1060 
Change-Id: Ia170dfc6e0aa442cf4d0afe43a136f58935d2c1e
Signed-off-by: Harshita Shree hshree@redhat.com
