### PR TITLE
WIP: libglusterfs: internal dict tweaks

### DIFF
--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -102,6 +102,7 @@ struct _data_pair {
     struct _data_pair *next;
     data_t *value;
     char *key;
+    uint32_t keylen;
 };
 
 struct _dict {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3278,7 +3278,7 @@ glusterd_dict_searialize(dict_t *dict_arr[], int count, int totcount, char *buf)
                     goto out;
                 }
 
-                keylen = strlen(pair->key);
+                keylen = pair->keylen;
                 netword = htobe32(keylen);
                 memcpy(buf, &netword, sizeof(netword));
                 buf += DICT_DATA_HDR_KEY_LEN;


### PR DESCRIPTION
This patch tries to utilize an assumption that the length
of most keys used in dict operations are either may be
optimized from `strlen([compile-time constant])` like in:
```
dict_op(dict, "key", val);
```
or specified explicitly with `SLEN()` macro:
```
dict_opn(dict, "key", SLEN("key"), val);
```
or calculated when the key is generated by using formatted
output:
```
keylen = snprintf(key, sizeof(key), format, args);
dict_opn(dict, key, keylen, val);
```
So if key length is known, it may be helpful to record it
internally, which may be useful to 1) avoid internal calls to
`strlen()` and 2) prefer `memcpy()`/`memcmp()` over (presumably
slower) `strcpy()`/`strcmp()`, at the cost of having extra
`uint32_t` member within `struct _data_pair`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000
