### PR TITLE
refactor logging.c - remove 'THIS' where possible, use 'log instead of 'ctx' where possible

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1759,17 +1759,17 @@ logging_init(glusterfs_ctx_t *ctx, const char *progpath)
     }
 
     /* finish log set parameters before init */
-    gf_log_set_loglevel(ctx, cmd_args->log_level);
+    ctx->log.loglevel = cmd_args->log_level;
 
-    gf_log_set_localtime(cmd_args->localtime_logging);
+    ctx->log.localtime = cmd_args->localtime_logging;
 
-    gf_log_set_logger(cmd_args->logger);
+    ctx->log.logger = cmd_args->logger;
 
-    gf_log_set_logformat(cmd_args->log_format);
+    ctx->log.logformat = cmd_args->log_format;
 
-    gf_log_set_log_buf_size(cmd_args->log_buf_size);
+    gf_log_set_log_buf_size(ctx, cmd_args->log_buf_size);
 
-    gf_log_set_log_flush_timeout(cmd_args->log_flush_timeout);
+    ctx->log.timeout = cmd_args->log_flush_timeout;
 
     if (gf_log_init(ctx, cmd_args->log_file, cmd_args->log_ident) == -1) {
         fprintf(stderr, "ERROR: failed to open logfile %s\n",

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -641,7 +641,7 @@ gf_print_trace(int32_t signum, glusterfs_ctx_t *ctx)
      * contents of the buffer to the log file before printing the backtrace
      * which helps in debugging.
      */
-    gf_log_flush();
+    gf_log_flush(ctx);
 
     gf_log_disable_suppression_before_exit(ctx);
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -863,15 +863,15 @@ gf_time_fmt(char *dst, size_t sz_dst, time_t utime, unsigned int fmt)
 
 static inline size_t
 gf_time_fmt_tv_FT(char *dst, size_t sz_dst, struct timeval *tv,
-                  glusterfs_ctx_t *ctx)
+                  gf_log_handle_t *log)
 {
     struct tm tm, *res;
     int localtime = 0;
     int len = 0;
     int pos = 0;
 
-    if (ctx != NULL)
-        localtime = ctx->log.localtime;
+    if (log != NULL)
+        localtime = log->localtime;
     else
         localtime = gf_log_get_localtime();
     res = localtime ? localtime_r(&tv->tv_sec, &tm)

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -212,7 +212,9 @@ gf_set_nofile(rlim_t high, rlim_t low);
 
 #else /* Darwin */
 
-#define gf_set_nofile(low, high) do { } while (0)
+#define gf_set_nofile(low, high)                                               \
+    do {                                                                       \
+    } while (0)
 
 #endif /* not GF_DARWIN_HOST_OS */
 

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -102,6 +102,7 @@ typedef struct gf_log_handle_ {
     gf_loglevel_t loglevel;
     gf_loglevel_t sys_log_level;
     int gf_log_syslog;
+    int log_control_file_found;
     char *filename;
     FILE *logfile;
     FILE *gf_log_logfile;
@@ -110,7 +111,6 @@ typedef struct gf_log_handle_ {
     gf_log_logger_t logger;
     gf_log_format_t logformat;
     char *ident;
-    int log_control_file_found;
     struct list_head lru_queue;
     pthread_mutex_t log_buf_lock;
     struct _gf_timer *log_flush_timer;

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -270,9 +270,9 @@ _gf_log_eh(const char *function, const char *fmt, ...)
 struct _glusterfs_ctx;
 
 void
-gf_log_disable_syslog(void);
+gf_log_disable_syslog(struct _glusterfs_ctx *ctx);
 void
-gf_log_enable_syslog(void);
+gf_log_enable_syslog(struct _glusterfs_ctx *ctx);
 gf_loglevel_t
 gf_log_get_loglevel(void);
 void
@@ -282,7 +282,7 @@ gf_log_get_localtime(void);
 void
 gf_log_set_localtime(int);
 void
-gf_log_flush(void);
+gf_log_flush(struct _glusterfs_ctx *ctx);
 gf_loglevel_t
 gf_log_get_xl_loglevel(void *xl);
 void
@@ -308,10 +308,10 @@ void
 gf_log_set_logformat(gf_log_format_t format);
 
 void
-gf_log_set_log_buf_size(uint32_t buf_size);
+gf_log_set_log_buf_size(struct _glusterfs_ctx *ctx, uint32_t buf_size);
 
 void
-gf_log_set_log_flush_timeout(uint32_t timeout);
+gf_log_set_log_flush_timeout(struct _glusterfs_ctx *ctx, uint32_t timeout);
 
 int
 gf_log_inject_timer_event(struct _glusterfs_ctx *ctx);

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -869,7 +869,7 @@ _gf_log_callingfn(const char *domain, const char *file, const char *function,
     if (-1 == ret)
         goto out;
 
-    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
 
     ret = gf_asprintf(&logline, "[%s] %c [%s:%d:%s] %s %d-%s: %s\n", timestr,
                       gf_level_strings[level], basename, line, function,
@@ -1136,7 +1136,7 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
     ret = gettimeofday(&tv, NULL);
     if (-1 == ret)
         goto out;
-    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
 
     /* TODO: Currently we print in the enhanced format, with a message ID
      * of 0. Need to enhance this to support format as configured */
@@ -1306,7 +1306,7 @@ gf_log_glusterlog(glusterfs_ctx_t *ctx, const char *domain, const char *file,
     gf_log_rotate(ctx);
 
     /* format the time stamp */
-    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
 
     /* generate footer */
     if (errnum) {
@@ -1410,8 +1410,10 @@ gf_syslog_log_repetitions(const char *domain, const char *file,
 
     SET_LOG_PRIO(level, priority);
 
-    gf_time_fmt_tv_FT(timestr_latest, sizeof timestr_latest, &latest, ctx);
-    gf_time_fmt_tv_FT(timestr_oldest, sizeof timestr_oldest, &oldest, ctx);
+    gf_time_fmt_tv_FT(timestr_latest, sizeof timestr_latest, &latest,
+                      &ctx->log);
+    gf_time_fmt_tv_FT(timestr_oldest, sizeof timestr_oldest, &oldest,
+                      &ctx->log);
 
     if (errnum) {
         syslog(priority,
@@ -1469,9 +1471,11 @@ gf_glusterlog_log_repetitions(glusterfs_ctx_t *ctx, const char *domain,
         goto err;
     }
 
-    gf_time_fmt_tv_FT(timestr_latest, sizeof timestr_latest, &latest, ctx);
+    gf_time_fmt_tv_FT(timestr_latest, sizeof timestr_latest, &latest,
+                      &ctx->log);
 
-    gf_time_fmt_tv_FT(timestr_oldest, sizeof timestr_oldest, &oldest, ctx);
+    gf_time_fmt_tv_FT(timestr_oldest, sizeof timestr_oldest, &oldest,
+                      &ctx->log);
 
     if (errnum)
         snprintf(errstr, sizeof(errstr) - 1, " [%s]", strerror(errnum));
@@ -2105,7 +2109,7 @@ log:
     if (-1 == ret)
         goto out;
 
-    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
 
     ret = gf_asprintf(&logline, "[%s] %c [%s:%d:%s] %d-%s: %s\n", timestr,
                       gf_level_strings[level], basename, line, function,
@@ -2262,7 +2266,7 @@ gf_cmd_log(const char *domain, const char *fmt, ...)
         goto out;
     }
 
-    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+    gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
 
     ret = gf_asprintf(&logline, "[%s] %s : %s\n", timestr, domain, msg);
     if (ret == -1) {

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -89,7 +89,7 @@ gf_log_flush_extra_msgs(gf_log_handle_t *log, uint32_t new);
 static int
 log_buf_init(log_buf_t *buf, const char *domain, const char *file,
              const char *function, int32_t line, gf_loglevel_t level,
-             int errnum, uint64_t msgid, char **appmsgstr, int graph_id);
+             int errnum, uint64_t msgid, char *appmsgstr, int graph_id);
 static void
 gf_log_rotate(gf_log_handle_t *log);
 
@@ -272,14 +272,14 @@ gf_log_set_log_flush_timeout(glusterfs_ctx_t *ctx, uint32_t timeout)
 static int
 log_buf_init(log_buf_t *buf, const char *domain, const char *file,
              const char *function, int32_t line, gf_loglevel_t level,
-             int errnum, uint64_t msgid, char **appmsgstr, int graph_id)
+             int errnum, uint64_t msgid, char *appmsgstr, int graph_id)
 {
     int ret = -1;
 
-    if (!buf || !domain || !file || !function || !appmsgstr || !*appmsgstr)
+    if (!buf || !domain || !file || !function || !appmsgstr)
         goto out;
 
-    buf->msg = gf_strdup(*appmsgstr);
+    buf->msg = gf_strdup(appmsgstr);
     if (!buf->msg)
         goto out;
 
@@ -1210,8 +1210,7 @@ out:
 static int
 gf_log_syslog(const char *domain, const char *file, const char *function,
               int32_t line, gf_loglevel_t level, int errnum, uint64_t msgid,
-              char **appmsgstr, char *callstr, int graph_id,
-              gf_log_format_t fmt)
+              char *appmsgstr, char *callstr, int graph_id, gf_log_format_t fmt)
 {
     int priority;
 
@@ -1223,21 +1222,21 @@ gf_log_syslog(const char *domain, const char *file, const char *function,
             if (!callstr) {
                 if (errnum)
                     syslog(priority, "[%s:%d:%s] %d-%s: %s [%s]", file, line,
-                           function, graph_id, domain, *appmsgstr,
+                           function, graph_id, domain, appmsgstr,
                            strerror(errnum));
                 else
                     syslog(priority, "[%s:%d:%s] %d-%s: %s", file, line,
-                           function, graph_id, domain, *appmsgstr);
+                           function, graph_id, domain, appmsgstr);
             } else {
                 if (errnum)
                     syslog(priority,
                            "[%s:%d:%s] %s %d-%s:"
                            " %s [%s]",
                            file, line, function, callstr, graph_id, domain,
-                           *appmsgstr, strerror(errnum));
+                           appmsgstr, strerror(errnum));
                 else
                     syslog(priority, "[%s:%d:%s] %s %d-%s: %s", file, line,
-                           function, callstr, graph_id, domain, *appmsgstr);
+                           function, callstr, graph_id, domain, appmsgstr);
             }
             break;
         case gf_logformat_withmsgid:
@@ -1248,14 +1247,14 @@ gf_log_syslog(const char *domain, const char *file, const char *function,
                            "]"
                            " [%s:%d:%s] %d-%s: %s [%s]",
                            msgid, file, line, function, graph_id, domain,
-                           *appmsgstr, strerror(errnum));
+                           appmsgstr, strerror(errnum));
                 else
                     syslog(priority,
                            "[MSGID: %" PRIu64
                            "]"
                            " [%s:%d:%s] %d-%s: %s",
                            msgid, file, line, function, graph_id, domain,
-                           *appmsgstr);
+                           appmsgstr);
             } else {
                 if (errnum)
                     syslog(priority,
@@ -1263,20 +1262,20 @@ gf_log_syslog(const char *domain, const char *file, const char *function,
                            "]"
                            " [%s:%d:%s] %s %d-%s: %s [%s]",
                            msgid, file, line, function, callstr, graph_id,
-                           domain, *appmsgstr, strerror(errnum));
+                           domain, appmsgstr, strerror(errnum));
                 else
                     syslog(priority,
                            "[MSGID: %" PRIu64
                            "]"
                            " [%s:%d:%s] %s %d-%s: %s",
                            msgid, file, line, function, callstr, graph_id,
-                           domain, *appmsgstr);
+                           domain, appmsgstr);
             }
             break;
         case gf_logformat_cee:
             /* TODO: Enhance CEE with additional parameters */
             gf_syslog(priority, "[%s:%d:%s] %d-%s: %s", file, line, function,
-                      graph_id, domain, *appmsgstr);
+                      graph_id, domain, appmsgstr);
             break;
 
         default:
@@ -1291,7 +1290,7 @@ gf_log_syslog(const char *domain, const char *file, const char *function,
 static int
 gf_log_glusterlog(gf_log_handle_t *log, const char *domain, const char *file,
                   const char *function, int32_t line, gf_loglevel_t level,
-                  int errnum, uint64_t msgid, char **appmsgstr, char *callstr,
+                  int errnum, uint64_t msgid, char *appmsgstr, char *callstr,
                   struct timeval tv, int graph_id, gf_log_format_t fmt)
 {
     char timestr[GF_TIMESTR_SIZE] = {
@@ -1324,13 +1323,13 @@ gf_log_glusterlog(gf_log_handle_t *log, const char *domain, const char *file,
                               "[%s] %c [%s:%d:%s]"
                               " %d-%s: %s",
                               timestr, gf_level_strings[level], file, line,
-                              function, graph_id, domain, *appmsgstr);
+                              function, graph_id, domain, appmsgstr);
         } else {
             ret = gf_asprintf(&header,
                               "[%s] %c [%s:%d:%s] %s"
                               " %d-%s: %s",
                               timestr, gf_level_strings[level], file, line,
-                              function, callstr, graph_id, domain, *appmsgstr);
+                              function, callstr, graph_id, domain, appmsgstr);
         }
     } else { /* gf_logformat_withmsgid */
         /* CEE log format unsupported in logger_glusterlog, so just
@@ -1341,7 +1340,7 @@ gf_log_glusterlog(gf_log_handle_t *log, const char *domain, const char *file,
                               "]"
                               " [%s:%d:%s] %d-%s: %s",
                               timestr, gf_level_strings[level], msgid, file,
-                              line, function, graph_id, domain, *appmsgstr);
+                              line, function, graph_id, domain, appmsgstr);
         } else {
             ret = gf_asprintf(&header,
                               "[%s] %c [MSGID: %" PRIu64
@@ -1349,7 +1348,7 @@ gf_log_glusterlog(gf_log_handle_t *log, const char *domain, const char *file,
                               " [%s:%d:%s] %s %d-%s: %s",
                               timestr, gf_level_strings[level], msgid, file,
                               line, function, callstr, graph_id, domain,
-                              *appmsgstr);
+                              appmsgstr);
         }
     }
     if (-1 == ret) {
@@ -1394,7 +1393,7 @@ static int
 gf_syslog_log_repetitions(const char *domain, const char *file,
                           const char *function, int32_t line,
                           gf_loglevel_t level, int errnum, uint64_t msgid,
-                          char **appmsgstr, char *callstr, int refcount,
+                          char *appmsgstr, char *callstr, int refcount,
                           struct timeval oldest, struct timeval latest,
                           int graph_id, gf_log_handle_t *log)
 {
@@ -1417,7 +1416,7 @@ gf_syslog_log_repetitions(const char *domain, const char *file,
                "] [%s:%d:%s] "
                "%d-%s: %s [%s] \" repeated %d times between %s"
                " and %s",
-               msgid, file, line, function, graph_id, domain, *appmsgstr,
+               msgid, file, line, function, graph_id, domain, appmsgstr,
                strerror(errnum), refcount, timestr_oldest, timestr_latest);
     } else {
         syslog(priority,
@@ -1425,7 +1424,7 @@ gf_syslog_log_repetitions(const char *domain, const char *file,
                "] [%s:%d:%s] "
                "%d-%s: %s \" repeated %d times between %s"
                " and %s",
-               msgid, file, line, function, graph_id, domain, *appmsgstr,
+               msgid, file, line, function, graph_id, domain, appmsgstr,
                refcount, timestr_oldest, timestr_latest);
     }
     return 0;
@@ -1435,7 +1434,7 @@ static int
 gf_glusterlog_log_repetitions(gf_log_handle_t *log, const char *domain,
                               const char *file, const char *function,
                               int32_t line, gf_loglevel_t level, int errnum,
-                              uint64_t msgid, char **appmsgstr, char *callstr,
+                              uint64_t msgid, char *appmsgstr, char *callstr,
                               int refcount, struct timeval oldest,
                               struct timeval latest, int graph_id)
 {
@@ -1459,7 +1458,7 @@ gf_glusterlog_log_repetitions(gf_log_handle_t *log, const char *domain,
                       "]"
                       " [%s:%d:%s] %d-%s: %s",
                       gf_level_strings[level], msgid, file, line, function,
-                      graph_id, domain, *appmsgstr);
+                      graph_id, domain, appmsgstr);
     if (-1 == ret) {
         goto err;
     }
@@ -1513,7 +1512,7 @@ static int
 gf_log_print_with_repetitions(gf_log_handle_t *log, const char *domain,
                               const char *file, const char *function,
                               int32_t line, gf_loglevel_t level, int errnum,
-                              uint64_t msgid, char **appmsgstr, char *callstr,
+                              uint64_t msgid, char *appmsgstr, char *callstr,
                               int refcount, struct timeval oldest,
                               struct timeval latest, int graph_id)
 {
@@ -1548,7 +1547,7 @@ static int
 gf_log_print_plain_fmt(gf_log_handle_t *log, const char *domain,
                        const char *file, const char *function, int32_t line,
                        gf_loglevel_t level, int errnum, uint64_t msgid,
-                       char **appmsgstr, char *callstr, struct timeval tv,
+                       char *appmsgstr, char *callstr, struct timeval tv,
                        int graph_id, gf_log_format_t fmt)
 {
     int ret = -1;
@@ -1584,14 +1583,14 @@ gf_log_flush_message(log_buf_t *buf, gf_log_handle_t *log)
     if (buf->refcount == 1) {
         (void)gf_log_print_plain_fmt(log, buf->domain, buf->file, buf->function,
                                      buf->line, buf->level, buf->errnum,
-                                     buf->msg_id, &buf->msg, NULL, buf->latest,
+                                     buf->msg_id, buf->msg, NULL, buf->latest,
                                      buf->graph_id, gf_logformat_withmsgid);
     }
 
     if (buf->refcount > 1) {
         gf_log_print_with_repetitions(
             log, buf->domain, buf->file, buf->function, buf->line, buf->level,
-            buf->errnum, buf->msg_id, &buf->msg, NULL, buf->refcount,
+            buf->errnum, buf->msg_id, buf->msg, NULL, buf->refcount,
             buf->oldest, buf->latest, buf->graph_id);
     }
     return;
@@ -1747,7 +1746,7 @@ gf_log_flush_timeout_cbk(void *data)
 static int
 _gf_msg_internal(glusterfs_ctx_t *ctx, const char *domain, const char *file,
                  const char *function, int32_t line, gf_loglevel_t level,
-                 int errnum, uint64_t msgid, char **appmsgstr, char *callstr,
+                 int errnum, uint64_t msgid, char *appmsgstr, char *callstr,
                  int graph_id)
 {
     int ret = -1;
@@ -1821,7 +1820,7 @@ _gf_msg_internal(glusterfs_ctx_t *ctx, const char *domain, const char *file,
             if (strcmp(function, iter->function))
                 continue;
 
-            if (strcmp(*appmsgstr, iter->msg))
+            if (strcmp(appmsgstr, iter->msg))
                 continue;
 
             // Ah! Found a match!
@@ -1968,12 +1967,12 @@ _gf_msg(const char *domain, const char *file, const char *function,
 
         if (!log_inited && ctx->log.gf_log_syslog) {
             ret = gf_log_syslog(domain, file, function, line, level, errnum,
-                                msgid, &msgstr, (callstr ? callstr : NULL),
+                                msgid, msgstr, (callstr ? callstr : NULL),
                                 (this->graph) ? this->graph->id : 0,
                                 gf_logformat_traditional);
         } else {
             ret = _gf_msg_internal(ctx, domain, file, function, line, level,
-                                   errnum, msgid, &msgstr,
+                                   errnum, msgid, msgstr,
                                    (callstr ? callstr : NULL),
                                    (this->graph) ? this->graph->id : 0);
         }

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -1733,7 +1733,6 @@ _gf_msg_internal(glusterfs_ctx_t *ctx, const char *domain, const char *file,
     int ret = -1;
     uint32_t size = 0;
     const char *basename = NULL;
-    xlator_t *this = NULL;
     log_buf_t *iter = NULL;
     log_buf_t *buf_tmp = NULL;
     log_buf_t *buf_new = NULL;

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -915,7 +915,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
     // continue even though gettimeofday() has failed
     ret = gettimeofday(&tv, NULL);
     if (0 == ret) {
-        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
         len = snprintf(sign_string, sizeof(sign_string),
                        "DUMP-START-TIME: %s\n", timestr);
 
@@ -961,7 +961,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
 
     ret = gettimeofday(&tv, NULL);
     if (0 == ret) {
-        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, ctx);
+        gf_time_fmt_tv_FT(timestr, sizeof timestr, &tv, &ctx->log);
         len = snprintf(sign_string, sizeof(sign_string), "\nDUMP-END-TIME: %s",
                        timestr);
         (void)sys_write(gf_dump_fd, sign_string, len);

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -921,12 +921,9 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
 
         // swallow the errors of write for start and end marker
         (void)sys_write(gf_dump_fd, sign_string, len);
+        memset(timestr, 0, sizeof(timestr));
     }
-
-    if (GF_PROC_DUMP_IS_OPTION_ENABLED(mem)) {
-        gf_proc_dump_mem_info();
-        gf_proc_dump_mempool_info(ctx);
-    }
+    gf_proc_dump_mempool_info(ctx);
 
     if (GF_PROC_DUMP_IS_OPTION_ENABLED(iobuf))
         iobuf_stats_dump(ctx->iobuf_pool);

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -921,7 +921,6 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
 
         // swallow the errors of write for start and end marker
         (void)sys_write(gf_dump_fd, sign_string, len);
-        memset(timestr, 0, sizeof(timestr));
     }
     gf_proc_dump_mempool_info(ctx);
 

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -1294,6 +1294,9 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
     gf_boolean_t syslog_flag = 0;
     glusterfs_ctx_t *ctx = this->ctx;
 
+    if (!ctx)
+        goto out;
+
     if (!strcmp("trusted.glusterfs.syslog", name)) {
         ret = gf_bin_to_string(key, sizeof(key), value, size);
         if (ret != 0) {
@@ -1346,8 +1349,6 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
         goto out;
     }
 
-    if (!ctx)
-        goto out;
     if (!ctx->active)
         goto out;
     trav = ctx->active->top;

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -1292,7 +1292,7 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
     int ret = -1;
     int log_level = -1;
     gf_boolean_t syslog_flag = 0;
-    glusterfs_ctx_t *ctx = NULL;
+    glusterfs_ctx_t *ctx = this->ctx;
 
     if (!strcmp("trusted.glusterfs.syslog", name)) {
         ret = gf_bin_to_string(key, sizeof(key), value, size);
@@ -1305,9 +1305,9 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
             goto out;
         }
         if (syslog_flag)
-            gf_log_enable_syslog();
+            gf_log_enable_syslog(ctx);
         else
-            gf_log_disable_syslog();
+            gf_log_disable_syslog(ctx);
 
         goto out;
     }
@@ -1331,7 +1331,7 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
         gf_smsg("glusterfs", gf_log_get_loglevel(), 0, LG_MSG_SET_LOG_LEVEL,
                 "new-value=%d", log_level, "old-value=%d",
                 gf_log_get_loglevel(), NULL);
-        gf_log_set_loglevel(this->ctx, log_level);
+        gf_log_set_loglevel(ctx, log_level);
         ret = 0;
         goto out;
     }
@@ -1346,7 +1346,6 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
         goto out;
     }
 
-    ctx = this->ctx;
     if (!ctx)
         goto out;
     if (!ctx->active)

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -1371,28 +1371,24 @@ out:
 int
 glusterd_check_log_level(const char *value)
 {
-    int log_level = -1;
-
     if (!strcasecmp(value, "CRITICAL")) {
-        log_level = GF_LOG_CRITICAL;
+        return GF_LOG_CRITICAL;
     } else if (!strcasecmp(value, "ERROR")) {
-        log_level = GF_LOG_ERROR;
+        return GF_LOG_ERROR;
     } else if (!strcasecmp(value, "WARNING")) {
-        log_level = GF_LOG_WARNING;
+        return GF_LOG_WARNING;
     } else if (!strcasecmp(value, "INFO")) {
-        log_level = GF_LOG_INFO;
+        return GF_LOG_INFO;
     } else if (!strcasecmp(value, "DEBUG")) {
-        log_level = GF_LOG_DEBUG;
+        return GF_LOG_DEBUG;
     } else if (!strcasecmp(value, "TRACE")) {
-        log_level = GF_LOG_TRACE;
+        return GF_LOG_TRACE;
     } else if (!strcasecmp(value, "NONE")) {
-        log_level = GF_LOG_NONE;
+        return GF_LOG_NONE;
     }
 
-    if (log_level == -1)
-        gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INVALID_INIT, NULL);
-
-    return log_level;
+    gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INVALID_INIT, NULL);
+    return -1;
 }
 
 int

--- a/tests/basic/logchecks.c
+++ b/tests/basic/logchecks.c
@@ -131,7 +131,7 @@ main(int argc, char *argv[])
 
     /* TEST 4: Check flush, nothing noticeable should occur :) */
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_11);
-    gf_log_flush();
+    gf_log_flush(ctx);
     gf_msg("logchecks", GF_LOG_CRITICAL, 0, logchecks_msg_6);
     gf_msg("logchecks", GF_LOG_ALERT, 0, logchecks_msg_11);
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3757,7 +3757,7 @@ ios_set_log_format_code(struct ios_conf *conf, char *dump_format_str)
         conf->dump_format = IOS_DUMP_TYPE_SAMPLES;
 }
 
-void
+static void
 xlator_set_loglevel(xlator_t *this, int log_level)
 {
     glusterfs_ctx_t *ctx = NULL;
@@ -3925,11 +3925,11 @@ reconfigure(xlator_t *this, dict_t *options)
     }
 
     GF_OPTION_RECONF("log-buf-size", log_buf_size, options, uint32, out);
-    gf_log_set_log_buf_size(log_buf_size);
+    gf_log_set_log_buf_size(this->ctx, log_buf_size);
 
     GF_OPTION_RECONF("log-flush-timeout", log_flush_timeout, options, time,
                      out);
-    gf_log_set_log_flush_timeout(log_flush_timeout);
+    gf_log_set_log_flush_timeout(this->ctx, log_flush_timeout);
 
     GF_OPTION_RECONF("threads", threads, options, int32, out);
     gf_async_adjust_threads(threads);
@@ -4159,10 +4159,10 @@ init(xlator_t *this)
     }
 
     GF_OPTION_INIT("log-buf-size", log_buf_size, uint32, out);
-    gf_log_set_log_buf_size(log_buf_size);
+    gf_log_set_log_buf_size(this->ctx, log_buf_size);
 
     GF_OPTION_INIT("log-flush-timeout", log_flush_timeout, time, out);
-    gf_log_set_log_flush_timeout(log_flush_timeout);
+    gf_log_set_log_flush_timeout(this->ctx, log_flush_timeout);
 
     GF_OPTION_INIT("threads", threads, int32, out);
     gf_async_adjust_threads(threads);


### PR DESCRIPTION
Mainly makes the code more readable, but also removes some 'THIS' calls.