### PR TITLE
io-threads: conf->mutex is getting lock contention

### DIFF
--- a/xlators/performance/io-threads/src/io-threads.h
+++ b/xlators/performance/io-threads/src/io-threads.h
@@ -48,17 +48,16 @@ typedef struct {
 
 struct iot_conf {
     pthread_mutex_t mutex;
+    sem_t sem;
     int32_t max_count;  /* configured maximum */
     int32_t curr_count; /* actual number of threads running */
     int32_t sleep_count;
     int32_t queue_size;
     time_t idle_time; /* in seconds */
-    pthread_cond_t cond;
     gf_atomic_t stub_cnt;
     uint32_t down;               /*PARENT_DOWN event is notified*/
     gf_boolean_t least_priority; /*Enable/Disable least-priority */
     gf_boolean_t mutex_inited;
-    gf_boolean_t cond_inited;
 
     gf_boolean_t watchdog_running;
 


### PR DESCRIPTION
After executing smallfile tool and replace pthread_mutex_lock
with pthread_mutex_trylock and we found some of the fops
are showing contention during conf->mutex access.

Solution: To avoid the contention reduce the critical
section code block and use semaphore for signalling purpose.
We have observed the contention is reduced significantly.

Fixes: #3397
Change-Id: Ibaeefdb944bf07eb344ea7b5936e71def5190bf1
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

