### PR TITLE
Fix gluster volume status timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,11 +344,11 @@ AC_ARG_WITH([tcmalloc],
         [AC_HELP_STRING([--without-tcmalloc], [Use gluster based mempool])],
         [with_tcmalloc="no"], [with_tcmalloc="yes"])
 if test "x$with_tcmalloc" = "xyes"; then
-    AC_CHECK_LIB([tcmalloc], [malloc], [],
+    AC_CHECK_LIB([tcmalloc_minimal], [malloc], [],
                  [AC_MSG_ERROR([tcmalloc library needs to be present])])
     BUILD_TCMALLOC=yes
     GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
-    GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+    GF_LDFLAGS="-ltcmalloc_minimal ${GF_LDFLAGS}"
     AC_DEFINE(GF_DISABLE_MEMPOOL, 1, [Disable the Gluster memory pooler.])
     USE_MEMPOOL=no
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -767,7 +767,7 @@ AS_IF([test "x$enable_fuse_notifications" != "xno"], [
 dnl Find out OpenSSL trusted certificates path
 AC_MSG_CHECKING([for OpenSSL trusted certificates path])
 SSL_CERT_PATH=$(openssl version -d | sed -e 's|OPENSSLDIR: "\(.*\)".*|\1|')
-if test -d $SSL_CERT_PATH 1>/dev/null 2>&1; then
+if test -d "${SSL_CERT_PATH}" 1>/dev/null 2>&1; then
    AC_MSG_RESULT([$SSL_CERT_PATH])
    AC_DEFINE_UNQUOTED(SSL_CERT_PATH, ["$SSL_CERT_PATH"], [Path to OpenSSL trusted certificates.])
    AC_SUBST(SSL_CERT_PATH)
@@ -1388,7 +1388,7 @@ exec_prefix=$old_exec_prefix
 
 ### Dirty hacky stuff to make LOCALSTATEDIR work
 if test "x$prefix" = xNONE; then
-   test $localstatedir = '${prefix}/var' && localstatedir=$ac_default_prefix/var
+   test "${localstatedir}" = '${prefix}/var' && localstatedir=$ac_default_prefix/var
    localstatedir=/var
 fi
 localstatedir="$(eval echo ${localstatedir})"
@@ -1819,7 +1819,7 @@ AM_CONDITIONAL([GF_LINUX_HOST_OS], test "${GF_HOST_OS}" = "GF_LINUX_HOST_OS")
 AM_CONDITIONAL([GF_DARWIN_HOST_OS], test "${GF_HOST_OS}" = "GF_DARWIN_HOST_OS")
 
 AC_SUBST(GLUSTERD_WORKDIR)
-AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d ${GLUSTERD_WORKDIR} && test -d ${sysconfdir}/glusterd )
+AM_CONDITIONAL([GF_INSTALL_GLUSTERD_WORKDIR], test ! -d "${GLUSTERD_WORKDIR}" && test -d "${sysconfdir}/glusterd" )
 AC_SUBST(GLUSTERD_VOLFILE)
 AC_SUBST(GLUSTERFS_LIBEXECDIR)
 AC_SUBST(GLUSTERFSD_MISCDIR)

--- a/doc/gluster.8
+++ b/doc/gluster.8
@@ -101,13 +101,7 @@ Stop rebalancing the specified volume.
 Display the rebalance status of the specified volume.
 .SS "Log Commands"
 .TP
-\fB\ volume log filename <VOLNAME> [BRICK] <DIRECTORY> \fB
-Set the log directory for the corresponding volume/brick.
-.TP
-\fB\ volume log locate <VOLNAME> [BRICK] \fB
-Locate the log file for corresponding volume/brick.
-.TP
-\fB\ volume log rotate <VOLNAME> [BRICK] \fB
+\fB\ volume log <VOLNAME> rotate [BRICK] \fB
 Rotate the log file for corresponding volume/brick.
 .TP
 \fB\ volume profile <VOLNAME> {start|info [peek|incremental [peek]|cumulative|clear]|stop} [nfs] \fR

--- a/doc/release-notes/10.0.md
+++ b/doc/release-notes/10.0.md
@@ -1,0 +1,199 @@
+# Release notes for Gluster 10.0
+
+This is a major release that includes a range of features, code improvements and stability fixes as noted below.
+
+A selection of the key features and changes are documented in this page.
+A full list of bugs that have been addressed is included further below.
+
+- [Announcements](#announcements)
+- [Highlights](#highlights)
+- [Bugs addressed in the release](#bugs-addressed)
+
+## Announcements
+
+1. Releases that receive maintenance updates post release 10 is 9
+([reference](https://www.gluster.org/release-schedule/))
+2. Release 10 will receive maintenance updates around the 15th of every alternative month, and the release 9 will recieve maintainance updates around 15th every three months. 
+
+
+
+
+## Highlights
+
+- Major performance improvement of ~20% w.r.t small files
+  as well as large files testing in controlled lab environments [#2771](https://github.com/gluster/glusterfs/issues/2771)
+- Randomized port selection for bricks, improves startup time [#786](https://github.com/gluster/glusterfs/issues/786)
+- Performance improvement with use of readdir instead of readdirp in fix-layout [#2241](https://github.com/gluster/glusterfs/issues/2241)
+- Heal time improvement with bigger window size [#2067](https://github.com/gluster/glusterfs/issues/2067)
+
+## Bugs addressed
+
+Bugs addressed since release-9 are listed below.
+
+[#504](https://github.com/gluster/glusterfs/issues/504)  AFR: remove memcpy() + ntoh32() pattern
+[#705](https://github.com/gluster/glusterfs/issues/705)  gf_backtrace_save inefficiencies
+[#782](https://github.com/gluster/glusterfs/issues/782)  Do not explicitly call strerror(errnum) when logging
+[#786](https://github.com/gluster/glusterfs/issues/786)  glusterd-pmap binds to 10K ports on startup (using IPv4)
+[#904](https://github.com/gluster/glusterfs/issues/904)  [bug:1649037] Translators allocate too much memory in their xlator_
+[#1000](https://github.com/gluster/glusterfs/issues/1000) [bug:1193929] GlusterFS can be improved
+[#1002](https://github.com/gluster/glusterfs/issues/1002) [bug:1679998] GlusterFS can be improved
+[#1052](https://github.com/gluster/glusterfs/issues/1052) [bug:1693692] Increase code coverage from regression tests
+[#1060](https://github.com/gluster/glusterfs/issues/1060) [bug:789278] Issues reported by Coverity static analysis tool
+[#1096](https://github.com/gluster/glusterfs/issues/1096) [bug:1622665] clang-scan report: glusterfs issues
+[#1101](https://github.com/gluster/glusterfs/issues/1101) [bug:1813029] volume brick fails to come online because other proce
+[#1251](https://github.com/gluster/glusterfs/issues/1251) performance: improve __afr_fd_ctx_get() function
+[#1339](https://github.com/gluster/glusterfs/issues/1339) Rebalance status is not shown correctly after node reboot
+[#1358](https://github.com/gluster/glusterfs/issues/1358) features/shard: wrong "inode->ref" leading to ASSERT in inode_unref
+[#1359](https://github.com/gluster/glusterfs/issues/1359) Cleanup --disable-mempool
+[#1380](https://github.com/gluster/glusterfs/issues/1380) fd_unref() optimization - do an atomic decrement outside the lock a
+[#1384](https://github.com/gluster/glusterfs/issues/1384) mount glusterfs volume, files larger than 64Mb only show 64Mb
+[#1406](https://github.com/gluster/glusterfs/issues/1406) shared storage volume fails to mount in ipv6 environment
+[#1415](https://github.com/gluster/glusterfs/issues/1415) Removing problematic language in geo-replication
+[#1423](https://github.com/gluster/glusterfs/issues/1423) shard_make_block_abspath() should be called with a string of of the
+[#1536](https://github.com/gluster/glusterfs/issues/1536) Improve dict_reset() efficiency
+[#1545](https://github.com/gluster/glusterfs/issues/1545) fuse_invalidate_entry() - too many repetitive calls to uuid_utoa()
+[#1583](https://github.com/gluster/glusterfs/issues/1583) Rework stats structure (xl->stats.total.metrics[fop_idx] and friend
+[#1584](https://github.com/gluster/glusterfs/issues/1584) MAINTAINERS file needs to be revisited and updated
+[#1596](https://github.com/gluster/glusterfs/issues/1596) 'this' NULL check relies on 'THIS' not being NULL
+[#1600](https://github.com/gluster/glusterfs/issues/1600) Save and re-use MYUUID
+[#1678](https://github.com/gluster/glusterfs/issues/1678) Improve gf_error_to_errno() and gf_errno_to_error() positive flow
+[#1695](https://github.com/gluster/glusterfs/issues/1695) Rebalance has a redundant lookup operation
+[#1702](https://github.com/gluster/glusterfs/issues/1702) Move GF_CLIENT_PID_GSYNCD check to start of the function.
+[#1703](https://github.com/gluster/glusterfs/issues/1703) Remove trivial check for GF_XATTR_SHARD_FILE_SIZE before calling sh
+[#1707](https://github.com/gluster/glusterfs/issues/1707) PL_LOCAL_GET_REQUESTS access the dictionary twice for the same info
+[#1717](https://github.com/gluster/glusterfs/issues/1717) glusterd: sequence of rebalance and replace/reset-brick presents re
+[#1723](https://github.com/gluster/glusterfs/issues/1723) DHT: further investigation for treating an ongoing mknod's linkto file
+[#1749](https://github.com/gluster/glusterfs/issues/1749) brick-process: call 'notify()' and 'fini()' of brick xlators in a p
+[#1755](https://github.com/gluster/glusterfs/issues/1755) Reduce calls to 'THIS' in fd_destroy() and others, where 'THIS' is
+[#1761](https://github.com/gluster/glusterfs/issues/1761) CONTRIBUTING.md regression can only be run by maintainers
+[#1764](https://github.com/gluster/glusterfs/issues/1764) Slow write on ZFS bricks after healing millions of files due to add
+[#1772](https://github.com/gluster/glusterfs/issues/1772) build: add LTO as a configure option
+[#1773](https://github.com/gluster/glusterfs/issues/1773) DHT/Rebalance - Remove unused variable dht_migrate_file
+[#1779](https://github.com/gluster/glusterfs/issues/1779) Add-brick command should check hostnames with bricks present in vol
+[#1825](https://github.com/gluster/glusterfs/issues/1825) Latency in io-stats should be in nanoseconds resolution, not micros
+[#1872](https://github.com/gluster/glusterfs/issues/1872) Question: How to check heal info without glusterd management layer
+[#1885](https://github.com/gluster/glusterfs/issues/1885) __posix_writev() - reduce memory copies and unneeded zeroing
+[#1888](https://github.com/gluster/glusterfs/issues/1888) GD_OP_VERSION needs to be updated for release-10
+[#1898](https://github.com/gluster/glusterfs/issues/1898) schedule_georep.py resulting in failure when used with python3
+[#1909](https://github.com/gluster/glusterfs/issues/1909) core: Avoid several dict OR key is NULL message in brick logs
+[#1925](https://github.com/gluster/glusterfs/issues/1925) dht_pt_getxattr does not seem to handle virtual xattrs.
+[#1935](https://github.com/gluster/glusterfs/issues/1935) logging to syslog instead of any glusterfs logs
+[#1943](https://github.com/gluster/glusterfs/issues/1943) glusterd-volgen: Add functionality to accept any custom xlator
+[#1952](https://github.com/gluster/glusterfs/issues/1952) posix-aio: implement GF_FOP_FSYNC
+[#1959](https://github.com/gluster/glusterfs/issues/1959) Broken links in the 2 replicas split-brain-issue - [Bug][Enhancemen
+[#1960](https://github.com/gluster/glusterfs/issues/1960) Add missing LOCK_DESTROY() calls
+[#1966](https://github.com/gluster/glusterfs/issues/1966) Can't print trace details due to memory allocation issues
+[#1977](https://github.com/gluster/glusterfs/issues/1977) Inconsistent locking in presence of disconnects
+[#1978](https://github.com/gluster/glusterfs/issues/1978) test case ./tests/bugs/core/bug-1432542-mpx-restart-crash.t is gett
+[#1981](https://github.com/gluster/glusterfs/issues/1981) Reduce posix_fdstat() calls in IO paths
+[#1991](https://github.com/gluster/glusterfs/issues/1991) mdcache: bug causes getxattr() to report ENODATA when fetching samb
+[#1992](https://github.com/gluster/glusterfs/issues/1992) dht: var decommission_subvols_cnt becomes invalid when config is up
+[#1996](https://github.com/gluster/glusterfs/issues/1996) Analyze if spinlocks have any benefit and remove them if not
+[#2001](https://github.com/gluster/glusterfs/issues/2001) Error handling in /usr/sbin/gluster-eventsapi produces AttributeErr
+[#2005](https://github.com/gluster/glusterfs/issues/2005) ./tests/bugs/replicate/bug-921231.t is continuously failing
+[#2013](https://github.com/gluster/glusterfs/issues/2013) dict_t hash-calculation can be removed when hash_size=1
+[#2024](https://github.com/gluster/glusterfs/issues/2024) Remove gfs_id variable or at least set to appropriate value
+[#2025](https://github.com/gluster/glusterfs/issues/2025) list_del() should not set prev and next
+[#2033](https://github.com/gluster/glusterfs/issues/2033) tests/bugs/nfs/bug-1053579.t fails on CentOS 8
+[#2038](https://github.com/gluster/glusterfs/issues/2038) shard_unlink() fails due to no space to create marker file
+[#2039](https://github.com/gluster/glusterfs/issues/2039) Do not allow POSIX IO backend switch when the volume is running
+[#2042](https://github.com/gluster/glusterfs/issues/2042) mount ipv6 gluster volume with serveral backup-volfile-servers,use
+[#2052](https://github.com/gluster/glusterfs/issues/2052) Revert the commit 50e953e2450b5183988c12e87bdfbc997e0ad8a8
+[#2054](https://github.com/gluster/glusterfs/issues/2054) cleanup call_stub_t from unused variables
+[#2063](https://github.com/gluster/glusterfs/issues/2063) Provide autoconf option to enable/disable storage.linux-io_uring du
+[#2067](https://github.com/gluster/glusterfs/issues/2067) Change self-heal-window-size to 1MB by default
+[#2075](https://github.com/gluster/glusterfs/issues/2075) Annotate synctasks with valgrind API if --enable-valgrind[=memcheck
+[#2080](https://github.com/gluster/glusterfs/issues/2080) Glustereventsd default port
+[#2083](https://github.com/gluster/glusterfs/issues/2083) GD_MSG_DICT_GET_FAILED should not include 'errno' but 'ret'
+[#2086](https://github.com/gluster/glusterfs/issues/2086) Move tests/00-geo-rep/00-georep-verify-non-root-setup.t to tests/00
+[#2096](https://github.com/gluster/glusterfs/issues/2096) iobuf_arena structure doesn't need passive and active iobufs, but l
+[#2099](https://github.com/gluster/glusterfs/issues/2099) 'force' option does not work in the replicated volume snapshot crea
+[#2101](https://github.com/gluster/glusterfs/issues/2101) Move 00-georep-verify-non-root-setup.t back to tests/00-geo-rep/
+[#2107](https://github.com/gluster/glusterfs/issues/2107) mount crashes when setfattr -n distribute.fix.layout -v "yes" is ex
+[#2116](https://github.com/gluster/glusterfs/issues/2116) enable quota for multiple volumes take more time
+[#2117](https://github.com/gluster/glusterfs/issues/2117) Concurrent quota enable causes glusterd deadlock
+[#2123](https://github.com/gluster/glusterfs/issues/2123) Implement an I/O framework
+[#2129](https://github.com/gluster/glusterfs/issues/2129) CID 1445996 Null pointer dereferences (FORWARD_NULL) /xlators/mgmt/
+[#2130](https://github.com/gluster/glusterfs/issues/2130) stack.h/c: remove unused variable and reorder struct
+[#2133](https://github.com/gluster/glusterfs/issues/2133) Changelog History Crawl failed after resuming stopped geo-replicati
+[#2134](https://github.com/gluster/glusterfs/issues/2134) Fix spurious failures caused by change in profile info duration to
+[#2138](https://github.com/gluster/glusterfs/issues/2138) glfs_write() dumps a core file file when buffer size is 1GB
+[#2154](https://github.com/gluster/glusterfs/issues/2154) "Operation not supported" doing a chmod on a symlink
+[#2159](https://github.com/gluster/glusterfs/issues/2159) Remove unused component tests
+[#2161](https://github.com/gluster/glusterfs/issues/2161) Crash caused by memory corruption
+[#2169](https://github.com/gluster/glusterfs/issues/2169) Stack overflow when parallel-readdir is enabled
+[#2180](https://github.com/gluster/glusterfs/issues/2180) CID 1446716: Memory - illegal accesses (USE_AFTER_FREE) /xlators/mg
+[#2187](https://github.com/gluster/glusterfs/issues/2187) [Input/output error] IO failure while performing shrink operation w
+[#2190](https://github.com/gluster/glusterfs/issues/2190) Move a test case tests/basic/glusterd-restart-shd-mux.t to flaky
+[#2192](https://github.com/gluster/glusterfs/issues/2192) 4+1 arbiter setup is broken
+[#2198](https://github.com/gluster/glusterfs/issues/2198) There are blocked inodelks for a long time
+[#2216](https://github.com/gluster/glusterfs/issues/2216) Fix coverity issues
+[#2232](https://github.com/gluster/glusterfs/issues/2232) "Invalid argument" when reading a directory with gfapi
+[#2234](https://github.com/gluster/glusterfs/issues/2234) Segmentation fault in directory quota daemon for replicated volume
+[#2239](https://github.com/gluster/glusterfs/issues/2239) rebalance crashes in dht on master
+[#2241](https://github.com/gluster/glusterfs/issues/2241) Using readdir instead of readdirp for fix-layout increases performa
+[#2253](https://github.com/gluster/glusterfs/issues/2253) Disable lookup-optimize by default in the virt group
+[#2258](https://github.com/gluster/glusterfs/issues/2258) Provide option to disable fsync in data migration
+[#2260](https://github.com/gluster/glusterfs/issues/2260) failed to list quota info after setting limit-usage
+[#2268](https://github.com/gluster/glusterfs/issues/2268) dht_layout_unref() only uses 'this' to check that 'this->private' i
+[#2278](https://github.com/gluster/glusterfs/issues/2278) nfs-ganesha does not start due to shared storage not ready, but ret
+[#2287](https://github.com/gluster/glusterfs/issues/2287) runner infrastructure fails to provide platfrom independent error c
+[#2294](https://github.com/gluster/glusterfs/issues/2294) dict.c: remove some strlen() calls if using DICT_LIST_IMP
+[#2308](https://github.com/gluster/glusterfs/issues/2308) Developer sessions for glusterfs
+[#2313](https://github.com/gluster/glusterfs/issues/2313) Long setting names mess up the columns and break parsing
+[#2317](https://github.com/gluster/glusterfs/issues/2317) Rebalance doesn't migrate some sparse files
+[#2328](https://github.com/gluster/glusterfs/issues/2328) "gluster volume set <volname> group samba" needs to include write-b
+[#2330](https://github.com/gluster/glusterfs/issues/2330) gf_msg can cause relock deadlock
+[#2334](https://github.com/gluster/glusterfs/issues/2334) posix_handle_soft() is doing an unnecessary stat
+[#2337](https://github.com/gluster/glusterfs/issues/2337) memory leak observed in lock fop
+[#2348](https://github.com/gluster/glusterfs/issues/2348) Gluster's test suite on RHEL 8 runs slower than on RHEL 7
+[#2351](https://github.com/gluster/glusterfs/issues/2351) glusterd: After upgrade on release 9.1 glusterd protocol is broken
+[#2353](https://github.com/gluster/glusterfs/issues/2353) Permission issue after upgrading to Gluster v9.1
+[#2360](https://github.com/gluster/glusterfs/issues/2360) extras: postscript fails on logrotation of snapd logs
+[#2364](https://github.com/gluster/glusterfs/issues/2364) After the service is restarted, a large number of handles are not r
+[#2370](https://github.com/gluster/glusterfs/issues/2370) glusterd: Issues with custom xlator changes
+[#2378](https://github.com/gluster/glusterfs/issues/2378) Remove sys_fstatat() from posix_handle_unset_gfid() function - not
+[#2380](https://github.com/gluster/glusterfs/issues/2380) Remove sys_lstat() from posix_acl_xattr_set() - not needed
+[#2388](https://github.com/gluster/glusterfs/issues/2388) Geo-replication gets delayed when there are many renames on primary
+[#2394](https://github.com/gluster/glusterfs/issues/2394) Spurious failure in tests/basic/fencing/afr-lock-heal-basic.t
+[#2398](https://github.com/gluster/glusterfs/issues/2398) Bitrot and scrub process showed like unknown in the gluster volume
+[#2404](https://github.com/gluster/glusterfs/issues/2404) Spurious failure of tests/bugs/ec/bug-1236065.t
+[#2407](https://github.com/gluster/glusterfs/issues/2407) configure glitch with CC=clang
+[#2410](https://github.com/gluster/glusterfs/issues/2410) dict_xxx_sizen variant compilation should fail on passing a variabl
+[#2414](https://github.com/gluster/glusterfs/issues/2414) Prefer mallinfo2() to mallinfo() if available
+[#2421](https://github.com/gluster/glusterfs/issues/2421) rsync should not try to sync internal xattrs.
+[#2429](https://github.com/gluster/glusterfs/issues/2429) Use file timestamps with nanosecond precision
+[#2431](https://github.com/gluster/glusterfs/issues/2431) Drop --disable-syslog configuration option
+[#2440](https://github.com/gluster/glusterfs/issues/2440) Geo-replication not working on Ubuntu 21.04
+[#2443](https://github.com/gluster/glusterfs/issues/2443) Core dumps on Gluster 9 - 3 replicas
+[#2446](https://github.com/gluster/glusterfs/issues/2446) client_add_lock_for_recovery() - new_client_lock() should be called
+[#2467](https://github.com/gluster/glusterfs/issues/2467) failed to open /proc/0/status: No such file or directory
+[#2470](https://github.com/gluster/glusterfs/issues/2470) sharding: [inode.c:1255:__inode_unlink] 0-inode: dentry not found
+[#2480](https://github.com/gluster/glusterfs/issues/2480) Brick going offline on another host as well as the host which reboo
+[#2502](https://github.com/gluster/glusterfs/issues/2502) xlator/features/locks/src/common.c has code duplication
+[#2507](https://github.com/gluster/glusterfs/issues/2507) Use appropriate msgid in gf_msg()
+[#2515](https://github.com/gluster/glusterfs/issues/2515) Unable to mount the gluster volume using fuse unless iptables is fl
+[#2522](https://github.com/gluster/glusterfs/issues/2522) ganesha_ha (extras/ganesha/ocf): ganesha_grace RA fails in start()
+[#2540](https://github.com/gluster/glusterfs/issues/2540) delay-gen doesn't work correctly for delays longer than 2 seconds
+[#2551](https://github.com/gluster/glusterfs/issues/2551) Sometimes the lock notification feature doesn't work
+[#2581](https://github.com/gluster/glusterfs/issues/2581) With strict-locks enabled clients which are holding posix locks sti
+[#2590](https://github.com/gluster/glusterfs/issues/2590) trusted.io-stats-dump extended attribute usage description error
+[#2611](https://github.com/gluster/glusterfs/issues/2611) Granular entry self-heal is taking more time than full entry self h
+[#2617](https://github.com/gluster/glusterfs/issues/2617) High CPU utilization of thread glfs_fusenoti and huge delays in som
+[#2620](https://github.com/gluster/glusterfs/issues/2620) Granular entry heal purging of index name trigger two lookups in th
+[#2625](https://github.com/gluster/glusterfs/issues/2625) auth.allow value is corrupted after add-brick operation
+[#2626](https://github.com/gluster/glusterfs/issues/2626) entry self-heal does xattrops unnecessarily in many cases
+[#2649](https://github.com/gluster/glusterfs/issues/2649) glustershd failed in bind with error "Address already in use"
+[#2652](https://github.com/gluster/glusterfs/issues/2652) Removal of deadcode: Pump
+[#2659](https://github.com/gluster/glusterfs/issues/2659) tests/basic/afr/afr-anon-inode.t crashed
+[#2664](https://github.com/gluster/glusterfs/issues/2664) Test suite produce uncompressed logs
+[#2693](https://github.com/gluster/glusterfs/issues/2693) dht: dht_local_wipe is crashed while running rename operation
+[#2771](https://github.com/gluster/glusterfs/issues/2771) Smallfile improvement in glusterfs
+[#2782](https://github.com/gluster/glusterfs/issues/2782) Glustereventsd does not listen on IPv4 when IPv6 is not available
+[#2789](https://github.com/gluster/glusterfs/issues/2789) An improper locking bug(e.g., deadlock) on the lock up_inode_ctx->c
+[#2798](https://github.com/gluster/glusterfs/issues/2798) FUSE mount option for localtime-logging is not exposed
+[#2816](https://github.com/gluster/glusterfs/issues/2816) Glusterfsd memory leak when subdir_mounting a volume
+[#2835](https://github.com/gluster/glusterfs/issues/2835) dht: found anomalies in dht_layout after commit c4cbdbcb3d02fb56a62
+[#2857](https://github.com/gluster/glusterfs/issues/2857) variable twice initialization.
+[#2862](https://github.com/gluster/glusterfs/issues/2862) The test case ./tests/bugs/bug-1702299.t is failing the regression
+[#2865](https://github.com/gluster/glusterfs/issues/2865) The test case tests/basic/0symbol-check.t is failing the regression

--- a/doc/release-notes/10.1.md
+++ b/doc/release-notes/10.1.md
@@ -1,0 +1,28 @@
+# Release notes for Gluster 10.1
+
+This is a bugfix and improvement release. The release notes for [10.0](10.0.md) contain a listing of all the new features that were added and bugs fixed in the GlusterFS 10 stable release.
+
+**NOTE:**
+- Next minor release tentative date: Week of 15th Mar, 2022
+- Users are highly encouraged to upgrade to newer releases of GlusterFS.
+
+## Important fixes in this release
+- Fix missing stripe count issue with upgrade from 9.x to 10.x
+- Fix IO failure when shrinking distributed dispersed volume with ongoing IO
+- Fix log spam introduced with glusterfs 10.0
+- Enable ltcmalloc_minimal instead of ltcmalloc
+
+## Builds are available at
+https://download.gluster.org/pub/gluster/glusterfs/10/10.1/
+
+## Bugs addressed
+[#2846](https://github.com/gluster/glusterfs/issues/2846) Avoid redundant logs in gluster
+[#2903](https://github.com/gluster/glusterfs/issues/2903) Fix worker disconnect due to AttributeError in geo-replication
+[#2910](https://github.com/gluster/glusterfs/issues/2910) Check for available ports in port_range in glusterd
+[#2939](https://github.com/gluster/glusterfs/issues/2939) Remove the deprecated commands from gluster man page
+[#2947](https://github.com/gluster/glusterfs/issues/2947) Fix IO failure when shrinking distributed dispersed volume with ongoing IO
+[#3071](https://github.com/gluster/glusterfs/issues/3071) Fix log spam introduced with glusterfs 10.0
+[#3000](https://github.com/gluster/glusterfs/issues/3000) Enable ltcmalloc_minimal instead of ltcmalloc
+[#3086](https://github.com/gluster/glusterfs/issues/3086) Handle excessive log in case dict is NUL
+[#3133](https://github.com/gluster/glusterfs/issues/3066) Fix missing stripe count issue with upgrade from 9.x to 10.x
+[#2962](https://github.com/gluster/glusterfs/issues/3066) Fix volume create failures without disperse count and ip addresses

--- a/geo-replication/syncdaemon/syncdutils.py
+++ b/geo-replication/syncdaemon/syncdutils.py
@@ -925,7 +925,7 @@ class Volinfo(object):
         vi = XET.fromstring(vix)
         if vi.find('opRet').text != '0':
             if prelude:
-                via = '(via %s) ' % prelude.join(' ')
+                via = '(via %s) ' % ' '.join(prelude)
             else:
                 via = ' '
             raise GsyncdError('getting volume info of %s%s '

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -272,7 +272,7 @@ BuildRequires:    libtsan
 BuildRequires:    bison flex
 BuildRequires:    gcc make libtool
 BuildRequires:    ncurses-devel readline-devel
-BuildRequires:    libxml2-devel openssl-devel
+BuildRequires:    libxml2-devel openssl-devel openssl
 BuildRequires:    libaio-devel libacl-devel
 BuildRequires:    python%{_pythonver}-devel
 %if ( 0%{?_with_tcmalloc:1} )
@@ -1651,6 +1651,9 @@ exit 0
 %endif
 
 %changelog
+* Mon Feb 21 2022 Xavi Hernandez <xhernandez@redhat.com>
+- add openssl as a build dependency.
+
 * Fri Jan 29 2021 Ravishankar N <ravishankar@redhat.com>
 - add liburing-devel as a requirement.
 

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -1179,17 +1179,16 @@ _gf_string2long(const char *str, long *n, int base)
     old_errno = errno;
     errno = 0;
     value = strtol(str, &tail, base);
-    if (str == tail)
+    if ((str == tail) || (*tail != 0)) {
         errno = EINVAL;
+        return -1;
+    }
 
     if (errno == ERANGE || errno == EINVAL)
         return -1;
 
     if (errno == 0)
         errno = old_errno;
-
-    if (tail[0] != '\0')
-        return -1;
 
     *n = value;
 

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -1580,9 +1580,19 @@ dict_get_with_refn(dict_t *this, char *key, const int keylen, data_t **data)
 int
 dict_get_with_ref(dict_t *this, char *key, data_t **data)
 {
-    if (!this || !key || !data) {
+    if (caa_unlikely(!this)) {
+        /* There are possibilities where dict can be NULL. so not so critical
+         * for users to know */
+        gf_msg_callingfn("dict", GF_LOG_DEBUG, EINVAL, LG_MSG_INVALID_ARG,
+                         "dict is NULL: %s", key);
+        return -EINVAL;
+    }
+    if (caa_unlikely(!key || !data)) {
+        /* is there a chance like this? then it can be a coding error, but in
+         * any case, this should be caught early, so good to log it out. */
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
-                         "dict OR key (%s) is NULL", key);
+                         "key (%s) or data ptr is NULL", key);
+
         return -EINVAL;
     }
 #if !DICT_LIST_IMP

--- a/tests/cluster.rc
+++ b/tests/cluster.rc
@@ -50,7 +50,7 @@ function define_glusterds() {
         sopt="management.glusterd-sockfile=${!b}/glusterd/gd.sock"
         #Get the logdir
         logdir=`gluster --print-logdir`
-        clopt="management.cluster-test-mode=${logdir}/$i";
+        clopt="management.logging-directory=${logdir}/$i";
         #Fetch the testcases name and prefix the glusterd log with it
         logfile=`echo ${0##*/}`_glusterd$i.log
         lopt="--log-file=$logdir/$i/$logfile"

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -719,6 +719,7 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local->mds_heal_fresh_lookup && layout) {
         dht_selfheal_dir_setattr(frame, &local->loc, &local->stbuf, 0xffffffff,
                                  layout);
+        return 0;
     }
 out:
     if (mds_heal_fresh_lookup)

--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -228,11 +228,14 @@ ec_manager_create(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_DISPATCH:
         case -EC_STATE_PREPARE_ANSWER:
         case -EC_STATE_REPORT:
+            cbk = fop->answer;
+
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.create != NULL) {
                 fop->cbks.create(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                                 NULL, NULL, NULL, NULL, NULL,
+                                 cbk == NULL ? NULL : cbk->xdata);
             }
 
             return EC_STATE_LOCK_REUSE;

--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -151,6 +151,7 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
 {
     posix_lock_t *plock = NULL;
     posix_lock_t *tmp = NULL;
+    pl_local_t *local;
     struct gf_flock ulock = {
         0,
     };
@@ -183,8 +184,9 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
                 pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
                              &plock->user_flock, -1, EINTR, NULL);
 
-                STACK_UNWIND_STRICT(lk, plock->frame, -1, EINTR,
-                                    &plock->user_flock, NULL);
+                local = plock->frame->local;
+                PL_STACK_UNWIND_AND_FREE(local, lk, plock->frame, -1, EINTR,
+                                         &plock->user_flock, NULL);
 
             } else {
                 gcount++;

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -1040,12 +1040,19 @@ int
 pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
          int can_block)
 {
-    int ret = 0;
-
-    errno = 0;
+    int ret;
 
     pthread_mutex_lock(&pl_inode->mutex);
     {
+        if (GF_ATOMIC_GET(((client_t *)lock->client)->bind) == 0) {
+            /* The client that sent the lock request has disconnected. Unless
+             * this is an unlock request or it's non-blocking, we forbid it. */
+            if (can_block && (lock->fl_type != F_UNLCK)) {
+                pthread_mutex_unlock(&pl_inode->mutex);
+                ret = -ENOTCONN;
+                goto out;
+            }
+        }
         /* Send unlock before the actual lock to
            prevent lock upgrade / downgrade
            problems only if:
@@ -1055,17 +1062,20 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
 
         if (can_block && !(__is_lock_grantable(pl_inode, lock))) {
             ret = pl_send_prelock_unlock(this, pl_inode, lock);
-            if (ret)
+            if (ret) {
                 gf_log(this->name, GF_LOG_DEBUG,
                        "Could not send pre-lock "
                        "unlock");
+            }
         }
+
+        ret = PL_LOCK_GRANTED;
 
         if (__is_lock_grantable(pl_inode, lock)) {
             if (pl_metalock_is_active(pl_inode)) {
                 __pl_queue_lock(pl_inode, lock);
                 pthread_mutex_unlock(&pl_inode->mutex);
-                ret = -2;
+                ret = PL_LOCK_QUEUED;
                 goto out;
             }
             gf_log(this->name, GF_LOG_TRACE,
@@ -1078,7 +1088,7 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
             if (pl_metalock_is_active(pl_inode)) {
                 __pl_queue_lock(pl_inode, lock);
                 pthread_mutex_unlock(&pl_inode->mutex);
-                ret = -2;
+                ret = PL_LOCK_QUEUED;
                 goto out;
             }
             gf_log(this->name, GF_LOG_TRACE,
@@ -1093,15 +1103,14 @@ pl_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
 
             lock->blocked = 1;
             __insert_lock(pl_inode, lock);
-            ret = -1;
+            ret = PL_LOCK_WOULD_BLOCK;
         } else {
             gf_log(this->name, GF_LOG_TRACE,
                    "%s (pid=%d) lk-owner:%s %" PRId64 " - %" PRId64 " => NOK",
                    lock->fl_type == F_UNLCK ? "Unlock" : "Lock",
                    lock->client_pid, lkowner_utoa(&lock->owner),
                    lock->user_flock.l_start, lock->user_flock.l_len);
-            errno = EAGAIN;
-            ret = -1;
+            ret = PL_LOCK_WOULD_BLOCK;
         }
     }
     pthread_mutex_unlock(&pl_inode->mutex);

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -1156,6 +1156,7 @@ pl_lock_preempt(pl_inode_t *pl_inode, posix_lock_t *reqlock)
     posix_lock_t *i = NULL;
     pl_rw_req_t *rw = NULL;
     pl_rw_req_t *itr = NULL;
+    pl_local_t *local;
     struct list_head unwind_blist = {
         0,
     };
@@ -1208,9 +1209,9 @@ pl_lock_preempt(pl_inode_t *pl_inode, posix_lock_t *reqlock)
     /* unwind blocked locks */
     list_for_each_entry_safe(lock, i, &unwind_blist, list)
     {
-        PL_STACK_UNWIND_AND_FREE(((pl_local_t *)lock->frame->local), lk,
-                                 lock->frame, -1, EBUSY, &lock->user_flock,
-                                 NULL);
+        local = lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, lock->frame, -1, EBUSY,
+                                 &lock->user_flock, NULL);
         __destroy_lock(lock);
     }
 

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -52,6 +52,12 @@
         }                                                                      \
     } while (0)
 
+enum {
+    PL_LOCK_GRANTED = 0,
+    PL_LOCK_WOULD_BLOCK,
+    PL_LOCK_QUEUED
+};
+
 posix_lock_t *
 new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
                gf_lkowner_t *owner, fd_t *fd, uint32_t lk_flags, int blocking,

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2755,7 +2755,13 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             }
 
             ret = pl_setlk(this, pl_inode, reqlock, can_block);
-            if (ret == -1) {
+            if (ret < 0) {
+                op_ret = -1;
+                op_errno = -ret;
+                __destroy_lock(reqlock);
+                goto out;
+            }
+            if (ret == PL_LOCK_WOULD_BLOCK) {
                 if ((can_block) && (F_UNLCK != lock_type)) {
                     goto out;
                 }
@@ -2763,7 +2769,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 op_ret = -1;
                 op_errno = EAGAIN;
                 __destroy_lock(reqlock);
-            } else if (ret == -2) {
+            } else if (ret == PL_LOCK_QUEUED) {
                 goto out;
             } else if ((0 == ret) && (F_UNLCK == flock->l_type)) {
                 /* For NLM's last "unlock on fd" detection */

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -282,6 +282,8 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
     posix_lock_t *lock = NULL;
     posix_lock_t *tmp = NULL;
     fd_t *fd = NULL;
+    pl_local_t *local;
+    int32_t op_errno;
 
     int can_block = 0;
     int32_t cmd = 0;
@@ -310,19 +312,26 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
 
         lock->blocked = 0;
         ret = pl_setlk(this, pl_inode, lock, can_block);
-        if (ret == -1) {
+        if (ret < 0) {
+            op_errno = -ret;
+        } else if (ret == PL_LOCK_WOULD_BLOCK) {
             if (can_block) {
                 continue;
             } else {
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
-                pl_trace_out(this, lock->frame, fd, NULL, cmd,
-                             &lock->user_flock, -1, EAGAIN, NULL);
-                pl_update_refkeeper(this, fd->inode);
-                STACK_UNWIND_STRICT(lk, lock->frame, -1, EAGAIN,
-                                    &lock->user_flock, NULL);
-                __destroy_lock(lock);
+                op_errno = EAGAIN;
             }
+        } else {
+            continue;
         }
+
+        pl_trace_out(this, lock->frame, fd, NULL, cmd, &lock->user_flock, -1,
+                     op_errno, NULL);
+        pl_update_refkeeper(this, fd->inode);
+        local = lock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, lock->frame, -1, op_errno,
+                                 &lock->user_flock, NULL);
+        __destroy_lock(lock);
     }
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -98,20 +98,24 @@ pmap_port_alloc(xlator_t *this)
 {
     struct pmap_registry *pmap = NULL;
     int p = 0;
+    int i;
 
     GF_ASSERT(this);
 
     pmap = pmap_registry_get(this);
 
-    while (true) {
-        /* coverity[DC.WEAK_CRYPTO] */
-        p = (rand() % (pmap->max_port - pmap->base_port + 1)) + pmap->base_port;
+    /* coverity[DC.WEAK_CRYPTO] */
+    p = (rand() % (pmap->max_port - pmap->base_port + 1)) + pmap->base_port;
+    for (i = pmap->base_port; i <= pmap->max_port; i++) {
         if (pmap_port_isfree(p)) {
-            break;
+            return p;
+        }
+        if (p++ >= pmap->max_port) {
+            p = pmap->base_port;
         }
     }
 
-    return p;
+    return 0;
 }
 
 /* pmap_assign_port does a pmap_registry_remove followed by pmap_port_alloc,

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -97,7 +97,6 @@ glusterd_validate_quorum(xlator_t *this, glusterd_op_t op, dict_t *dict,
 
     ret = glusterd_volinfo_find(volname, &volinfo);
     if (ret) {
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_VOLINFO_GET_FAIL, NULL);
         ret = 0;
         goto out;
     }
@@ -254,7 +253,7 @@ glusterd_is_volume_in_server_quorum(glusterd_volinfo_t *volinfo)
 
     ret = dict_get_str(volinfo->dict, GLUSTERD_QUORUM_TYPE_KEY, &quorum_type);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_QUORUM_TYPE_KEY, NULL);
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -789,6 +789,16 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
     }
     total_len += ret;
 
+    if (conf->op_version < GD_OP_VERSION_10_0) {
+        ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
+                       GLUSTERD_STORE_KEY_VOL_STRIPE_CNT, STRIPE_COUNT);
+        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+            ret = -1;
+            goto out;
+        }
+        total_len += ret;
+    }
+
     if ((conf->op_version >= GD_OP_VERSION_3_7_6) && volinfo->arbiter_count) {
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
                        GLUSTERD_STORE_KEY_VOL_ARBITER_CNT,

--- a/xlators/mgmt/glusterd/src/glusterd-store.h
+++ b/xlators/mgmt/glusterd/src/glusterd-store.h
@@ -37,6 +37,7 @@ typedef enum glusterd_store_ver_ac_ {
 #define GLUSTERD_STORE_KEY_VOL_STATUS "status"
 #define GLUSTERD_STORE_KEY_VOL_PORT "port"
 #define GLUSTERD_STORE_KEY_VOL_SUB_COUNT "sub_count"
+#define GLUSTERD_STORE_KEY_VOL_STRIPE_CNT "stripe_count"
 #define GLUSTERD_STORE_KEY_VOL_REPLICA_CNT "replica_count"
 #define GLUSTERD_STORE_KEY_VOL_DISPERSE_CNT "disperse_count"
 #define GLUSTERD_STORE_KEY_VOL_REDUNDANCY_CNT "redundancy_count"

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -23,6 +23,7 @@
 #include "glusterd-snapshot-utils.h"
 #include "glusterd-messages.h"
 #include "glusterd-errno.h"
+#include <glusterfs/syscall.h>
 
 extern glusterd_op_info_t opinfo;
 
@@ -1790,6 +1791,62 @@ out:
     return ret;
 }
 
+int
+gd_try_connect(rpc_transport_t *this, char *remote_host, int remote_port, struct sockaddr* sockaddr)
+{
+    int sock = -1;
+    int ret = -1;
+    socklen_t sockaddr_len = 0;
+    struct in6_addr serveraddr;
+    struct addrinfo *addr_info = NULL;
+    int flags = 0;
+
+    ret = gf_resolve_ip6(remote_host, remote_port, sockaddr->sa_family,
+                         &this->dnscache, &addr_info);
+    if (ret)
+        goto out;
+    sock = sys_socket(sockaddr->sa_family, SOCK_STREAM, 0);
+    if (sock < 0)
+    {
+        ret = -1;
+        goto out;
+    }
+    memcpy(sockaddr, addr_info->ai_addr, addr_info->ai_addrlen);
+    sockaddr_len = addr_info->ai_addrlen;
+
+    flags = fcntl(sock, F_GETFL);
+
+    if (flags >= 0)
+    {
+        ret = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+        if (ret)
+            gf_msg_debug(THIS->name, 0, "fcntl returns: %d, %s", ret, strerror(errno));
+    }
+
+    ret = connect(sock, (struct sockaddr *)sockaddr, sockaddr_len);
+    if (ret)
+        gf_msg_debug(THIS->name, 0, "connect returns: %d, %s", ret, strerror(errno));
+
+    if (ret)
+    {
+        if (errno != EINPROGRESS)
+            goto out;
+
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(sock, &wfds);
+        struct timeval tv = {3, 0};
+        if (select(sock + 1,NULL, &wfds, NULL, &tv) != 1)
+            goto out;
+    }
+
+    ret = 0;
+out:
+    if (sock > 0)
+        sys_close(sock);
+    return ret;
+}
+
 void
 gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
 {
@@ -1813,9 +1870,30 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
     uint32_t op_errno = 0;
     gf_boolean_t cluster_lock = _gf_false;
     time_t timeout = 0;
+    glusterd_peerinfo_t *peerinfo = NULL;
+    char *af = NULL;
 
     conf = this->private;
     GF_ASSERT(conf);
+
+    ret = dict_get_str(this->options, "transport.address-family", &af);
+    if (ret || af == NULL)
+        af = "inet";
+    RCU_READ_LOCK;
+    cds_list_for_each_entry_rcu(peerinfo, &conf->peers, uuid_list)
+    {
+        if (peerinfo->connected == 0)
+            continue;
+        struct sockaddr sockaddr = {0};
+        if (!strcmp("inet6", af))
+            sockaddr.sa_family = AF_INET6;
+        else
+            sockaddr.sa_family = AF_INET;
+        ret = gd_try_connect(req->trans, peerinfo->hostname, peerinfo->port, &sockaddr);
+        if (ret)
+            peerinfo->connected = 0;
+    }
+    RCU_READ_UNLOCK;
 
     ret = dict_get_int32(op_ctx, GD_SYNC_OPCODE_KEY, &tmp_op);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5297,7 +5297,7 @@ glusterd_get_global_server_quorum_ratio(dict_t *opts, double *quorum)
     ret = dict_get_strn(opts, GLUSTERD_QUORUM_RATIO_KEY,
                         SLEN(GLUSTERD_QUORUM_RATIO_KEY), &quorum_str);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(THIS->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_QUORUM_RATIO_KEY, NULL);
     } else {
         ret = gf_string2percent(quorum_str, quorum);

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1485,15 +1485,28 @@ init(xlator_t *this)
     if (len < 0 || len >= PATH_MAX)
         exit(2);
 
-    dir_data = dict_get(this->options, "cluster-test-mode");
+    dir_data = dict_get(this->options, "logging-directory");
     if (!dir_data) {
-        /* Use default working dir */
-        len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
-                       DEFAULT_LOG_FILE_DIRECTORY);
+        // Check for deprecated 'cluster-test-mode' option
+        dir_data = dict_get(this->options, "cluster-test-mode");
+        if (dir_data) {
+            len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
+                           dir_data->data);
+            gf_msg(
+                this->name, GF_LOG_WARNING, 0, GD_MSG_CLUSTER_RC_ENABLE,
+                "gluster log directory is set to %s. The option "
+                "'cluster-test-mode' is deprecated and will be removed soon. "
+                "Please use the new option 'logging-directory' instead.",
+                dir_data->data);
+        } else {
+            /* Use default working dir */
+            len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s",
+                           DEFAULT_LOG_FILE_DIRECTORY);
+        }
     } else {
         len = snprintf(logdir, VALID_GLUSTERD_PATHMAX, "%s", dir_data->data);
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_CLUSTER_RC_ENABLE,
-               "cluster-test-mode is enabled logdir is %s", dir_data->data);
+               "gluster log directory is set to %s", dir_data->data);
     }
     if (len < 0 || len >= PATH_MAX)
         exit(2);

--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -87,7 +87,7 @@ parse_backup_volfile_servers ()
                    END{if(sk!=0 || err){printf " SyntaxError";}else{printf " SyntaxOK";}}')
 
     servers=$(echo $servers)
-    if [ "$servers" == "SyntaxOK" ]; then
+    if [ "$servers" = "SyntaxOK" ]; then
         echo ""
         return
     fi
@@ -363,7 +363,7 @@ start_glusterfs ()
             if [ -n "$backup_volfile_servers" ]; then
                 backup_servers=$(parse_backup_volfile_servers ${backup_volfile_servers})
                 syntax_status=$(echo ${backup_servers##*' '})
-                if [ "$syntax_status" == "SyntaxError" ]; then
+                if [ "$syntax_status" = "SyntaxError" ]; then
                     warn "ERROR: Invalid backup-volfile-servers specified.. exiting"
                     exit 1
                 fi

--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -79,7 +79,7 @@ parse_backup_volfile_servers ()
                    END{if(sk!=0 || err){printf " SyntaxError";}else{printf " SyntaxOK";}}')
 
     servers=$(echo $servers)
-    if [ "$servers" == "SyntaxOK" ]; then
+    if [ "$servers" = "SyntaxOK" ]; then
         echo ""
         return
     fi
@@ -284,7 +284,7 @@ start_glusterfs ()
             if [ -n "$backup_volfile_servers" ]; then
                 backup_servers=$(parse_backup_volfile_servers ${backup_volfile_servers})
                 syntax_status=$(echo ${backup_servers##*' '})
-                if [ "$syntax_status" == "SyntaxError" ]; then
+                if [ "$syntax_status" = "SyntaxError" ]; then
                     warn "ERROR: Invalid backup-volfile-servers specified.. exiting"
                     exit 1
                 fi


### PR DESCRIPTION
Once one of nodes' network is suddenly dropped, it
takes several seconds for glusterd to perceive this change.

However, timeout may occurs during this period, when
other nodes treat the dropped one as normal, send
some request to it, and wait for response.

Meawhile, above behavior may also extend the update time
of the dropped node, which in turn causes timeouts to
occur more frequently during that period.

By considering this, a pre-check is seem to be feasible to make
sure the latest status of each node can be always obtained in time.

Fixes: https://github.com/gluster/glusterfs/issues/3443