### PR TITLE
posix-handle: remove posix_handle_unset() and call posix_handle_unset…

### DIFF
--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -292,7 +292,7 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
                        "Found stale gfid "
                        "handle %s, removing it.",
                        gfid_path);
-                posix_handle_unset(this, gfid, NULL);
+                posix_handle_unset_gfid(this, gfid);
             }
         }
         goto parent;
@@ -844,7 +844,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                  * remove the old symlink in order for
                  * posix_gfid_set to set the symlink to the
                  * new dir.*/
-                posix_handle_unset(this, stbuf.ia_gfid, NULL);
+                posix_handle_unset_gfid(this, stbuf.ia_gfid);
         }
     } else if (frame->root->pid != GF_SERVER_PID_TRASH) {
         op_ret = -1;
@@ -1151,7 +1151,7 @@ posix_unlink_gfid_handle_and_entry(call_frame_t *frame, xlator_t *this,
 
         if (loc->inode->fd_count == 0) {
             UNLOCK(&loc->inode->lock);
-            ret = posix_handle_unset(this, stbuf->ia_gfid, NULL);
+            ret = posix_handle_unset_gfid(this, stbuf->ia_gfid);
         } else {
             UNLOCK(&loc->inode->lock);
             ret = posix_move_gfid_to_unlink(this, stbuf->ia_gfid, loc);
@@ -1644,7 +1644,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     if (op_ret == 0) {
         if (posix_symlinks_match(this, loc, stbuf.ia_gfid))
-            posix_handle_unset(this, stbuf.ia_gfid, NULL);
+            posix_handle_unset_gfid(this, stbuf.ia_gfid);
     }
 
     if (op_errno == EEXIST)
@@ -1989,7 +1989,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     if (IA_ISDIR(oldloc->inode->ia_type))
-        posix_handle_unset(this, oldloc->inode->gfid, NULL);
+        posix_handle_unset_gfid(this, oldloc->inode->gfid);
 
     pthread_mutex_lock(&ctx_old->pgfid_lock);
     {
@@ -2081,10 +2081,10 @@ unlock:
     }
 
     if (was_dir)
-        posix_handle_unset(this, victim, NULL);
+        posix_handle_unset_gfid(this, victim);
 
     if (was_present && !was_dir && nlink == 1)
-        posix_handle_unset(this, victim, NULL);
+        posix_handle_unset_gfid(this, victim);
 
     if (IA_ISDIR(oldloc->inode->ia_type)) {
         posix_handle_soft(this, real_newpath, newloc, oldloc->inode->gfid,

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -879,41 +879,6 @@ posix_handle_unset_gfid(xlator_t *this, uuid_t gfid)
 }
 
 int
-posix_handle_unset(xlator_t *this, uuid_t gfid, const char *basename)
-{
-    int ret;
-    struct iatt stat;
-    char *path = NULL;
-
-    if (!basename) {
-        ret = posix_handle_unset_gfid(this, gfid);
-        return ret;
-    }
-
-    MAKE_HANDLE_PATH(path, this, gfid, basename);
-    if (!path) {
-        gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_HANDLE_DELETE,
-               "Failed to create handle path for %s (%s)", basename,
-               uuid_utoa(gfid));
-        return -1;
-    }
-
-    /* stat is being used only for gfid, so passing a NULL inode
-     * doesn't fetch time attributes which is fine
-     */
-    ret = posix_istat(this, NULL, gfid, basename, &stat, _gf_false);
-    if (ret == -1) {
-        gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE, "%s",
-               path);
-        return -1;
-    }
-
-    ret = posix_handle_unset_gfid(this, stat.ia_gfid);
-
-    return ret;
-}
-
-int
 posix_create_link_if_gfid_exists(xlator_t *this, uuid_t gfid, char *real_path,
                                  inode_table_t *itable)
 {

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -208,7 +208,7 @@ posix_handle_soft(xlator_t *this, const char *real_path, loc_t *loc,
                   uuid_t gfid, struct stat *buf);
 
 int
-posix_handle_unset(xlator_t *this, uuid_t gfid, const char *basename);
+posix_handle_unset_gfid(xlator_t *this, uuid_t gfid);
 
 int
 posix_create_link_if_gfid_exists(xlator_t *this, uuid_t gfid, char *real_path,

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -980,7 +980,7 @@ posix_gfid_unset(xlator_t *this, dict_t *xdata)
         goto out;
     }
 
-    posix_handle_unset(this, uuid, NULL);
+    posix_handle_unset_gfid(this, uuid);
 out:
     return;
 }
@@ -1418,7 +1418,7 @@ janitor_walker(const char *fpath, const struct stat *sb, int typeflag,
             gf_msg_trace(THIS->name, 0, "unlinking %s", fpath);
             sys_unlink(fpath);
             if (stbuf.ia_nlink == 1)
-                posix_handle_unset(this, stbuf.ia_gfid, NULL);
+                posix_handle_unset_gfid(this, stbuf.ia_gfid);
             break;
 
         case S_IFDIR:


### PR DESCRIPTION
…_gfid() directly

basename was always NULL from all callers, so essentially it's just a call
to posix_handle_unset_gfid()

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

