### PR TITLE
afr.h: ensure AFR_FRAME_INIT() checks for memory allocation succcess

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -6435,7 +6435,7 @@ out:
 int
 afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno)
 {
-    int __ret = -1;
+    int __ret;
     local->op_ret = -1;
     local->op_errno = EUCLEAN;
 

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1070,6 +1070,8 @@ afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd);
                 mem_put(frame->local);                                         \
                 frame->local = NULL;                                           \
             }                                                                  \
+        } else {                                                               \
+            op_errno = ENOMEM;                                                 \
         }                                                                      \
         frame->local;                                                          \
     })

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1062,12 +1062,15 @@ afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd);
 
 #define AFR_FRAME_INIT(frame, op_errno)                                        \
     ({                                                                         \
-        frame->local = mem_get0(THIS->local_pool);                             \
-        if (afr_local_init(frame->local, frame->this->private, &op_errno)) {   \
-            afr_local_cleanup(frame->local, frame->this);                      \
-            mem_put(frame->local);                                             \
-            frame->local = NULL;                                               \
-        };                                                                     \
+        xlator_t *__this = frame->this;                                        \
+        frame->local = mem_get0(__this->local_pool);                           \
+        if (caa_likely(frame->local)) {                                        \
+            if (afr_local_init(frame->local, __this->private, &op_errno)) {    \
+                afr_local_cleanup(frame->local, __this);                       \
+                mem_put(frame->local);                                         \
+                frame->local = NULL;                                           \
+            }                                                                  \
+        }                                                                      \
         frame->local;                                                          \
     })
 


### PR DESCRIPTION
AFR_FRAME_INIT() macro called mem_get0() to allocate frame->local but did not check for success, before
calling afr_local_init() with the resulting pointer. Fixed so it is checked.

While at it, got rid of a call to THIS and replaced it with frame->this.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

