### PR TITLE
libglusterfs, index, nfs: drop int_to_data()

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -728,27 +728,6 @@ data_ref(data_t *this)
 }
 
 data_t *
-int_to_data(int64_t value)
-{
-    data_t *data = get_new_data();
-
-    if (!data) {
-        return NULL;
-    }
-
-    data->len = gf_asprintf(&data->data, "%" PRId64, value);
-    if (-1 == data->len) {
-        gf_msg_debug("dict", 0, "asprintf failed");
-        data_destroy(data);
-        return NULL;
-    }
-    data->len++; /* account for terminating NULL */
-    data->data_type = GF_DATA_TYPE_INT;
-
-    return data;
-}
-
-data_t *
 data_from_int64(int64_t value)
 {
     data_t *data = get_new_data();

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -175,8 +175,6 @@ dict_lookup(dict_t *this, char *key, data_t **data);
    TODO: provide converts for different byte sizes, signedness, and void *
  */
 data_t *
-int_to_data(int64_t value);
-data_t *
 str_to_data(char *value);
 data_t *
 strn_to_data(char *value, const int vallen);

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -133,6 +133,7 @@ create_frame
 data_copy
 data_destroy
 data_from_dynptr
+data_from_int32
 data_from_uint64
 data_ref
 data_to_bin
@@ -807,7 +808,6 @@ __inode_table_set_lru_limit
 inode_table_set_lru_limit
 inode_unlink
 inode_unref
-int_to_data
 iobref_add
 iobref_clear
 iobref_merge

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -2277,7 +2277,7 @@ index_make_xattrop_watchlist(xlator_t *this, index_priv_t *priv,
         goto out;
     }
 
-    dummy = int_to_data(1);
+    dummy = data_from_int32(1);
     if (!dummy) {
         ret = -1;
         goto out;

--- a/xlators/nfs/server/src/netgroups.c
+++ b/xlators/nfs/server/src/netgroups.c
@@ -306,7 +306,7 @@ _netgroup_entry_deinit(struct netgroup_entry *ngentry)
          */
         name = strdupa(ngentry->netgroup_name);
 
-        dint = int_to_data(1);
+        dint = data_from_int32(1);
         dict_set(__deleted_entries, name, dint);
 
         GF_FREE(ngentry->netgroup_name);


### PR DESCRIPTION
Drop (presumably obsolete) `int_to_data()` and change related
code to use convenient `data_from_int32()` instead, assuming
that 32-bit value is enough for these particular use cases.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000