### PR TITLE
run-tests.sh: provide an option to just list the tests to be run

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -388,7 +388,7 @@ function run_tests()
                 continue
             fi
             if [ x"$list_only" == x"yes" ]; then
-                echo ${t}
+                echo $(realpath --relative-to "$(dirname "${0}")" "${t}")
                 continue
             fi
             total_run_tests=$((total_run_tests+1))


### PR DESCRIPTION
A new option (-l) has been added that just scans the available tests
and filters them using the normal conditions, but then it only outputs
the name of the test instead of executing it.

Change-Id: Ifeb91acf1b454ae8c3b311c1bdccb7485b099db2
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

