### PR TITLE
tests: remove redundant vers=3 option for nfs

### DIFF
--- a/tests/basic/afr/tarissue.t
+++ b/tests/basic/afr/tarissue.t
@@ -23,7 +23,7 @@ TEST $CLI volume start $V0
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT "1" is_nfs_export_available;
 
 # Mount NFS
-mount_nfs $H0:/$V0 $N0 vers=3
+mount_nfs $H0:/$V0 $N0
 
 #Create files
 TEST mkdir -p $N0/nfs/dir1/dir2

--- a/tests/basic/quota-anon-fd-nfs.t
+++ b/tests/basic/quota-anon-fd-nfs.t
@@ -53,7 +53,7 @@ TEST $CLI volume quota $V0 soft-timeout 0
 TEST $CLI volume quota $V0 hard-timeout 0
 
 EXPECT_WITHIN $NFS_EXPORT_TIMEOUT "1" is_nfs_export_available;
-TEST mount_nfs $H0:/$V0 $N0 noac,soft,nolock,vers=3;
+TEST mount_nfs $H0:/$V0 $N0 noac,soft,nolock;
 deep=/0/1/2/3/4/5/6/7/8/9
 TEST mkdir -p $N0/$deep
 


### PR DESCRIPTION
'vers=3' option is implicitly added by nfs_mount() function, so it's
redundant to pass it as an argument. Additionally, some versions of
mount scripts complain if the option is passed twice.

Change-Id: Ief7ac73441882403c9c0ce599dfc2bf45795d017
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

