### PR TITLE
tests: minor issues

### DIFF
--- a/tests/00-geo-rep/georep-upgrade.t
+++ b/tests/00-geo-rep/georep-upgrade.t
@@ -53,8 +53,8 @@ TEST python3 extras/glusterfs-georep-upgrade.py $brick
 #After upgrade
 ###############################################################################################
 echo "After upgrade:"
-EXPECT '1' echo $(grep $updated_data1 $htime_file1 | wc -l)
-EXPECT '1' echo $(grep $updated_data2 $htime_file2 | wc -l)
+EXPECT '1' echo $(grep -a $updated_data1 $htime_file1 | wc -l)
+EXPECT '1' echo $(grep -a $updated_data2 $htime_file2 | wc -l)
 
 #Check directory structure inside changelogs
 TEST ! ls /bricks/brick1/.glusterfs/changelogs/CHANGELOG.$epoch1

--- a/tests/bugs/glusterd/bug-948729/bug-948729-force.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-force.t
@@ -80,8 +80,6 @@ TEST   $CLI1 volume add-brick $V2 $H1:$B4/$V0/brick3 force
 #FIX-ME: replace-brick does not work with the newly introduced cluster test
 #####framework
 
-rmdir /$uuid1 /$uuid2 /$uuid3;
-
 $CLI volume stop $V0
 $CLI volume stop $V1
 $CLI volume stop $V2
@@ -92,6 +90,9 @@ UMOUNT_LOOP $B3/$V0
 UMOUNT_LOOP $B4/$V0
 UMOUNT_LOOP $B5/$V0
 UMOUNT_LOOP $B6/$V0
+
+rm -rf /$uuid1/.glusterfs /$uuid2/.glusterfs /$uuid3/.glusterfs;
+rmdir /$uuid1 /$uuid2 /$uuid3;
 
 rm -f $B1/brick1
 rm -f $B2/brick2

--- a/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
@@ -70,6 +70,9 @@ UMOUNT_LOOP $B1/$V0
 UMOUNT_LOOP $B2/$V0
 UMOUNT_LOOP $B3/$V0
 
+rm -rf /$uuid1/.glusterfs /$uuid2/.glusterfs /$uuid3/.glusterfs;
+rmdir /$uuid1 /$uuid2 /$uuid3;
+
 rm -f  $B1/brick1
 rm -f  $B2/brick2
 rm -f  $B3/brick3

--- a/tests/bugs/glusterd/bug-948729/bug-948729.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729.t
@@ -72,6 +72,9 @@ UMOUNT_LOOP $B1/$V0
 UMOUNT_LOOP $B2/$V0
 UMOUNT_LOOP $B3/$V0
 
+rm -rf /$uuid1/.glusterfs /$uuid2/.glusterfs /$uuid3/.glusterfs;
+rmdir /$uuid1 /$uuid2 /$uuid3;
+
 rm -f  $B1/brick1
 rm -f  $B2/brick2
 rm -f  $B3/brick3

--- a/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
+++ b/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
@@ -59,3 +59,5 @@ EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 1
 # check for the size at mount point, it should be same as previous
 total_space_new=$(df -P $M0 | tail -1 | awk '{ print $2}')
 TEST [ $total_space -eq $total_space_new ]
+
+cleanup


### PR DESCRIPTION
Some versions of grep consider that the htime file is binary, causing
test failures. If has been fixed by forcing it to interpret the data
as text.

Also fixed some clean up issues.

Change-Id: I20def8d2ea3e75c8db0aca8d6d7a3c4a8ecbba96
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

