### PR TITLE
tests: fix pid check inside containers

### DIFF
--- a/tests/bugs/protocol/bug-808400-fcntl.c
+++ b/tests/bugs/protocol/bug-808400-fcntl.c
@@ -39,7 +39,9 @@ run_child(char *filename)
         goto out;
     }
 
-    if ((lock.l_type == F_UNLCK) || (ppid != lock.l_pid)) {
+    /* In containerized environments, fuse may not be able to send a
+     * proper pid. In those cases it's 0. */
+    if ((lock.l_type == F_UNLCK) || ((lock.l_pid != 0) && (ppid != lock.l_pid))) {
         fprintf(stderr,
                 "no locks present, though parent has held "
                 "one\n");


### PR DESCRIPTION
Inside a container, kernel's fuse module may pass 'pid' as 0 in some
cases. This caused a failure of test bugs/protocol/bug-808400-fcntl.c
when run unside a container because it was explicitly checking the pid.

Fixed it by allowing the pid to be the expected value or 0.

Change-Id: I97fbbe1311d0ab093ddb6881abc1da707e581a44
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

