### PR TITLE
tests: make loop devices container-friendly

### DIFF
--- a/tests/include.rc
+++ b/tests/include.rc
@@ -13,7 +13,8 @@ GMV0=${GMV0:=primary};	      # primary volume name to use in geo-rep tests
 GSV0=${GSV0:=secondary};      # secondary volume name to use in geo-rep tests
 GSV1=${GSV1:=secondary1}      # secondary volume name to use in geo-rep tests
 B0=${B0:=/d/backends};        # top level of brick directories
-WORKDIRS="$B0 $M0 $M1 $M2 $M3 $N0 $N1"
+DEVDIR=${DEVDIR:=/d/dev} # directory for loop device management
+WORKDIRS="$B0 $M0 $M1 $M2 $M3 $N0 $N1 $DEVDIR"
 
 ROOT_GFID="00000000-0000-0000-0000-000000000001"
 DOT_SHARD_GFID="be318638-e8a0-4c6d-977d-7a937aa84806"
@@ -659,11 +660,9 @@ function cleanup()
         # TODO: This should be a function DESTROY_LOOP
         case `uname -s` in
         Linux)
-                LOOPDEVICES=`losetup -a | grep "$B0/" | \
-                             awk '{print $1}' | tr -d :`
-                for l in $LOOPDEVICES;
-                do
-                        losetup -d $l
+                for l in ${DEVDIR}/loop*; do
+                        losetup -d "${l}"
+                        rm -f "${l}"
                 done
                 ;;
         NetBSD)
@@ -1010,7 +1009,9 @@ function SETUP_LOOP ()
 
   case ${OSTYPE} in
   Linux)
-    losetup --find --show ${backend}
+    dev="$(losetup --find --show ${backend})"
+    ln -sf "${dev}" "${DEVDIR}/$(basename "${dev}")"
+    echo "${dev}"
     ;;
   NetBSD)
     vnd=`vnconfig -l|awk -F: '/not in use/{print $1; exit}'`

--- a/tests/snapshot.rc
+++ b/tests/snapshot.rc
@@ -115,7 +115,10 @@ function _cleanup_lvm_again() {
 
     vgremove -fyS "vg_name=~^${LVM_PREFIX}_vg"
 
-    find $B0 -name "${LVM_PREFIX}_loop" | xargs -r losetup -d
+    for dev in ${DEVDIR}/loop*; do
+        losetup -d "${dev}"
+        rm -f "${dev}"
+    done
 
     find $B0 -name "${LVM_PREFIX}*" | xargs -r rm -rf
 }
@@ -124,12 +127,11 @@ function _cleanup_lvm_again() {
 ########################################################
 function _create_vhd() {
     local dir=$1
-    local num=$2
-    local loop_num=`expr $2 + 8`
 
     fallocate -l${VHD_SIZE} $dir/${LVM_PREFIX}_vhd
-    mknod -m660 $dir/${LVM_PREFIX}_loop b 7 $loop_num
-    /sbin/losetup $dir/${LVM_PREFIX}_loop $dir/${LVM_PREFIX}_vhd
+    dev="$(losetup -f --show "${dir}/${LVM_PREFIX}_vhd")"
+    ln -sf "${dev}" "${DEVDIR}/$(basename "${dev}")"
+    ln -sf "${DEVDIR}/$(basename "${dev}")" "${dir}/${LVM_PREFIX}_loop"
 }
 
 function _create_lv() {
@@ -176,6 +178,7 @@ function _remove_vhd() {
     local dir=$1
 
     losetup -d $dir/${LVM_PREFIX}_loop
+    rm -f "$(readlink "${dir}/${LVM_PREFIX}_loop")"
     rm -f $dir/${LVM_PREFIX}_loop
     rm -f $dir/${LVM_PREFIX}_vhd
 }

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -108,7 +108,10 @@ function _cleanup_zfs_again() {
 
     /sbin/zfs list | grep $ZFS_PREFIX | awk '{print $1}' | xargs -r -L 1 zpool destroy -f
 
-    find $B0 -name "${ZFS_PREFIX}_loop" | xargs -r losetup -d
+    for dev in ${DEVDIR}/loop*; do
+        losetup -d "${dev}"
+        rm -f "${dev}"
+    done
 
     find $B0 -name "*${ZFS_PREFIX}*" | xargs -r rm -rf
 
@@ -123,13 +126,12 @@ function _cleanup_zfs_again() {
 ########################################################
 function _create_zfs_vhd() {
     local dir=$1
-    local num=$2
-    local loop_num=`expr $2 + 8`
 
     mkdir -p $dir
     fallocate -l${VHD_SIZE} $dir/${ZFS_PREFIX}_vhd
-    mknod -m660 $dir/${ZFS_PREFIX}_loop b 7 $loop_num
-    /sbin/losetup $dir/${ZFS_PREFIX}_loop $dir/${ZFS_PREFIX}_vhd
+    dev="$(losetup -f --show "${dir}/${ZFS_PREFIX}_vhd")"
+    ln -sf "${dev}" "${DEVDIR}/$(basename "${dev}")"
+    ln -sf "${DEVDIR}/$(basename "${dev}")" "${dir}/${ZFS_PREFIX}_loop"
 }
 
 function _create_zpool() {
@@ -166,6 +168,7 @@ function _remove_zfs_vhd() {
     local dir=$1
 
     losetup -d $dir/${ZFS_PREFIX}_loop
+    rm -f "$(readlink "${dir}/${ZFS_PREFIX}_loop")"
     rm -f $dir/${ZFS_PREFIX}_loop
     rm -f $dir/${ZFS_PREFIX}_vhd
 }


### PR DESCRIPTION
On a container, global loop devices may be seen by everyone. Instead
potentially using colliding devices simultaneously and blindly deleting
all of them on cleanup, let the kernel assign the names to avoid
concurrent use of the same device and destroy only those created by
the current container.

Change-Id: Idc61a47665ab009c5b335d04ff6ad3946ef49b79
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

