### PR TITLE
tests: make lvm container-friendly

### DIFF
--- a/tests/bugs/glusterd/bug-1595320.t
+++ b/tests/bugs/glusterd/bug-1595320.t
@@ -15,7 +15,6 @@ function count_brick_processes {
 }
 
 # Setup 3 LVMS
-LVM_PREFIX="test"
 TEST init_n_bricks 3
 TEST setup_lvm 3
 
@@ -71,7 +70,7 @@ TEST [ $n -eq 0 ]
 
 # Mount the brick root
 TEST mkdir -p $brick_root
-TEST mount -t xfs -o nouuid  /dev/test_vg_3/brick_lvm $brick_root
+TEST mount -t xfs -o nouuid  /dev/${LVM_PREFIX}_vg_3/brick_lvm $brick_root
 
 # Replace brick_pid file to test brick_attach code
 TEST cp $b1_pid_file $b3_pid_file

--- a/tests/bugs/replicate/bug-1728770-pass-xattrs.t
+++ b/tests/bugs/replicate/bug-1728770-pass-xattrs.t
@@ -33,7 +33,7 @@ TEST $CLI volume start $V0;
 
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0;
 #corrupt last disk
-dd if=/dev/urandom of=/dev/mapper/patchy_snap_vg_6-brick_lvm bs=512K count=200 status=progress && sync
+dd if=/dev/urandom of=/dev/mapper/${LVM_PREFIX}_vg_6-brick_lvm bs=512K count=200 status=progress && sync
 
 
 # Test the disk is now returning EIO for touch and ls

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -23,6 +23,7 @@ META_MNT=${META_MNT:=/var/run/gluster/shared_storage}; # Mount point of shared g
 
 CC=cc
 OSTYPE=$(uname -s)
+GFREG_ID="$(hostname -s)"
 
 env_dir=$(dirname $0)
 while true; do
@@ -645,7 +646,7 @@ function cleanup()
         rpcinfo -d 100227 3 2>/dev/null || true;
 
         # unmount brick filesystems after killing daemons
-        MOUNTPOINTS=`mount | grep "$B0/" | awk '{print $3}'`
+        MOUNTPOINTS=`findmnt -nRlT "${B0}" -o TARGET,SOURCE | grep "$B0/" | awk '{print $2}'`
         for m in $MOUNTPOINTS;
         do
                 umount $flag $m

--- a/tests/snapshot.rc
+++ b/tests/snapshot.rc
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 LVM_DEFINED=0
-LVM_PREFIX="patchy_snap_${GFREG_ID}"
+# Replace any '-' by '_' to avoid that device manager modifies the name of
+# the device (it replaces '-' by '--' in /dev/mapper)
+LVM_PREFIX="patchy_snap_${GFREG_ID//-/_}"
 LVM_COUNT=0
 VHD_SIZE="300M"
 

--- a/tests/snapshot.rc
+++ b/tests/snapshot.rc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 LVM_DEFINED=0
-LVM_PREFIX="patchy_snap"
+LVM_PREFIX="patchy_snap_${GFREG_ID}"
 LVM_COUNT=0
 VHD_SIZE="300M"
 
@@ -78,19 +78,7 @@ function cleanup_lvm() {
     pkill gluster
     sleep 2
 
-    if [ "$LVM_DEFINED" = "1" ]; then
-        _cleanup_lvm >/dev/null 2>&1
-    fi
-
-    _cleanup_lvm_again >/dev/null 2>&1
-    # TODO Delete cleanup has open bug
-    # once fixed delete this
-    mount | grep "run/gluster/snaps" | awk '{print $3}' | xargs umount 2> /dev/null
-    mount | grep "patchy_snap" | awk '{print $3}' | xargs umount 2> /dev/null
-    \rm -rf /var/run/gluster/snaps/*
-    lvscan | grep "/dev/patchy_snap" | awk '{print $2}'| xargs lvremove -f 2> /dev/null
-    vgs | grep patchy_snap | awk '{print $1}' | xargs vgremove -f 2>/dev/null
-    \rm -rf /dev/patchy*
+    _cleanup_lvm_again
     return 0
 }
 
@@ -116,35 +104,18 @@ function _setup_lvm() {
     done
 }
 
-function _cleanup_lvm() {
-    local count=$LVM_COUNT
-    local b
-    local i
-
-    for i in `seq 1 $count`; do
-        b="B$i"
-        _umount_lv $i
-        _remove_lv $i
-        _remove_vhd ${!b}
-    done
-}
-
 function _cleanup_lvm_again() {
     local file
 
-    mount | grep $LVM_PREFIX | awk '{print $3}' | xargs -r ${UMOUNT_F}
+    findmnt -nRlT "${B0}" -o TARGET,SOURCE | grep "${LVM_PREFIX}" | awk '{print $2}' | xargs -r ${UMOUNT_F}
+    findmnt -nRlo TARGET,SOURCE | grep "run/gluster/snaps" | awk '{print $2}' | xargs -r ${UMOUNT_F}
+    \rm -rf /var/run/gluster/snaps/*
 
-    /sbin/vgs | grep $LVM_PREFIX | awk '{print $1}' | xargs -r vgremove -f
+    vgremove -fyS "vg_name=~^${LVM_PREFIX}_vg"
 
     find $B0 -name "${LVM_PREFIX}_loop" | xargs -r losetup -d
 
     find $B0 -name "${LVM_PREFIX}*" | xargs -r rm -rf
-
-    find /run/gluster/snaps -name "*${LVM_PREFIX}*" | xargs -r rm -rf
-
-    for file in `ls /run/gluster/snaps`; do
-        find /run/gluster/snaps/$file -mmin -2 | xargs -r rm -rf
-    done
 }
 
 ########################################################
@@ -166,11 +137,12 @@ function _create_lv() {
     local thinpoolsize="200M"
     local virtualsize="150M"
 
+    wipefs -a "${dir}/${LVM_PREFIX}_loop"
     /sbin/pvcreate $dir/${LVM_PREFIX}_loop
     /sbin/vgcreate ${!vg} $dir/${LVM_PREFIX}_loop
 
-    /sbin/lvcreate -L ${thinpoolsize} -T /dev/${!vg}/thinpool
-    /sbin/lvcreate -V ${virtualsize} -T /dev/${!vg}/thinpool -n brick_lvm
+    /sbin/lvcreate -L ${thinpoolsize} -T ${!vg}/thinpool
+    /sbin/lvcreate -V ${virtualsize} -T ${!vg}/thinpool -n brick_lvm
 
     mkfs.xfs -f /dev/${!vg}/brick_lvm
 }
@@ -195,7 +167,7 @@ function _remove_lv() {
     local num=$1
     local vg="VG$num"
 
-    vgremove -f ${!vg}
+    vgremove -fy ${!vg}
 }
 
 function _remove_vhd() {

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 ZFS_DEFINED=0
-ZFS_PREFIX="patchy_snap_${GFREG_ID}"
+# Replace any '-' by '_' to avoid that device manager modifies the name of
+# the device (it replaces '-' by '--' in /dev/mapper)
+ZFS_PREFIX="patchy_snap_${GFREG_ID//-/_}"
 ZFS_COUNT=0
 VHD_SIZE="300M"
 

--- a/tests/snapshot_zfs.rc
+++ b/tests/snapshot_zfs.rc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ZFS_DEFINED=0
-ZFS_PREFIX="patchy_snap"
+ZFS_PREFIX="patchy_snap_${GFREG_ID}"
 ZFS_COUNT=0
 VHD_SIZE="300M"
 
@@ -62,8 +62,7 @@ function cleanup_zfs() {
 
     _cleanup_zfs_again >/dev/null 2>&1
     \rm -rf /var/run/gluster/snaps/*
-    zfs list | grep "patchy_snap" | awk '{print $1}'| xargs -L 1 -r zpool destroy -f 2>/dev/null
-    \rm -rf /patchy*
+    zfs list | grep "${ZFS_PREFIX}" | awk '{print $1}'| xargs -L 1 -r zpool destroy -f 2>/dev/null
     return 0
 }
 
@@ -108,6 +107,8 @@ function _cleanup_zfs_again() {
     /sbin/zfs list | grep $ZFS_PREFIX | awk '{print $1}' | xargs -r -L 1 zpool destroy -f
 
     find $B0 -name "${ZFS_PREFIX}_loop" | xargs -r losetup -d
+
+    find $B0 -name "*${ZFS_PREFIX}*" | xargs -r rm -rf
 
     find /run/gluster/snaps -name "*${ZFS_PREFIX}*" | xargs -r rm -rf
 


### PR DESCRIPTION
It's hard to make LVM work inside a container, but some changes have
been done to simplify it by adding a unique identifier (the hostname)
as part of the volume group name. This way it's possible to not
touch anything created by other containers during cleanup.

Also added some cleanup improvements.

Change-Id: I0fd8ff904faa71e30c4aaec1965b215176ebd7e1
Updates: #3469
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

