### PR TITLE
libglusterfs, rpc: drop old string data format

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -34,9 +34,8 @@ struct dict_cmp {
                              "data is NULL");                                  \
             return ret_val;                                                    \
         }                                                                      \
-        /* Not of the asked type, or old version */                            \
-        if ((data->data_type != type) &&                                       \
-            (data->data_type != GF_DATA_TYPE_STR_OLD)) {                       \
+        /* Not of the asked type. */                                           \
+        if (data->data_type != type) {                                         \
             gf_msg_callingfn("dict", GF_LOG_DEBUG, EINVAL, LG_MSG_INVALID_ARG, \
                              "key %s, %s type asked, has %s type", key,        \
                              data_type_name[type],                             \
@@ -964,7 +963,6 @@ bin_to_data(void *value, int32_t len)
 
 static char *data_type_name[GF_DATA_TYPE_MAX] = {
     [GF_DATA_TYPE_UNKNOWN] = "unknown",
-    [GF_DATA_TYPE_STR_OLD] = "string-old-version",
     [GF_DATA_TYPE_INT] = "integer",
     [GF_DATA_TYPE_UINT] = "unsigned integer",
     [GF_DATA_TYPE_DOUBLE] = "float",
@@ -2402,27 +2400,6 @@ err:
     return ret;
 }
 
-/* This function is called only by the volgen for now.
-   Check how else you can handle it */
-int
-dict_set_option(dict_t *this, char *key, char *str)
-{
-    data_t *data = data_from_dynstr(str);
-    int ret = 0;
-
-    if (!data) {
-        ret = -EINVAL;
-        goto err;
-    }
-
-    data->data_type = GF_DATA_TYPE_STR_OLD;
-    ret = dict_set(this, key, data);
-    if (ret < 0)
-        data_destroy(data);
-err:
-    return ret;
-}
-
 int
 dict_add_dynstr_with_alloc(dict_t *this, char *key, char *str)
 {
@@ -2989,7 +2966,7 @@ dict_unserialize(char *orig_buf, int32_t size, dict_t **fill)
         }
         value->len = vallen;
         value->data = gf_memdup(buf, vallen);
-        value->data_type = GF_DATA_TYPE_STR_OLD;
+        value->data_type = GF_DATA_TYPE_STR;
         value->is_static = _gf_false;
         buf += vallen;
 
@@ -3420,7 +3397,7 @@ dict_unserialize_specific_keys(char *orig_buf, int32_t size, dict_t **fill,
         }
         value->len = vallen;
         value->data = gf_memdup(buf, vallen);
-        value->data_type = GF_DATA_TYPE_STR_OLD;
+        value->data_type = GF_DATA_TYPE_STR;
         value->is_static = _gf_false;
         buf += vallen;
 

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -387,8 +387,6 @@ dict_set_static_bin(dict_t *this, char *key, void *ptr, size_t size)
 }
 
 GF_MUST_CHECK int
-dict_set_option(dict_t *this, char *key, char *str);
-GF_MUST_CHECK int
 dict_set_str(dict_t *this, char *key, char *str);
 GF_MUST_CHECK int
 dict_set_strn(dict_t *this, char *key, const int keylen, char *str);

--- a/libglusterfs/src/glusterfs/glusterfs-fops.h
+++ b/libglusterfs/src/glusterfs/glusterfs-fops.h
@@ -225,7 +225,8 @@ typedef enum gf_upcall_flags_t gf_upcall_flags_t;
 
 enum gf_dict_data_type_t {
     GF_DATA_TYPE_UNKNOWN = 0,
-    GF_DATA_TYPE_STR_OLD = 1,
+    /* Backward compatibility placeholder, do not use. */
+    GF_DATA_TYPE_STR_OLD = -1,
     GF_DATA_TYPE_INT = 2,
     GF_DATA_TYPE_UINT = 3,
     GF_DATA_TYPE_DOUBLE = 4,

--- a/libglusterfs/src/graph.y
+++ b/libglusterfs/src/graph.y
@@ -240,7 +240,7 @@ volume_option (char *key, char *value)
         }
 
         set_value = gf_strdup (value);
-	ret = dict_set_option (curr->options, key, set_value);
+	ret = dict_set_str (curr->options, key, set_value);
 
         if (ret == 1) {
                 gf_msg ("parser", GF_LOG_ERROR, 0,

--- a/rpc/xdr/src/glusterfs3.h
+++ b/rpc/xdr/src/glusterfs3.h
@@ -52,7 +52,6 @@
 /* refer 2717 */
 #define GF_O_PATH 010000000
 
-
 #define XLATE_BIT(from, to, bit)                                               \
     do {                                                                       \
         if (from & bit)                                                        \
@@ -768,7 +767,6 @@ dict_to_xdr(dict_t *this, gfx_dict *dict)
                 break;
 
             case GF_DATA_TYPE_PTR:
-            case GF_DATA_TYPE_STR_OLD:
                 index++;
                 /* Ideally, each type of data stored in dictionary
                    should have type. A pointer type shouldn't be
@@ -920,7 +918,6 @@ xdr_to_dict(gfx_dict *dict, dict_t **to)
                 }
                 break;
             case GF_DATA_TYPE_PTR:
-            case GF_DATA_TYPE_STR_OLD:
                 value = GF_MALLOC(xpair->value.gfx_value_u.other.other_len + 1,
                                   gf_common_mt_char);
                 if (!value) {

--- a/rpc/xdr/src/glusterfs4-xdr.x
+++ b/rpc/xdr/src/glusterfs4-xdr.x
@@ -102,7 +102,6 @@ union gfx_value switch (int type) {
         case GF_DATA_TYPE_GFUUID:
                 opaque uuid[16];
         case GF_DATA_TYPE_PTR:
-        case GF_DATA_TYPE_STR_OLD:
                 opaque other<>;
         case GF_DATA_TYPE_MDATA:
                 gfx_mdata_iatt mdata_iatt;


### PR DESCRIPTION
Drop `GF_DATA_TYPE_STR_OLD` dict data type and related code,
prefer `GF_DATA_TYPE_STR` in volgen and serialization.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000