### PR TITLE
[dict.c]: Remove dead code function

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -2955,25 +2955,6 @@ out:
  *          failure: -errno
  */
 
-int
-dict_serialize(dict_t *this, char *buf)
-{
-    int ret = -1;
-
-    if (!this || !buf) {
-        gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
-                         "dict is null!");
-        goto out;
-    }
-
-    LOCK(&this->lock);
-    {
-        ret = dict_serialize_lk(this, buf);
-    }
-    UNLOCK(&this->lock);
-out:
-    return ret;
-}
 
 /**
  * dict_unserialize - unserialize a buffer into a dict

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -153,8 +153,6 @@ dict_key_count(dict_t *this);
 int32_t
 dict_serialized_length(dict_t *dict);
 int32_t
-dict_serialize(dict_t *dict, char *buf);
-int32_t
 dict_unserialize(char *buf, int32_t size, dict_t **fill);
 
 int32_t


### PR DESCRIPTION
dict_serialize() was used to implement lock to dict_serialize_lk() which
serialize a dictionary into a buffer but dict_serialize_lk() was already
implemented with lock where used so removing dict_serialize().

Updates:#1000
Change-Id: I291453f0b0c5702b77d0d77d3388438a7d8d2772
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

