### PR TITLE
tests: new testing tool

### DIFF
--- a/tools/tests/centos7/config
+++ b/tools/tests/centos7/config
@@ -1,0 +1,30 @@
+{
+    "templates": [
+        "domain.xml",
+        "meta-data",
+        "user-data",
+        "user-data-settings"
+    ],
+
+    "vm": {
+        "image": {
+            "url": "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2",
+            "checksums": "https://cloud.centos.org/centos/7/images/sha256sum.txt.asc",
+            "key": "https://centos.org/keys/RPM-GPG-KEY-CentOS-7",
+            "fingerprint": "6341 ab27 53d7 8a78 a7c2 7bb1 24c6 a8a7 f4a8 0eb5"
+        },
+        "domain": "domain.xml",
+        "cpus": 4,
+        "memory": 8,
+        "disk": 20
+    },
+
+    "containers": {
+        "images": {
+            "builder": "gf-builder",
+            "testing": "gf-testing"
+        },
+        "space": 10,
+        "workers": 6
+    }
+}

--- a/tools/tests/centos7/domain.xml
+++ b/tools/tests/centos7/domain.xml
@@ -1,0 +1,58 @@
+<domain type="kvm">
+  <name>$vm_name</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://centos.org/centos/7.0"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit="GiB">$vm_memory</memory>
+  <currentMemory unit="GiB">$vm_memory</currentMemory>
+  <vcpu>$vm_cpus</vcpu>
+  <sysinfo type="smbios">
+    <system>
+      <entry name="serial">$cloud_init_datasource</entry>
+    </system>
+  </sysinfo>
+  <os>
+    <type arch="$vm_arch" machine="$vm_machine">hvm</type>
+    <boot dev="hd"/>
+    <smbios mode="sysinfo"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode="host-model"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>$vm_emulator</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" cache="unsafe" discard="unmap"/>
+      <source file="$vm_disk"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+  <commandline xmlns="http://libvirt.org/schemas/domain/qemu/1.0">
+    <arg value="-netdev"/>
+    <arg value="user,id=gfnet0,net=$vm_network,hostfwd=tcp:127.0.0.1:$host_port-:22"/>
+    <arg value="-device"/>
+    <arg value="virtio-net-pci,netdev=gfnet0"/>
+  </commandline>
+</domain>
+

--- a/tools/tests/centos7/gf-builder
+++ b/tools/tests/centos7/gf-builder
@@ -1,0 +1,59 @@
+FROM centos:7.9.2009
+
+ENV container docker
+ENV PYTHON /usr/bin/python2
+
+RUN yum install -y systemd epel-release
+
+RUN yum install -y \
+        @"Development Tools" diffutils util-linux file \
+        hostname which less e2fsprogs xfsprogs attr net-tools procps psmisc \
+        nfs-utils bind-utils iproute bc vim-common dbench git sysvinit-tools initscripts cronie \
+        libselinux-utils perl-Test-Harness yajl rsync lvm2 python3 python-devel python3-prettytable \
+        pyxattr gperftools-devel openssh-server openssl openssl-devel \
+        libuuid-devel libacl-devel libaio-devel libxml2-devel \
+        userspace-rcu-devel readline-devel && \
+    yum clean all
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/ && \
+     for i in *; do \
+         [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; \
+     done); \
+    (cd /lib/systemd/system/multi-user.target.wants/ && \
+     for i in *; do \
+         [ $i == systemd-user-sessions.service ] || rm -f $i; \
+     done); \
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl enable sshd
+RUN systemctl enable rpcbind
+
+# Prefer IPv4 over IPv6
+RUN echo "precedence ::ffff:0:0/96 100" >/etc/gai.conf
+
+RUN sed -i 's/^\s*#\?\s*\(udev_rules\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(thin_pool_discards\)\s*=.*/\1 = "passdown"/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(issue_discards\)\s*=.*/\1 = 1/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(cache_mode\)\s*=.*/\1 = "writeback"/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(sysfs_scan\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(error_when_full\)\s*=.*/\1 = 1/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(use_lvmetad\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(use_lvmpolld\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(notify_dbus\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(udev_sync\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(scan\)\s*=.*/\1 = ["\/d\/dev"]/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(obtain_device_list_from_udev\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+RUN sed -i 's/^\s*#\?\s*\(write_cache_state\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+
+RUN sed -i 's/^\s*hosts\s*:.*/hosts: files/' /etc/nsswitch.conf
+RUN sed -i 's/^\s*#\?\s*PasswordAuthentication\s.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+RUN ssh-keygen -t rsa -b 2048 -N "" -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+
+CMD ["/sbin/init"]

--- a/tools/tests/centos7/gf-testing
+++ b/tools/tests/centos7/gf-testing
@@ -1,0 +1,14 @@
+FROM glusterfs/builder
+
+COPY . /root/glusterfs
+
+WORKDIR /root/glusterfs
+
+RUN ./autogen.sh
+RUN ./configure --enable-debug --enable-gnfs --disable-linux-io_uring
+RUN make -j install
+
+RUN echo "/usr/local/lib" >/etc/ld.so.conf.d/glusterfs.conf
+RUN ldconfig
+
+CMD ["/sbin/init"]

--- a/tools/tests/centos7/meta-data
+++ b/tools/tests/centos7/meta-data
@@ -1,0 +1,2 @@
+instance-id: $vm_name
+local-hostname: $vm_name

--- a/tools/tests/centos7/user-data
+++ b/tools/tests/centos7/user-data
@@ -1,0 +1,2 @@
+#include http://$httpd_address/config/user-data-settings
+#include http://$httpd_address/config/user-data-prepare

--- a/tools/tests/centos7/user-data-prepare
+++ b/tools/tests/centos7/user-data-prepare
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+touch /etc/cloud/cloud-init.disabled
+
+sed -i 's/myhostname//g' /etc/nsswitch.conf
+
+pip3 install requests
+
+echo "precedence ::ffff:0:0/96 100" >/etc/gai.conf
+
+sed -i 's/^\s*#\?\s*\(udev_rules\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(thin_pool_discards\)\s*=.*/\1 = "passdown"/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(issue_discards\)\s*=.*/\1 = 1/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(cache_mode\)\s*=.*/\1 = "writeback"/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(sysfs_scan\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(error_when_full\)\s*=.*/\1 = 1/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(use_lvmetad\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(use_lvmpolld\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(notify_dbus\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(udev_sync\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(obtain_device_list_from_udev\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+sed -i 's/^\s*#\?\s*\(write_cache_state\)\s*=.*/\1 = 0/' /etc/lvm/lvm.conf
+

--- a/tools/tests/centos7/user-data-settings
+++ b/tools/tests/centos7/user-data-settings
@@ -1,0 +1,27 @@
+#cloud-config
+
+preserve_hostname: false
+hostname: $vm_name
+fqdn: $vm_name.glusterfs.local
+
+system_info:
+  default_user:
+    name: root
+
+users:
+  - name: root
+    ssh_authorized_keys:
+      - $vm_key
+
+ssh_pwauth: false
+
+packages:
+  - lvm2
+  - git
+  - podman
+  - python3
+
+power_state:
+  delay: now
+  mode: poweroff
+

--- a/tools/tests/gftest
+++ b/tools/tests/gftest
@@ -1,0 +1,623 @@
+#!/usr/bin/python3
+
+from urllib.request import urlretrieve
+from pathlib import Path
+from copy import deepcopy
+from xml.etree import ElementTree
+import json
+import os
+import hashlib
+import shutil
+import libvirt
+import sys
+import click
+from socketserver import TCPServer
+from http.server import SimpleHTTPRequestHandler
+import functools
+from threading import Thread
+import gnupg
+import subprocess
+import string
+import time
+
+libvirt.registerErrorHandler(lambda x, y: None, None)
+
+class Config(object):
+    base = Path(sys.argv[0]).parent
+
+    def __init__(self, base, prefix, data):
+        self.base = base
+        self.prefix = prefix
+        self.data = data
+
+    @classmethod
+    def open(cls, name):
+        path = cls.base / name
+        base = path.expanduser()
+        file = base / 'config'
+        if not(file.exists()):
+            raise click.ClickException(f"'{file}' not found")
+        with open(file, 'r') as f:
+            data = json.load(f)
+        return cls(base, "", data)
+
+    @classmethod
+    def create(cls, name):
+        path = cls.base / name
+        base = path.expanduser()
+        file = base / 'config'
+        if base.exists():
+            raise click.ClickException(f"'{base}' already exists")
+        base.mkdir(parents = True, exist_ok = False)
+        return cls(base, "", {})
+
+    def copy(self, cfg, ctx = {}):
+        for item in cfg.base.iterdir():
+            shutil.copy(item, self.base / item.name)
+        with open(self.base / 'config', 'r') as f:
+            self.data = json.load(f)
+        if 'templates' in self.data:
+            for item in self.data.get('templates'):
+                self.render(self.base / item, ctx)
+            del self.data['templates']
+        self.save()
+
+    def render(self, path, ctx):
+        with open(path, 'r') as f:
+            tpl = string.Template(f.read())
+        data = tpl.substitute(ctx)
+        with open(path, 'w') as f:
+            f.write(data)
+
+    def save(self):
+        if len(self.prefix) > 0:
+            raise click.ClickException("Cannot save partial configuration")
+        with open(self.base / 'config', 'w') as f:
+            json.dump(self.data, f)
+
+    def delete(self):
+        if len(self.prefix) > 0:
+            raise click.ClickException("Cannot delete partial configuration")
+        for item in self.base.iterdir():
+            item.unlink()
+        self.base.rmdir()
+
+    def get(self, name, default = None):
+        data = self.data
+        for key in name.split('/'):
+            if type(data) is not dict:
+                raise click.ClickException(f"Invalid option '{name}'")
+            if key not in data:
+                if default is None:
+                    raise click.ClickException(f"Option '{name}' not found")
+                data = default
+                break
+            data = data[key]
+        if type(data) is dict:
+            if len(self.prefix) > 0:
+                name = f'{self.prefix}/{name}'
+            data = Config(self.base, name, data)
+        return data
+
+    def set(self, name, value):
+        keys = name.split('/')
+        last = keys.pop()
+        data = self.data
+        for key in keys:
+            if type(data) is not dict:
+                raise click.ClickException(f"Invalid option '{name}'")
+            if key not in data:
+                data[key] = {}
+            data = data[key]
+        data[last] = value
+
+class UserConfig(Config):
+    base = Path('~/.glusterfs/gftest')
+
+class Image(object):
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.path = self.get_image(cfg.get('url'))
+
+    def get_key(self, gpg, url, fingerprint):
+        for key in gpg.list_keys():
+            if key['fingerprint'].lower() == fingerprint:
+                return
+        path, _ = urlretrieve(url)
+        try:
+            info = gpg.scan_keys(path)
+            if len(info) != 1:
+                raise click.ClickException("Unexpected number of keys")
+            if info[0]['fingerprint'].lower() != fingerprint:
+                raise click.ClickException("Unexpected key fingerprint")
+            with open(path, 'rb') as f:
+                data = f.read()
+            key = gpg.import_keys(data)
+        finally:
+            os.unlink(path)
+        if key.imported != 1:
+            raise click.ClickException("Key import failed")
+
+    def verify_signature(self, path, url, fingerprint):
+        click.echo("Validating checksum's signature...")
+        gpg = gnupg.GPG()
+        self.get_key(gpg, url, fingerprint)
+        with open(path, 'rb') as f:
+            ver = gpg.verify_file(f)
+            if not(ver.valid):
+                os.unlink(path)
+                raise click.ClickException("Invalid file signature")
+
+    def get_checksum(self, url, name):
+        base = Path('~/.glusterfs/cache').expanduser() / name
+        base.mkdir(parents = True, exist_ok = True)
+        path = base / 'checksums'
+        if not(path.exists()):
+            urlretrieve(self.cfg.get('checksums'), path)
+        key = self.cfg.get('key', False)
+        if key is not False:
+            fp = self.cfg.get('fingerprint').replace(' ', '').lower()
+            self.verify_signature(path, key, fp)
+        with open(path, 'r') as f:
+            for line in f.readlines():
+                data = line.strip().split()
+                if (len(data) == 2) and (data[1] == name):
+                    return data[0].lower()
+        os.unlink(path)
+        raise click.ClickException("Image checksum not found")
+
+    def compute_checksum(self, path):
+        click.echo("Verifying VM image's checksum...")
+        sha256 = hashlib.sha256()
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(131072), b''):
+                sha256.update(chunk)
+        return sha256.hexdigest().lower()
+
+    def get_image(self, url):
+        name = url.split('/')[-1]
+        base = Path('~/.glusterfs/cache').expanduser() / name
+        base.mkdir(parents = True, exist_ok = True)
+        path = base / 'image.qcow2'
+        if not(path.exists()):
+            click.echo("Downloading VM image...")
+            urlretrieve(url, path)
+        cs = self.cfg.get('checksums', False)
+        if cs is not False:
+            cs = self.get_checksum(cs, url.split('/')[-1])
+            if self.compute_checksum(path) != cs:
+                os.unlink(path)
+                raise click.ClickException("Image checksum doesn't match")
+        return path
+
+    def create(self, path, size):
+        click.echo("Creating VM disk...")
+        path = path / 'image.qcow2'
+        subprocess.run([
+            'qemu-img',
+            'create',
+            '-q',
+            '-f', 'qcow2',
+            '-F', 'qcow2',
+            '-b', str(self.path),
+            str(path),
+            f'{size}G'
+        ], check = True)
+        return path
+
+class HTTPRequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, handlers, *args, **kwargs):
+        self.handlers = handlers
+        super().__init__(*args, **kwargs)
+
+    def log_message(self, *args):
+        pass
+
+    def resolve_path(self, path):
+        items = path.split('?', 1)[0].split('/')
+        if (len(items) <= 1) or (items[1] not in self.handlers):
+            return None
+        path = '/'.join(items[2:])
+        return f'{self.handlers[items[1]]}/{path}'
+
+    def translate_path(self, path):
+        path = self.resolve_path(path)
+        if path is None:
+            path = '/file-not-found'
+        return path
+
+    def do_PUT(self):
+        path = self.resolve_path(self.path)
+        if path is None:
+            self.send_response(400)
+            msg = "Failed"
+        else:
+            length = int(self.headers['Content-Length'])
+            Path(path).parent.mkdir(parents = True, exist_ok = True)
+            with open(path, 'wb') as f:
+                while length > 0:
+                    data = self.rfile.read(min(length, 131072))
+                    f.write(data)
+                    length -= len(data)
+            self.send_response(201)
+            msg = "Uploaded"
+        self.end_headers()
+        self.wfile.write(f"{msg}\n".encode('utf-8'))
+
+class HTTPServer(object):
+    def __init__(self, handlers):
+        self.handlers = handlers
+
+    def __call__(self, *args, **kwargs):
+        return HTTPRequestHandler(self.handlers, *args, **kwargs)
+
+    def __enter__(self):
+        self.httpd = TCPServer(("127.0.0.1", 0), self)
+        self.port = self.httpd.server_address[1]
+        self.thread = Thread(target = self.server)
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_bt):
+        self.httpd.shutdown()
+        self.thread.join()
+
+    def server(self):
+        self.httpd.serve_forever()
+
+class VM(object):
+    options = [
+        'UserKnownHostsFile=/dev/null',
+        'StrictHostKeyChecking=no',
+        'LogLevel=ERROR'
+    ]
+
+    def __init__(self, cfg, name, conn, dom):
+        self.cfg = cfg
+        self.name = name
+        self.conn = conn
+        self.dom = dom
+        self.network = cfg.get('vm/network')
+        self.prefix = '.'.join(self.network.split('.')[:-1])
+        self.host = f'{self.prefix}.2'
+
+    @classmethod
+    def install(cls, cfg, path, name, conn, timeout):
+        click.echo("Installing VM...")
+
+        with open(path, 'r') as f:
+            spec = f.read()
+
+        try:
+            dom = conn.defineXML(spec)
+        except libvirt.libvirtError as exc:
+            raise click.ClickException(f"Unable to create '{name}': {exc.get_error_message()}")
+
+        vm = cls(cfg, name, conn, dom)
+
+        try:
+            timeout = vm.start(timeout)
+            vm.wait(libvirt.VIR_DOMAIN_SHUTOFF, timeout)
+        except:
+            vm.kill(ignore = True)
+            vm.destroy(ignore = True)
+            raise
+
+        return vm
+
+    @classmethod
+    def create(cls, cfg, name, cpus, memory, disk, network, port, key, timeout):
+        pubkey = Path(key + '.pub').expanduser()
+        if not(pubkey.exists()):
+            raise click.ClickException(f"Public key '{pubkey}' not found")
+        with open(pubkey, 'r') as f:
+            pubkey = f.read()
+
+        conn = libvirt.open()
+        arch = cfg.get('arch', 'x86_64')
+        machine = cfg.get('machine', 'q35')
+        xml = conn.getDomainCapabilities(arch = arch, machine = machine, virttype = 'kvm')
+        data = ElementTree.fromstring(xml)
+        emulator = data.findtext('./path')
+
+        net = '.'.join(network.split('.')[:-1])
+
+        if cpus is None:
+            cpus = cfg.get('cpus', 2)
+        if memory is None:
+            memory = cfg.get('memory', 8)
+        if disk is None:
+            disk = cfg.get('disk', 20)
+
+        user = UserConfig.create(name)
+
+        try:
+            img = Image(cfg.get('image')).create(user.base, disk)
+
+            with HTTPServer({ 'config': user.base}) as httpd:
+                ctx = {
+                    'vm_name': name,
+                    'vm_arch': arch,
+                    'vm_machine': machine,
+                    'vm_emulator': emulator,
+                    'vm_memory': memory,
+                    'vm_cpus': cpus,
+                    'vm_disk': img,
+                    'vm_network': f'{net}.0/24',
+                    'vm_key': pubkey,
+                    'host_port': port,
+                    'httpd_address': f'{net}.2:{httpd.port}',
+                    'cloud_init_datasource': f'ds=nocloud-net;s=http://{net}.2:{httpd.port}/config/'
+                }
+                user.copy(cfg, ctx)
+                user.set('vm/network', f'{net}.0')
+                user.set('vm/port', port)
+                user.set('vm/key', str(key))
+                user.set('vm/cpus', str(cpus))
+                user.set('vm/memory', str(memory))
+                user.set('vm/disk', str(disk))
+                user.save()
+
+                return cls.install(user, user.base / cfg.get('domain'), name, conn, timeout)
+        except:
+            user.delete()
+            raise
+
+    @classmethod
+    def open(cls, name):
+        user = UserConfig.open(name)
+        conn = libvirt.open()
+        try:
+            dom = conn.lookupByName(name)
+        except libvirt.libvirtError as exc:
+            raise click.ClickException(f"Unable to access '{name}': {exc.get_error_message()}")
+        except:
+            raise click.ClickException(f"Unable to access '{name}'")
+        return cls(user, name, conn, dom)
+
+    def ping(self):
+        try:
+            print(self.run('uname -a', capture = True, error = False))
+            return True
+        except:
+            return False
+
+    def start(self, timeout):
+        try:
+            if self.dom.state()[0] == libvirt.VIR_DOMAIN_RUNNING:
+                return timeout
+            self.dom.create()
+        except libvirt.libvirtError as exc:
+            raise click.ClickException(f"Unable to start '{self.name}': {exc.get_error_message()}")
+        except:
+            raise click.ClickException(f"Unable to start '{self.name}'")
+
+        timeout = self.wait(libvirt.VIR_DOMAIN_RUNNING, timeout)
+
+        while True:
+            try:
+                iflist = self.dom.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT)
+            except:
+                iflist = []
+            for iface in iflist:
+                if 'addrs' not in iflist[iface]:
+                    continue
+
+                addrs = iflist[iface]['addrs']
+                if addrs is None:
+                    continue
+
+                for addr in addrs:
+                    if 'addr' not in addr:
+                        continue
+
+                    addr = '.'.join(addr['addr'].split('.')[:-1])
+                    if addr == self.prefix:
+                        return timeout
+
+            if timeout <= 0:
+                raise click.ClickException(f"Timed out waiting for '{self.name}'")
+            time.sleep(0.2)
+            timeout -= 0.2
+
+    def stop(self, timeout):
+        try:
+            if self.dom.state()[0] == libvirt.VIR_DOMAIN_SHUTOFF:
+                return timeout
+            self.dom.shutdown()
+        except libvirt.libvirtError as exc:
+            raise click.ClickException(f"Unable to stop '{self.name}': {exc.get_error_message()}")
+        except:
+            raise click.ClickException(f"Unable to stop '{self.name}'")
+
+        return self.wait(libvirt.VIR_DOMAIN_SHUTOFF, timeout)
+
+    def kill(self, ignore = False):
+        try:
+            self.dom.destroy()
+        except libvirt.libvirtError as exc:
+            if not(ignore):
+                raise click.ClickException(f"Unable to kill '{self.name}': {exc.get_error_message()}")
+        except:
+            if not(ignore):
+                raise click.ClickException(f"Unable to kill '{self.name}'")
+
+    def destroy(self, ignore = False):
+        try:
+            self.dom.undefine()
+            self.cfg.delete()
+        except libvirt.libvirtError as exc:
+            if not(ignore):
+                raise click.ClickException(f"Unable to destroy '{self.name}': {exc.get_error_message()}")
+        except:
+            if not(ignore):
+                raise click.ClickException(f"Unable to destroy '{self.name}'")
+
+    def wait(self, state, timeout):
+        while self.dom.state()[0] != state:
+            if timeout <= 0:
+                raise click.ClickException(f"Timed out waiting for '{self.name}'")
+            time.sleep(0.2)
+            timeout -= 0.2
+        return timeout
+
+    def run(self, cmd, capture = False, error = True, ignore = False, env = None):
+        stdout = subprocess.PIPE if capture else None
+        stderr = None if error else subprocess.DEVNULL
+
+        cmdline = [
+            'ssh',
+            '-qt',
+            '-p', str(self.cfg.get('vm/port')),
+            '-i', self.cfg.get('vm/key')
+        ]
+        for opt in VM.options:
+            cmdline.extend(['-o', opt])
+        cmdline.append('root@127.0.0.1')
+        if env is not None:
+            cmdline.append('env')
+            cmdline.extend([f'{n}={env[n]}' for n in env])
+        cmdline.append(cmd)
+
+        proc = subprocess.run(cmdline, stdout = stdout, stderr = stderr, check = not(ignore), text = True, encoding = 'utf-8')
+        return proc.stdout
+
+@click.group()
+@click.version_option('0.1')
+def gftest():
+    pass
+
+@gftest.command()
+@click.option('-k', '--key', default = '~/.ssh/id_rsa')
+@click.option('-n', '--net', default = '192.168.254.0')
+@click.option('-p', '--port', type = int, default = 2222)
+@click.option('-t', '--template', default = 'centos7')
+@click.option('-c', '--cpus', type = int)
+@click.option('-m', '--memory', type = int)
+@click.option('-d', '--disk', type = int)
+@click.option('-o', '--timeout', type = int, default = 120)
+@click.argument('name', required = True)
+def create(key, net, port, template, cpus, memory, disk, timeout, name):
+    cfg = Config.open(template)
+    vm = VM.create(cfg.get('vm'), name, cpus, memory, disk, net, port, key, timeout)
+    click.echo("Restarting VM...")
+    try:
+        vm.start(45)
+        while not(vm.ping()):
+            time.sleep(1)
+        container = vm.cfg.get('containers/images/builder')
+        with HTTPServer({'config': vm.cfg.base}) as httpd:
+            click.echo("Creating builder container...")
+            vm.run(f'podman build --squash -t glusterfs/builder -f http://{vm.host}:{httpd.port}/config/{container} /root/')
+    except:
+        vm.kill(ignore = True)
+        vm.destroy(ignore = True)
+        raise
+
+@gftest.command()
+@click.argument('name', required = True)
+def destroy(name):
+    vm = VM.open(name)
+    vm.kill(ignore = True)
+    vm.destroy(ignore = True)
+
+@gftest.command()
+@click.option('-t', '--timeout', type = int, default = 45)
+@click.argument('name', required = True)
+def poweron(timeout, name):
+    vm = VM.open(name)
+    timeout = vm.start(timeout)
+    while not(vm.ping()):
+        if timeout <= 0:
+            raise click.ClickException(f"Timed out waiting for '{self.name}'")
+        time.sleep(1)
+        timeout -= 1
+
+@gftest.command()
+@click.option('-t', '--timeout', type = int, default = 15)
+@click.argument('name', required = True)
+def shutdown(timeout, name):
+    VM.open(name).stop(timeout)
+
+@gftest.command()
+@click.argument('name', required = True)
+def poweroff(name):
+    VM.open(name).kill()
+
+@gftest.command()
+@click.option('-c', '--commit', required = True)
+@click.argument('name', required = True)
+def build(commit, name):
+    subprocess.run(['git', 'update-server-info'], capture_output = True, check = True)
+    proc = subprocess.run(['git', 'rev-parse', '--show-toplevel'], capture_output = True, check = True, text = True, encoding = 'utf-8')
+    root = Path(proc.stdout.strip()) / '.git'
+    vm = VM.open(name)
+    vm.run('rm -rf /root/glusterfs')
+    try:
+        container = vm.cfg.get('containers/images/testing')
+        with HTTPServer({'config': vm.cfg.base, 'glusterfs': root}) as httpd:
+            vm.run(f'git clone -b {commit} http://{vm.host}:{httpd.port}/glusterfs /root/glusterfs')
+            vm.run(f'podman build --squash -t glusterfs/testing -f http://{vm.host}:{httpd.port}/config/{container} /root/glusterfs')
+    except:
+        vm.run('rm -rf /root/glusterfs')
+        raise
+
+@gftest.command()
+@click.option('-s', '--space', type = int)
+@click.option('-w', '--workers', type = int)
+@click.argument('name', required = True)
+def spawn(space, workers, name):
+    vm = VM.open(name)
+    if space is None:
+        space = vm.cfg.get('containers/space', 10)
+    if workers is None:
+        workers = vm.cfg.get('containers/workers', 8)
+    vm.run('modprobe zram')
+    zram = vm.run(f'zramctl -f -s {space * workers + 1}G', capture = True)
+    loop = vm.run(f'losetup -f --show {zram}', capture = True)
+    vm.run(f'pvcreate {loop}')
+    vm.run(f'vgcreate vg_{name} {loop}')
+    vm.run(f'lvcreate -l 100%FREE -Zn -T vg_{name}/tp')
+    for i in range(workers):
+        vm.run(f'lvcreate -V {space}G -T vg_{name}/tp -n lv_{name}_{i:02d}')
+        vm.run(f'mkfs.xfs -q -i size=512 /dev/vg_{name}/lv_{name}_{i:02d}')
+        vm.run(f'mkdir -p /mnt/mnt_{i:02d}')
+        vm.run(f'mount -o discard /dev/vg_{name}/lv_{name}_{i:02d} /mnt/mnt_{i:02d}')
+        vm.run(f'podman run -d --rm --privileged --name {name}{i:02d} --hostname {name}{i:02d} --tmpfs /tmp:exec -v /dev:/dev -v /mnt/mnt_{i:02d}:/d:Z glusterfs/testing /sbin/init')
+
+@gftest.command()
+@click.argument('name', required = True)
+def kill(name):
+    vm = VM.open(name)
+    vm.run('podman rm -f --all')
+    vm.run('umount /mnt/mnt_*')
+    vm.run('rmdir /mnt/mnt_*')
+    vm.run('dmsetup remove_all')
+    vm.run('losetup -D')
+    vm.run('zramctl -r /dev/zram*', ignore = True)
+
+@gftest.command()
+@click.argument('name', required = True)
+@click.argument('directory', type = click.Path(), required = True)
+def run(name, directory):
+    vm = VM.open(name)
+    Path(directory).mkdir(parents = True, exist_ok = True)
+    with HTTPServer({'config': vm.cfg.base, 'run': directory}) as httpd:
+        env = {'HOST_URL': f'http://{vm.host}:{httpd.port}'}
+        vm.run('/root/glusterfs/tools/tests/regression', env = env)
+
+@gftest.command()
+@click.argument('name', required = True)
+@click.argument('container', type = int, required = False)
+def sh(name, container):
+    vm = VM.open(name)
+    with HTTPServer({'config': vm.cfg.base}) as httpd:
+        if container is None:
+            env = { 'HOST_URL': f'http://{vm.host}:{httpd.port}' }
+            vm.run('bash -ils', env = env, ignore = True)
+        else:
+            vm.run(f'podman exec -ti -e HOST_URL=http://{vm.host}:{httpd.port} {name}{container:02d} /bin/bash', ignore = True)
+
+if __name__ == "__main__":
+    gftest()
+

--- a/tools/tests/prove_run
+++ b/tools/tests/prove_run
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -u
+
+function reset() {
+    while pgrep gluster >/dev/null; do
+        pkill -9 gluster
+        sleep 0.1
+    done
+
+    findmnt -t fuse.glusterfs -o TARGET | tail -n +2 | xargs -r -n 1 umount
+    mkdir -p /d/dev
+    vgremove -fyS "vg_name=~_$(hostname -s)_"
+    for dev in $(ls /d/dev/ 2>/dev/null); do
+        losetup -d /d/dev/${dev}
+        rm -f /d/dev/${dev}
+    done
+}
+
+function clean_all() {
+    rm -rf /d/* 2>/dev/null
+    mkdir /d/dev
+    fstrim /d
+
+    rm -rf /var/log/glusterfs 2>/dev/null
+    mkdir -p /var/log/glusterfs 2>/dev/null
+
+    rm -rf /var/lib/glusterd 2>/dev/null
+    tar -xf /tmp/glusterd-backup.tgz -C /var/lib
+}
+
+function prepare() {
+    reset
+
+    tar -czf /tmp/glusterd-backup.tgz -C /var/lib glusterd
+
+    clean_all
+}
+
+function terminate() {
+    local name="${1}"
+    local url
+
+    reset
+
+    tar -czf /tmp/glusterfs-logs.tgz -C /var/log glusterfs
+
+    if [[ -n "${HOST_URL}" ]]; then
+        url="${HOST_URL}/run/${name%.t}.$(date --utc +"%Y%m%d%H%M%S").tgz"
+        curl -s -X PUT --upload-file /tmp/glusterfs-logs.tgz "${url}" >/dev/null
+    fi
+
+    clean_all
+}
+
+prepare
+
+ROOT="/root/glusterfs"
+NAME="$(realpath --relative-to "${ROOT}" "${1}")"
+LOG="/tmp/output.log"
+
+pushd "${ROOT}" >/dev/null
+
+echo "$(date --utc --rfc-3339 seconds) - $(hostname -s)" >"${LOG}"
+res="0"
+if ! prove -vmfe /bin/bash "${NAME}" >>"${LOG}" 2>&1; then
+    res="1"
+fi
+echo "$(date --utc --rfc-3339 seconds) - Result: ${res}" >>"${LOG}"
+
+mv "${LOG}" /var/log/glusterfs/
+
+popd >/dev/null
+
+terminate "${NAME}"
+
+exit ${res}
+

--- a/tools/tests/regression
+++ b/tools/tests/regression
@@ -1,0 +1,231 @@
+#!/usr/bin/python3
+
+import sys
+import os
+from multiprocessing import Process, Queue, Event
+from threading import Thread
+import time
+import requests
+import subprocess
+import signal
+from pathlib import Path
+
+HOST_URL = os.environ.get('HOST_URL')
+
+subprocess.run(['modprobe', 'dm_thin_pool', 'dm_snapshot'], check = True)
+
+class TestStats(object):
+    def __init__(self):
+        self.data = {}
+        self.selected = []
+
+    def __enter__(self):
+        self.data = {}
+        self.selected = []
+        self.get()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_bt):
+        self.put()
+
+    def __iter__(self):
+        self.selected.sort(key = lambda x: (-self.data[x]['avg'], x))
+        return iter(self.selected)
+
+    def get(self):
+        if HOST_URL is None:
+            return
+        res = requests.get(f'{HOST_URL}/run/tests.json')
+        if res.status_code == 200:
+            self.data = res.json()
+
+    def put(self):
+        if HOST_URL is not None:
+            data = {}
+            for name in self.data:
+                item = self.data[name]
+                if item['count'] > 0:
+                    data[name] = item
+            requests.put(f'{HOST_URL}/run/tests.json', json = data)
+
+    def get_data(self, name):
+        if name not in self.data:
+            self.data[name] = { 'count': 0, 'elapsed': 0, 'retries': 0, 'avg': float('inf') }
+        return self.data[name]
+
+    def select(self, name):
+        self.get_data(name)
+        self.selected.append(name)
+
+    def add(self, name, elapsed, retries):
+        item = self.get_data(name)
+        item['count'] += 1
+        item['elapsed'] += elapsed
+        item['retries'] += retries
+        item['avg'] = item['elapsed'] / item['count']
+
+class GlusterTesting(object):
+    def __init__(self, stats):
+        self.stats = stats
+        self.procs = []
+        self.requests = Queue()
+        self.results = Queue()
+        self.event = Event()
+
+    def __enter__(self):
+        proc = subprocess.run(['podman', 'ps', '--format', '{{.Names}}'], stdout=subprocess.PIPE, check = True, universal_newlines = True, encoding = 'utf-8')
+        containers = proc.stdout.splitlines()
+        for i in range(len(containers)):
+            proc = Process(target = self.worker, args = (containers[i].strip(),))
+            proc.start()
+            self.procs.append(proc)
+        self.event.clear()
+        self.monitor_thread = Thread(target = self.monitor)
+        self.monitor_thread.start()
+        self.collect_thread = Thread(target = self.collect)
+        self.collect_thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_bt):
+        old = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        for i in range(len(self.procs)):
+            self.process(None)
+        for proc in self.procs:
+            proc.join()
+        self.results.put(None)
+        self.collect_thread.join()
+        self.event.set()
+        self.monitor_thread.join()
+        signal.signal(signal.SIGINT, old)
+
+    def scan_loadavg(self):
+        with open('/proc/loadavg', 'r') as f:
+            data = f.readline().strip().split()[:4]
+        runnable, total = data[3].split('/')
+        return [float(data[0]), float(data[1]), float(data[2]), int(runnable), int(total)]
+
+    def scan_meminfo(self):
+        free = -1
+        avail = -1
+        count = 0
+        with open('/proc/meminfo', 'r') as f:
+            for line in f.readlines():
+                name, value = line.strip().split(':')
+                if name == 'MemFree':
+                    free = int(value.strip().split()[0])
+                elif name == 'MemAvailable':
+                    avail = int(value.strip().split()[0])
+                else:
+                    continue
+                count += 1
+                if count >= 2:
+                    break
+        return [free / 1024, avail / 1024]
+
+    def scan_stat(self):
+        with open('/proc/stat', 'r') as f:
+            for line in f.readlines():
+                data = line.strip().split()
+                if data[0] == 'cpu':
+                    break
+        return [int(x) for x in data[1:9]]
+
+    def monitor(self):
+        with open('/tmp/monitor', 'w') as state:
+            hz = os.sysconf(os.sysconf_names['SC_CLK_TCK']) / 100
+            previous = self.scan_stat()
+            last = time.time()
+            while not(self.event.wait(1)):
+                now = time.time()
+                delay = (now - last) * hz
+
+                data = [f'{now:.6f}']
+                data.extend([f'{x:8.2f}' for x in self.scan_meminfo()])
+                load = self.scan_loadavg()
+                data.extend([f'{x:6.2f}' for x in load[:3]])
+                data.extend([f'{x:6d}' for x in load[3:]])
+                cpu = self.scan_stat()
+                data.extend([f'{(cpu[i] - previous[i]) / delay:6.2f}' for i in range(8)])
+
+                state.write(' '.join(data) + '\n')
+
+                last = now
+                previous = cpu
+
+    def collect(self):
+        start = time.time()
+        total = len(self.stats.selected)
+        count = 0
+        data = self.results.get()
+        while data is not None:
+            container = data[0]
+            name = data[1]
+            elapsed = data[2]
+            retries = data[3]
+
+            if retries < 0:
+                res = '31;1mFAILED'
+                retries = -retries
+            elif retries == 1:
+                res = '32;1mPASSED'
+            else:
+                res = '33;1mPASSED'
+
+            count += 1
+
+            runtime = (time.time() - start) / 60
+            msg = f"{count:4d}/{total} {runtime:5.1f} [{container}] {elapsed:6.1f} {retries} \x1b[{res}\x1b[0m {name}\n"
+            sys.stdout.write(msg)
+
+            self.stats.add(name, elapsed, retries)
+
+            data = self.results.get()
+
+    def process(self, name):
+        self.requests.put(name)
+
+    def worker(self, container):
+        try:
+            name = self.requests.get()
+            while name is not None:
+                elapsed = time.time()
+                retries = self.launch(container, name)
+                elapsed = time.time() - elapsed
+
+                self.results.put((container, name, elapsed, retries))
+
+                name = self.requests.get()
+        except KeyboardInterrupt:
+            pass
+
+    def launch(self, container, name):
+        cmd = ['podman', 'exec']
+        if HOST_URL is not None:
+            cmd.extend(['-e', f'HOST_URL={HOST_URL}'])
+        cmd.extend([container, '/root/glusterfs/tools/tests/prove_run', name])
+        for i in range(2):
+            proc = subprocess.run(cmd, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL, check = False, universal_newlines = True, encoding = 'utf-8')
+            if proc.returncode == 0:
+                return i + 1
+        return -2
+
+if __name__ == "__main__":
+    with TestStats() as tests:
+        cmd = [str(Path(sys.argv[0]).parent.parent.parent / 'run-tests.sh'), '-l']
+        cmd.extend(sys.argv[1:])
+        proc = subprocess.run(cmd, stdout = subprocess.PIPE, check = True, universal_newlines = True, encoding = 'utf-8')
+        count = 0
+        for line in proc.stdout.splitlines():
+            tests.select(line.strip())
+            count += 1
+
+        print(f"{count} test(s) found")
+
+        with GlusterTesting(tests) as test:
+            for name in iter(tests):
+                test.process(name)
+
+    if HOST_URL is not None:
+        with open('/tmp/monitor', 'r') as f:
+            requests.put(f'{HOST_URL}/run/monitor', data = f)
+


### PR DESCRIPTION
A new tool gftest has been created to automate and simplify the
preparation of an environment to run tests. It can also process
the full set of regression tests in parallel to significantly
reduce the total execution time.

It's written in python and requires these components:

- libvirt
- qemu-kvm
- gnupg
- python-click

All other modules should already be present in a default installation.

Using this tool is quite simple:

1. Create the VM

```
gftest create [OPTIONS] <name>

Options:
  --template <name> Template to use (default: centos7)
  --port <num>      Port to access the VM (default: 2222)
  --key <path>      Private key for SSH (default: ~/.ssh/id_rsa)
  --cpus <num>      Number of virtual cores of the VM
  --memory <num>    Memory assigned to the VM in GiB
  --disk <num>      Disk space for the VM in GiB
```

This creates a KVM VM named \<name\> that can be accessed through the
specified port on the local host (i.e. `ssh -p <port> root@127.0.0.1`)
using the specified private key. All other option will be taken from
the template if not present.

This process also creates a container inside the VM with all the
required packages and configurations to build Gluster and run the
tests.

2. Build the code

```
gftest build [OPTIONS] <name>

Options:
  --commit <id>  SHA/name of the commit to compile
```

This copies the current git repo to the VM and compiles the specified
commit in a container image.

3. Start the workers

```
gftest spawn [OPTIONS] <name>

Options:
  --workers <num>  Number of workers to create
  --space <num>    Space allocated for running tests in GiB
```

This starts the specified number of container instances of the compiled
Gluster image.

4. Run the tests

```
gftest run <name> <output dir>
```

This runs the full set of tests in parallel in all available containers
and puts the results into the \<output dir\>.

It also collects statistics for each test and CPU and memory state
during the full run.

5. Access the VM or container for manual testing/debugging

```
gftest sh <name> [<idx>]
```

Without `idx` it opens a shell session to the VM. With an index it opens
a shell session to the idx-th testing container.

There are some additional commands:

- `gftest kill <name>`
  Stops and destroys all testing containers.

- `gftest shutdown <name>`
  Gracefully shuts down the VM.

- `gftest poweroff <name>`
  Forcibly stops the VM.

- `gftest poweron <name>`
  Starts the VM.

Updates: https://github.com/gluster/glusterfs/issues/3469
Change-Id: I169877a4c5197d001bf2822ad7116559f7d78754
Signed-off-by: Xavi Hernandez \<xhernandez@redhat.com\>