### PR TITLE
glusterd: cleanup internal data structures

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -68,7 +68,6 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, time_t frame_timeout,
     } else
         ret = 0;
 
-    conn->frame_timeout = frame_timeout;
     conn->rpc = rpc;
     conn->notify = notify;
 out:

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.h
@@ -23,7 +23,6 @@ struct glusterd_conn_ {
     /* Existing daemons tend to specialize their respective
      * notify implementations, so ... */
     glusterd_conn_notify_t notify;
-    time_t frame_timeout;
     char sockpath[PATH_MAX];
 };
 

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -2968,7 +2968,7 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
              * friend.  The friend state machine will take care of
              * correcting the state as required
              */
-            peerinfo->state.state = GD_FRIEND_STATE_BEFRIENDED;
+            peerinfo->state = GD_FRIEND_STATE_BEFRIENDED;
 
             ret = glusterd_friend_add_from_peerinfo(peerinfo, 0, &args);
         } else {
@@ -3829,7 +3829,7 @@ glusterd_probe_begin(rpcsvc_request_t *req, const char *hoststr, int port,
         }
 
     } else if (peerinfo->connected &&
-               (GD_FRIEND_STATE_BEFRIENDED == peerinfo->state.state)) {
+               (GD_FRIEND_STATE_BEFRIENDED == peerinfo->state)) {
         if (peerinfo->detaching) {
             ret = -1;
             if (op_errno)
@@ -5950,7 +5950,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
                 peerinfo->hostname);
         fprintf(fp, "Peer%d.uuid: %s\n", count, gd_peer_uuid_str(peerinfo));
         fprintf(fp, "Peer%d.state: %s\n", count,
-                glusterd_friend_sm_state_name_get(peerinfo->state.state));
+                glusterd_friend_sm_state_name_get(peerinfo->state));
         fprintf(fp, "Peer%d.connected: %s\n", count,
                 peerinfo->connected ? "Connected" : "Disconnected");
 
@@ -6668,10 +6668,10 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
                    "Peer <%s> (<%s>), in state <%s>, has disconnected "
                    "from glusterd.",
                    peerinfo->hostname, uuid_utoa(peerinfo->uuid),
-                   glusterd_friend_sm_state_name_get(peerinfo->state.state));
+                   glusterd_friend_sm_state_name_get(peerinfo->state));
             gf_event(EVENT_PEER_DISCONNECT, "peer=%s;uuid=%s;state=%s",
                      peerinfo->hostname, uuid_utoa(peerinfo->uuid),
-                     glusterd_friend_sm_state_name_get(peerinfo->state.state));
+                     glusterd_friend_sm_state_name_get(peerinfo->state));
 
             if (peerinfo->connected) {
                 if (conf->op_version < GD_OP_VERSION_3_6_0) {
@@ -6698,7 +6698,7 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
             }
 
             if ((peerinfo->quorum_contrib != QUORUM_DOWN) &&
-                (peerinfo->state.state == GD_FRIEND_STATE_BEFRIENDED)) {
+                (peerinfo->state == GD_FRIEND_STATE_BEFRIENDED)) {
                 peerinfo->quorum_contrib = QUORUM_DOWN;
                 quorum_action = _gf_true;
                 peerinfo->quorum_action = _gf_false;
@@ -6707,7 +6707,7 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
             /* Remove peer if it is not a friend and connection/handshake
              *  fails, and notify cli. Happens only during probe.
              */
-            if (peerinfo->state.state == GD_FRIEND_STATE_DEFAULT) {
+            if (peerinfo->state == GD_FRIEND_STATE_DEFAULT) {
                 glusterd_friend_remove_notify(peerctx, op_errno);
                 goto out;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -710,7 +710,7 @@ glusterd_mgmt_v3_initiate_lockdown(glusterd_op_t op, dict_t *dict,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_lock(op, dict, peerinfo, &args, MY_UUID, peer_uuid);
@@ -1058,7 +1058,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_pre_validate_req(op, req_dict, peerinfo, &args, MY_UUID,
@@ -1407,7 +1407,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_brick_op_req(op, req_dict, peerinfo, &args, MY_UUID,
@@ -1685,7 +1685,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             continue;
 
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_commit_req(op, req_dict, peerinfo, &args, MY_UUID,
@@ -1944,7 +1944,7 @@ glusterd_mgmt_v3_post_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             continue;
 
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_post_commit_req(op, req_dict, peerinfo, &args, MY_UUID,
@@ -2170,7 +2170,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_post_validate_req(op, op_ret, req_dict, peerinfo, &args,
@@ -2353,7 +2353,7 @@ glusterd_mgmt_v3_release_peer_locks(glusterd_op_t op, dict_t *dict,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         gd_mgmt_v3_unlock(op, dict, peerinfo, &args, MY_UUID, peer_uuid);

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -799,7 +799,7 @@ glusterd_count_connected_peers(int32_t *count)
     {
         /* Find peer who is connected and is a friend */
         if ((peerinfo->connected) &&
-            (peerinfo->state.state == GD_FRIEND_STATE_BEFRIENDED)) {
+            (peerinfo->state == GD_FRIEND_STATE_BEFRIENDED)) {
             (*count)++;
         }
     }
@@ -4089,7 +4089,7 @@ glusterd_op_ac_send_lock(glusterd_op_sm_event_t *event, void *ctx)
 
         if (!peerinfo->connected || !peerinfo->mgmt)
             continue;
-        if ((peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) &&
+        if ((peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) &&
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
 
@@ -4191,7 +4191,7 @@ glusterd_op_ac_send_unlock(glusterd_op_sm_event_t *event, void *ctx)
 
         if (!peerinfo->connected || !peerinfo->mgmt || !peerinfo->locked)
             continue;
-        if ((peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) &&
+        if ((peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) &&
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
         /* Based on the op_version,
@@ -4806,7 +4806,7 @@ glusterd_op_ac_send_stage_op(glusterd_op_sm_event_t *event, void *ctx)
 
         if (!peerinfo->connected || !peerinfo->mgmt)
             continue;
-        if ((peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) &&
+        if ((peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) &&
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
 
@@ -5423,7 +5423,7 @@ glusterd_op_ac_send_commit_op(glusterd_op_sm_event_t *event, void *ctx)
 
         if (!peerinfo->connected || !peerinfo->mgmt)
             continue;
-        if ((peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) &&
+        if ((peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) &&
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
 

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -325,7 +325,7 @@ glusterd_op_stage_replace_brick(dict_t *dict, char **op_errstr,
             *op_errstr = gf_strdup(msg);
             goto out;
 
-        } else if (GD_FRIEND_STATE_BEFRIENDED != peerinfo->state.state) {
+        } else if (GD_FRIEND_STATE_BEFRIENDED != peerinfo->state) {
             RCU_READ_UNLOCK;
             ret = -1;
             snprintf(msg, sizeof(msg),

--- a/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
@@ -167,7 +167,7 @@ glusterd_reset_brick_prevalidate(dict_t *dict, char **op_errstr,
             *op_errstr = gf_strdup(msg);
             goto out;
 
-        } else if (GD_FRIEND_STATE_BEFRIENDED != peerinfo->state.state) {
+        } else if (GD_FRIEND_STATE_BEFRIENDED != peerinfo->state) {
             RCU_READ_UNLOCK;
             ret = -1;
             snprintf(msg, sizeof(msg),

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -91,8 +91,6 @@ glusterd_shdsvc_init(void *data, glusterd_conn_t *mux_conn,
 
     /* Initialize the connection mgmt */
     if (mux_conn && mux_svc->rpc) {
-        /* multiplexed svc */
-        svc->conn.frame_timeout = mux_conn->frame_timeout;
         /* This will be unrefed from glusterd_shd_svcproc_cleanup*/
         svc->conn.rpc = rpc_clnt_ref(mux_svc->rpc);
         ret = snprintf(svc->conn.sockpath, sizeof(svc->conn.sockpath), "%s",

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -532,7 +532,7 @@ glusterd_should_update_peer(glusterd_peerinfo_t *peerinfo,
                             glusterd_peerinfo_t *cur_peerinfo)
 {
     if ((peerinfo == cur_peerinfo) ||
-        (peerinfo->state.state == GD_FRIEND_STATE_BEFRIENDED))
+        (peerinfo->state == GD_FRIEND_STATE_BEFRIENDED))
         return _gf_true;
 
     return _gf_false;
@@ -1098,11 +1098,11 @@ glusterd_friend_sm_transition_state(uuid_t peerid, char *peername,
         goto out;
     }
 
-    (void)glusterd_sm_tr_log_transition_add(
-        &peerinfo->sm_log, peerinfo->state.state, state[event_type].next_state,
-        event_type);
+    (void)glusterd_sm_tr_log_transition_add(&peerinfo->sm_log, peerinfo->state,
+                                            state[event_type].next_state,
+                                            event_type);
 
-    uatomic_set(&peerinfo->state.state, state[event_type].next_state);
+    uatomic_set(&peerinfo->state, state[event_type].next_state);
 
     ret = 0;
 out:
@@ -1423,7 +1423,7 @@ gd_does_peer_affect_quorum(glusterd_friend_sm_state_t old_state,
         (event_type != GD_FRIEND_EVENT_RCVD_ACC) &&
         (event_type != GD_FRIEND_EVENT_LOCAL_ACC))
         goto out;
-    if ((peerinfo->state.state == GD_FRIEND_STATE_BEFRIENDED) &&
+    if ((peerinfo->state == GD_FRIEND_STATE_BEFRIENDED) &&
         peerinfo->connected) {
         affects = _gf_true;
     }
@@ -1469,7 +1469,7 @@ glusterd_friend_sm()
                 GF_FREE(event);
                 continue;
             }
-            old_state = peerinfo->state.state;
+            old_state = peerinfo->state;
             RCU_READ_UNLOCK;
             gf_msg_debug("glusterd", 0, "Dequeued event of type: '%s'",
                          glusterd_friend_sm_event_name_get(event_type));

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -42,11 +42,6 @@ typedef enum glusterd_friend_sm_state_ {
     GD_FRIEND_STATE_MAX
 } glusterd_friend_sm_state_t;
 
-typedef struct glusterd_peer_state_info_ {
-    glusterd_friend_sm_state_t state;
-    struct timeval transition_time;
-} glusterd_peer_state_info_t;
-
 typedef struct glusterd_peer_hostname_ {
     char *hostname;
     struct cds_list_head hostname_list;
@@ -73,7 +68,7 @@ struct glusterd_peerinfo_ {
     char uuid_str[50]; /* Retrieve this using
                         * gd_peer_uuid_str ()
                         */
-    glusterd_peer_state_info_t state;
+    glusterd_friend_sm_state_t state;
     char *hostname;
     struct cds_list_head hostnames;
     int port;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -115,7 +115,7 @@ glusterd_find_missed_snap(dict_t *rsp_dict, glusterd_volinfo_t *vol,
              * if peer is not connected or not   *
              * friend add it to missed snap list */
             if (!(peerinfo->connected) ||
-                (peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)) {
+                (peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)) {
                 ret = glusterd_add_missed_snaps_to_dict(
                     rsp_dict, vol, brickinfo, brick_count + 1, op);
                 if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-statedump.c
+++ b/xlators/mgmt/glusterd/src/glusterd-statedump.c
@@ -56,7 +56,7 @@ glusterd_dump_peer(glusterd_peerinfo_t *peerinfo, char *input_key, int index,
     gf_proc_dump_write(key, "%d", peerinfo->port);
 
     gf_proc_dump_build_key(key, subkey, "state");
-    gf_proc_dump_write(key, "%d", peerinfo->state.state);
+    gf_proc_dump_write(key, "%d", peerinfo->state);
 
     gf_proc_dump_build_key(key, subkey, "quorum-action");
     gf_proc_dump_write(key, "%d", peerinfo->quorum_action);

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -4490,7 +4490,7 @@ glusterd_store_peer_write(int fd, glusterd_peerinfo_t *peerinfo)
 
     ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%s\n%s=%d\n",
                    GLUSTERD_STORE_KEY_PEER_UUID, uuid_utoa(peerinfo->uuid),
-                   GLUSTERD_STORE_KEY_PEER_STATE, peerinfo->state.state);
+                   GLUSTERD_STORE_KEY_PEER_STATE, peerinfo->state);
     if (ret < 0 || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
@@ -4656,7 +4656,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
                     gf_uuid_parse(value, peerinfo->uuid);
             } else if (!strncmp(GLUSTERD_STORE_KEY_PEER_STATE, key,
                                 SLEN(GLUSTERD_STORE_KEY_PEER_STATE))) {
-                peerinfo->state.state = atoi(value);
+                peerinfo->state = atoi(value);
             } else if (!strncmp(GLUSTERD_STORE_KEY_PEER_HOSTNAME, key,
                                 SLEN(GLUSTERD_STORE_KEY_PEER_HOSTNAME))) {
                 ret = gd_add_address_to_peer(peerinfo, value, _gf_false);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -435,9 +435,10 @@ glusterd_muxsvc_common_rpc_notify(glusterd_svc_proc_t *mux_proc,
                 }
             }
             if (mux_proc->status != GF_SVC_DIED) {
-                svc = (cds_list_empty(&mux_proc->svcs) ? NULL :
-                       cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
-                                      mux_svc));
+                svc = (cds_list_empty(&mux_proc->svcs)
+                           ? NULL
+                           : cds_list_entry(mux_proc->svcs.next, glusterd_svc_t,
+                                            mux_svc));
                 if (svc && !glusterd_proc_is_running(&svc->proc)) {
                     mux_proc->status = GF_SVC_DIED;
                 } else {
@@ -509,7 +510,6 @@ glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
     else
         ret = 0;
 
-    conn->frame_timeout = frame_timeout;
     conn->rpc = rpc;
     mux_proc->notify = notify;
 out:

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1835,7 +1835,7 @@ gd_lock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, dict_t *op_ctx,
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         if (cluster_lock) {
@@ -2098,7 +2098,7 @@ stage_done:
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         (void)gd_syncop_mgmt_stage_op(peerinfo, &args, MY_UUID, tmp_uuid, op,
@@ -2246,7 +2246,7 @@ commit_done:
         if (!peerinfo->connected)
             continue;
         if (op != GD_OP_SYNC_VOLUME &&
-            peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+            peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
             continue;
 
         (void)gd_syncop_mgmt_commit_op(peerinfo, &args, MY_UUID, tmp_uuid, op,
@@ -2326,7 +2326,7 @@ gd_unlock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, int *op_ret,
             if (!peerinfo->connected)
                 continue;
             if (op != GD_OP_SYNC_VOLUME &&
-                peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+                peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
                 continue;
 
             /* Only unlock peers that were locked */
@@ -2355,7 +2355,7 @@ gd_unlock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, int *op_ret,
                 if (!peerinfo->connected)
                     continue;
                 if (op != GD_OP_SYNC_VOLUME &&
-                    peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED)
+                    peerinfo->state != GD_FRIEND_STATE_BEFRIENDED)
                     continue;
 
                 gd_syncop_mgmt_v3_unlock(op_ctx, peerinfo, &args, MY_UUID,

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -7587,7 +7587,7 @@ glusterd_new_brick_validate(char *brick, glusterd_brickinfo_t *brickinfo,
             goto out;
         }
 
-        if (peerinfo->state.state != GD_FRIEND_STATE_BEFRIENDED) {
+        if (peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) {
             snprintf(op_errstr, len,
                      "Host %s is not in \'Peer "
                      "in Cluster\' state",


### PR DESCRIPTION
Since `transition_time` of `glusterd_peer_state_info_t` is not
used anywhere, drop the latter and move `state` field directly
into `glusterd_peerinfo_t`, drop assigned-only `frame_timeout`
member from `struct glusterd_conn_`, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

