### PR TITLE
libglusterfs, shard: fix -Wformat-overflow noise

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -2918,7 +2918,7 @@ gf_is_local_addr(char *hostname)
 
     for (res = result; res != NULL; res = res->ai_next) {
         get_ip_from_addrinfo(res, &ip);
-        gf_msg_debug(this->name, 0, "%s ", ip);
+        gf_msg_debug(this->name, 0, "%s ", (ip ? ip : "<unknown>"));
 
         if (ip) {
             found = (gf_is_loopback_localhost(res->ai_addr, hostname) ||

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -598,19 +598,14 @@ shard_call_count_return(call_frame_t *frame)
 static char *
 shard_internal_dir_string(shard_internal_dir_type_t type)
 {
-    char *str = NULL;
-
     switch (type) {
         case SHARD_INTERNAL_DIR_DOT_SHARD:
-            str = GF_SHARD_DIR;
-            break;
+            return GF_SHARD_DIR;
         case SHARD_INTERNAL_DIR_DOT_SHARD_REMOVE_ME:
-            str = GF_SHARD_REMOVE_ME_DIR;
-            break;
+            return GF_SHARD_REMOVE_ME_DIR;
         default:
-            break;
+            return "<unknown>";
     }
-    return str;
 }
 
 static int


### PR DESCRIPTION
Fix the following `-Wformat-overflow` warnings (as reported by gcc 11.3):
```
common-utils.c: In function ‘gf_is_local_addr’:
./glusterfs/logging.h:235:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  235 |         _gf_msg(dom, __FILE__, __FUNCTION__, __LINE__, GF_LOG_DEBUG, errnum,   \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  236 |                 0, 0, ##fmt);                                                  \
      |                 ~~~~~~~~~~~~
```
and:
```
shard.c: In function ‘shard_mkdir_internal_dir’:
../../../../libglusterfs/src/glusterfs/logging.h:199:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  199 |         _gf_msg(dom, __FILE__, __FUNCTION__, __LINE__, level, errnum, 0,       \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  200 |                 msgid, ##fmt);                                                 \
      |                 ~~~~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

