### PR TITLE
posix: fix compilation issue

### DIFF
--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -854,7 +854,7 @@ posix_handle_soft(xlator_t *this, const char *real_path, loc_t *loc,
     return ret;
 }
 
-static int
+int
 posix_handle_unset_gfid(xlator_t *this, uuid_t gfid)
 {
     int ret = 0;


### PR DESCRIPTION
An issue has been introduced as a result of commits fa5861bb and
203703eb. This patch fixes the issue by making function
`posix_handle_unset_gfid()` non static.

Change-Id: I97a5d1d36a908deec94b09b7e548f9d1def2880c
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

