### PR TITLE
Fix ta_brick parse failure

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -153,16 +153,13 @@ cli_cmd_ta_brick_parse(const char **words, int wordcount, char **ta_brick)
 
     brick->name = words[wordcount - 1];
     brick->len = strlen(words[wordcount - 1]);
-    *ta_brick = GF_MALLOC(brick->len + 3, gf_common_mt_char);
+    gf_asprintf(ta_brick, " %s ", brick->name);
     if (*ta_brick == NULL) {
         ret = -1;
         gf_log("cli", GF_LOG_ERROR, "Out of memory");
         goto out;
     }
 
-    strcat(*ta_brick, " ");
-    strcat(*ta_brick, brick->name);
-    strcat(*ta_brick, " ");
 out:
     if (tmp_host) {
         GF_FREE(tmp_host);


### PR DESCRIPTION
Set ta_brick as empty after malloc, to ensure
the correct brick info can be obtained by glusterd.

Fixes: #3507

Change-Id: I674bdb9554731b6f456bb7ce0b685ebb4fe7f234
Signed-off-by: ChenJinhao <chen.jinhao@zte.com.cn>

