### PR TITLE
fix force-migration.t execute failed

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2874,7 +2874,10 @@ gf_defrag_migrate_single_file(void *opaque)
 
             LOCK(&defrag->lock);
             {
-                defrag->total_failures += 1;
+                if (fop_errno == EBUSY)
+                    defrag->skipped += 1;
+                else
+                    defrag->total_failures += 1;
             }
             UNLOCK(&defrag->lock);
         }


### PR DESCRIPTION
Rebalancing a file that is being read or wrote may
cause the rebalance procedure failed since this file
is counted in 'total_failures'.

After this modifiction, it will be counted in 'skipped'
as expected in test case.

Fixes: #3513
Change-Id: I4472851ff3d0104c777a6274910daceaacab7bbd
Signed-off-by: ChenJinhao <chen.jinhao@zte.com.cn>

