### PR TITLE
posix, io-stats: fix -Wstringop and -Wformat warnings

### DIFF
--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -4082,7 +4082,7 @@ init(xlator_t *this)
     ret = dict_get_strn(this->options, "volume-id", SLEN("volume-id"),
                         &volume_id);
     if (!ret) {
-        strncpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
+        memcpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
     }
     /*
      * Init it just after calloc, so that we are sure the lock is inited

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -381,9 +381,9 @@ posix_handle_pump(xlator_t *this, char *buf, int len, int maxlen,
     memmove(buf + base_len + blen, buf + base_len,
             (strlen(buf) - base_len) + 1);
 
-    strncpy(base_str + pfx_len, linkname + 6, 42);
+    memcpy(base_str + pfx_len, linkname + 6, 42);
 
-    strncpy(buf + pfx_len, linkname + 6, link_len - 6);
+    memcpy(buf + pfx_len, linkname + 6, link_len - 6);
 out:
     return len + blen;
 err:
@@ -400,8 +400,8 @@ err:
 */
 
 int
-posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *ubuf,
-                  size_t size)
+posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *buf,
+                  size_t maxlen)
 {
     struct posix_private *priv = NULL;
     char *uuid_str = NULL;
@@ -411,8 +411,6 @@ posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *ubuf,
     char *base_str = NULL;
     int base_len = 0;
     int pfx_len;
-    int maxlen;
-    char *buf;
     int index = 0;
     int dfd = 0;
     char newstr[POSIX_GFID_HASH2_LEN] = {
@@ -422,14 +420,6 @@ posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *ubuf,
     priv = this->private;
 
     uuid_str = uuid_utoa(gfid);
-
-    if (ubuf) {
-        buf = ubuf;
-        maxlen = size;
-    } else {
-        maxlen = PATH_MAX;
-        buf = alloca(maxlen);
-    }
 
     index = gfid[0];
     dfd = priv->arrdfd[index];

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -3466,9 +3466,6 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
     char dirpath[PATH_MAX] = {
         0,
     };
-    char pgfidstr[UUID_CANONICAL_FORM_LEN + 1] = {
-        0,
-    };
     int len;
 
     priv = this->private;
@@ -3557,9 +3554,7 @@ posix_get_ancestry_non_directory(xlator_t *this, inode_t *leaf_inode,
 
         nlink_samepgfid = be32toh(nlink_samepgfid);
 
-        snprintf(pgfidstr, sizeof(pgfidstr), "%s",
-                 key + SLEN(PGFID_XATTR_KEY_PREFIX));
-        gf_uuid_parse(pgfidstr, pgfid);
+        gf_uuid_parse(key + SLEN(PGFID_XATTR_KEY_PREFIX), pgfid);
 
         handle_size = POSIX_GFID_HANDLE_SIZE(priv->base_path_length);
 


### PR DESCRIPTION
Since the length is known, fix the following `-Wstringop-truncation`
warnings by using `memcpy()` instead of `strncpy()`:
```
posix-handle.c:384:5: warning: ‘strncpy’ output may be truncated copying 42 bytes from a string of length 505 [-Wstringop-truncation]
  384 |     strncpy(base_str + pfx_len, linkname + 6, 42);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
io-stats.c: In function ‘init’:
io-stats.c:4085:9: warning: ‘strncpy’ specified bound 37 equals destination size [-Wstringop-truncation]
 4085 |         strncpy(this->graph->volume_id, volume_id, GF_UUID_BUF_SIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Also simplify `posix_handle_path()`, assuming that the passed `buf`
is always non-NULL, and `posix_get_ancestry_non_directory()` assuming
that an extra copy is not needed to parse UUID from data, thus
eliminating the following `-Wformat-truncation` warning:
```
posix-inode-fd-ops.c: In function ‘posix_get_ancestry_non_directory’:
posix-inode-fd-ops.c:3560:47: warning: ‘%s’ directive output may be truncated writing up to 4081 bytes into a region of size 37 [-Wformat-truncation=]
 3560 |         snprintf(pgfidstr, sizeof(pgfidstr), "%s",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
 3561 |                  key + SLEN(PGFID_XATTR_KEY_PREFIX));
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
posix-inode-fd-ops.c:3560:9: note: ‘snprintf’ output between 1 and 4082 bytes into a destination of size 37
 3560 |         snprintf(pgfidstr, sizeof(pgfidstr), "%s",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3561 |                  key + SLEN(PGFID_XATTR_KEY_PREFIX));
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000