### PR TITLE
Locks: Optimize the lock flow when fd's are not correctly reopened after a brick reconnection

### DIFF
--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -229,6 +229,8 @@ afr_openfd_fix_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     UNLOCK(&local->fd->lock);
 
+    afr_migrate_locks(priv, local);
+
     call_count = afr_frame_return(frame);
     if (call_count == 0)
         AFR_STACK_DESTROY(frame);
@@ -310,6 +312,9 @@ afr_do_fix_open(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->need_open[i])
             continue;
+        LOCK(&priv->lock);
+        local->need_migrate_lock[i] = 1;
+        UNLOCK(&priv->lock);
 
         if (IA_IFDIR == local->fd->inode->ia_type) {
             gf_msg_debug(this->name, 0, "opening fd for dir %s on subvolume %s",

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -904,6 +904,7 @@ typedef struct _afr_local {
     gf_boolean_t need_full_crawl;
     gf_boolean_t is_read_txn;
     gf_boolean_t is_new_entry;
+    unsigned char *need_migrate_lock;
 
     /* For fix_open */
     unsigned char *need_open;
@@ -1269,6 +1270,8 @@ afr_handle_replies_quorum(call_frame_t *frame, xlator_t *this);
 gf_boolean_t
 afr_ta_dict_contains_pending_xattr(dict_t *dict, afr_private_t *priv,
                                    int child);
+int
+afr_migrate_locks(afr_private_t *priv, afr_local_t *local);
 
 void
 afr_selfheal_childup(xlator_t *this, afr_private_t *priv);


### PR DESCRIPTION
When the brick is reconnected, we will use the synchronization process to open the reconnected brick before locking.

Fixes:#3183


Signed-off-by: JamesWSWu 

