### PR TITLE
[dict.c]: Remove dead code function

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -2858,45 +2858,6 @@ out:
     return ret;
 }
 
-/**
- * dict_serialized_length - return the length of serialized dict
- *
- * @this:   dict to be serialized
- * @return: success: len
- *        : failure: -errno
- */
-
-int
-dict_serialized_length(dict_t *this)
-{
-    int ret = -EINVAL;
-
-    if (!this) {
-        gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
-                         "dict is null!");
-        goto out;
-    }
-
-    LOCK(&this->lock);
-    {
-        ret = dict_serialized_length_lk(this);
-    }
-    UNLOCK(&this->lock);
-
-out:
-    return ret;
-}
-
-/**
- * dict_serialize - serialize a dictionary into a buffer
- *
- * @this: dict to serialize
- * @buf:  buffer to serialize into. This must be
- *        at least dict_serialized_length (this) large
- *
- * @return: success: 0
- *          failure: -errno
- */
 
 
 /**

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -173,8 +173,7 @@ dict_reset(dict_t *dict);
 int
 dict_key_count(dict_t *this);
 
-int32_t
-dict_serialized_length(dict_t *dict);
+
 int32_t
 dict_unserialize(char *buf, int32_t size, dict_t **fill);
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3327,8 +3327,12 @@ glusterd_dict_arr_serialize(dict_t *dict_arr[], int count, char **buf,
 
     for (i = 0; i < count; i++) {
         if (dict_arr[i]) {
-            len += dict_serialized_length_lk(dict_arr[i]);
-            totcount += dict_arr[i]->count;
+            LOCK(&dict_arr[i]->lock);
+            {
+                len += dict_serialized_length_lk(dict_arr[i]);
+                totcount += dict_arr[i]->count;
+            }
+            UNLOCK(&dict_arr[i]->lock);
         }
     }
 


### PR DESCRIPTION
1.dict_serialized_length() was used to implement lock to
dict_serialized_length_lk() but not used so removing it
as it is already implemented with lock

2.dict_serialized_length_lk() must be implemented with
lock so added where missing

Change-Id: Id3640087b133427871689b108a42edd909c006c6
Updates:#1000
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

