### PR TITLE
libglusterfs: add function to set limit of open file descriptors

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -13,7 +13,6 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/resource.h>
 #include <sys/file.h>
 #include <netdb.h>
 #include <signal.h>

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/resource.h>
 #include <sys/wait.h>
 #include <dlfcn.h>
 #include <pthread.h>

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -25,6 +25,7 @@
 #include <fnmatch.h>
 #include <uuid/uuid.h>
 #include <urcu/compiler.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 
@@ -200,6 +201,17 @@ get_xattrs_to_heal();
 
 char *
 gf_gethostname(void);
+
+#ifndef GF_DARWIN_HOST_OS
+
+void
+gf_set_nofile(rlim_t high, rlim_t low);
+
+#else /* Darwin */
+
+#define gf_set_nofile(low, high) do { } while (0)
+
+#endif /* not GF_DARWIN_HOST_OS */
 
 /* The DHT file rename operation is not a straightforward rename.
  * It involves creating linkto and linkfiles, and can unlink or rename the

--- a/libglusterfs/src/glusterfs/libglusterfs-messages.h
+++ b/libglusterfs/src/glusterfs/libglusterfs-messages.h
@@ -339,6 +339,11 @@ GLFS_NEW(LIBGLUSTERFS, LG_MSG_IO_BAD_RETURN, "Unexpected return value", 1,
     GLFS_I32(ret)
 )
 
+GLFS_NEW(LIBGLUSTERFS, LG_MSG_NOFILE_FAILED,
+    "Failed to set maximum number of open file descriptors", 2,
+    GLFS_I64(low), GLFS_I64(high)
+)
+
 #define LG_MSG_EPOLL_FD_CREATE_FAILED_STR "epoll fd creation failed"
 #define LG_MSG_INVALID_POLL_IN_STR "invalid poll_in value"
 #define LG_MSG_INVALID_POLL_OUT_STR "invalid poll_out value"

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -657,6 +657,7 @@ gf_rsync_strong_checksum
 gf_rsync_md5_checksum
 gf_rsync_weak_checksum
 gf_set_log_file_path
+gf_set_nofile
 gf_set_timestamp
 gf_set_volfile_server_common
 _gf_smsg

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -15,7 +15,6 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/xlators/features/quota/src/quota-enforcer-client.c
+++ b/xlators/features/quota/src/quota-enforcer-client.c
@@ -12,7 +12,6 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/resource.h>
 #include <sys/file.h>
 #include <netdb.h>
 #include <signal.h>

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -32,7 +32,6 @@
 #include "glusterd-messages.h"
 #include "glusterd-errno.h"
 
-#include <sys/resource.h>
 #include <inttypes.h>
 
 #include "glusterd-syncop.h"

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -10,7 +10,6 @@
 
 #include <time.h>
 #include <sys/uio.h>
-#include <sys/resource.h>
 #include <sys/mount.h>
 
 #include <libgen.h>

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -10,7 +10,6 @@
 #include <inttypes.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/resource.h>
 #include <sys/statvfs.h>
 
 #include <glusterfs/compat.h>

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -10,7 +10,6 @@
 
 #include <time.h>
 #include <sys/uio.h>
-#include <sys/resource.h>
 
 #include <libgen.h>
 #include <glusterfs/compat-uuid.h>

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -10,7 +10,6 @@
 #include <inttypes.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/resource.h>
 #include <sys/statvfs.h>
 #include <sys/mount.h>
 #include <signal.h>

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -33,7 +33,6 @@
 #include <glusterfs/common-utils.h>
 #include <glusterfs/quota-common-utils.h>
 
-#include <sys/resource.h>
 #include <inttypes.h>
 #include <dirent.h>
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -43,7 +43,6 @@
 #include "glusterd-shd-svc-helper.h"
 #include "protocol-utils.h"
 
-#include <sys/resource.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <sys/types.h>

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -11,7 +11,6 @@
 #include <time.h>
 #include <grp.h>
 #include <sys/uio.h>
-#include <sys/resource.h>
 
 #include <libgen.h>
 #include <glusterfs/compat-uuid.h>
@@ -1552,22 +1551,7 @@ init(xlator_t *this)
     vgtool = _gf_none;
 #endif
 
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
-        lim.rlim_cur = 65536;
-        lim.rlim_max = 65536;
-
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_SET_XATTR_FAIL,
-                    "Failed to set 'ulimit -n 65536'", NULL);
-        } else {
-            gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_FILE_DESC_LIMIT_SET,
-                   "Maximum allowed open file descriptors "
-                   "set to 65536");
-        }
-    }
-#endif
+    gf_set_nofile(0, 65536);
 
     dir_data = dict_get(this->options, "run-directory");
 

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -9,7 +9,6 @@
 */
 
 #include <sys/time.h>
-#include <sys/resource.h>
 
 #include "socket.h"
 #include "server.h"
@@ -1287,30 +1286,8 @@ server_init(xlator_t *this)
         goto err;
     }
 
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
+    gf_set_nofile(1048576, 65536);
 
-        lim.rlim_cur = 1048576;
-        lim.rlim_max = 1048576;
-
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_ULIMIT_SET_FAILED,
-                    "errno=%s", strerror(errno), NULL);
-            lim.rlim_cur = 65536;
-            lim.rlim_max = 65536;
-
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_FD_NOT_FOUND,
-                        "errno=%s", strerror(errno), NULL);
-            } else {
-                gf_msg_trace(this->name, 0,
-                             "max open fd set "
-                             "to 64k");
-            }
-        }
-    }
-#endif
     if (!this->ctx->cmd_args.volfile_id) {
         /* In some use cases this is a valid case, but
            document this to be annoying log in that case */

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -17,7 +17,6 @@
 #include <openssl/md5.h>
 #include <stdint.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 #include <errno.h>
 #include <libgen.h>
 #include <pthread.h>
@@ -993,32 +992,9 @@ posix_init(xlator_t *this)
                "Could not lock brick directory (%s)", strerror(op_errno));
         goto out;
     }
-#ifndef GF_DARWIN_HOST_OS
-    {
-        struct rlimit lim;
-        lim.rlim_cur = 1048576;
-        lim.rlim_max = 1048576;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-            gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_SET_ULIMIT_FAILED,
-                   "Failed to set 'ulimit -n "
-                   " 1048576'");
-            lim.rlim_cur = 65536;
-            lim.rlim_max = 65536;
+    gf_set_nofile(1048576, 65536);
 
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
-                gf_msg(this->name, GF_LOG_WARNING, errno,
-                       P_MSG_SET_FILE_MAX_FAILED,
-                       "Failed to set maximum allowed open "
-                       "file descriptors to 64k");
-            } else {
-                gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_MAX_FILE_OPEN,
-                       "Maximum allowed "
-                       "open file descriptors set to 65536");
-            }
-        }
-    }
-#endif
     _private->shared_brick_count = 1;
     ret = dict_get_int32(this->options, "shared-brick-count",
                          &_private->shared_brick_count);

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -16,7 +16,6 @@
 
 #include <stdint.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 #include <errno.h>
 #include <libgen.h>
 #include <pthread.h>

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -11,7 +11,6 @@
 
 #include <stdint.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 #include <errno.h>
 #include <libgen.h>
 #include <pthread.h>

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -17,7 +17,6 @@
 #include <openssl/md5.h>
 #include <stdint.h>
 #include <sys/time.h>
-#include <sys/resource.h>
 #include <errno.h>
 #include <libgen.h>
 #include <pthread.h>


### PR DESCRIPTION
Introduce `gf_set_nofile()` to wrap commonly (well, beyond Darwin)
used `setrlimit(RLIMIT_NOFILE, ...)`, adjust related code and drop
useless inclusion of `sys/resource.h` here and there.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000