### PR TITLE
glusterd: pack volume info status flags into a bitfield

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -476,6 +476,22 @@ union gf_sock_union {
 
 #define MAX_IOVEC 16
 
+/* Macro to declare basic operations on a bitfield. */
+
+#define GF_DECLARE_BITOP(type, ptr, member, flag, suffix)                     \
+                                                                              \
+static inline gf_boolean_t ptr##_has_##suffix(type *ptr) {                    \
+    return ptr->member & flag;                                                \
+}                                                                             \
+                                                                              \
+static inline void ptr##_set_##suffix(type *ptr) {                            \
+    ptr->member |= flag;                                                      \
+}                                                                             \
+                                                                              \
+static inline void ptr##_clear_##suffix(type *ptr) {                          \
+    ptr->member &= ~flag;                                                     \
+}                                                                             \
+
 static inline gf_boolean_t
 gf_irrelevant_entry(struct dirent *entry)
 {

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1787,9 +1787,6 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
     gf1_op_commands cmd = GF_OP_CMD_NONE;
     char *task_id_str = NULL;
     xlator_t *this = THIS;
-    gsync_status_param_t param = {
-        0,
-    };
 
     ret = op_version_check(this, GD_OP_VER_PERSISTENT_AFR_XATTRS, msg,
                            sizeof(msg));
@@ -2012,9 +2009,8 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
             /* If geo-rep is configured, for this volume, it should be
              * stopped.
              */
-            param.volinfo = volinfo;
-            ret = glusterd_check_geo_rep_running(&param, op_errstr);
-            if (ret || param.is_active) {
+            ret = glusterd_check_geo_rep_running(volinfo, op_errstr);
+            if (ret || volinfo_has_georep_active(volinfo)) {
                 ret = -1;
                 goto out;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.h
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.h
@@ -42,11 +42,6 @@ typedef struct glusterd_gsync_status_temp {
     char *node;
 } glusterd_gsync_status_temp_t;
 
-typedef struct gsync_status_param {
-    glusterd_volinfo_t *volinfo;
-    int is_active;
-} gsync_status_param_t;
-
 int
 gsync_status(char *primary, char *secondary, char *conf_path, int *status,
              gf_boolean_t *is_template_in_use);
@@ -57,7 +52,7 @@ glusterd_check_geo_rep_configured(glusterd_volinfo_t *volinfo,
 int
 _get_secondary_status(dict_t *dict, char *key, data_t *value, void *data);
 int
-glusterd_check_geo_rep_running(gsync_status_param_t *param, char **op_errstr);
+glusterd_check_geo_rep_running(glusterd_volinfo_t *volinfo, char **op_errstr);
 
 int
 glusterd_get_gsync_status_mst(glusterd_volinfo_t *volinfo, dict_t *rsp_dict,

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -318,8 +318,9 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
                     svc->proc.logfile, "--brick-name", gfproxyd_id, "-S",
                     svc->conn.sockpath, NULL);
 
-    if (volinfo->memory_accounting)
+    if (volinfo_has_memory_accounting(volinfo))
         runner_add_arg(&runner, "--mem-accounting");
+
     if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
                       SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
                       &localtime_logging) == 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5030,7 +5030,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
                 }
                 keylen = sprintf(dict_key, "value%d", count);
 
-                if (volinfo->memory_accounting)
+                if (volinfo_has_memory_accounting(volinfo))
                     ret = dict_set_nstrn(dict, dict_key, keylen, "Enabled",
                                          SLEN("Enabled"));
                 else

--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -779,12 +779,11 @@ glusterd_mgmt_v3_unlock(const char *name, uuid_t uuid, char *type)
         dict_deln(priv->mgmt_v3_lock_timer, key_dup, keylen);
     }
     ret = glusterd_volinfo_find(name, &volinfo);
-    if (volinfo && volinfo->stage_deleted) {
-        /* this indicates a volume still exists and the volume delete
-         * operation has failed in some of the phases, need to ensure
-         * stage_deleted flag is set back to false
-         */
-        volinfo->stage_deleted = _gf_false;
+    if (volinfo && volinfo_has_stage_deleted(volinfo)) {
+        /* This indicates a volume still exists and the volume delete
+           operation has failed in some of the phases, need to ensure
+           stage_deleted flag is set back to false. */
+        volinfo_clear_stage_deleted(volinfo);
         gf_log(this->name, GF_LOG_INFO,
                "Volume %s still exist, setting "
                "stage deleted flag to false for the volume",

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -2130,7 +2130,7 @@ glusterd_options_reset(glusterd_volinfo_t *volinfo, char *key,
     }
 
     gd_update_volume_op_versions(volinfo);
-    if (!volinfo->is_snap_volume) {
+    if (!volinfo_has_snap_volume(volinfo)) {
         svc = &(volinfo->snapd.svc);
         ret = svc->manager(svc, volinfo, PROC_START_NO_WAIT);
         if (ret)
@@ -2630,7 +2630,7 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
                 if (glusterd_dict_set_skip_cliot_key(volinfo))
                     goto out;
 
-                if (!volinfo->is_snap_volume) {
+                if (!volinfo_has_snap_volume(volinfo)) {
                     svc = &(volinfo->snapd.svc);
                     ret = svc->manager(svc, volinfo, PROC_START_NO_WAIT);
                     if (ret)
@@ -2947,12 +2947,17 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
         }
 
         if (strcmp(key, "config.memory-accounting") == 0) {
-            ret = gf_string2boolean(value, &volinfo->memory_accounting);
+            gf_boolean_t val = _gf_false;
+            ret = gf_string2boolean(value, &val);
             if (ret == -1) {
                 gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_INVALID_ENTRY,
                        "Invalid value in key-value pair.");
                 goto out;
             }
+            if (val)
+                volinfo_set_memory_accounting(volinfo);
+            else
+                volinfo_clear_memory_accounting(volinfo);
         }
 
         if (strcmp(key, "config.transport") == 0) {
@@ -3050,7 +3055,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
     if (!global_opts_set) {
         gd_update_volume_op_versions(volinfo);
 
-        if (!volinfo->is_snap_volume) {
+        if (!volinfo_has_snap_volume(volinfo)) {
             svc = &(volinfo->snapd.svc);
             ret = svc->manager(svc, volinfo, PROC_START_NO_WAIT);
             if (ret)
@@ -3095,7 +3100,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
             volinfo = voliter;
             gd_update_volume_op_versions(volinfo);
 
-            if (!volinfo->is_snap_volume) {
+            if (!volinfo_has_snap_volume(volinfo)) {
                 svc = &(volinfo->snapd.svc);
                 ret = svc->manager(svc, volinfo, PROC_START_NO_WAIT);
                 if (ret)

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -299,8 +299,10 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
     runner_argprintf(&runner, "%s", pidfile);
     runner_add_arg(&runner, "-l");
     runner_argprintf(&runner, "%s", logfile);
-    if (volinfo->memory_accounting)
+
+    if (volinfo_has_memory_accounting(volinfo))
         runner_add_arg(&runner, "--mem-accounting");
+
     if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
                       SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
                       &localtime_logging) == 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -272,8 +272,8 @@ glusterd_shdsvc_manager(glusterd_svc_t *svc, void *data, int flags)
     volinfo = data;
     GF_VALIDATE_OR_GOTO("glusterd", volinfo, out);
 
-    if (volinfo->is_snap_volume) {
-        /* healing of a snap volume is not supported yet*/
+    if (volinfo_has_snap_volume(volinfo)) {
+        /* Healing of a snap volume is not supported yet. */
         ret = 0;
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -773,8 +773,8 @@ glusterd_peer_detach_cleanup(glusterd_conf_t *priv)
             gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_STALE_VOL_DELETE_INFO,
                    "Deleting stale volume %s", volinfo->volname);
 
-            /*Stop snapd daemon service if snapd daemon is running*/
-            if (!volinfo->is_snap_volume) {
+            /* Stop snapd daemon service if snapd daemon is running. */
+            if (!volinfo_has_snap_volume(volinfo)) {
                 svc = &(volinfo->snapd.svc);
                 ret = svc->stop(svc, SIGTERM);
                 if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -45,7 +45,7 @@
 #define GLUSTERD_GET_BRICK_DIR(path, volinfo, priv)                            \
     do {                                                                       \
         int32_t _brick_len;                                                    \
-        if (volinfo->is_snap_volume) {                                         \
+        if (volinfo_has_snap_volume(volinfo)) {                                \
             _brick_len = snprintf(path, PATH_MAX, "%s/snaps/%s/%s/%s",         \
                                   priv->workdir, volinfo->snapshot->snapname,  \
                                   volinfo->volname, GLUSTERD_BRICK_INFO_DIR);  \
@@ -2659,7 +2659,8 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
          */
         if (gf_uuid_is_null(brickinfo->uuid))
             (void)glusterd_resolve_brick(brickinfo);
-        if (brickinfo->real_path[0] == '\0' && !volinfo->is_snap_volume &&
+        if (brickinfo->real_path[0] == '\0' &&
+            !volinfo_has_snap_volume(volinfo) &&
             gf_uuid_is_null(volinfo->restored_from_snap)) {
             /* By now if the brick is a local brick then it will be
              * able to resolve which is the only thing we want now
@@ -3387,7 +3388,7 @@ glusterd_store_retrieve_volume(char *volname, glusterd_snap_t *snap)
         goto out;
     volinfo->snapshot = snap;
     if (snap)
-        volinfo->is_snap_volume = _gf_true;
+        volinfo_set_snap_volume(volinfo);
 
     ret = glusterd_store_update_volinfo(volinfo);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -115,7 +115,7 @@ glusterd_svcs_manager(glusterd_volinfo_t *volinfo)
     conf = THIS->private;
     GF_ASSERT(conf);
 
-    if (volinfo && volinfo->is_snap_volume)
+    if (volinfo && volinfo_has_snap_volume(volinfo))
         return 0;
 
 #if BUILD_GNFS

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -2496,8 +2496,8 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (ret)
         return -1;
 
-    volname = volinfo->is_snap_volume ? volinfo->parent_volname
-                                      : volinfo->volname;
+    volname = (volinfo_has_snap_volume(volinfo) ? volinfo->parent_volname
+                                                : volinfo->volname);
 
     if (volname && !strcmp(volname, GLUSTER_SHARED_STORAGE)) {
         ret = xlator_set_fixed_option(xl, "strict-auth-accept", "true");
@@ -4313,7 +4313,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* As of now snapshot volume is read-only. Read-only xlator is loaded
      * in client graph so that AFR & DHT healing can be done in server.
      */
-    if (volinfo->is_snap_volume) {
+    if (volinfo_has_snap_volume(volinfo)) {
         xl = volgen_graph_add(graph, "features/read-only", volname);
         if (!xl) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GRAPH_FEATURE_ADD_FAIL,
@@ -4467,7 +4467,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     uss_enabled = dict_get_str_boolean(set_dict, "features.uss", _gf_false);
     if (uss_enabled == -1)
         goto out;
-    if (uss_enabled && !volinfo->is_snap_volume) {
+    if (uss_enabled && !volinfo_has_snap_volume(volinfo)) {
         ret = volgen_graph_build_snapview_client(graph, volinfo, volname,
                                                  set_dict);
         if (ret == -1)
@@ -5526,7 +5526,7 @@ generate_brick_volfiles(glusterd_volinfo_t *volinfo)
              * 'marker.tstamp' to decide the volume-mark, i.e.,
              * geo-rep start time just after session is created.
              */
-            if (volinfo->is_snap_volume) {
+            if (volinfo_has_snap_volume(volinfo)) {
                 get_parent_vol_tstamp_file(parent_tstamp_file, volinfo);
                 ret = gf_set_timestamp(parent_tstamp_file, tstamp_file);
                 if (ret) {
@@ -5775,8 +5775,8 @@ generate_client_volfiles(glusterd_volinfo_t *volinfo,
     dict_t *dict = NULL;
     gf_transport_type type = GF_TRANSPORT_TCP;
 
-    volname = volinfo->is_snap_volume ? volinfo->parent_volname
-                                      : volinfo->volname;
+    volname = (volinfo_has_snap_volume(volinfo) ? volinfo->parent_volname
+                                                : volinfo->volname);
 
     if (volname && !strcmp(volname, GLUSTER_SHARED_STORAGE) &&
         client_type != GF_CLIENT_TRUSTED) {

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -405,11 +405,8 @@ struct glusterd_volinfo_ {
                                          * updating the volinfo
                                          */
     gf_transport_type transport_type;
-    gf_boolean_t is_snap_volume;
-    gf_boolean_t memory_accounting;
-    gf_boolean_t stage_deleted; /* volume has passed staging
-                                 * for delete operation
-                                 */
+    uint32_t flags;
+
     char parent_volname[GD_VOLUME_NAME_MAX];
     /* In case of a snap volume
        i.e (is_snap_volume == TRUE) this
@@ -427,6 +424,27 @@ struct glusterd_volinfo_ {
 
     char snap_plugin[NAME_MAX]; /* Snapshot Plugin name */
 };
+
+/* Possible bits in 'flags' field of the above. */
+
+#define GD_VOLINFO_SNAP_VOLUME (1 << 0)
+#define GD_VOLINFO_MEMORY_ACCOUNTING (1 << 1)
+#define GD_VOLINFO_STAGE_DELETED (1 << 2)
+#define GD_VOLINFO_GEOREP_ACTIVE (1 << 3)
+
+/* And related functions. */
+
+GF_DECLARE_BITOP(glusterd_volinfo_t, volinfo, flags, GD_VOLINFO_SNAP_VOLUME,
+                 snap_volume)
+
+GF_DECLARE_BITOP(glusterd_volinfo_t, volinfo, flags,
+                 GD_VOLINFO_MEMORY_ACCOUNTING, memory_accounting)
+
+GF_DECLARE_BITOP(glusterd_volinfo_t, volinfo, flags, GD_VOLINFO_STAGE_DELETED,
+                 stage_deleted)
+
+GF_DECLARE_BITOP(glusterd_volinfo_t, volinfo, flags, GD_VOLINFO_GEOREP_ACTIVE,
+                 georep_active)
 
 typedef enum gd_snap_status_ {
     GD_SNAP_STATUS_NONE,
@@ -511,7 +529,7 @@ enum glusterd_op_ret {
 #define GLUSTERD_GET_VOLUME_DIR(path, volinfo, priv)                           \
     do {                                                                       \
         int32_t _vol_dir_len;                                                  \
-        if (volinfo->is_snap_volume) {                                         \
+        if (volinfo_has_snap_volume(volinfo)) {                                \
             _vol_dir_len = snprintf(                                           \
                 path, PATH_MAX, "%s/snaps/%s/%s", priv->workdir,               \
                 volinfo->snapshot->snapname, volinfo->volname);                \
@@ -561,7 +579,7 @@ enum glusterd_op_ret {
 #define GLUSTERD_GET_VOLUME_PID_DIR(path, volinfo, priv)                       \
     do {                                                                       \
         int32_t _vol_pid_len;                                                  \
-        if (volinfo->is_snap_volume) {                                         \
+        if (volinfo_has_snap_volume(volinfo)) {                                \
             _vol_pid_len = snprintf(path, PATH_MAX, "%s/snaps/%s/%s",          \
                                     priv->rundir, volinfo->snapshot->snapname, \
                                     volinfo->volname);                         \


### PR DESCRIPTION
Pack georep status volume flag among other boolean flags
into the only bitfield within `glusterd_volinfo_t`, thus
dropping `gsync_status_param_t` quirk and simplifying
related georep code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000