### PR TITLE
rpc, cli, dht, glusterd: unify defrag related enums

### DIFF
--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -4003,7 +4003,7 @@ cli_cmd_volume_defrag_parse(const char **words, int wordcount, dict_t **options)
     char *option = NULL;
     char *volname = NULL;
     char *command = NULL;
-    gf_cli_defrag_type cmd = 0;
+    gf_defrag_type_t cmd = 0;
 
     GF_ASSERT(words);
     GF_ASSERT(options);

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -3143,7 +3143,7 @@ out:
 #endif
 
 int
-cli_xml_output_vol_rebalance(gf_cli_defrag_type op, dict_t *dict, int op_ret,
+cli_xml_output_vol_rebalance(gf_defrag_type_t op, dict_t *dict, int op_ret,
                              int op_errno, char *op_errstr)
 {
 #if (HAVE_LIB_XML)

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -450,7 +450,7 @@ cli_xml_output_peer_status(dict_t *dict, int op_ret, int op_errno,
                            char *op_errstr);
 
 int
-cli_xml_output_vol_rebalance(gf_cli_defrag_type op, dict_t *dict, int op_ret,
+cli_xml_output_vol_rebalance(gf_defrag_type_t op, dict_t *dict, int op_ret,
                              int op_errno, char *op_errstr);
 
 int

--- a/rpc/xdr/src/cli1-xdr.x
+++ b/rpc/xdr/src/cli1-xdr.x
@@ -13,7 +13,7 @@
 #endif
 %#include <glusterfs/compat.h>
 
- enum gf_cli_defrag_type {
+enum gf_defrag_type_t {
 	GF_DEFRAG_CMD_NONE = 0,
         GF_DEFRAG_CMD_START,
         GF_DEFRAG_CMD_STOP,
@@ -35,7 +35,7 @@
         GF_DEFRAG_CMD_TYPE_MAX
 };
 
- enum gf_defrag_status_t {
+enum gf_defrag_status_t {
         GF_DEFRAG_STATUS_NOT_STARTED,
         GF_DEFRAG_STATUS_STARTED,
         GF_DEFRAG_STATUS_STOPPED,

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -11007,7 +11007,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
     int have_heard_from_all = 0;
     gf_defrag_info_t *defrag = NULL;
     dict_t *dict = NULL;
-    gf_defrag_type cmd = 0;
+    gf_defrag_type_t cmd = 0;
     dict_t *output = NULL;
     va_list ap;
     struct gf_upcall *up_data = NULL;

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -10,6 +10,7 @@
 
 #include <regex.h>
 
+#include "cli1-xdr.h"
 #include "dht-mem-types.h"
 #include "dht-messages.h"
 #include <glusterfs/call-stub.h>
@@ -388,41 +389,6 @@ struct dht_du {
     uint32_t frsize; /*fragment size*/
 };
 typedef struct dht_du dht_du_t;
-
-enum gf_defrag_type {
-    GF_DEFRAG_CMD_NONE = 0,
-    GF_DEFRAG_CMD_START = 1,
-    GF_DEFRAG_CMD_STOP = 1 + 1,
-    GF_DEFRAG_CMD_STATUS = 1 + 2,
-    GF_DEFRAG_CMD_START_LAYOUT_FIX = 1 + 3,
-    GF_DEFRAG_CMD_START_FORCE = 1 + 4,
-    GF_DEFRAG_CMD_DETACH_STATUS = 1 + 11,
-    GF_DEFRAG_CMD_DETACH_START = 1 + 13,
-    GF_DEFRAG_CMD_DETACH_COMMIT = 1 + 14,
-    GF_DEFRAG_CMD_DETACH_COMMIT_FORCE = 1 + 15,
-    GF_DEFRAG_CMD_DETACH_STOP = 1 + 16,
-    /* new labels are used so it will help
-     * while removing old labels by easily differentiating.
-     * A few labels are added so that the count remains same
-     * between this enum and the ones on the xdr file.
-     * different values for the same enum cause errors and
-     * confusion.
-     */
-};
-typedef enum gf_defrag_type gf_defrag_type;
-
-enum gf_defrag_status_t {
-    GF_DEFRAG_STATUS_NOT_STARTED,
-    GF_DEFRAG_STATUS_STARTED,
-    GF_DEFRAG_STATUS_STOPPED,
-    GF_DEFRAG_STATUS_COMPLETE,
-    GF_DEFRAG_STATUS_FAILED,
-    GF_DEFRAG_STATUS_LAYOUT_FIX_STARTED,
-    GF_DEFRAG_STATUS_LAYOUT_FIX_STOPPED,
-    GF_DEFRAG_STATUS_LAYOUT_FIX_COMPLETE,
-    GF_DEFRAG_STATUS_LAYOUT_FIX_FAILED,
-};
-typedef enum gf_defrag_status_t gf_defrag_status_t;
 
 typedef struct gf_defrag_pattern_list gf_defrag_pattern_list_t;
 

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1637,7 +1637,7 @@ int
 glusterd_remove_brick_validate_bricks(gf1_op_commands cmd, int32_t brick_count,
                                       dict_t *dict, glusterd_volinfo_t *volinfo,
                                       char **errstr,
-                                      gf_cli_defrag_type cmd_defrag)
+                                      gf_defrag_type_t cmd_defrag)
 {
     char *brick = NULL;
     char msg[2048] = "";

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -484,7 +484,7 @@ __glusterd_handle_defrag_volume(rpcsvc_request_t *req)
     int32_t op = GD_OP_NONE;
     dict_t *dict = NULL;
     char *volname = NULL;
-    gf_cli_defrag_type cmd = 0;
+    gf_defrag_type_t cmd = 0;
     char msg[2048] = {
         0,
     };

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -460,7 +460,7 @@ gd_is_remove_brick_committed(glusterd_volinfo_t *volinfo);
 int
 glusterd_remove_brick_validate_bricks(gf1_op_commands cmd, int32_t brick_count,
                                       dict_t *dict, glusterd_volinfo_t *volinfo,
-                                      char **errstr, gf_cli_defrag_type);
+                                      char **errstr, gf_defrag_type_t type);
 int
 glusterd_get_secondary_details_confpath(glusterd_volinfo_t *volinfo,
                                         dict_t *dict, char **secondary_url,

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -321,7 +321,7 @@ struct glusterd_rebalance_ {
     uint64_t skipped_files;
     uint64_t rebalance_failures;
     glusterd_defrag_info_t *defrag;
-    gf_cli_defrag_type defrag_cmd;
+    gf_defrag_type_t defrag_cmd;
     gf_defrag_status_t defrag_status;
     uuid_t rebalance_id;
     double rebalance_time;


### PR DESCRIPTION
Since `gf_cli_defrag_type` is actually used beyond cli,
consistently rename it to `gf_defrag_type_t` and use the
only definition from `cli1-xdr.x` everywhere, as well as
with `gf_defrag_status_t`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

