### PR TITLE
glusterd: simplify locking timers

### DIFF
--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -116,8 +116,7 @@ enum gf_common_mem_types_ {
     gf_common_mt_pthread_t,      /* used only in one location */
     gf_common_ping_local_t,      /* used only in one location */
     gf_common_volfile_t,
-    gf_common_mt_mgmt_v3_lock_timer_t, /* used only in one location */
-    gf_common_mt_server_cmdline_t,     /* used only in one location */
+    gf_common_mt_server_cmdline_t, /* used only in one location */
     gf_common_mt_latency_t,
     gf_common_mt_end,
 };

--- a/xlators/mgmt/glusterd/src/glusterd-locks.h
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.h
@@ -14,11 +14,6 @@ typedef struct glusterd_mgmt_v3_lock_object_ {
     uuid_t lock_owner;
 } glusterd_mgmt_v3_lock_obj;
 
-typedef struct glusterd_mgmt_v3_lock_timer_ {
-    gf_timer_t *timer;
-    xlator_t *xl;
-} glusterd_mgmt_v3_lock_timer;
-
 typedef struct glusterd_mgmt_v3_lock_valid_entities {
     char *type;                 /* Entity type like vol, snap */
     gf_boolean_t default_value; /* The default value that  *


### PR DESCRIPTION
Since `xlator_t` pointer may be directly accessed from the
timer object itself, drop `glusterd_mgmt_v3_lock_timer`,
corresponding memory type, and simplify related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000