### PR TITLE
glusterd: fix -Wdeprecated-non-prototype warnings by clang-15

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -389,13 +389,10 @@ out:
 }
 
 int
-glusterd_gfproxydsvc_reconfigure(void *data)
+glusterd_gfproxydsvc_reconfigure(glusterd_volinfo_t *volinfo)
 {
     int ret = -1;
     gf_boolean_t identical = _gf_false;
-    glusterd_volinfo_t *volinfo = NULL;
-
-    volinfo = data;
 
     if (!volinfo->gfproxyd.svc.inited)
         goto manager;

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
@@ -36,7 +36,7 @@ int
 glusterd_gfproxydsvc_stop(glusterd_svc_t *svc, int sig);
 
 int
-glusterd_gfproxydsvc_reconfigure();
+glusterd_gfproxydsvc_reconfigure(glusterd_volinfo_t *volinfo);
 
 void
 glusterd_gfproxydsvc_build_volfile_path(char *server, char *workdir,

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -8349,7 +8349,7 @@ glusterd_op_set_req(rpcsvc_request_t *req)
 }
 
 int32_t
-glusterd_op_clear_op(glusterd_op_t op)
+glusterd_op_clear_op(void)
 {
     opinfo.op = GD_OP_NONE;
 
@@ -8395,7 +8395,7 @@ glusterd_op_free_ctx(glusterd_op_t op, void *ctx)
 }
 
 void *
-glusterd_op_get_ctx()
+glusterd_op_get_ctx(void)
 {
     return opinfo.op_ctx;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -200,10 +200,10 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
                       char *err_str, size_t err_len);
 
 int32_t
-glusterd_op_txn_complete();
+glusterd_op_txn_complete(uuid_t *txn_id);
 
 void *
-glusterd_op_get_ctx();
+glusterd_op_get_ctx(void);
 
 int32_t
 glusterd_op_set_req(rpcsvc_request_t *req);
@@ -216,7 +216,7 @@ int32_t
 glusterd_op_get_op();
 
 int32_t
-glusterd_op_clear_op();
+glusterd_op_clear_op(void);
 
 int32_t
 glusterd_op_free_ctx(glusterd_op_t op, void *ctx);

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
@@ -13,7 +13,11 @@
 
 #include "glusterd-svc-mgmt.h"
 
+struct glusterd_volinfo_;
+typedef struct glusterd_volinfo_ glusterd_volinfo_t;
+
 typedef struct glusterd_shdsvc_ glusterd_shdsvc_t;
+
 struct glusterd_shdsvc_ {
     glusterd_svc_t svc;
     gf_boolean_t attached;
@@ -33,7 +37,7 @@ int
 glusterd_shdsvc_start(glusterd_svc_t *svc, int flags);
 
 int
-glusterd_shdsvc_reconfigure();
+glusterd_shdsvc_reconfigure(glusterd_volinfo_t *volinfo);
 
 int
 glusterd_shdsvc_restart();

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
@@ -15,9 +15,12 @@
 #include "glusterd-conn-mgmt.h"
 #include "glusterd-rcu.h"
 
-struct glusterd_svc_;
+struct glusterd_volinfo_;
+typedef struct glusterd_volinfo_ glusterd_volinfo_t;
 
+struct glusterd_svc_;
 typedef struct glusterd_svc_ glusterd_svc_t;
+
 typedef struct glusterd_svc_proc_ glusterd_svc_proc_t;
 
 typedef void (*glusterd_svc_build_t)(glusterd_svc_t *svc);
@@ -26,7 +29,7 @@ typedef int (*glusterd_svc_manager_t)(glusterd_svc_t *svc, void *data,
                                       int flags);
 typedef int (*glusterd_svc_start_t)(glusterd_svc_t *svc, int flags);
 typedef int (*glusterd_svc_stop_t)(glusterd_svc_t *svc, int sig);
-typedef int (*glusterd_svc_reconfigure_t)(void *data);
+typedef int (*glusterd_svc_reconfigure_t)(glusterd_volinfo_t *volinfo);
 
 typedef int (*glusterd_muxsvc_conn_notify_t)(glusterd_svc_proc_t *mux_proc,
                                              rpc_clnt_event_t event);

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -2397,7 +2397,7 @@ out:
          * we release the cluster or mgmt_v3 lock
          * and clear the op */
 
-        glusterd_op_clear_op(op);
+        glusterd_op_clear_op();
         if (cluster_lock)
             glusterd_unlock(MY_UUID);
         else {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -9593,7 +9593,7 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
         ctx_dict = aggr;
 
     } else {
-        ctx_dict = glusterd_op_get_ctx(GD_OP_STATUS_VOLUME);
+        ctx_dict = glusterd_op_get_ctx();
     }
 
     ret = dict_get_int32n(ctx_dict, "cmd", SLEN("cmd"), &cmd);


### PR DESCRIPTION
Fix a few `-Wdeprecated-non-prototype` warnings reported by `clang-15`, for example:
```
In file included from glusterd-op-sm.c:24:
./glusterd-op-sm.h:203:1: warning: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
glusterd_op_txn_complete();
^
```
and adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000