### PR TITLE
gf_dirent_for_name2() - copy an existing iatt struct if such exists

### DIFF
--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -1094,7 +1094,7 @@ args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
         {
             stub_entry = gf_dirent_for_name2(entry->d_name, entry->d_len,
                                              entry->d_ino, entry->d_off,
-                                             entry->d_type);
+                                             entry->d_type, NULL);
             if (!stub_entry)
                 goto out;
             list_add_tail(&stub_entry->list, &args->entries.list);

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -58,7 +58,7 @@ gf_dirent_for_name(const char *name);
 gf_dirent_t *
 gf_dirent_for_name2(const char *name, const size_t name_len,
                     const uint64_t d_ino, const uint64_t d_off,
-                    const uint32_t d_type);
+                    const uint32_t d_type, const struct iatt *d_stat);
 gf_dirent_t *
 entry_copy(gf_dirent_t *source);
 void

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -6905,7 +6905,7 @@ dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     list:
         entry = gf_dirent_for_name2(orig_entry->d_name, orig_entry->d_len,
                                     orig_entry->d_ino, orig_entry->d_off,
-                                    orig_entry->d_type);
+                                    orig_entry->d_type, &orig_entry->d_stat);
         if (!entry) {
             goto unwind;
         }
@@ -6919,8 +6919,6 @@ dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                 layout->search_unhashed++;
             }
         }
-
-        entry->d_stat = orig_entry->d_stat;
 
         if (orig_entry->dict)
             entry->dict = dict_ref(orig_entry->dict);
@@ -7151,7 +7149,7 @@ dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             add = _gf_false;
             entry = gf_dirent_for_name2(orig_entry->d_name, orig_entry->d_len,
                                         orig_entry->d_ino, orig_entry->d_off,
-                                        orig_entry->d_type);
+                                        orig_entry->d_type, NULL);
             if (!entry) {
                 gf_msg(this->name, GF_LOG_ERROR, ENOMEM, DHT_MSG_NO_MEMORY,
                        "Memory allocation failed ");

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3202,7 +3202,7 @@ gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
         }
         tmp_container->df_entry = gf_dirent_for_name2(
             df_entry->d_name, df_entry->d_len, df_entry->d_ino, 0,
-            df_entry->d_type);
+            df_entry->d_type, &df_entry->d_stat);
         if (!tmp_container->df_entry) {
             gf_log(this->name, GF_LOG_ERROR,
                    "Failed to allocate "
@@ -3212,8 +3212,6 @@ gf_defrag_get_entry(xlator_t *this, int i, struct dht_container **container,
         }
 
         tmp_container->local_subvol_index = i;
-
-        tmp_container->df_entry->d_stat = df_entry->d_stat;
 
         tmp_container->parent_loc = GF_CALLOC(1, sizeof(*loc), gf_dht_mt_loc_t);
         if (!tmp_container->parent_loc) {

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -564,7 +564,7 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
         last_off = (u_long)telldir(dir);
 
         this_entry = gf_dirent_for_name2(entry->d_name, entry_dname_len,
-                                         entry->d_ino, last_off, 0);
+                                         entry->d_ino, last_off, 0, NULL);
 
         if (!this_entry) {
             gf_msg(THIS->name, GF_LOG_ERROR, errno,

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -423,9 +423,9 @@ meta_default_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
             if (this_size + filled_size > size)
                 goto unwind;
 
-            list = gf_dirent_for_name2(dirents->name, dirents_name_len, i + 42,
-                                       i + 1,
-                                       gf_d_type_from_ia_type(dirents->type));
+            list = gf_dirent_for_name2(
+                dirents->name, dirents_name_len, i + 42, i + 1,
+                gf_d_type_from_ia_type(dirents->type), NULL);
             if (!list)
                 break;
 

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -149,7 +149,7 @@ unserialize_rsp_dirent_v2(xlator_t *this, struct gfx_readdir_rsp *rsp,
     trav = rsp->reply;
     while (trav) {
         entry = gf_dirent_for_name2(trav->name, trav->d_len, trav->d_ino, 0,
-                                    trav->d_type);
+                                    trav->d_type, NULL);
         if (!entry)
             goto out;
 
@@ -186,7 +186,7 @@ unserialize_rsp_direntp_v2(xlator_t *this, fd_t *fd,
 
     while (trav) {
         entry = gf_dirent_for_name2(trav->name, trav->d_len, trav->d_ino, 0,
-                                    trav->d_type);
+                                    trav->d_type, NULL);
         if (!entry)
             goto out;
 

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -109,11 +109,10 @@ posix_make_ancestral_node(const char *priv_base_path, char *path, int pathsize,
         strcat(path, "/");
 
     if (type & POSIX_ANCESTRY_DENTRY) {
-        entry = gf_dirent_for_name2(dir_name, dir_name_len, -1, 0, 0);
+        entry = gf_dirent_for_name2(dir_name, dir_name_len, -1, 0, 0, iabuf);
         if (!entry)
             goto out;
 
-        entry->d_stat = *iabuf;
         entry->inode = inode_ref(inode);
 
         list_add_tail(&entry->list, &head->list);

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -5749,7 +5749,8 @@ posix_fill_readdir(fd_t *fd, struct posix_fd *pfd, off_t off, size_t size,
         last_off = (u_long)telldir(pfd->dir);
 
         this_entry = gf_dirent_for_name2(entry->d_name, entry_dname_len,
-                                         entry->d_ino, last_off, entry->d_type);
+                                         entry->d_ino, last_off, entry->d_type,
+                                         NULL);
 
         if (!this_entry) {
             gf_msg(THIS->name, GF_LOG_ERROR, errno,
@@ -5977,7 +5978,10 @@ posix_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         if (op_ret >= 0) {
             op_ret = 0;
 
-            list_for_each_entry(entry, &entries.list, list) { op_ret++; }
+            list_for_each_entry(entry, &entries.list, list)
+            {
+                op_ret++;
+            }
         }
 
         STACK_UNWIND_STRICT(readdirp, frame, op_ret, op_errno, &entries, NULL);


### PR DESCRIPTION
Instead of just memset() it with zeros, if we do have an existing ones we can copy,
do it. In few places, such as entry_copy(), dht_readdirp_cbk() and others, we can do it.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

