### PR TITLE
global-threadpool: Create new threads within the leader

### DIFF
--- a/libglusterfs/src/async.c
+++ b/libglusterfs/src/async.c
@@ -345,14 +345,18 @@ gf_async_worker_create(void)
 static void
 gf_async_worker_enable(void)
 {
+    /* We have consumed a spare worker. We create another one for future
+     * needs. It is important to create the spare worker inside the leader
+     * threads since we use thread unsafe functions inside like
+     * __cds_wfs_pop_blocking. So we perform the spare worker creation
+     * before sending the leader transfer signal.
+     */
+    gf_async_worker_create();
+
     /* This will wake one of the spare workers. If all workers are busy now,
      * the signal will be queued so that the first one that completes its
      * work will become the leader. */
     gf_async_sigbroadcast(GF_ASYNC_SIGCTRL);
-
-    /* We have consumed a spare worker. We create another one for future
-     * needs. */
-    gf_async_worker_create();
 }
 
 static void


### PR DESCRIPTION
We were sending the signal to transfer the leader before
we create a new leader. Which means, there is a potential
chance that the new thread creation will be executed twice
which is not what we are intended to perform

Fixes: #3527 
Change-Id: I8446ae3130894f351e6bd1197f26ce97d8cb1eef
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

