### PR TITLE
gfapi: glfs_fstatat implementation

### DIFF
--- a/api/src/gfapi.aliases
+++ b/api/src/gfapi.aliases
@@ -200,3 +200,4 @@ _pub_glfs_set_statedump_path _glfs_set_statedump_path@GFAPI_7.0
 
 _pub_glfs_h_creat_open _glfs_h_creat_open@GFAPI_6.6
 _pub_glfs_openat _glfs_openat@GFAPI_11.0
+_pub_glfs_fstatat _glfs_fstatat@GFAPI_11.0

--- a/api/src/gfapi.map
+++ b/api/src/gfapi.map
@@ -285,4 +285,5 @@ GFAPI_7.0 {
 GFAPI_11.0 {
 	global:
 		glfs_openat;
+		glfs_fstatat;
 } GFAPI_7.0;

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -812,6 +812,10 @@ glfs_stat(glfs_t *fs, const char *path, struct stat *buf) __THROW
     GFAPI_PUBLIC(glfs_stat, 3.4.0);
 
 int
+glfs_fstatat(struct glfs_fd *glfd, const char *path, struct stat *buf,
+             int flags) __THROW GFAPI_PUBLIC(glfs_fstatat, 11.0);
+
+int
 glfs_fstat(glfs_fd_t *fd, struct stat *buf) __THROW
     GFAPI_PUBLIC(glfs_fstat, 3.4.0);
 

--- a/tests/basic/gfapi/gfapi-o-path.c
+++ b/tests/basic/gfapi/gfapi-o-path.c
@@ -40,6 +40,9 @@ main(int argc, char *argv[])
     const char *buff =
         "An opinion should be the result of thought, "
         "not a substitute for it.";
+    struct stat stbuf = {
+        0,
+    };
 
     if (argc != 4) {
         fprintf(stderr, "Invalid argument\n");
@@ -101,6 +104,15 @@ main(int argc, char *argv[])
 
     ret = glfs_write(fd3, buff, strlen(buff), flags);
     VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_write(filename_2)", ret, out);
+
+    ret = glfs_fstatat(fd1, filename, &stbuf, 0);
+    VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_fstatat", ret, out);
+
+    if (strlen(buff) != stbuf.st_size) {
+        ret = -1;
+        VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_fstatat(Size mismatch)", ret,
+                                         out);
+    }
 
     ret = 0;
 out:


### PR DESCRIPTION
Example:

```c
struct stat stbuf = {
    0,
};
fd1 = glfs_open(fs, "/", O_PATH);
glfs_fstatat(fd1, filename, &stbuf, 0);
printf("Size: %zu\n", stbuf->st_size);
```

Change-Id: I6d4c95ce91191566d2b9a198d5ba382bbad22264
Updates: https://github.com/gluster/glusterfs/issues/2717
Sponsored-By: iXsystems, Inc <https://www.ixsystems.com/>
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>