### PR TITLE
mgmt: Remove old code related to version 3.x

### DIFF
--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -128,8 +128,6 @@
 
 #define GD_OP_VERSION_11_0 110000 /* Op-version for GlusterFS 11.0 */
 
-#define GD_OP_VER_PERSISTENT_AFR_XATTRS GD_OP_VERSION_3_6_0
-
 #include "glusterfs/xlator.h"
 #include "glusterfs/options.h"
 

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -312,7 +312,10 @@ __get_posixlk_count(pl_inode_t *pl_inode)
     posix_lock_t *lock = NULL;
     int32_t count = 0;
 
-    list_for_each_entry(lock, &pl_inode->ext_list, list) { count++; }
+    list_for_each_entry(lock, &pl_inode->ext_list, list)
+    {
+        count++;
+    }
 
     return count;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -99,29 +99,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
         goto out;
     }
 
-    if (conf->op_version < GD_OP_VERSION_3_7_0) {
-        snprintf(msg, sizeof(msg),
-                 "Cannot execute command. The "
-                 "cluster is operating at version %d. Bitrot command "
-                 "%s is unavailable in this version",
-                 conf->op_version, gd_bitrot_op_list[type]);
-        ret = -1;
-        goto out;
-    }
-
     if (type == GF_BITROT_CMD_SCRUB_STATUS) {
-        /* Backward compatibility handling for scrub status command*/
-        if (conf->op_version < GD_OP_VERSION_3_7_7) {
-            snprintf(msg, sizeof(msg),
-                     "Cannot execute command. "
-                     "The cluster is operating at version %d. "
-                     "Bitrot scrub status command unavailable in "
-                     "this version",
-                     conf->op_version);
-            ret = -1;
-            goto out;
-        }
-
         ret = dict_get_str(dict, "scrub-value", &scrub);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -668,54 +668,66 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
         goto out;
     }
 
-    /* Based on the op_version, acquire a cluster or mgmt_v3 lock */
-    if (priv->op_version < GD_OP_VERSION_3_6_0) {
-        ret = glusterd_lock(MY_UUID);
-        if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GLUSTERD_LOCK_FAIL,
-                   "Unable to acquire lock on localhost, ret: %d", ret);
-            snprintf(err_str, err_len,
-                     "Another transaction is in progress. "
-                     "Please try again after some time.");
-            goto out;
-        }
+    /* If no volname is given as a part of the command, locks will
+     * not be held */
+    ret = dict_get_str(dict, "volname", &tmp);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
+               "No Volume name present. "
+               "Locks not being held.");
+        goto local_locking_done;
     } else {
-        /* If no volname is given as a part of the command, locks will
-         * not be held */
-        ret = dict_get_str(dict, "volname", &tmp);
-        if (ret) {
-            gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
-                   "No Volume name present. "
-                   "Locks not being held.");
-            goto local_locking_done;
-        } else {
-            /* Use a copy of volname, as cli response will be
-             * sent before the unlock, and the volname in the
-             * dict, might be removed */
-            volname = gf_strdup(tmp);
-            if (!volname)
-                goto out;
-        }
-
-        /* Cli will add timeout key to dict if the default timeout is
-         * other than 2 minutes. Here we use this value to check whether
-         * mgmt_v3_lock_timeout should be set to default value or we
-         * need to change the value according to timeout value
-         * i.e, timeout + 120 seconds. */
-        ret = dict_get_time(dict, "timeout", &timeout);
-        if (!ret)
-            priv->mgmt_v3_lock_timeout = timeout + 120;
-
-        ret = glusterd_mgmt_v3_lock(volname, MY_UUID, &op_errno, "vol");
-        if (ret) {
-            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_LOCK_GET_FAIL,
-                   "Unable to acquire lock for %s", volname);
-            snprintf(err_str, err_len,
-                     "Another transaction is in progress for %s. "
-                     "Please try again after some time.",
-                     volname);
+        /* Use a copy of volname, as cli response will be
+         * sent before the unlock, and the volname in the
+         * dict, might be removed */
+        volname = gf_strdup(tmp);
+        if (!volname)
             goto out;
-        }
+    }
+
+    /* Cli will add timeout key to dict if the default timeout is
+     * other than 2 minutes. Here we use this value to check whether
+     * mgmt_v3_lock_timeout should be set to default value or we
+     * need to change the value according to timeout value
+     * i.e, timeout + 120 seconds. */
+    ret = dict_get_time(dict, "timeout", &timeout);
+    if (!ret)
+        priv->mgmt_v3_lock_timeout = timeout + 120;
+
+    ret = glusterd_mgmt_v3_lock(volname, MY_UUID, &op_errno, "vol");
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_LOCK_GET_FAIL,
+               "Unable to acquire lock for %s", volname);
+        snprintf(err_str, err_len,
+                 "Another transaction is in progress for %s. "
+                 "Please try again after some time.",
+                 volname);
+        /* Use a copy of volname, as cli response will be
+         * sent before the unlock, and the volname in the
+         * dict, might be removed */
+        volname = gf_strdup(tmp);
+        if (!volname)
+            goto out;
+    }
+
+    /* Cli will add timeout key to dict if the default timeout is
+     * other than 2 minutes. Here we use this value to check whether
+     * mgmt_v3_lock_timeout should be set to default value or we
+     * need to change the value according to timeout value
+     * i.e, timeout + 120 seconds. */
+    ret = dict_get_time(dict, "timeout", &timeout);
+    if (!ret)
+        priv->mgmt_v3_lock_timeout = timeout + 120;
+
+    ret = glusterd_mgmt_v3_lock(volname, MY_UUID, &op_errno, "vol");
+    if (ret) {
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_LOCK_GET_FAIL,
+               "Unable to acquire lock for %s", volname);
+        snprintf(err_str, err_len,
+                 "Another transaction is in progress for %s. "
+                 "Please try again after some time.",
+                 volname);
+        goto out;
     }
 
     locked = 1;
@@ -724,7 +736,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
 local_locking_done:
     /* If no volname is given as a part of the command, locks will
      * not be held, hence sending stage event. */
-    if (volname || (priv->op_version < GD_OP_VERSION_3_6_0))
+    if (volname)
         event_type = GD_OP_EVENT_START_LOCK;
     else {
         txn_op_info.state = GD_OP_STATE_LOCK_SENT;
@@ -753,17 +765,11 @@ local_locking_done:
 
 out:
     if (locked && ret) {
-        /* Based on the op-version, we release the
-         * cluster or mgmt_v3 lock */
-        if (priv->op_version < GD_OP_VERSION_3_6_0)
-            glusterd_unlock(MY_UUID);
-        else {
-            ret = glusterd_mgmt_v3_unlock(volname, MY_UUID, "vol");
-            if (ret)
-                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
-                       "Unable to release lock for %s", volname);
-            ret = -1;
-        }
+        ret = glusterd_mgmt_v3_unlock(volname, MY_UUID, "vol");
+        if (ret)
+            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
+                   "Unable to release lock for %s", volname);
+        ret = -1;
     }
 
     if (volname)
@@ -4534,16 +4540,6 @@ __glusterd_handle_status_volume(rpcsvc_request_t *req)
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_STATUS_VOL_REQ_RCVD,
                "Received status volume req for volume %s", volname);
     }
-    if ((cmd & GF_CLI_STATUS_CLIENT_LIST) &&
-        (conf->op_version < GD_OP_VERSION_3_13_0)) {
-        snprintf(err_str, sizeof(err_str),
-                 "The cluster is operating "
-                 "at version less than %d. Getting the client-list "
-                 "is not allowed in this state.",
-                 GD_OP_VERSION_3_13_0);
-        ret = -1;
-        goto out;
-    }
 
     if ((cmd & GF_CLI_STATUS_QUOTAD) &&
         (conf->op_version == GD_OP_VERSION_MIN)) {
@@ -4551,39 +4547,6 @@ __glusterd_handle_status_volume(rpcsvc_request_t *req)
                  "The cluster is operating "
                  "at version 1. Getting the status of quotad is not "
                  "allowed in this state.");
-        ret = -1;
-        goto out;
-    }
-
-    if ((cmd & GF_CLI_STATUS_SNAPD) &&
-        (conf->op_version < GD_OP_VERSION_3_6_0)) {
-        snprintf(err_str, sizeof(err_str),
-                 "The cluster is operating "
-                 "at a lesser version than %d. Getting the status of "
-                 "snapd is not allowed in this state",
-                 GD_OP_VERSION_3_6_0);
-        ret = -1;
-        goto out;
-    }
-
-    if ((cmd & GF_CLI_STATUS_BITD) &&
-        (conf->op_version < GD_OP_VERSION_3_7_0)) {
-        snprintf(err_str, sizeof(err_str),
-                 "The cluster is operating "
-                 "at a lesser version than %d. Getting the status of "
-                 "bitd is not allowed in this state",
-                 GD_OP_VERSION_3_7_0);
-        ret = -1;
-        goto out;
-    }
-
-    if ((cmd & GF_CLI_STATUS_SCRUB) &&
-        (conf->op_version < GD_OP_VERSION_3_7_0)) {
-        snprintf(err_str, sizeof(err_str),
-                 "The cluster is operating "
-                 "at a lesser version than %d. Getting the status of "
-                 "scrub is not allowed in this state",
-                 GD_OP_VERSION_3_7_0);
         ret = -1;
         goto out;
     }
@@ -6558,11 +6521,11 @@ out:
     return ret;
 }
 
-int
+static int
 __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
                            rpc_clnt_event_t event, void *data)
 {
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     int ret = 0;
     int32_t op_errno = ENOTCONN;
@@ -6572,13 +6535,9 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
     glusterd_volinfo_t *volinfo = NULL;
     glusterfs_ctx_t *ctx = NULL;
 
-    uuid_t uuid;
-
     peerctx = mydata;
     if (!peerctx)
         return 0;
-
-    conf = this->private;
 
     switch (event) {
         case RPC_CLNT_DESTROY:
@@ -6591,6 +6550,9 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
         default:
             break;
     }
+
+    this = THIS;
+    conf = this->private;
     ctx = this->ctx;
     GF_VALIDATE_OR_GOTO(this->name, ctx, out);
     if (ctx->cleanup_started) {
@@ -6665,23 +6627,16 @@ __glusterd_peer_rpc_notify(struct rpc_clnt *rpc, void *mydata,
                      glusterd_friend_sm_state_name_get(peerinfo->state));
 
             if (peerinfo->connected) {
-                if (conf->op_version < GD_OP_VERSION_3_6_0) {
-                    glusterd_get_lock_owner(&uuid);
-                    if (!gf_uuid_is_null(uuid) &&
-                        !gf_uuid_compare(peerinfo->uuid, uuid))
-                        glusterd_unlock(peerinfo->uuid);
-                } else {
-                    cds_list_for_each_entry(volinfo, &conf->volumes, vol_list)
-                    {
-                        ret = glusterd_mgmt_v3_unlock(volinfo->volname,
-                                                      peerinfo->uuid, "vol");
-                        if (ret)
-                            gf_msg(this->name, GF_LOG_WARNING, 0,
-                                   GD_MSG_MGMTV3_UNLOCK_FAIL,
-                                   "Lock not released "
-                                   "for %s",
-                                   volinfo->volname);
-                    }
+                cds_list_for_each_entry(volinfo, &conf->volumes, vol_list)
+                {
+                    ret = glusterd_mgmt_v3_unlock(volinfo->volname,
+                                                  peerinfo->uuid, "vol");
+                    if (ret)
+                        gf_msg(this->name, GF_LOG_WARNING, 0,
+                               GD_MSG_MGMTV3_UNLOCK_FAIL,
+                               "Lock not released "
+                               "for %s",
+                               volinfo->volname);
                 }
 
                 op_errno = GF_PROBE_ANOTHER_CLUSTER;

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -710,26 +710,6 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
             goto out;
     }
 
-    /* Cli will add timeout key to dict if the default timeout is
-     * other than 2 minutes. Here we use this value to check whether
-     * mgmt_v3_lock_timeout should be set to default value or we
-     * need to change the value according to timeout value
-     * i.e, timeout + 120 seconds. */
-    ret = dict_get_time(dict, "timeout", &timeout);
-    if (!ret)
-        priv->mgmt_v3_lock_timeout = timeout + 120;
-
-    ret = glusterd_mgmt_v3_lock(volname, MY_UUID, &op_errno, "vol");
-    if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_LOCK_GET_FAIL,
-               "Unable to acquire lock for %s", volname);
-        snprintf(err_str, err_len,
-                 "Another transaction is in progress for %s. "
-                 "Please try again after some time.",
-                 volname);
-        goto out;
-    }
-
     locked = 1;
     gf_msg_debug(this->name, 0, "Acquired lock on localhost");
 

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -158,11 +158,8 @@ int32_t
 glusterd_generate_txn_id(dict_t *dict, uuid_t **txn_id)
 {
     int32_t ret = -1;
-    glusterd_conf_t *priv = NULL;
     xlator_t *this = THIS;
 
-    priv = this->private;
-    GF_ASSERT(priv);
     GF_ASSERT(dict);
 
     *txn_id = GF_MALLOC(sizeof(uuid_t), gf_common_mt_uuid_t);
@@ -171,10 +168,7 @@ glusterd_generate_txn_id(dict_t *dict, uuid_t **txn_id)
         goto out;
     }
 
-    if (priv->op_version < GD_OP_VERSION_3_6_0)
-        gf_uuid_copy(**txn_id, priv->global_txn_id);
-    else
-        gf_uuid_generate(**txn_id);
+    gf_uuid_generate(**txn_id);
 
     ret = dict_set_bin(dict, "transaction_id", *txn_id, sizeof(**txn_id));
     if (ret) {
@@ -1784,19 +1778,6 @@ glusterd_op_stage_status_volume(dict_t *dict, char **op_errstr)
                  "allowed in this state.");
         gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_QUOTA_GET_STAT_FAIL,
                 msg, NULL);
-        ret = -1;
-        goto out;
-    }
-
-    if ((cmd & GF_CLI_STATUS_SNAPD) &&
-        (priv->op_version < GD_OP_VERSION_3_6_0)) {
-        snprintf(msg, sizeof(msg),
-                 "The cluster is operating at "
-                 "version less than %d. Getting the "
-                 "status of snapd is not allowed in this state.",
-                 GD_OP_VERSION_3_6_0);
-        gf_smsg(this->name, GF_LOG_ERROR, errno, GD_MSG_SNAP_STATUS_FAIL, msg,
-                NULL);
         ret = -1;
         goto out;
     }
@@ -4083,56 +4064,35 @@ glusterd_op_ac_send_lock(glusterd_op_sm_event_t *event, void *ctx)
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
 
-        /* Based on the op_version, acquire a cluster or mgmt_v3 lock */
-        if (priv->op_version < GD_OP_VERSION_3_6_0) {
-            proc = &peerinfo->mgmt->proctable[GLUSTERD_MGMT_CLUSTER_LOCK];
-            if (proc->fn) {
-                ret = proc->fn(NULL, this, peerinfo);
-                if (ret) {
-                    RCU_READ_UNLOCK;
-                    gf_msg(this->name, GF_LOG_WARNING, 0,
-                           GD_MSG_LOCK_REQ_SEND_FAIL,
-                           "Failed to send lock request "
-                           "for operation 'Volume %s' to "
-                           "peer %s",
-                           gd_op_list[opinfo.op], peerinfo->hostname);
-                    goto out;
-                }
-                /* Mark the peer as locked*/
-                peerinfo->locked = _gf_true;
-                pending_count++;
-            }
-        } else {
-            dict = glusterd_op_get_ctx();
-            dict_ref(dict);
+        dict = glusterd_op_get_ctx();
+        dict_ref(dict);
 
-            proc = &peerinfo->mgmt_v3->proctable[GLUSTERD_MGMT_V3_LOCK];
-            if (proc->fn) {
-                ret = dict_set_static_ptr(dict, "peerinfo", peerinfo);
-                if (ret) {
-                    RCU_READ_UNLOCK;
-                    gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
-                           "failed to set peerinfo");
-                    dict_unref(dict);
-                    goto out;
-                }
-
-                ret = proc->fn(NULL, this, dict);
-                if (ret) {
-                    RCU_READ_UNLOCK;
-                    gf_msg(this->name, GF_LOG_WARNING, 0,
-                           GD_MSG_MGMTV3_LOCK_REQ_SEND_FAIL,
-                           "Failed to send mgmt_v3 lock "
-                           "request for operation "
-                           "'Volume %s' to peer %s",
-                           gd_op_list[opinfo.op], peerinfo->hostname);
-                    dict_unref(dict);
-                    goto out;
-                }
-                /* Mark the peer as locked*/
-                peerinfo->locked = _gf_true;
-                pending_count++;
+        proc = &peerinfo->mgmt_v3->proctable[GLUSTERD_MGMT_V3_LOCK];
+        if (proc->fn) {
+            ret = dict_set_static_ptr(dict, "peerinfo", peerinfo);
+            if (ret) {
+                RCU_READ_UNLOCK;
+                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
+                       "failed to set peerinfo");
+                dict_unref(dict);
+                goto out;
             }
+
+            ret = proc->fn(NULL, this, dict);
+            if (ret) {
+                RCU_READ_UNLOCK;
+                gf_msg(this->name, GF_LOG_WARNING, 0,
+                       GD_MSG_MGMTV3_LOCK_REQ_SEND_FAIL,
+                       "Failed to send mgmt_v3 lock "
+                       "request for operation "
+                       "'Volume %s' to peer %s",
+                       gd_op_list[opinfo.op], peerinfo->hostname);
+                dict_unref(dict);
+                goto out;
+            }
+            /* Mark the peer as locked*/
+            peerinfo->locked = _gf_true;
+            pending_count++;
         }
     }
     RCU_READ_UNLOCK;
@@ -4184,62 +4144,40 @@ glusterd_op_ac_send_unlock(glusterd_op_sm_event_t *event, void *ctx)
         if ((peerinfo->state != GD_FRIEND_STATE_BEFRIENDED) &&
             (glusterd_op_get_op() != GD_OP_SYNC_VOLUME))
             continue;
-        /* Based on the op_version,
-         * release the cluster or mgmt_v3 lock */
-        if (priv->op_version < GD_OP_VERSION_3_6_0) {
-            proc = &peerinfo->mgmt->proctable[GLUSTERD_MGMT_CLUSTER_UNLOCK];
-            if (proc->fn) {
-                ret = proc->fn(NULL, this, peerinfo);
-                if (ret) {
-                    opinfo.op_errstr = gf_strdup(
-                        "Unlocking failed for one of "
-                        "the peer.");
-                    gf_msg(this->name, GF_LOG_ERROR, 0,
-                           GD_MSG_CLUSTER_UNLOCK_FAILED,
-                           "Unlocking failed for operation"
-                           " volume %s on peer %s",
-                           gd_op_list[opinfo.op], peerinfo->hostname);
-                    continue;
-                }
-                pending_count++;
-                peerinfo->locked = _gf_false;
-            }
-        } else {
-            dict = glusterd_op_get_ctx();
-            dict_ref(dict);
+        dict = glusterd_op_get_ctx();
+        dict_ref(dict);
 
-            proc = &peerinfo->mgmt_v3->proctable[GLUSTERD_MGMT_V3_UNLOCK];
-            if (proc->fn) {
-                ret = dict_set_static_ptr(dict, "peerinfo", peerinfo);
-                if (ret) {
-                    opinfo.op_errstr = gf_strdup(
-                        "Unlocking failed for one of the "
-                        "peer.");
-                    gf_msg(this->name, GF_LOG_ERROR, 0,
-                           GD_MSG_CLUSTER_UNLOCK_FAILED,
-                           "Unlocking failed for operation"
-                           " volume %s on peer %s",
-                           gd_op_list[opinfo.op], peerinfo->hostname);
-                    dict_unref(dict);
-                    continue;
-                }
-
-                ret = proc->fn(NULL, this, dict);
-                if (ret) {
-                    opinfo.op_errstr = gf_strdup(
-                        "Unlocking failed for one of the "
-                        "peer.");
-                    gf_msg(this->name, GF_LOG_ERROR, 0,
-                           GD_MSG_CLUSTER_UNLOCK_FAILED,
-                           "Unlocking failed for operation"
-                           " volume %s on peer %s",
-                           gd_op_list[opinfo.op], peerinfo->hostname);
-                    dict_unref(dict);
-                    continue;
-                }
-                pending_count++;
-                peerinfo->locked = _gf_false;
+        proc = &peerinfo->mgmt_v3->proctable[GLUSTERD_MGMT_V3_UNLOCK];
+        if (proc->fn) {
+            ret = dict_set_static_ptr(dict, "peerinfo", peerinfo);
+            if (ret) {
+                opinfo.op_errstr = gf_strdup(
+                    "Unlocking failed for one of the "
+                    "peer.");
+                gf_msg(this->name, GF_LOG_ERROR, 0,
+                       GD_MSG_CLUSTER_UNLOCK_FAILED,
+                       "Unlocking failed for operation"
+                       " volume %s on peer %s",
+                       gd_op_list[opinfo.op], peerinfo->hostname);
+                dict_unref(dict);
+                continue;
             }
+
+            ret = proc->fn(NULL, this, dict);
+            if (ret) {
+                opinfo.op_errstr = gf_strdup(
+                    "Unlocking failed for one of the "
+                    "peer.");
+                gf_msg(this->name, GF_LOG_ERROR, 0,
+                       GD_MSG_CLUSTER_UNLOCK_FAILED,
+                       "Unlocking failed for operation"
+                       " volume %s on peer %s",
+                       gd_op_list[opinfo.op], peerinfo->hostname);
+                dict_unref(dict);
+                continue;
+            }
+            pending_count++;
+            peerinfo->locked = _gf_false;
         }
     }
     RCU_READ_UNLOCK;
@@ -5089,7 +5027,6 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
     int count = 0;
     uint32_t cmd = GF_CLI_STATUS_NONE;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char *volname = NULL;
     glusterd_volinfo_t *volinfo = NULL;
     char *port = 0;
@@ -5098,8 +5035,6 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
         0,
     };
     int keylen;
-
-    conf = this->private;
 
     if (ctx)
         op_ctx = ctx;
@@ -5162,12 +5097,6 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
             ret = glusterd_volinfo_find(volname, &volinfo);
             if (ret)
                 goto out;
-            if (conf->op_version < GD_OP_VERSION_3_7_0 &&
-                volinfo->transport_type == GF_TRANSPORT_RDMA) {
-                ret = glusterd_op_modify_port_key(op_ctx, brick_index_max);
-                if (ret)
-                    goto out;
-            }
             /* add 'brick%d.peerid' into op_ctx with value of 'brick%d.path'.
                nfs/sshd like services have this additional uuid */
             {
@@ -5768,28 +5697,17 @@ glusterd_op_txn_complete(uuid_t *txn_id)
     glusterd_op_reset_ctx();
     glusterd_op_clear_errstr();
 
-    /* Based on the op-version, we release the cluster or mgmt_v3 lock */
-    if (priv->op_version < GD_OP_VERSION_3_6_0) {
-        ret = glusterd_unlock(MY_UUID);
-        /* unlock can't/shouldn't fail here!! */
-        if (ret)
-            gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_GLUSTERD_UNLOCK_FAIL,
-                   "Unable to clear local lock, ret: %d", ret);
-        else
-            gf_msg_debug(this->name, 0, "Cleared local lock");
-    } else {
-        ret = dict_get_str(ctx, "volname", &volname);
-        if (ret)
-            gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
-                   "No Volume name present. "
-                   "Locks have not been held.");
+    ret = dict_get_str(ctx, "volname", &volname);
+    if (ret)
+        gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
+               "No Volume name present. "
+               "Locks have not been held.");
 
-        if (volname) {
-            ret = glusterd_mgmt_v3_unlock(volname, MY_UUID, "vol");
-            if (ret)
-                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
-                       "Unable to release lock for %s", volname);
-        }
+    if (volname) {
+        ret = glusterd_mgmt_v3_unlock(volname, MY_UUID, "vol");
+        if (ret)
+            gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
+                   "Unable to release lock for %s", volname);
     }
 
     ret = glusterd_op_send_cli_response(op, op_ret, op_errno, req, ctx,

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -667,9 +667,6 @@ out:
 
 /* gd_add_friend_to_dict() adds details of @friend into @dict with the given
  * @prefix. All the parameters are compulsory.
- *
- * The complete address list is added to the dict only if the cluster op-version
- * is >= GD_OP_VERSION_3_6_0
  */
 int
 gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
@@ -677,15 +674,11 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[100] = {
         0,
     };
     glusterd_peer_hostname_t *address = NULL;
     int count = 0;
-
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
 
     GF_VALIDATE_OR_GOTO(this->name, (friend != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
@@ -709,11 +702,6 @@ gd_add_friend_to_dict(glusterd_peerinfo_t *friend, dict_t *dict,
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set key %s in dict", key);
-        goto out;
-    }
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
         goto out;
     }
 
@@ -753,16 +741,12 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[100] = {
         0,
     };
     char *hostname = NULL;
     int count = 0;
     int i = 0;
-
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
 
     GF_VALIDATE_OR_GOTO(this->name, (peerinfo != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
@@ -782,11 +766,6 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,
                "Could not add address to peer");
-        goto out;
-    }
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
         goto out;
     }
 
@@ -885,20 +864,11 @@ gd_add_peer_hostnames_to_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[64] = {
         0,
     };
     glusterd_peer_hostname_t *addr = NULL;
     int count = 0;
-
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
-        goto out;
-    }
 
     GF_VALIDATE_OR_GOTO(this->name, (peerinfo != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -720,27 +720,6 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
     switch (cmd) {
         case GF_DEFRAG_CMD_START:
         case GF_DEFRAG_CMD_START_LAYOUT_FIX:
-            /* Check if the connected clients are all of version
-             * glusterfs-3.6 and higher. This is needed to prevent some data
-             * loss issues that could occur when older clients are connected
-             * when rebalance is run. This check can be bypassed by using
-             * 'force'
-             */
-            ret = glusterd_check_client_op_version_support(
-                volname, GD_OP_VERSION_3_6_0, NULL);
-            if (ret) {
-                ret = gf_asprintf(op_errstr,
-                                  "Volume %s has one or "
-                                  "more connected clients of a version"
-                                  " lower than GlusterFS-v3.6.0. "
-                                  "Starting rebalance in this state "
-                                  "could lead to data loss.\nPlease "
-                                  "disconnect those clients before "
-                                  "attempting this command again.",
-                                  volname);
-                goto out;
-            }
-            /* Fall through */
         case GF_DEFRAG_CMD_START_FORCE:
             if (is_origin_glusterd(dict)) {
                 ret = glusterd_generate_and_set_task_id(
@@ -1019,27 +998,6 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
     switch (cmd) {
         case GF_DEFRAG_CMD_START:
         case GF_DEFRAG_CMD_START_LAYOUT_FIX:
-            /* Check if the connected clients are all of version
-             * glusterfs-3.6 and higher. This is needed to prevent some data
-             * loss issues that could occur when older clients are connected
-             * when rebalance is run. This check can be bypassed by using
-             * 'force'
-             */
-            ret = glusterd_check_client_op_version_support(
-                volname, GD_OP_VERSION_3_6_0, NULL);
-            if (ret) {
-                ret = gf_asprintf(op_errstr,
-                                  "Volume %s has one or "
-                                  "more connected clients of a version"
-                                  " lower than GlusterFS-v3.6.0. "
-                                  "Starting rebalance in this state "
-                                  "could lead to data loss.\nPlease "
-                                  "disconnect those clients before "
-                                  "attempting this command again.",
-                                  volname);
-                goto out;
-            }
-            /* Fall through */
         case GF_DEFRAG_CMD_START_FORCE:
             if (is_origin_glusterd(dict)) {
                 op_ctx = glusterd_op_get_ctx();

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -996,7 +996,7 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
 
         /* Compare missed_snapshot list with the peer *
          * if volume comparison is successful */
-        if ((op_ret == 0) && (conf->op_version >= GD_OP_VERSION_3_6_0)) {
+        if (op_ret == 0) {
             ret = glusterd_import_friend_missed_snap_list(ev_ctx->vols);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0,

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -519,22 +519,13 @@ gd_add_brick_snap_details_to_dict(dict_t *dict, char *prefix,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[256] = {
         0,
     };
 
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
-
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (prefix != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (brickinfo != NULL), out);
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
-        goto out;
-    }
 
     snprintf(key, sizeof(key), "%s.snap_status", prefix);
     ret = dict_set_int32(dict, key, brickinfo->snap_status);
@@ -614,22 +605,13 @@ gd_add_vol_snap_details_to_dict(dict_t *dict, char *prefix,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[256] = {
         0,
     };
 
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
-
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (volinfo != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (prefix != NULL), out);
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
-        goto out;
-    }
 
     snprintf(key, sizeof(key), "%s.restored_from_snap", prefix);
     ret = dict_set_dynstr_with_alloc(dict, key,
@@ -939,7 +921,6 @@ gd_import_new_brick_snap_details(dict_t *dict, char *prefix,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[512] = {
         0,
     };
@@ -950,17 +931,9 @@ gd_import_new_brick_snap_details(dict_t *dict, char *prefix,
     char *mnt_opts = NULL;
     char *mount_dir = NULL;
 
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
-
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (prefix != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (brickinfo != NULL), out);
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
-        goto out;
-    }
 
     snprintf(key, sizeof(key), "%s.snap_status", prefix);
     ret = dict_get_int32(dict, key, &brickinfo->snap_status);
@@ -1031,10 +1004,6 @@ out:
 
 /*
  * Imports the snapshot details of a volume if required and available
- *
- * Snapshot details will be imported only if cluster.op_version is greater than
- * or equal to GD_OP_VERSION_3_6_0, the op-version from which volume snapshot is
- * supported.
  */
 int
 gd_import_volume_snap_details(dict_t *dict, glusterd_volinfo_t *volinfo,
@@ -1042,7 +1011,6 @@ gd_import_volume_snap_details(dict_t *dict, glusterd_volinfo_t *volinfo,
 {
     int ret = -1;
     xlator_t *this = THIS;
-    glusterd_conf_t *conf = NULL;
     char key[256] = {
         0,
     };
@@ -1051,18 +1019,10 @@ gd_import_volume_snap_details(dict_t *dict, glusterd_volinfo_t *volinfo,
     char *restored_snapname = NULL;
     char *snap_plugin = NULL;
 
-    conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
-
     GF_VALIDATE_OR_GOTO(this->name, (dict != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (volinfo != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (prefix != NULL), out);
     GF_VALIDATE_OR_GOTO(this->name, (volname != NULL), out);
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        ret = 0;
-        goto out;
-    }
 
     snprintf(key, sizeof(key), "%s.is_snap_volume", prefix);
     uint32_t is_snap_int;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -8672,16 +8672,12 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
     };
     glusterd_op_t cli_op = GD_OP_SNAP;
     int type = 0;
-    glusterd_conf_t *conf = NULL;
     char *host_uuid = NULL;
     char err_str[2048] = "";
     xlator_t *this = THIS;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
-
-    conf = this->private;
-    GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
@@ -8729,19 +8725,8 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
         goto out;
     }
 
-    if (conf->op_version < GD_OP_VERSION_3_6_0) {
-        snprintf(err_str, sizeof(err_str),
-                 "Cluster operating version"
-                 " is lesser than the supported version "
-                 "for a snapshot");
-        op_errno = EG_OPNOTSUP;
-        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_UNSUPPORTED_VERSION,
-               "%s (%d < %d)", err_str, conf->op_version, GD_OP_VERSION_3_6_0);
-        ret = -1;
-        goto out;
-    }
-
     ret = dict_get_int32(dict, "type", &type);
+
     if (ret < 0) {
         snprintf(err_str, sizeof(err_str), "Command type not found");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND, "%s",

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -2417,7 +2417,10 @@ gd_get_brick_count(struct cds_list_head *bricks)
 {
     glusterd_pending_node_t *pending_node = NULL;
     int npeers = 0;
-    cds_list_for_each_entry(pending_node, bricks, list) { npeers++; }
+    cds_list_for_each_entry(pending_node, bricks, list)
+    {
+        npeers++;
+    }
     return npeers;
 }
 
@@ -2586,9 +2589,6 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
                "Failed to set originator_uuid.");
         goto out;
     }
-
-    if (conf->op_version < GD_OP_VERSION_3_6_0)
-        cluster_lock = _gf_true;
 
     /* Based on the op_version, acquire a cluster or mgmt_v3 lock */
     if (cluster_lock) {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -11154,35 +11154,32 @@ glusterd_enable_default_options(glusterd_volinfo_t *volinfo, char *option)
     }
 #endif
 
-    if (conf->op_version >= GD_OP_VERSION_3_7_0) {
-        /* Set needed volume options in volinfo->dict
-         * For ex.,
-         *
-         * if (!option || !strcmp("someoption", option) {
-         *      ret = dict_set_str(volinfo->dict, "someoption", "on");
-         *      ...
-         * }
-         * */
+    /* Set needed volume options in volinfo->dict
+     * For ex.,
+     *
+     * if (!option || !strcmp("someoption", option) {
+     *      ret = dict_set_str(volinfo->dict, "someoption", "on");
+     *      ...
+     * }
+     * */
 
-        /* Option 'features.quota-deem-statfs' should not be turned off
-         * with 'gluster volume reset <VOLNAME>', since quota features
-         * can be reset only with 'gluster volume quota <VOLNAME>
-         * disable'.
-         */
+    /* Option 'features.quota-deem-statfs' should not be turned off
+     * with 'gluster volume reset <VOLNAME>', since quota features
+     * can be reset only with 'gluster volume quota <VOLNAME>
+     * disable'.
+     */
 
-        if (!option || !strcmp("features.quota-deem-statfs", option)) {
-            if (glusterd_is_volume_quota_enabled(volinfo)) {
-                ret = dict_set_dynstr_with_alloc(
-                    volinfo->dict, "features.quota-deem-statfs", "on");
-                if (ret) {
-                    gf_msg(this->name, GF_LOG_ERROR, -ret,
-                           GD_MSG_DICT_SET_FAILED,
-                           "Failed to set option "
-                           "'features.quota-deem-statfs' "
-                           "on volume %s",
-                           volinfo->volname);
-                    goto out;
-                }
+    if (!option || !strcmp("features.quota-deem-statfs", option)) {
+        if (glusterd_is_volume_quota_enabled(volinfo)) {
+            ret = dict_set_dynstr_with_alloc(
+                volinfo->dict, "features.quota-deem-statfs", "on");
+            if (ret) {
+                gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+                       "Failed to set option "
+                       "'features.quota-deem-statfs' "
+                       "on volume %s",
+                       volinfo->volname);
+                goto out;
             }
         }
     }


### PR DESCRIPTION
There are many places that either bail out if it's an old version (very old version)
or check first if it's newer than it (and it always is, these days).
Removed all that code.

Updates: #3543
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

