### PR TITLE
glusterd: consistently use volume info reference counting

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -113,13 +113,12 @@ glusterd_cleanup_snaps_for_volume(glusterd_volinfo_t *volinfo)
             continue;
         }
 
-        ret = glusterd_volinfo_delete(snap_vol);
-        if (ret) {
+        if (glusterd_volinfo_unref(snap_vol)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_VOL_DELETE_FAIL,
                    "Failed to remove "
                    "volinfo %s ",
                    snap_vol->volname);
-            op_ret = ret;
+            op_ret = -1;
             continue;
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -4783,7 +4783,7 @@ glusterd_volinfo_dup(glusterd_volinfo_t *volinfo,
     ret = 0;
 out:
     if (ret && (NULL != new_volinfo)) {
-        (void)glusterd_volinfo_delete(new_volinfo);
+        (void)glusterd_volinfo_unref(new_volinfo);
     }
     return ret;
 }
@@ -9406,7 +9406,7 @@ out:
          * if it was added there.
          */
         if (new_volinfo)
-            (void)glusterd_volinfo_delete(new_volinfo);
+            (void)glusterd_volinfo_unref(new_volinfo);
     } else {
         cds_list_for_each_entry_safe(voliter, temp_volinfo,
                                      &orig_vol->snap_volumes, snapvol_list)

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -246,9 +246,6 @@ glusterd_volinfo_t *
 glusterd_volinfo_unref(glusterd_volinfo_t *volinfo);
 
 int32_t
-glusterd_volinfo_delete(glusterd_volinfo_t *volinfo);
-
-int32_t
 glusterd_brickinfo_delete(glusterd_brickinfo_t *brickinfo);
 
 int32_t

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -417,8 +417,7 @@ struct glusterd_volinfo_ {
     int op_version;
     int client_op_version;
     int32_t quota_xattr_version;
-    pthread_mutex_t reflock;
-    int refcnt;
+    gf_atomic_t refcnt;
     gd_quorum_status_t quorum_status;
 
     glusterd_snapdsvc_t snapd;


### PR DESCRIPTION
Ensure that `glusterd_volinfo_t` objects are always freed by using
`glusterd_volinfo_unref()` with respect to reference counting (thus
making `glusterd_volinfo_delete()` static), and prefer convenient
`gf_atomic_t` and `GF_ATOMIC` ops over heavyweight mutex-based
implementation for the reference counting itself.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000