### PR TITLE
mount/fuse: gf_fse_mt_invalidate_node_t type is at risk of memory leak

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -7238,7 +7238,7 @@ struct volume_options options[] = {
     {
         .key = {"invalidate-limit"},
         .type = GF_OPTION_TYPE_INT,
-        .default_value = "0",
+        .default_value = "65536",
         .min = 0,
         .description = "suspend invalidations as of 'lru-limit' if the number "
                        "of outstanding invalidations reaches this limit "


### PR DESCRIPTION
Fixes: #3553
Signed-off-by: Jifeng Zhou <z583340363@gmail.com>

