### PR TITLE
gfapi: Implement glfs_fchownat

### DIFF
--- a/api/src/gfapi.aliases
+++ b/api/src/gfapi.aliases
@@ -200,3 +200,4 @@ _pub_glfs_set_statedump_path _glfs_set_statedump_path@GFAPI_7.0
 
 _pub_glfs_h_creat_open _glfs_h_creat_open@GFAPI_6.6
 _pub_glfs_openat _glfs_openat@GFAPI_11.0
+_pub_glfs_fchownat _glfs_fchownat@GFAPI_11.0

--- a/api/src/gfapi.map
+++ b/api/src/gfapi.map
@@ -285,4 +285,5 @@ GFAPI_7.0 {
 GFAPI_11.0 {
 	global:
 		glfs_openat;
+		glfs_fchownat;
 } GFAPI_7.0;

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -4279,6 +4279,64 @@ pub_glfs_chown(struct glfs *fs, const char *path, uid_t uid, gid_t gid)
     return ret;
 }
 
+GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_fchownat, 11.0)
+int
+pub_glfs_fchownat(struct glfs_fd *pglfd, const char *path, uid_t uid, gid_t gid,
+                  int flags)
+{
+    int ret = 0;
+    struct glfs_stat stat = {
+        0,
+    };
+
+    if (uid != (uid_t)-1) {
+        stat.glfs_st_uid = uid;
+        stat.glfs_st_mask = GLFS_STAT_UID;
+    }
+
+    if (gid != (uid_t)-1) {
+        stat.glfs_st_gid = gid;
+        stat.glfs_st_mask = stat.glfs_st_mask | GLFS_STAT_GID;
+    }
+
+    xlator_t *subvol = NULL;
+    loc_t loc = {
+        0,
+    };
+    struct iatt iatt = {
+        0,
+    };
+    int glvalid;
+    int no_follow = 0;
+
+    DECLARE_OLD_THIS;
+    __GLFS_ENTRY_VALIDATE_FD(pglfd, invalid_fs);
+
+    no_follow = (flags & AT_SYMLINK_NOFOLLOW) == AT_SYMLINK_NOFOLLOW;
+    subvol = setup_fopat_args(pglfd, path, !no_follow, &loc, &iatt);
+    if (!subvol) {
+        ret = -1;
+        errno = EIO;
+        goto out;
+    }
+
+    glfs_iatt_from_statx(&iatt, &stat);
+    glfsflags_from_gfapiflags(&stat, &glvalid);
+
+    if (stat.glfs_st_mask) {
+        ret = syncop_setattr(subvol, &loc, &iatt, glvalid, 0, 0, NULL, NULL);
+        DECODE_SYNCOP_ERR(ret);
+    }
+
+out:
+    cleanup_fopat_args(pglfd, subvol, ret, &loc);
+
+    __GLFS_EXIT_FS;
+
+invalid_fs:
+    return ret;
+}
+
 GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_lchown, 3.4.0)
 int
 pub_glfs_lchown(struct glfs *fs, const char *path, uid_t uid, gid_t gid)

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -939,6 +939,10 @@ glfs_fchown(glfs_fd_t *fd, uid_t uid, gid_t gid) __THROW
     GFAPI_PUBLIC(glfs_fchown, 3.4.0);
 
 int
+glfs_fchownat(struct glfs_fd *glfd, const char *path, uid_t uid, gid_t gid,
+              int flags) __THROW GFAPI_PUBLIC(glfs_fchownat, 11.0);
+
+int
 glfs_utimens(glfs_t *fs, const char *path,
              const struct timespec times[2]) __THROW
     GFAPI_PUBLIC(glfs_utimens, 3.4.0);

--- a/tests/basic/gfapi/gfapi-o-path.c
+++ b/tests/basic/gfapi/gfapi-o-path.c
@@ -41,6 +41,10 @@ main(int argc, char *argv[])
         "An opinion should be the result of thought, "
         "not a substitute for it.";
 
+    struct stat stbuf = {
+        0,
+    };
+
     if (argc != 4) {
         fprintf(stderr, "Invalid argument\n");
         return 1;
@@ -101,6 +105,18 @@ main(int argc, char *argv[])
 
     ret = glfs_write(fd3, buff, strlen(buff), flags);
     VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_write(filename_2)", ret, out);
+
+    ret = glfs_fchownat(fd1, filename, 1001, 1001, flags);
+    VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_fchownat", ret, out);
+
+    ret = glfs_stat(fs, filepath, &stbuf);
+    VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_stat", ret, out);
+
+    if (stbuf.st_uid != 1001 || stbuf.st_gid != 1001) {
+        ret = -1;
+        VALIDATE_AND_GOTO_LABEL_ON_ERROR("glfs_fchownat operation failed", ret,
+                                         out);
+    }
 
     ret = 0;
 out:


### PR DESCRIPTION
Example,
```C
struct stat stbuf = {
    0,
};
fd1 = glfs_open(fs, "/", O_PATH);
int uid = 1001;
int gid = 1001;
glfs_fchownat(fd1, filename, uid, gid, 0);
glfs_fstatat(fd1, filename, &stbuf, 0);
printf("UID=%d, GID=%d\n", stbuff.st_uid, stbuf.st_gid);
```

Updates: #2717
Sponsored-By: iXsystems, Inc https://www.ixsystems.com/
Depends-On: #3541, #3542
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>

