### PR TITLE
[write-behind]:Remove unused function

### DIFF
--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -470,7 +470,6 @@ out:
 static wb_request_t *
 __wb_request_ref(wb_request_t *req)
 {
-    GF_VALIDATE_OR_GOTO("write-behind", req, out);
 
     if (req->refcount < 0) {
         gf_msg("wb-request", GF_LOG_WARNING, 0,
@@ -485,7 +484,6 @@ __wb_request_ref(wb_request_t *req)
 out:
     return req;
 }
-
 
 gf_boolean_t
 wb_enqueue_common(wb_inode_t *wb_inode, call_stub_t *stub, int tempted)

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -470,7 +470,6 @@ out:
 static wb_request_t *
 __wb_request_ref(wb_request_t *req)
 {
-
     if (req->refcount < 0) {
         gf_msg("wb-request", GF_LOG_WARNING, 0,
                WRITE_BEHIND_MSG_RES_UNAVAILABLE, "refcount(%d) is < 0",


### PR DESCRIPTION
Remove unused function
1.__wb_request_ref used directly instead of wb_request_ref

2.wb_open & wb_create-> dead code

Change-Id: I057eb6bd818802a00f21ffe5418b1f181916eff4
Updates:#1000
Signed-off-by: Preet Bhatia <pbhatia@redhat.com>

