### PR TITLE
posix/gfid2path: Brick crashed if parent gfid link is not available

### DIFF
--- a/xlators/storage/posix/src/posix-gfid-path.c
+++ b/xlators/storage/posix/src/posix-gfid-path.c
@@ -165,6 +165,18 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
             /* Convert pargfid to path */
             ret = posix_resolve_dirgfid_to_path(pargfid, priv->base_path,
                                                 &xattr_value[37], &paths[i]);
+            if (ret == -1) {
+                *op_errno = errno;
+                gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_PGFID_OP,
+                       "Parent GFID to path conversion failed"
+                       " %s: key = %s parebt GFID: %s base name: %s",
+                       real_path, keybuffer, pargfid_str, &xattr_value[37]);
+                /* if ret == -1, then paths[i] will not be allocated, hence
+                 * no need to free the memory here
+                 */
+                break;
+            }
+
             i++;
 
         ignore:


### PR DESCRIPTION
If the parent gfid link is unavailable for some reason, then the
brick will be crashed since it fails to find the path during gfid
to path conversion. Because there are no error whether the readlink
failed or not.

There is a race condition when resolving GFID split brain where the
parent dir could have renamed to a landfill location, so there can
be a case where parent gfid link is not available while a gfid to path
request in progress.

Change-Id: Icd71ccdb4ea2f9e454246c490e65cb609768ea02
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

