### PR TITLE
server: fix error message

### DIFF
--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -2179,9 +2179,8 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (op_ret < 0) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
-                "frame=%" PRId64, uuid_utoa(state->resolve.gfid),
-                "ICREATE_gfid=%s", uuid_utoa(state->resolve.gfid),
-                "op_errno=%s", strerror(op_errno), NULL);
+                "frame=%" PRId64, frame->root->unique, "ICREATE_gfid=%s",
+                uuid_utoa(state->resolve.gfid), NULL);
         goto out;
     }
 


### PR DESCRIPTION
Adjust error message in `server4_icreate_cbk()` to print call
stack ID instead of (wrongly used in this context) resolve UUID,
 and drop redundant call to `strerror()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000