### PR TITLE
gfapi: Implement glfs_fchmodat

### DIFF
--- a/api/src/gfapi.aliases
+++ b/api/src/gfapi.aliases
@@ -200,3 +200,4 @@ _pub_glfs_set_statedump_path _glfs_set_statedump_path@GFAPI_7.0
 
 _pub_glfs_h_creat_open _glfs_h_creat_open@GFAPI_6.6
 _pub_glfs_openat _glfs_openat@GFAPI_11.0
+_pub_glfs_openat _glfs_fchmodat@GFAPI_11.0

--- a/api/src/gfapi.map
+++ b/api/src/gfapi.map
@@ -285,4 +285,5 @@ GFAPI_7.0 {
 GFAPI_11.0 {
 	global:
 		glfs_openat;
+		glfs_fchmodat;
 } GFAPI_7.0;

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -927,6 +927,10 @@ glfs_fchmod(glfs_fd_t *fd, mode_t mode) __THROW
     GFAPI_PUBLIC(glfs_fchmod, 3.4.0);
 
 int
+glfs_fchmodat(struct glfs_fd *glfd, const char *path, mode_t mode,
+              int flags) __THROW GFAPI_PUBLIC(glfs_fchmodat, 11.0);
+
+int
 glfs_chown(glfs_t *fs, const char *path, uid_t uid, gid_t gid) __THROW
     GFAPI_PUBLIC(glfs_chown, 3.4.0);
 


### PR DESCRIPTION
Example,
```C
struct stat stbuf = {
    0,
};
fd1 = glfs_open(fs, "/", O_PATH);
int file_mode = 0777;
glfs_fchownat(fd1, filename, file_mode, 0);
glfs_fstatat(fd1, filename, &stbuf, 0);
printf("File Mode = %o\n", stbuf.st_mode & 0777);
```


Updates: https://github.com/gluster/glusterfs/issues/2717
Sponsored-By: iXsystems, Inc https://www.ixsystems.com/
Depends On: #3541 
Signed-off-by: Shree Vatsa N [vatsa@kadalu.tech](mailto:vatsa@kadalu.tech)