### PR TITLE
[glusterd]:Updated common code

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -2187,25 +2187,7 @@ out:
 }
 
 int
-glusterd_post_commit_add_brick(dict_t *dict, char **op_errstr)
-{
-    int ret = 0;
-    char *volname = NULL;
-
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
-
-    if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
-               "Unable to get volume name");
-        goto out;
-    }
-    ret = glusterd_replace_old_auth_allow_list(volname);
-out:
-    return ret;
-}
-
-int
-glusterd_post_commit_replace_brick(dict_t *dict, char **op_errstr)
+glusterd_post_commit_brick_operation(dict_t *dict, char **op_errstr)
 {
     int ret = 0;
     char *volname = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -409,7 +409,7 @@ gd_mgmt_v3_post_commit_fn(glusterd_op_t op, dict_t *dict, char **op_errstr,
 
     switch (op) {
         case GD_OP_ADD_BRICK:
-            ret = glusterd_post_commit_add_brick(dict, op_errstr);
+            ret = glusterd_post_commit_brick_operation(dict, op_errstr);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_COMMIT_OP_FAIL,
                        "Add-brick post commit failed.");
@@ -417,7 +417,7 @@ gd_mgmt_v3_post_commit_fn(glusterd_op_t op, dict_t *dict, char **op_errstr,
             }
             break;
         case GD_OP_REPLACE_BRICK:
-            ret = glusterd_post_commit_replace_brick(dict, op_errstr);
+            ret = glusterd_post_commit_brick_operation(dict, op_errstr);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_COMMIT_OP_FAIL,
                        "Replace-brick post commit failed.");

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.h
@@ -90,8 +90,5 @@ int
 glusterd_op_reset_brick(dict_t *dict, dict_t *rsp_dict);
 
 int
-glusterd_post_commit_add_brick(dict_t *dict, char **op_errstr);
-
-int
-glusterd_post_commit_replace_brick(dict_t *dict, char **op_errstr);
+glusterd_post_commit_brick_operation(dict_t *dict, char **op_errstr);
 #endif /* _GLUSTERD_MGMT_H_ */


### PR DESCRIPTION
glusterd_post_commit_add_brick() & glusterd_post_commit_replace_brick()
are same function so updated in single function and updated the required
changes

Change-Id: I5b44e99001fdd96374e409a51c3a1327933328bd
Updates:#1000
Signed-off-by: Preet Bhatia pbhatia@redhat.com

