### PR TITLE
glusterd: drop unused function arguments here and there

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -349,7 +349,7 @@ is_bitd_configure_noop(xlator_t *this, glusterd_volinfo_t *volinfo)
     else {
         cds_list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
         {
-            if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+            if (!glusterd_is_local_brick(brickinfo))
                 continue;
             noop = _gf_false;
             return noop;
@@ -513,7 +513,7 @@ glusterd_should_i_stop_bitd()
         else {
             cds_list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
             {
-                if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+                if (!glusterd_is_local_brick(brickinfo))
                     continue;
                 stopped = _gf_false;
                 return stopped;

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -1695,7 +1695,7 @@ glusterd_remove_brick_validate_bricks(gf1_op_commands cmd, int32_t brick_count,
             goto out;
         }
 
-        if (glusterd_is_local_brick(THIS, volinfo, brickinfo)) {
+        if (glusterd_is_local_brick(brickinfo)) {
             switch (cmd) {
                 case GF_OP_CMD_START:
                     goto check;

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -4828,7 +4828,7 @@ glusterd_check_restart_gsync_session(glusterd_volinfo_t *volinfo,
     if (ret == 0) {
         dict_del(volinfo->gsync_active_secondaries, key);
         ret = glusterd_start_gsync(volinfo, secondary, path_list, conf_path,
-                                   uuid_utoa(MY_UUID), NULL, _gf_false);
+                                   NULL, _gf_false);
         if (!ret) {
             /* Add secondary to the dict indicating geo-rep session is
              * running.*/
@@ -5562,7 +5562,6 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 {
     int32_t ret = -1;
     int32_t type = -1;
-    char *host_uuid = NULL;
     char *secondary = NULL;
     char *secondary_url = NULL;
     char *secondary_vol = NULL;
@@ -5585,10 +5584,6 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
 
     ret = dict_get_int32(dict, "type", &type);
-    if (ret < 0)
-        goto out;
-
-    ret = dict_get_str(dict, "host-uuid", &host_uuid);
     if (ret < 0)
         goto out;
 
@@ -5701,7 +5696,7 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         }
 
         ret = glusterd_start_gsync(volinfo, secondary, path_list, conf_path,
-                                   host_uuid, op_errstr, _gf_false);
+                                   op_errstr, _gf_false);
 
         /* Delete added secondary in the dict if start fails*/
         if (ret)

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -426,9 +426,8 @@ out:
 }
 
 static int
-glusterd_rebalance_cmd_validate(int cmd, char *volname,
-                                glusterd_volinfo_t **volinfo, char *op_errstr,
-                                size_t len)
+glusterd_rebalance_cmd_validate(char *volname, glusterd_volinfo_t **volinfo,
+                                char *op_errstr, size_t len)
 {
     int ret = -1;
 
@@ -631,8 +630,7 @@ glusterd_set_rebalance_id_in_rsp_dict(dict_t *req_dict, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = glusterd_rebalance_cmd_validate(cmd, volname, &volinfo, msg,
-                                          sizeof(msg));
+    ret = glusterd_rebalance_cmd_validate(volname, &volinfo, msg, sizeof(msg));
     if (ret) {
         gf_msg_debug(this->name, 0, "failed to validate");
         goto out;
@@ -717,8 +715,7 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = glusterd_rebalance_cmd_validate(cmd, volname, &volinfo, msg,
-                                          sizeof(msg));
+    ret = glusterd_rebalance_cmd_validate(volname, &volinfo, msg, sizeof(msg));
     if (ret) {
         gf_msg_debug(this->name, 0, "failed to validate");
         goto out;
@@ -863,8 +860,7 @@ glusterd_mgmt_v3_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = glusterd_rebalance_cmd_validate(cmd, volname, &volinfo, msg,
-                                          sizeof(msg));
+    ret = glusterd_rebalance_cmd_validate(volname, &volinfo, msg, sizeof(msg));
     if (ret) {
         gf_msg_debug(this->name, 0, "cmd validate failed");
         goto out;
@@ -1021,8 +1017,7 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = glusterd_rebalance_cmd_validate(cmd, volname, &volinfo, msg,
-                                          sizeof(msg));
+    ret = glusterd_rebalance_cmd_validate(volname, &volinfo, msg, sizeof(msg));
     if (ret) {
         gf_msg_debug(this->name, 0, "failed to validate");
         goto out;
@@ -1176,8 +1171,7 @@ glusterd_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = glusterd_rebalance_cmd_validate(cmd, volname, &volinfo, msg,
-                                          sizeof(msg));
+    ret = glusterd_rebalance_cmd_validate(volname, &volinfo, msg, sizeof(msg));
     if (ret) {
         gf_msg_debug(this->name, 0, "cmd validate failed");
         goto out;

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -363,7 +363,7 @@ glusterd_do_volume_quorum_action(xlator_t *this, glusterd_volinfo_t *volinfo,
 
     list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
     {
-        if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+        if (!glusterd_is_local_brick(brickinfo))
             continue;
         if (quorum_status == DOESNT_MEET_QUORUM) {
             ret = glusterd_brick_stop(volinfo, brickinfo, _gf_false);
@@ -406,7 +406,7 @@ out:
     if (quorum_status_unchanged) {
         list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
         {
-            if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+            if (!glusterd_is_local_brick(brickinfo))
                 continue;
             ret = glusterd_brick_start(volinfo, brickinfo, _gf_false, _gf_true);
             if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -7067,7 +7067,7 @@ glusterd_get_single_snap_status(char **op_errstr, dict_t *rsp_dict,
         }
         cds_list_for_each_entry(brickinfo, &snap_volinfo->bricks, brick_list)
         {
-            if (!glusterd_is_local_brick(this, snap_volinfo, brickinfo)) {
+            if (!glusterd_is_local_brick(brickinfo)) {
                 brickcount++;
                 continue;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -331,8 +331,9 @@ glusterd_spawn_daemons(void *opaque);
 
 int
 glusterd_start_gsync(glusterd_volinfo_t *primary_vol, char *secondary,
-                     char *path_list, char *conf_path, char *glusterd_uuid_str,
-                     char **op_errstr, gf_boolean_t is_pause);
+                     char *path_list, char *conf_path, char **op_errstr,
+                     gf_boolean_t is_pause);
+
 int
 glusterd_get_local_brickpaths(glusterd_volinfo_t *volinfo, char **pathlist);
 
@@ -386,8 +387,8 @@ int
 glusterd_get_dist_leaf_count(glusterd_volinfo_t *volinfo);
 
 gf_boolean_t
-glusterd_is_local_brick(xlator_t *this, glusterd_volinfo_t *volinfo,
-                        glusterd_brickinfo_t *brickinfo);
+glusterd_is_local_brick(glusterd_brickinfo_t *brickinfo);
+
 int
 glusterd_validate_volume_id(dict_t *op_dict, glusterd_volinfo_t *volinfo);
 

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -6051,7 +6051,7 @@ build_bitd_volume_graph(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     cds_list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
     {
-        if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+        if (!glusterd_is_local_brick(brickinfo))
             continue;
 
         xl = volgen_graph_build_client(&cgraph, volinfo, brickinfo->hostname,
@@ -6124,7 +6124,7 @@ build_bitd_graph(volgen_graph_t *graph, dict_t *mod_dict)
 
         cds_list_for_each_entry(brickinfo, &voliter->bricks, brick_list)
         {
-            if (!glusterd_is_local_brick(this, voliter, brickinfo))
+            if (!glusterd_is_local_brick(brickinfo))
                 continue;
             numbricks++;
         }
@@ -6205,7 +6205,7 @@ build_scrub_volume_graph(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     cds_list_for_each_entry(brickinfo, &volinfo->bricks, brick_list)
     {
-        if (!glusterd_is_local_brick(this, volinfo, brickinfo))
+        if (!glusterd_is_local_brick(brickinfo))
             continue;
 
         xl = volgen_graph_build_client(&cgraph, volinfo, brickinfo->hostname,

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1464,8 +1464,8 @@ glusterd_destroy_hostname_list(struct list_head *hostname_list_head)
 }
 
 static int32_t
-glusterd_handle_upgrade_downgrade(dict_t *options, glusterd_conf_t *conf,
-                                  gf_boolean_t upgrade, gf_boolean_t downgrade)
+glusterd_handle_upgrade_downgrade(glusterd_conf_t *conf, gf_boolean_t upgrade,
+                                  gf_boolean_t downgrade)
 {
     int ret = 0;
     gf_boolean_t regenerate_volfiles = _gf_false;
@@ -2046,8 +2046,7 @@ init(xlator_t *this)
     }
 
     GF_ATOMIC_INIT(conf->blockers, 0);
-    ret = glusterd_handle_upgrade_downgrade(this->options, conf, upgrade,
-                                            downgrade);
+    ret = glusterd_handle_upgrade_downgrade(conf, upgrade, downgrade);
     if (ret)
         goto out;
 


### PR DESCRIPTION
Drop unused arguments of `glusterd_handle_upgrade_downgrade()`,
`glusterd_is_local_brick()`, `glusterd_rebalance_cmd_validate()`,
`glusterd_volume_ta_brickinfo_get()` and `glusterd_start_gsync()`,
adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000