### PR TITLE
libglusterfs: remove duplicated Darwin macros

### DIFF
--- a/libglusterfs/src/glusterfs/compat.h
+++ b/libglusterfs/src/glusterfs/compat.h
@@ -71,28 +71,6 @@
 
 #endif /* HAVE_LLISTXATTR */
 
-#ifdef GF_DARWIN_HOST_OS
-#include <machine/endian.h>
-#include <libkern/OSByteOrder.h>
-#include <sys/xattr.h>
-
-#define htobe16(x) OSSwapHostToBigInt16(x)
-#define htole16(x) OSSwapHostToLittleInt16(x)
-#define be16toh(x) OSSwapBigToHostInt16(x)
-#define le16toh(x) OSSwapLittleToHostInt16(x)
-
-#define htobe32(x) OSSwapHostToBigInt32(x)
-#define htole32(x) OSSwapHostToLittleInt32(x)
-#define be32toh(x) OSSwapBigToHostInt32(x)
-#define le32toh(x) OSSwapLittleToHostInt32(x)
-
-#define htobe64(x) OSSwapHostToBigInt64(x)
-#define htole64(x) OSSwapHostToLittleInt64(x)
-#define be64toh(x) OSSwapBigToHostInt64(x)
-#define le64toh(x) OSSwapLittleToHostInt64(x)
-
-#endif
-
 #ifdef GF_BSD_HOST_OS
 /* In case of FreeBSD and NetBSD */
 


### PR DESCRIPTION
Remove duplicated definitions of Darwin-specific byte swap macros.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000