### PR TITLE
libglusterfs, ec, glusterd: variadic dict iterator

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -1193,6 +1193,35 @@ dict_foreach(dict_t *dict,
     return ret;
 }
 
+int
+dict_foreachv(dict_t *dict,
+              int (*fn)(dict_t *this, char *key, data_t *value, va_list ap),
+              ...)
+{
+    int ret;
+    int count = 0;
+    va_list ap, cp;
+    data_pair_t *next = NULL;
+    data_pair_t *pairs = dict->members_list;
+
+    va_start(ap, fn);
+    while (pairs) {
+        next = pairs->next;
+        va_copy(cp, ap);
+        ret = fn(dict, pairs->key, pairs->value, cp);
+        va_end(cp);
+        if (ret < 0) {
+            count = ret;
+            break;
+        }
+        count++;
+        pairs = next;
+    }
+
+    va_end(ap);
+    return count;
+}
+
 /* return values:
    -1 = failure,
     0 = no matches found,
@@ -2857,8 +2886,6 @@ dict_serialize_lk(dict_t *this, char *buf)
 out:
     return ret;
 }
-
-
 
 /**
  * dict_unserialize - unserialize a buffer into a dict

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -173,7 +173,6 @@ dict_reset(dict_t *dict);
 int
 dict_key_count(dict_t *this);
 
-
 int32_t
 dict_unserialize(char *buf, int32_t size, dict_t **fill);
 
@@ -256,6 +255,11 @@ int
 dict_foreach(dict_t *this,
              int (*fn)(dict_t *this, char *key, data_t *value, void *data),
              void *data);
+
+int
+dict_foreachv(dict_t *this,
+              int (*fn)(dict_t *this, char *key, data_t *value, va_list ap),
+              ...);
 
 int
 dict_foreach_fnmatch(dict_t *dict, char *pattern,

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -363,6 +363,7 @@ dict_dump_to_statedump
 dict_dump_to_str
 dict_dump_to_log
 dict_foreach
+dict_foreachv
 dict_foreach_fnmatch
 dict_foreach_match
 dict_for_key_value

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -134,12 +134,6 @@ typedef struct glusterd_pr_brick_rsp_conv_t {
     dict_t *dict;
 } glusterd_pr_brick_rsp_conv_t;
 
-typedef struct glusterd_heal_rsp_conv_ {
-    dict_t *dict;
-    glusterd_volinfo_t *volinfo;
-    xlator_t *this;
-} glusterd_heal_rsp_conv_t;
-
 typedef struct glusterd_status_rsp_conv_ {
     int count;
     int brick_index_max;


### PR DESCRIPTION
Introduce `dict_foreachv()` to use variadic function while iterating
over the dictionary. This is mostly intended to write more generic
code instead of inventing special proxy types just to pass an assorted
set of parameters to an iterator function. Typical use cases within
`ec` and `glusterd` xlators are included.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000