### PR TITLE
[WIP] iobuf.c: use a single 136K buffer size for iobufs that are pre-allocated

### DIFF
--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -22,8 +22,9 @@
 /* Make sure this array is sorted based on pagesize */
 static const struct iobuf_init_config gf_iobuf_init_config[] = {
     /* { pagesize, num_pages }, */
-    {128, 1024},     {512, 512},       {2 * 1024, 512}, {8 * 1024, 128},
-    {32 * 1024, 64}, {128 * 1024, 32}, {256 * 1024, 8}, {1 * 1024 * 1024, 2},
+    {136 * 1024, 32},
+    {256 * 1024, 8},
+    {1 * 1024 * 1024, 2},
 };
 
 static int


### PR DESCRIPTION
1. There's no need for the <=128K, as they are now handled by regular memory allocation.
2. >128K, there are very few options. A common one is 128K, aligned (to 4K - so we add 4K) and perhaps few more bytes.
    This adds up to 136K.

Updates: #2863
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

