### PR TITLE
WIP: iobuf: get rid of 'standard allocation arena'

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -218,7 +218,7 @@ cli_submit_request(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
     if (req) {
         xdr_size = xdr_sizeof(xdrproc, req);
-        iobuf = iobuf_get_from_small(xdr_size);
+        iobuf = iobuf_get_from_regular_allocation(xdr_size, _gf_false);
         if (!iobuf) {
             goto out;
         };

--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -139,7 +139,7 @@ struct iobref {
 };
 
 struct iobuf *
-iobuf_get_from_small(const size_t page_size);
+iobuf_get_from_regular_allocation(const size_t page_size, bool align);
 
 struct iobref *
 iobref_new(void);

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -808,7 +808,7 @@ iobref_new
 iobref_ref
 iobref_size
 iobref_unref
-iobuf_get_from_small
+iobuf_get_from_regular_allocation
 iobuf_get
 iobuf_get2
 iobuf_get_page_aligned


### PR DESCRIPTION
Just use regular memory allocation.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

