### PR TITLE
server: brick_mux_regression job is getting crashed

### DIFF
--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -863,10 +863,16 @@ server_reconfigure(xlator_t *this, dict_t *options)
     this->ctx->statedump_path = gf_strdup(statedump_path);
 
 do_auth:
-    if (conf->auth_modules)
-        gf_auth_fini(conf->auth_modules);
-    else
+    if (conf->auth_modules) {
+        /* In case of brick_mux the vol_opt object is cleaned by
+           xlator_mem_free so no need to call gf_auth_fini to cleanup
+           the object
+        */
+        if (!this->ctx->cmd_args.brick_mux)
+            gf_auth_fini(conf->auth_modules);
+    } else {
         conf->auth_modules = dict_new();
+    }
 
     dict_foreach(options, get_auth_types, conf->auth_modules);
     ret = validate_auth_options(kid, options);


### PR DESCRIPTION
After commit (2e825b35352ae77bc74e356301b9bb90defc43e0) server
xlator call gf_auth_fini during reconfigure code path to
cleanup vol_opt object. In case of brick_mux environment
the object is already cleaned while during xlator cleanup
so it is not required in case of brick_mux.

Solution: To avoid a crash call gf_auth_fini only for
non brick_mux environment.

Fixes: #3600
Change-Id: I6837027b681a58518f2e8d184fe94db368d25387
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

