### PR TITLE
georep : Use change-interval config instead of an harcoded value for xsync

### DIFF
--- a/geo-replication/syncdaemon/primary.py
+++ b/geo-replication/syncdaemon/primary.py
@@ -1536,7 +1536,7 @@ class GPrimaryChangelogMixin(GPrimaryCommon):
         self.changelogs_batch_process(changes)
 
     def register(self, register_time, status):
-        self.sleep_interval = gconf.get("change-interval")
+        self.sleep_interval = gconf.get("change-interval", 60)
         self.changelog_done_func = libgfchangelog.done
         self.tempdir = self.setup_working_dir()
         self.processed_changelogs_dir = os.path.join(self.tempdir,
@@ -1656,7 +1656,7 @@ class GPrimaryXsyncMixin(GPrimaryChangelogMixin):
         self.counter = 0
         self.comlist = []
         self.stimes = []
-        self.sleep_interval = 60
+        self.sleep_interval = gconf.get("change-interval", 60)
         self.tempdir = self.setup_working_dir()
         logging.info(lf('Working dir',
                         path=self.tempdir))


### PR DESCRIPTION
XSync is currently using an hardcoded value of 60 seconds between syncs during the loop.
So, when we configure a georep session to use xsync as change detector, it's not using the change-interval config.