### PR TITLE
Converted CALLOC to MALLOC

### DIFF
--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -1499,7 +1499,7 @@ pub_glfs_h_create_from_handle(struct glfs *fs, unsigned char *handle, int len,
         glfs_iatt_to_stat(fs, &iatt, stat);
 
 found:
-    object = GF_CALLOC(1, sizeof(struct glfs_object), glfs_mt_glfs_object_t);
+    object = GF_MALLOC(sizeof(struct glfs_object), glfs_mt_glfs_object_t);
     if (object == NULL) {
         errno = ENOMEM;
         ret = -1;
@@ -2004,7 +2004,7 @@ glfs_h_find_handle(struct glfs *fs, unsigned char *handle, int len)
         goto out;
     }
 
-    object = GF_CALLOC(1, sizeof(struct glfs_object), glfs_mt_glfs_object_t);
+    object = GF_MALLOC(sizeof(struct glfs_object), glfs_mt_glfs_object_t);
     if (object == NULL) {
         errno = ENOMEM;
         goto out;
@@ -2335,7 +2335,7 @@ pub_glfs_h_poll_upcall370(struct glfs *fs, struct glfs_callback_arg *up_arg)
             struct glfs_callback_inode_arg *cb_inode = NULL;
             struct glfs_upcall_inode *up_inode = NULL;
 
-            cb_inode = GF_CALLOC(1, sizeof(struct glfs_callback_inode_arg),
+            cb_inode = GF_MALLOC(sizeof(struct glfs_callback_inode_arg),
                                  glfs_mt_upcall_inode_t);
             if (!cb_inode) {
                 errno = ENOMEM;
@@ -2557,7 +2557,7 @@ pub_glfs_object_copy(struct glfs_object *src)
 
     GF_VALIDATE_OR_GOTO("glfs_dup_object", src, out);
 
-    object = GF_CALLOC(1, sizeof(struct glfs_object), glfs_mt_glfs_object_t);
+    object = GF_MALLOC(sizeof(struct glfs_object), glfs_mt_glfs_object_t);
     if (object == NULL) {
         errno = ENOMEM;
         gf_smsg(THIS->name, GF_LOG_WARNING, errno, API_MSG_CREATE_HANDLE_FAILED,

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -1165,7 +1165,7 @@ glfs_create_object(loc_t *loc, struct glfs_object **retobject)
 {
     struct glfs_object *object = NULL;
 
-    object = GF_CALLOC(1, sizeof(struct glfs_object), glfs_mt_glfs_object_t);
+    object = GF_MALLOC(sizeof(struct glfs_object), glfs_mt_glfs_object_t);
     if (object == NULL) {
         errno = ENOMEM;
         return -1;

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -340,12 +340,12 @@ afr_shd_selfheal(struct subvol_healer *healer, int child, uuid_t gfid)
     UNLOCK(&priv->lock);
 
     if (eh) {
-        shd_event = GF_CALLOC(1, sizeof(*shd_event), gf_afr_mt_shd_event_t);
+        shd_event = GF_MALLOC(sizeof(*shd_event), gf_afr_mt_shd_event_t);
         if (!shd_event)
             goto out;
 
-        shd_event->child = child;
         shd_event->path = path;
+        shd_event->child = child;
 
         if (eh_save_history(eh, shd_event) < 0)
             goto out;

--- a/xlators/features/changelog/lib/src/gf-changelog-journal-handler.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-journal-handler.c
@@ -661,15 +661,15 @@ gf_changelog_queue_journal(gf_changelog_processor_t *jnl_proc,
     size_t len = 0;
     gf_changelog_entry_t *entry = NULL;
 
-    entry = GF_CALLOC(1, sizeof(gf_changelog_entry_t),
+    entry = GF_MALLOC(sizeof(gf_changelog_entry_t),
                       gf_changelog_mt_libgfchangelog_entry_t);
     if (!entry)
         return;
-    INIT_LIST_HEAD(&entry->list);
 
     len = strlen(event->u.journal.path);
     (void)memcpy(entry->path, event->u.journal.path, len + 1);
     entry->path[len] = '\0';
+    INIT_LIST_HEAD(&entry->list);
 
     pthread_mutex_lock(&jnl_proc->lock);
     {

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -581,7 +581,7 @@ glusterd_peer_hostname_new(const char *hostname,
     GF_ASSERT(hostname);
     GF_ASSERT(name);
 
-    peer_hostname = GF_CALLOC(1, sizeof(*peer_hostname),
+    peer_hostname = GF_MALLOC(sizeof(*peer_hostname),
                               gf_gld_mt_peer_hostname_t);
 
     if (!peer_hostname) {


### PR DESCRIPTION
Converted calloc to malloc as already initialized
all fields after allocation and make changes to ensure
initialization happens in the order

Change-Id: I2df2628213dec1bba70a2e3aadeb16704f9591dd
Updates:#1000
Signed-off-by: Preet Bhatia pbhatia@redhat.com

