### PR TITLE
Multiple files: reduce redirection for measure_latency variable

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -588,6 +588,7 @@ create_fuse_mount(glusterfs_ctx_t *ctx)
     }
 
     root->ctx = ctx;
+    root->measure_latency = _gf_true;
     root->options = dict_new();
     if (!root->options)
         goto err;
@@ -1563,9 +1564,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
      * set it in all error paths before "goto err"
      */
     ret = -1;
-
-    /* monitoring should be enabled by default */
-    ctx->measure_latency = true;
 
     ctx->process_uuid = generate_glusterfs_ctx_id();
     if (!ctx->process_uuid) {

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -145,7 +145,7 @@ global_xl_reconfigure(xlator_t *this, dict_t *options)
     dict_dump_to_log(options);
 
     GF_OPTION_RECONF("measure-latency", bool_opt, options, bool, out);
-    this->ctx->measure_latency = bool_opt;
+    this->measure_latency = bool_opt;
 
     GF_OPTION_RECONF("metrics-dump-path", this->ctx->config.metrics_dumppath,
                      options, str, out);
@@ -163,7 +163,7 @@ global_xl_init(xlator_t *this)
     gf_boolean_t bool_opt = false;
 
     GF_OPTION_INIT("measure-latency", bool_opt, bool, out);
-    this->ctx->measure_latency = bool_opt;
+    this->measure_latency = bool_opt;
 
     GF_OPTION_INIT("metrics-dump-path", this->ctx->config.metrics_dumppath, str,
                    out);

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -795,6 +795,7 @@ struct _xlator {
     /* Flag to avoid throw duplicate PARENT_DOWN event */
     uint32_t parent_down;
 
+    gf_boolean_t measure_latency;
     gf_boolean_t is_autoloaded;
 
     /* Is this pass_through? */

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -245,6 +245,7 @@ glusterfs_graph_insert(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
         return -1;
 
     ixl->ctx = ctx;
+    ixl->measure_latency = _gf_true;
     ixl->graph = graph;
     ixl->options = dict_new();
     if (!ixl->options)
@@ -661,6 +662,7 @@ glusterfs_graph_prepare(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
     /* XXX: this->ctx setting */
     for (trav = graph->first; trav; trav = trav->next) {
         trav->ctx = ctx;
+        trav->measure_latency = _gf_true;
     }
 
     /* XXX: DOB setting */
@@ -1484,6 +1486,7 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
         goto out;
 
     ixl->ctx = ctx;
+    ixl->measure_latency = _gf_true;
     ixl->graph = parent_graph;
     ixl->options = dict_new();
     if (!ixl->options)

--- a/libglusterfs/src/stack.c
+++ b/libglusterfs/src/stack.c
@@ -42,9 +42,9 @@ create_frame(xlator_t *xl, call_pool_t *pool)
     list_add(&frame->frames, &stack->myframes);
 
     stack->pool = pool;
-    stack->ctx = xl->ctx;
+    stack->measure_latency = xl->measure_latency;
 
-    if (frame->root->ctx->measure_latency) {
+    if (frame->root->measure_latency) {
         timespec_now(&stack->tv);
         memcpy(&frame->begin, &stack->tv, sizeof(stack->tv));
     }
@@ -113,7 +113,7 @@ gf_proc_dump_call_frame(call_frame_t *call_frame, const char *key_buf, ...)
     memcpy(&my_frame, call_frame, sizeof(my_frame));
     UNLOCK(&call_frame->lock);
 
-    if (my_frame.root->ctx->measure_latency) {
+    if (my_frame.root->measure_latency) {
         len = gf_time_fmt_FT(timestr, sizeof(timestr), my_frame.begin.tv_sec);
         snprintf(timestr + len, sizeof(timestr) - len, ".%" GF_PRI_SNSECONDS,
                  my_frame.begin.tv_nsec);
@@ -276,7 +276,7 @@ gf_proc_dump_call_frame_to_dict(call_frame_t *call_frame, char *prefix,
     if (ret)
         return;
 
-    if (tmp_frame.root->ctx->measure_latency) {
+    if (tmp_frame.root->measure_latency) {
         snprintf(key, sizeof(key), "%s.timings", prefix);
         snprintf(msg, sizeof(msg),
                  "%ld.%" GF_PRI_SNSECONDS " -> %ld.%" GF_PRI_SNSECONDS,

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -538,7 +538,7 @@ gf_proc_dump_single_xlator_info(xlator_t *trav)
     if (trav->cleanup_starting)
         return;
 
-    if (ctx->measure_latency)
+    if (trav->measure_latency)
         gf_proc_dump_xl_latency_info(trav);
 
     gf_proc_dump_xlator_mem_info(trav);

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -340,7 +340,7 @@ rpcsvc_program_actor(rpcsvc_request_t *req)
         goto err;
     }
 
-    if (svc->xl->ctx->measure_latency) {
+    if (svc->xl->measure_latency) {
         timespec_now(&req->begin);
     }
 

--- a/xlators/meta/src/measure-file.c
+++ b/xlators/meta/src/measure-file.c
@@ -17,7 +17,7 @@
 static int
 measure_file_fill(xlator_t *this, inode_t *file, strfd_t *strfd)
 {
-    strprintf(strfd, "%d\n", this->ctx->measure_latency);
+    strprintf(strfd, "%d\n", this->measure_latency);
 
     return strfd->size;
 }
@@ -28,7 +28,7 @@ measure_file_write(xlator_t *this, fd_t *fd, struct iovec *iov, int count)
     long int num = -1;
 
     num = strtol(iov[0].iov_base, NULL, 0);
-    this->ctx->measure_latency = !!num;
+    this->measure_latency = !!num;
 
     return iov_length(iov, count);
 }

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -693,7 +693,7 @@ rda_fill_fd(call_frame_t *frame, xlator_t *this, fd_t *fd)
 err:
     if (nframe) {
         rda_local_wipe(nframe->local);
-        FRAME_DESTROY(nframe, frame->root->ctx->measure_latency);
+        FRAME_DESTROY(nframe, frame->root->measure_latency);
     }
 
     return -1;


### PR DESCRIPTION
As far as I can see, we have the ctx variable in the call_stack_t structure only to be able to access the measure_latency boolean.
Example from create_frame():

    if (frame->root->ctx->measure_latency) {
        timespec_now(&stack->tv);
        memcpy(&frame->begin, &stack->tv, sizeof(stack->tv));
    }

I did not see any other use for the ctx variable apart from that boolean.
We can instead just copy that boolean and reduce one level of indirection (which seem to be happening in create_frame(), FRAME_DESTROY() and STACK_UNWIND_STRICT macro)

Updates: #1874
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

