### PR TITLE
glusterd: refactor to use simpler dict APIs

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -284,7 +284,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         snprintf(err_str, sizeof(err_str),
@@ -306,7 +306,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
+    ret = dict_get_int32(dict, "count", &brick_count);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -316,21 +316,19 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                          &replica_count);
+    ret = dict_get_int32(dict, "replica-count", &replica_count);
     if (!ret) {
         gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_SUCCESS,
                "replica-count is %d", replica_count);
     }
 
-    ret = dict_get_int32n(dict, "arbiter-count", SLEN("arbiter-count"),
-                          &arbiter_count);
+    ret = dict_get_int32(dict, "arbiter-count", &arbiter_count);
     if (!ret) {
         gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_SUCCESS,
                "arbiter-count is %d", arbiter_count);
     }
 
-    if (!dict_getn(dict, "force", SLEN("force"))) {
+    if (!dict_get_sizen(dict, "force")) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get flag");
         goto out;
@@ -374,8 +372,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     if (ret == 1)
         replica_count = 0;
 
-    ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
-                          replica_count);
+    ret = dict_set_int32_sizen(dict, "replica-count", replica_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "failed to set the replica-count in dict");
@@ -383,7 +380,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     }
 
 brick_val:
-    ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+    ret = dict_get_str(dict, "bricks", &bricks);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -394,7 +391,7 @@ brick_val:
     }
 
     if (type != volinfo->type) {
-        ret = dict_set_int32n(dict, "type", SLEN("type"), type);
+        ret = dict_set_int32_sizen(dict, "type", type);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "failed to set the new type in dict");
@@ -651,7 +648,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -661,7 +658,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get brick "
@@ -679,7 +676,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "command", SLEN("command"), &cmd);
+    ret = dict_get_int32(dict, "command", &cmd);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get cmd "
@@ -689,8 +686,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                          &replica_count);
+    ret = dict_get_int32(dict, "replica-count", &replica_count);
     if (!ret) {
         gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "request to change replica-count to %d", replica_count);
@@ -701,12 +697,11 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
                itself */
             goto out;
         }
-        dict_deln(dict, "replica-count", SLEN("replica-count"));
+        dict_del_sizen(dict, "replica-count");
         if (ret) {
             replica_count = 0;
         } else {
-            ret = dict_set_int32n(dict, "replica-count", SLEN("replica-count"),
-                                  replica_count);
+            ret = dict_set_int32_sizen(dict, "replica-count", replica_count);
             if (ret) {
                 gf_msg(this->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                        "failed to set the replica_count "
@@ -892,8 +887,7 @@ _glusterd_restart_gsync_session(dict_t *this, char *key, data_t *value,
     } else
         return 0;
 
-    ret = dict_set_dynstrn(param->rsp_dict, "secondary", SLEN("secondary"),
-                           secondary_buf);
+    ret = dict_set_dynstr_sizen(param->rsp_dict, "secondary", secondary_buf);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to store secondary");
@@ -1001,17 +995,15 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
         brick = strtok_r(brick_list + 1, " \n", &saveptr);
 
     if (dict) {
-        ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                              &replica_count);
+        ret = dict_get_int32(dict, "replica-count", &replica_count);
         if (!ret)
             gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_SUCCESS,
                    "replica-count is set %d", replica_count);
-        ret = dict_get_int32n(dict, "arbiter-count", SLEN("arbiter-count"),
-                              &arbiter_count);
+        ret = dict_get_int32(dict, "arbiter-count", &arbiter_count);
         if (!ret)
             gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_SUCCESS,
                    "arbiter-count is set %d", arbiter_count);
-        ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+        ret = dict_get_int32(dict, "type", &type);
         if (!ret)
             gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_DICT_GET_SUCCESS,
                    "type is set %d, need to change it", type);
@@ -1084,9 +1076,8 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
      */
     if (type && glusterd_is_volume_replicate(volinfo) &&
         conf->op_version >= GD_OP_VERSION_3_12_2) {
-        ret = dict_set_nstrn(volinfo->dict, "performance.client-io-threads",
-                             SLEN("performance.client-io-threads"), "off",
-                             SLEN("off"));
+        ret = dict_set_sizen_str_sizen(volinfo->dict,
+                                       "performance.client-io-threads", "off");
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set "
@@ -1321,7 +1312,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     conf = this->private;
     GF_ASSERT(conf);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -1339,8 +1330,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (ret)
         goto out;
 
-    ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                          &replica_count);
+    ret = dict_get_int32(dict, "replica-count", &replica_count);
     if (ret) {
         gf_msg_debug(this->name, 0, "Unable to get replica count");
     }
@@ -1378,8 +1368,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
          * don't have this check, an older peer added as arbiter brick
          * will not have the  arbiter xlator in its volfile. */
         if ((replica_count == 3) && (conf->op_version < GD_OP_VERSION_3_8_0)) {
-            ret = dict_get_int32n(dict, "arbiter-count", SLEN("arbiter-count"),
-                                  &arbiter_count);
+            ret = dict_get_int32(dict, "arbiter-count", &arbiter_count);
             if (ret) {
                 gf_msg_debug(this->name, 0,
                              "No arbiter count present in the dict");
@@ -1514,7 +1503,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     if (!count) {
-        ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+        ret = dict_get_int32(dict, "count", &count);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get count");
@@ -1523,7 +1512,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     if (!bricks) {
-        ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+        ret = dict_get_str(dict, "bricks", &bricks);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "Unable to get bricks");
@@ -1613,8 +1602,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         i++;
     }
 
-    ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
-                          local_brick_count);
+    ret = dict_set_int32_sizen(rsp_dict, "brick_count", local_brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count");
@@ -1800,7 +1788,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                "Unable to get volume name");
@@ -1819,7 +1807,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
     if (ret)
         goto out;
 
-    ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
+    ret = dict_get_int32(dict, "command", &flag);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick command");
@@ -1827,7 +1815,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
     }
     cmd = flag;
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
+    ret = dict_get_int32(dict, "count", &brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick count");
@@ -1857,7 +1845,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
             goto out;
         case GF_OP_CMD_START: {
             if ((volinfo->type == GF_CLUSTER_TYPE_REPLICATE) &&
-                dict_getn(dict, "replica-count", SLEN("replica-count"))) {
+                dict_get_sizen(dict, "replica-count")) {
                 snprintf(msg, sizeof(msg),
                          "Migration of data is not "
                          "needed when reducing replica count. Use the"
@@ -1953,9 +1941,7 @@ glusterd_op_stage_remove_brick(dict_t *dict, char **op_errstr)
                     goto out;
                 }
             } else {
-                ret = dict_get_strn(dict, GF_REMOVE_BRICK_TID_KEY,
-                                    SLEN(GF_REMOVE_BRICK_TID_KEY),
-                                    &task_id_str);
+                ret = dict_get_str(dict, GF_REMOVE_BRICK_TID_KEY, &task_id_str);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_WARNING, -ret,
                            GD_MSG_DICT_GET_FAILED, "Missing remove-brick-id");
@@ -2129,7 +2115,7 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
     int32_t count = 0;
     glusterd_conf_t *priv = THIS->private;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
@@ -2145,14 +2131,14 @@ glusterd_op_add_brick(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
 
-    ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+    ret = dict_get_str(dict, "bricks", &bricks);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get bricks");
@@ -2192,7 +2178,7 @@ glusterd_post_commit_brick_operation(dict_t *dict, char **op_errstr)
     int ret = 0;
     char *volname = NULL;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
@@ -2218,7 +2204,7 @@ glusterd_set_rebalance_id_for_remove_brick(dict_t *req_dict, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
     GF_ASSERT(req_dict);
 
-    ret = dict_get_strn(rsp_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(rsp_dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not found");
         goto out;
@@ -2231,7 +2217,7 @@ glusterd_set_rebalance_id_for_remove_brick(dict_t *req_dict, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(rsp_dict, "command", SLEN("command"), &cmd);
+    ret = dict_get_int32(rsp_dict, "command", &cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
@@ -2243,8 +2229,7 @@ glusterd_set_rebalance_id_for_remove_brick(dict_t *req_dict, dict_t *rsp_dict)
      * req_dict here. */
 
     if (is_origin_glusterd(rsp_dict)) {
-        ret = dict_get_strn(req_dict, GF_REMOVE_BRICK_TID_KEY,
-                            SLEN(GF_REMOVE_BRICK_TID_KEY), &task_id_str);
+        ret = dict_get_str(req_dict, GF_REMOVE_BRICK_TID_KEY, &task_id_str);
         if (ret) {
             snprintf(msg, sizeof(msg), "Missing rebalance id for remove-brick");
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_REBALANCE_ID_MISSING,
@@ -2306,7 +2291,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
     conf = this->private;
     GF_VALIDATE_OR_GOTO(this->name, conf, out);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BRICK_ADD_FAIL,
@@ -2321,7 +2306,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "command", SLEN("command"), &flag);
+    ret = dict_get_int32(dict, "command", &flag);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
@@ -2379,8 +2364,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
             /* coverity[MIXED_ENUMS] */
             volinfo->rebal.defrag_cmd = cmd;
             volinfo->rebal.defrag_status = GF_DEFRAG_STATUS_NOT_STARTED;
-            ret = dict_get_strn(dict, GF_REMOVE_BRICK_TID_KEY,
-                                SLEN(GF_REMOVE_BRICK_TID_KEY), &task_id_str);
+            ret = dict_get_str(dict, GF_REMOVE_BRICK_TID_KEY, &task_id_str);
             if (ret) {
                 gf_msg_debug(this->name, errno, "Missing remove-brick-id");
                 ret = 0;
@@ -2421,7 +2405,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
             break;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
@@ -2438,7 +2422,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
             ret = -1;
             goto out;
         }
-        ret = dict_set_int32n(bricks_dict, "count", SLEN("count"), count);
+        ret = dict_set_int32_sizen(bricks_dict, "count", count);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to save remove-brick count");
@@ -2482,8 +2466,7 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
     if (start_remove)
         volinfo->rebal.dict = dict_ref(bricks_dict);
 
-    ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                          &replica_count);
+    ret = dict_get_int32(dict, "replica-count", &replica_count);
     if (!ret) {
         gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "changing replica count %d to %d on volume %s",
@@ -2513,9 +2496,8 @@ glusterd_op_remove_brick(dict_t *dict, char **op_errstr)
 
     if (!glusterd_is_volume_replicate(volinfo) &&
         conf->op_version >= GD_OP_VERSION_3_12_2) {
-        ret = dict_set_nstrn(volinfo->dict, "performance.client-io-threads",
-                             SLEN("performance.client-io-threads"), "on",
-                             SLEN("on"));
+        ret = dict_set_sizen_str_sizen(volinfo->dict,
+                                       "performance.client-io-threads", "on");
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set "
@@ -2605,7 +2587,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
@@ -2627,7 +2609,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "barrier", SLEN("barrier"), &barrier_op);
+    ret = dict_get_str(dict, "barrier", &barrier_op);
     if (ret == -1) {
         gf_asprintf(op_errstr,
                     "Barrier op for volume %s not present "
@@ -2654,7 +2636,7 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
@@ -2670,7 +2652,7 @@ glusterd_op_barrier(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "barrier", SLEN("barrier"), &barrier_op);
+    ret = dict_get_str(dict, "barrier", &barrier_op);
     if (ret) {
         gf_asprintf(op_errstr,
                     "Barrier op for volume %s not present "

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -42,8 +42,7 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, time_t frame_timeout,
     if (ret)
         goto out;
 
-    ret = dict_set_int32n(options, "transport.socket.ignore-enoent",
-                          SLEN("transport.socket.ignore-enoent"), 1);
+    ret = dict_set_int32_sizen(options, "transport.socket.ignore-enoent", 1);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=transport.socket.ignore-enoent", NULL);

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -115,9 +115,8 @@ glusterd_gfproxydsvc_init(glusterd_volinfo_t *volinfo)
         goto out;
     }
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0) {
         volfileserver = "localhost";
     }
     ret = glusterd_proc_init(&(svc->proc), gfproxyd_svc_name, pidfile, logdir,
@@ -320,9 +319,8 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
 
     if (volinfo->memory_accounting)
         runner_add_arg(&runner, "--mem-accounting");
-    if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
-                      SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
-                      &localtime_logging) == 0) {
+    if (dict_get_str(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
+                     &localtime_logging) == 0) {
         if (strcmp(localtime_logging, "enable") == 0)
             runner_add_arg(&runner, "--localtime-logging");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -682,7 +682,7 @@ glusterd_op_txn_begin(rpcsvc_request_t *req, glusterd_op_t op, void *ctx,
     } else {
         /* If no volname is given as a part of the command, locks will
          * not be held */
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &tmp);
+        ret = dict_get_str(dict, "volname", &tmp);
         if (ret) {
             gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                    "No Volume name present. "
@@ -1132,14 +1132,14 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_HOSTNAME_NOTFOUND_IN_DICT,
                "Failed to get hostname");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "port", SLEN("port"), &port);
+    ret = dict_get_int32(dict, "port", &port);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PORT_NOTFOUND_IN_DICT,
                "Failed to get port");
@@ -1159,8 +1159,8 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
     gf_msg("glusterd", GF_LOG_INFO, 0, GD_MSG_CLI_REQ_RECVD,
            "Received CLI probe req %s %d", hostname, port);
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"), &bind_name) == 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &bind_name) == 0) {
         gf_msg_debug("glusterd", 0,
                      "only checking probe address vs. bind address");
         ret = gf_is_same_address(bind_name, hostname);
@@ -1319,20 +1319,20 @@ __glusterd_handle_cli_deprobe(rpcsvc_request_t *req)
     gf_msg("glusterd", GF_LOG_INFO, 0, GD_MSG_CLI_REQ_RECVD,
            "Received CLI deprobe req");
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_HOSTNAME_NOTFOUND_IN_DICT,
                "Failed to get hostname");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "port", SLEN("port"), &port);
+    ret = dict_get_int32(dict, "port", &port);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PORT_NOTFOUND_IN_DICT,
                "Failed to get port");
         goto out;
     }
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+    ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_FLAGS_NOTFOUND_IN_DICT,
                "Failed to get flags");
@@ -1527,7 +1527,7 @@ __glusterd_handle_cli_get_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+    ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_FLAGS_NOTFOUND_IN_DICT,
                "failed to get flags");
@@ -1734,7 +1734,7 @@ __glusterd_handle_cli_uuid_get(rpcsvc_request_t *req)
     }
 
     uuid_utoa_r(MY_UUID, uuid_str);
-    ret = dict_set_strn(rsp_dict, "uuid", SLEN("uuid"), uuid_str);
+    ret = dict_set_str_sizen(rsp_dict, "uuid", uuid_str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set uuid in "
@@ -1813,7 +1813,7 @@ __glusterd_handle_cli_list_volume(rpcsvc_request_t *req)
         count++;
     }
 
-    ret = dict_set_int32n(dict, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(dict, "count", count);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -1990,7 +1990,7 @@ __glusterd_handle_reset_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get volume "
@@ -2074,7 +2074,7 @@ __glusterd_handle_set_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get volume "
@@ -2090,7 +2090,7 @@ __glusterd_handle_set_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "key1", SLEN("key1"), &key);
+    ret = dict_get_str(dict, "key1", &key);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get key while"
@@ -2101,7 +2101,7 @@ __glusterd_handle_set_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "value1", SLEN("value1"), &value);
+    ret = dict_get_str(dict, "value1", &value);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get value while"
@@ -2187,7 +2187,7 @@ __glusterd_handle_sync_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get hostname");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_HOSTNAME_NOTFOUND_IN_DICT,
@@ -2195,9 +2195,9 @@ __glusterd_handle_sync_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
-        ret = dict_get_int32n(dict, "flags", SLEN("flags"), (int32_t *)&flags);
+        ret = dict_get_int32(dict, "flags", (int32_t *)&flags);
         if (ret) {
             snprintf(msg, sizeof(msg), "Failed to get volume name or flags");
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_FLAGS_NOTFOUND_IN_DICT,
@@ -2777,7 +2777,7 @@ glusterd_handle_friend_update_delete(dict_t *dict)
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret)
         goto out;
 
@@ -2911,14 +2911,14 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "op", SLEN("op"), &op);
+    ret = dict_get_int32(dict, "op", &op);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=op", NULL);
@@ -3185,7 +3185,7 @@ __glusterd_handle_cli_profile_volume(rpcsvc_request_t *req)
         dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len, &dict);
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -3199,7 +3199,7 @@ __glusterd_handle_cli_profile_volume(rpcsvc_request_t *req)
            "Received volume profile req "
            "for volume %s",
            volname);
-    ret = dict_get_int32n(dict, "op", SLEN("op"), &op);
+    ret = dict_get_int32(dict, "op", &op);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "Unable to get operation");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s",
@@ -3398,8 +3398,8 @@ __glusterd_handle_umount(rpcsvc_request_t *req)
     gf_msg("glusterd", GF_LOG_INFO, 0, GD_MSG_UMOUNT_REQ_RCVD,
            "Received umount req");
 
-    if (dict_get_strn(this->options, "mountbroker-root",
-                      SLEN("mountbroker-root"), &mountbroker_root) != 0) {
+    if (dict_get_str(this->options, "mountbroker-root", &mountbroker_root) !=
+        0) {
         rsp.op_errno = ENOENT;
         goto out;
     }
@@ -3563,7 +3563,7 @@ glusterd_transport_inet_options_build(dict_t *dict, const char *hostname,
      * wait too long after cli timesout before being able to resume normal
      * operations
      */
-    ret = dict_set_int32n(dict, "frame-timeout", SLEN("frame-timeout"), 600);
+    ret = dict_set_int32_sizen(dict, "frame-timeout", 600);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set frame-timeout");
@@ -3571,21 +3571,19 @@ glusterd_transport_inet_options_build(dict_t *dict, const char *hostname,
     }
 
     /* Set keepalive options */
-    ret = dict_get_int32n(this->options, "transport.socket.keepalive-interval",
-                          SLEN("transport.socket.keepalive-interval"),
-                          &interval);
+    ret = dict_get_int32(this->options, "transport.socket.keepalive-interval",
+                         &interval);
     if (ret) {
         gf_msg("glusterd", GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get socket keepalive-interval");
     }
-    ret = dict_get_int32n(this->options, "transport.socket.keepalive-time",
-                          SLEN("transport.socket.keepalive-time"), &time);
+    ret = dict_get_int32(this->options, "transport.socket.keepalive-time",
+                         &time);
     if (ret) {
         gf_msg("glusterd", GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get socket keepalive-time");
     }
-    ret = dict_get_int32n(this->options, "transport.tcp-user-timeout",
-                          SLEN("transport.tcp-user-timeout"), &timeout);
+    ret = dict_get_int32(this->options, "transport.tcp-user-timeout", &timeout);
     if (ret) {
         gf_msg("glusterd", GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get tcp-user-timeout");
@@ -3647,12 +3645,11 @@ glusterd_friend_rpc_create(xlator_t *this, glusterd_peerinfo_t *peerinfo,
      */
 
     if (this->options) {
-        data = dict_getn(this->options, "transport.socket.bind-address",
-                         SLEN("transport.socket.bind-address"));
+        data = dict_get_sizen(this->options, "transport.socket.bind-address");
         if (data) {
             ret = dict_set_sizen(options, "transport.socket.source-addr", data);
         }
-        data = dict_getn(this->options, "ping-timeout", SLEN("ping-timeout"));
+        data = dict_get_sizen(this->options, "ping-timeout");
         if (data) {
             ret = dict_set_sizen(options, "ping-timeout", data);
         }
@@ -3662,9 +3659,8 @@ glusterd_friend_rpc_create(xlator_t *this, glusterd_peerinfo_t *peerinfo,
      * is enabled
      */
     if (this->ctx->secure_mgmt) {
-        ret = dict_set_nstrn(options, "transport.socket.ssl-enabled",
-                             SLEN("transport.socket.ssl-enabled"), "on",
-                             SLEN("on"));
+        ret = dict_set_sizen_str_sizen(options, "transport.socket.ssl-enabled",
+                                       "on");
         if (ret) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "failed to set ssl-enabled in dict");
@@ -4123,7 +4119,7 @@ glusterd_xfer_cli_probe_resp(rpcsvc_request_t *req, int32_t op_ret,
                               sizeof(errstr), hostname, port);
 
     if (dict) {
-        ret = dict_get_strn(dict, "cmd-str", SLEN("cmd-str"), &cmd_str);
+        ret = dict_get_str(dict, "cmd-str", &cmd_str);
         if (ret)
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CMDSTR_NOTFOUND_IN_DICT,
                    "Failed to get "
@@ -4239,7 +4235,7 @@ glusterd_xfer_cli_deprobe_resp(rpcsvc_request_t *req, int32_t op_ret,
                                 sizeof(errstr), hostname);
 
     if (dict) {
-        ret = dict_get_strn(dict, "cmd-str", SLEN("cmd-str"), &cmd_str);
+        ret = dict_get_str(dict, "cmd-str", &cmd_str);
         if (ret)
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_CMDSTR_NOTFOUND_IN_DICT,
                    "Failed to get "
@@ -4338,7 +4334,7 @@ unlock:
         }
     }
 
-    ret = dict_set_int32n(friends, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(friends, "count", count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -4397,7 +4393,7 @@ glusterd_get_volumes(rpcsvc_request_t *req, dict_t *dict, int32_t flags)
         goto respond;
     }
     if (flags == GF_CLI_GET_NEXT_VOLUME) {
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(dict, "volname", &volname);
 
         if (ret) {
             if (priv->volumes.next) {
@@ -4422,7 +4418,7 @@ glusterd_get_volumes(rpcsvc_request_t *req, dict_t *dict, int32_t flags)
             count++;
         }
     } else if (flags == GF_CLI_GET_VOLUME) {
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(dict, "volname", &volname);
 
         if (ret)
             goto respond;
@@ -4441,7 +4437,7 @@ glusterd_get_volumes(rpcsvc_request_t *req, dict_t *dict, int32_t flags)
     }
 
 respond:
-    ret = dict_set_int32n(volumes, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(volumes, "count", count);
     if (ret)
         goto out;
     ret = dict_allocate_and_serialize(volumes, &rsp.dict.dict_val,
@@ -4526,7 +4522,7 @@ __glusterd_handle_status_volume(rpcsvc_request_t *req)
         goto out;
 
     if (!(cmd & GF_CLI_STATUS_ALL)) {
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(dict, "volname", &volname);
         if (ret) {
             snprintf(err_str, sizeof(err_str),
                      "Unable to get "
@@ -4661,7 +4657,7 @@ __glusterd_handle_cli_clearlocks_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -4809,7 +4805,7 @@ __glusterd_handle_barrier(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLNAME_NOTFOUND_IN_DICT,
                "Volname not present in "
@@ -4890,7 +4886,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
     GF_ASSERT(req);
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get volume "
@@ -4906,7 +4902,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "key", SLEN("key"), &key);
+    ret = dict_get_str(dict, "key", &key);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get key "
@@ -4984,7 +4980,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
                                         next release. Consider using `volume \
                                         get all` instead for global options";
 
-                ret = dict_set_strn(dict, "warning", SLEN("warning"), warn_str);
+                ret = dict_set_str_sizen(dict, "warning", warn_str);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                            "Failed to set warning "
@@ -5116,7 +5112,7 @@ glusterd_get_volume_opts(rpcsvc_request_t *req, dict_t *dict)
         /* Request is for a single option, explicitly set count to 1
          * in the dictionary.
          */
-        ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
+        ret = dict_set_int32_sizen(dict, "count", 1);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Failed to set count "
@@ -5261,9 +5257,7 @@ glusterd_print_gsync_status(FILE *fp, dict_t *gsync_dict)
     GF_VALIDATE_OR_GOTO(THIS->name, fp, out);
     GF_VALIDATE_OR_GOTO(THIS->name, gsync_dict, out);
 
-    ret = dict_get_int32n(gsync_dict, "gsync-count", SLEN("gsync-count"),
-                          &gsync_count);
-
+    ret = dict_get_int32(gsync_dict, "gsync-count", &gsync_count);
     fprintf(fp, "Volume%d.gsync_count: %d\n", volcount, gsync_count);
 
     if (gsync_count == 0) {
@@ -5466,22 +5460,21 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     brick_req->dict.dict_val = NULL;
     brick_req->dict.dict_len = 0;
 
-    ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
-                        brickinfo->path);
+    ret = dict_set_str_sizen(dict, "brick-name", brickinfo->path);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=brick-name", NULL);
         goto out;
     }
 
-    ret = dict_set_int32n(dict, "cmd", SLEN("cmd"), GF_CLI_STATUS_CLIENTS);
+    ret = dict_set_int32_sizen(dict, "cmd", GF_CLI_STATUS_CLIENTS);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=cmd", NULL);
         goto out;
     }
 
-    ret = dict_set_strn(dict, "volname", SLEN("volname"), volinfo->volname);
+    ret = dict_set_str_sizen(dict, "volname", volinfo->volname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=volname", NULL);
@@ -5499,8 +5492,7 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     if (args.op_ret)
         goto out;
 
-    ret = dict_get_int32n(args.dict, "clientcount", SLEN("clientcount"),
-                          &client_count);
+    ret = dict_get_int32(args.dict, "clientcount", &client_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Couldn't get client count");
@@ -5815,7 +5807,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
 
     GF_VALIDATE_OR_GOTO(this->name, dict, out);
 
-    ret = dict_get_strn(dict, "odir", SLEN("odir"), &tmp_str);
+    ret = dict_get_str(dict, "odir", &tmp_str);
     if (ret) {
         odirlen = gf_asprintf(&odir, "%s", "/var/run/gluster/");
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
@@ -5847,7 +5839,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "filename", SLEN("filename"), &tmp_str);
+    ret = dict_get_str(dict, "filename", &tmp_str);
     if (ret) {
         now = gf_time();
         strftime(timestamp, sizeof(timestamp), "%Y%m%d_%H%M%S",
@@ -5874,7 +5866,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
     GF_FREE(odir);
     GF_FREE(filename);
 
-    ret = dict_set_dynstrn(dict, "ofilepath", SLEN("ofilepath"), ofilepath);
+    ret = dict_set_dynstr_sizen(dict, "ofilepath", ofilepath);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Unable to set output path");

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.c
@@ -245,8 +245,8 @@ glusterd_hooks_set_volume_args(dict_t *dict, runner_t *runner)
 
     glusterd_hooks_add_custom_args(dict, runner);
     if (flag == 1) {
-        ret = dict_get_str_sizen(this->options, "transport.address-family",
-                                 &inet_family);
+        ret = dict_get_str(this->options, "transport.address-family",
+                           &inet_family);
         if (!ret) {
             runner_argprintf(runner, "transport.address-family=%s",
                              inet_family);

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -463,7 +463,7 @@ gd_mgmt_v3_post_validate_fn(glusterd_op_t op, int32_t op_ret, dict_t *dict,
             break;
         }
         case GD_OP_ADD_BRICK: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to get"
@@ -488,7 +488,7 @@ gd_mgmt_v3_post_validate_fn(glusterd_op_t op, int32_t op_ret, dict_t *dict,
             break;
         }
         case GD_OP_START_VOLUME: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to get"
@@ -507,7 +507,7 @@ gd_mgmt_v3_post_validate_fn(glusterd_op_t op, int32_t op_ret, dict_t *dict,
             break;
         }
         case GD_OP_STOP_VOLUME: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to get"
@@ -1126,7 +1126,7 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
         case GD_OP_REPLACE_BRICK:
         case GD_OP_RESET_BRICK:
         case GD_OP_PROFILE_VOLUME: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_CRITICAL, -ret,
                        GD_MSG_DICT_GET_FAILED,
@@ -1148,7 +1148,7 @@ glusterd_mgmt_v3_build_payload(dict_t **req, char **op_errstr, dict_t *dict,
                 ret = -1;
                 goto out;
             }
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_CRITICAL, -ret,
                        GD_MSG_DICT_GET_FAILED,
@@ -2733,7 +2733,7 @@ glusterd_set_barrier_value(dict_t *dict, char *option)
      * As of now only snapshot of single volume is supported,
      * Hence volname1 is directly fetched
      */
-    ret = dict_get_strn(dict, "volname1", SLEN("volname1"), &volname);
+    ret = dict_get_str(dict, "volname1", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Volname not present in "
@@ -2831,8 +2831,7 @@ glusterd_mgmt_v3_initiate_snap_phases(rpcsvc_request_t *req, glusterd_op_t op,
     }
 
     /* Marking the operation as complete synctasked */
-    ret = dict_set_int32n(dict, "is_synctasked", SLEN("is_synctasked"),
-                          _gf_true);
+    ret = dict_set_int32_sizen(dict, "is_synctasked", _gf_true);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set synctasked flag.");
@@ -2923,7 +2922,7 @@ glusterd_mgmt_v3_initiate_snap_phases(rpcsvc_request_t *req, glusterd_op_t op,
        above and along with it the originator glusterd also goes down?
        Who will initiate the cleanup?
     */
-    ret = dict_set_int32n(req_dict, "cleanup", SLEN("cleanup"), 1);
+    ret = dict_set_int32_sizen(req_dict, "cleanup", 1);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "failed to set dict");

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -524,8 +524,8 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     GF_ASSERT(op_errno);
     *op_errno = 0;
 
-    if (dict_get_strn(this->options, "mountbroker-root",
-                      SLEN("mountbroker-root"), &mountbroker_root) != 0) {
+    if (dict_get_str(this->options, "mountbroker-root", &mountbroker_root) !=
+        0) {
         *op_errno = ENOENT;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "'option mountbroker-root' "

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -556,14 +556,13 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
 
             brick_req->op = GLUSTERD_BRICK_XLATOR_OP;
             brick_req->name = "";
-            ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
-                                  (int32_t *)&heal_op);
+            ret = dict_get_int32(dict, "heal-op", (int32_t *)&heal_op);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=heal-op", NULL);
                 goto out;
             }
-            ret = dict_set_int32n(dict, "xl-op", SLEN("xl-op"), heal_op);
+            ret = dict_set_int32_sizen(dict, "xl-op", heal_op);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                         "Key=xl-op", NULL);
@@ -580,8 +579,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             }
             brick_req->op = GLUSTERD_BRICK_STATUS;
             brick_req->name = "";
-            ret = dict_set_strn(dict, "brick-name", SLEN("brick-name"),
-                                brickinfo->path);
+            ret = dict_set_str_sizen(dict, "brick-name", brickinfo->path);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                         "Key=brick-name", NULL);
@@ -599,7 +597,7 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
             }
 
             brick_req->op = GLUSTERD_BRICK_XLATOR_DEFRAG;
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
@@ -706,7 +704,7 @@ glusterd_node_op_build_payload(glusterd_op_t op, gd1_mgmt_brick_op_req **req,
 
             brick_req->op = GLUSTERD_NODE_BITROT;
 
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=volname", NULL);
@@ -862,8 +860,7 @@ glusterd_validate_shared_storage(char *value, char *errstr)
     }
 
     if (!strncmp(value, "disable", SLEN("disable"))) {
-        ret = dict_get_strn(conf->opts, GLUSTERD_SHARED_STORAGE_KEY,
-                            SLEN(GLUSTERD_SHARED_STORAGE_KEY), &op);
+        ret = dict_get_str(conf->opts, GLUSTERD_SHARED_STORAGE_KEY, &op);
         if (ret || !strncmp(op, "disable", SLEN("disable"))) {
             snprintf(errstr, PATH_MAX,
                      "Shared storage volume "
@@ -1061,7 +1058,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
         }
     }
 
-    ret = dict_get_int32_sizen(dict, "count", &dict_count);
+    ret = dict_get_int32(dict, "count", &dict_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Count(dict),not set in Volume-Set");
@@ -1095,7 +1092,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_str_sizen(dict, "volname", &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
@@ -1571,7 +1568,7 @@ glusterd_op_stage_reset_volume(dict_t *dict, char **op_errstr)
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -1591,7 +1588,7 @@ glusterd_op_stage_reset_volume(dict_t *dict, char **op_errstr)
             goto out;
     }
 
-    ret = dict_get_strn(dict, "key", SLEN("key"), &key);
+    ret = dict_get_str(dict, "key", &key);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get option key");
@@ -1683,7 +1680,7 @@ glusterd_op_stage_sync_volume(dict_t *dict, char **op_errstr)
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
@@ -1696,7 +1693,7 @@ glusterd_op_stage_sync_volume(dict_t *dict, char **op_errstr)
 
     if (glusterd_gf_is_local_addr(hostname)) {
         // volname is not present in case of sync all
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(dict, "volname", &volname);
         if (!ret) {
             ret = glusterd_volinfo_find(volname, &volinfo);
             if (ret) {
@@ -1804,7 +1801,7 @@ glusterd_op_stage_status_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -1917,7 +1914,7 @@ glusterd_op_stage_status_volume(dict_t *dict, char **op_errstr)
             goto out;
         }
     } else if ((cmd & GF_CLI_STATUS_BRICK) != 0) {
-        ret = dict_get_strn(dict, "brick", SLEN("brick"), &brick);
+        ret = dict_get_str(dict, "brick", &brick);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                     "Key=brick", NULL);
@@ -1963,7 +1960,7 @@ glusterd_op_stage_stats_volume(dict_t *dict, char **op_errstr)
     int32_t stats_op = GF_CLI_STATS_NONE;
     glusterd_volinfo_t *volinfo = NULL;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Volume name get failed");
         goto out;
@@ -1982,7 +1979,7 @@ glusterd_op_stage_stats_volume(dict_t *dict, char **op_errstr)
     if (ret)
         goto out;
 
-    ret = dict_get_int32n(dict, "op", SLEN("op"), &stats_op);
+    ret = dict_get_int32(dict, "op", &stats_op);
     if (ret) {
         snprintf(msg, sizeof(msg), "Volume profile op get failed");
         goto out;
@@ -2187,14 +2184,14 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     gf_boolean_t quorum_action = _gf_false;
 
     conf = this->private;
-    ret = dict_get_strn(dict, "key", SLEN("key"), &key);
+    ret = dict_get_str(dict, "key", &key);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get key");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "force", SLEN("force"), &is_force);
+    ret = dict_get_int32(dict, "force", &is_force);
     if (ret)
         is_force = 0;
 
@@ -2229,8 +2226,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     if (ret)
         goto out;
 
-    ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
-                        SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+    ret = dict_set_str_sizen(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
+                             next_version);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
@@ -2244,8 +2241,8 @@ glusterd_op_reset_all_volume_options(xlator_t *this, dict_t *dict)
     if (glusterd_is_quorum_changed(conf->opts, key, NULL))
         quorum_action = _gf_true;
 
-    ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
-                           SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+    ret = dict_set_dynstr_sizen(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
+                                next_version);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
@@ -2282,7 +2279,7 @@ glusterd_op_reset_volume(dict_t *dict, char **op_rspstr)
     gf_boolean_t quorum_action = _gf_false;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -2294,11 +2291,11 @@ glusterd_op_reset_volume(dict_t *dict, char **op_rspstr)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "force", SLEN("force"), &is_force);
+    ret = dict_get_int32(dict, "force", &is_force);
     if (ret)
         is_force = 0;
 
-    ret = dict_get_strn(dict, "key", SLEN("key"), &key);
+    ret = dict_get_str(dict, "key", &key);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get option key");
@@ -2448,9 +2445,8 @@ glusterd_update_volumes_dict(glusterd_volinfo_t *volinfo)
                 goto out;
             }
         }
-        ret = dict_get_strn(volinfo->dict, "transport.address-family",
-                            SLEN("transport.address-family"),
-                            &address_family_str);
+        ret = dict_get_str(volinfo->dict, "transport.address-family",
+                           &address_family_str);
         if (ret) {
             if (volinfo->transport_type == GF_TRANSPORT_TCP) {
                 ret = dict_set_dynstr_with_alloc(
@@ -2490,9 +2486,8 @@ glusterd_set_brick_mx_opts(dict_t *dict, char *key, char *value,
     priv = this->private;
 
     if (!strcmp(key, GLUSTERD_BRICK_MULTIPLEX_KEY)) {
-        ret = dict_set_dynstrn(priv->opts, GLUSTERD_BRICK_MULTIPLEX_KEY,
-                               SLEN(GLUSTERD_BRICK_MULTIPLEX_KEY),
-                               gf_strdup(value));
+        ret = dict_set_dynstr_sizen(priv->opts, GLUSTERD_BRICK_MULTIPLEX_KEY,
+                                    gf_strdup(value));
     }
 
 out:
@@ -2512,8 +2507,8 @@ glusterd_set_brick_graceful_cleanup(dict_t *dict, char *key, char *value,
             ret = -1;
             goto out;
         }
-        ret = dict_set_dynstrn(priv->opts, GLUSTER_BRICK_GRACEFUL_CLEANUP,
-                               SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), dup_value);
+        ret = dict_set_dynstr_sizen(priv->opts, GLUSTER_BRICK_GRACEFUL_CLEANUP,
+                                    dup_value);
     }
 
 out:
@@ -2528,7 +2523,7 @@ out:
 static int
 glusterd_dict_set_skip_cliot_key(glusterd_volinfo_t *volinfo)
 {
-    return dict_set_int32n(volinfo->dict, "skip-CLIOT", SLEN("skip-CLIOT"), 1);
+    return dict_set_int32_sizen(volinfo->dict, "skip-CLIOT", 1);
 }
 
 static int
@@ -2550,14 +2545,14 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     gf_boolean_t svcs_reconfigure = _gf_false;
 
     conf = this->private;
-    ret = dict_get_strn(dict, "key1", SLEN("key1"), &key);
+    ret = dict_get_str(dict, "key1", &key);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "value1", SLEN("value1"), &value);
+    ret = dict_get_str(dict, "value1", &value);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "invalid key,value pair in 'volume set'");
@@ -2697,8 +2692,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     if (ret)
         goto out;
 
-    ret = dict_set_strn(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
-                        SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+    ret = dict_set_str_sizen(dup_opt, GLUSTERD_GLOBAL_OPT_VERSION,
+                             next_version);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
@@ -2712,8 +2707,8 @@ glusterd_op_set_all_volume_options(xlator_t *this, dict_t *dict,
     if (glusterd_is_quorum_changed(conf->opts, key, value))
         quorum_action = _gf_true;
 
-    ret = dict_set_dynstrn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
-                           SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+    ret = dict_set_dynstr_sizen(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
+                                next_version);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
@@ -2753,8 +2748,7 @@ glusterd_op_get_max_opversion(char **op_errstr, dict_t *rsp_dict)
 
     GF_VALIDATE_OR_GOTO(THIS->name, rsp_dict, out);
 
-    ret = dict_set_int32n(rsp_dict, "max-opversion", SLEN("max-opversion"),
-                          GD_OP_VERSION_MAX);
+    ret = dict_set_int32_sizen(rsp_dict, "max-opversion", GD_OP_VERSION_MAX);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Setting value for max-opversion to dict failed");
@@ -2882,7 +2876,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
     if (!volinfo_dict_orig)
         goto out;
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &dict_count);
+    ret = dict_get_int32(dict, "count", &dict_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Count(dict),not set in Volume-Set");
@@ -2894,7 +2888,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -3169,7 +3163,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         snprintf(msg, sizeof(msg),
                  "hostname couldn't be "
@@ -3186,7 +3180,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     // volname is not present in case of sync all
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (!ret) {
         ret = glusterd_volinfo_find(volname, &volinfo);
         if (ret) {
@@ -3221,7 +3215,7 @@ glusterd_op_sync_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
             vol_count = count++;
         }
     }
-    ret = dict_set_int32n(rsp_dict, "count", SLEN("count"), vol_count);
+    ret = dict_set_int32_sizen(rsp_dict, "count", vol_count);
 
 out:
     gf_msg_debug("glusterd", 0, "Returning %d", ret);
@@ -3280,7 +3274,7 @@ glusterd_op_stats_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     glusterd_volinfo_t *volinfo = NULL;
     int32_t stats_op = GF_CLI_STATS_NONE;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume name get failed");
@@ -3295,7 +3289,7 @@ glusterd_op_stats_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "op", SLEN("op"), &stats_op);
+    ret = dict_get_int32(dict, "op", &stats_op);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume profile op get failed");
@@ -3376,7 +3370,7 @@ _add_remove_bricks_to_dict(dict_t *dict, glusterd_volinfo_t *volinfo,
     GF_ASSERT(volinfo);
     GF_ASSERT(prefix);
 
-    ret = dict_get_int32n(volinfo->rebal.dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(volinfo->rebal.dict, "count", &count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get brick count");
@@ -3513,7 +3507,7 @@ glusterd_aggregate_task_status(dict_t *rsp_dict, glusterd_volinfo_t *volinfo)
         }
         tasks++;
     }
-    ret = dict_set_int32n(rsp_dict, "tasks", SLEN("tasks"), tasks);
+    ret = dict_set_int32_sizen(rsp_dict, "tasks", tasks);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Error setting tasks count in dict");
@@ -3613,9 +3607,8 @@ glusterd_add_node_to_dict(char *server, dict_t *dict, int count,
      * by entities other than gluster.
      */
     if (!strcmp(server, priv->nfs_svc.name)) {
-        if (dict_getn(vol_opts, "nfs.port", SLEN("nfs.port"))) {
-            ret = dict_get_int32n(vol_opts, "nfs.port", SLEN("nfs.port"),
-                                  &port);
+        if (dict_get_sizen(vol_opts, "nfs.port")) {
+            ret = dict_get_int32(vol_opts, "nfs.port", &port);
             if (ret) {
                 gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                         "Key=nfs.port", NULL);
@@ -3677,7 +3670,7 @@ glusterd_get_all_volnames(dict_t *dict)
         vol_count++;
     }
 
-    ret = dict_set_int32n(dict, "vol_count", SLEN("vol_count"), vol_count);
+    ret = dict_set_int32_sizen(dict, "vol_count", vol_count);
 
 out:
     if (ret)
@@ -3819,7 +3812,7 @@ glusterd_op_status_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     if (cmd & GF_CLI_STATUS_ALL)
         goto out;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret)
         goto out;
 
@@ -3876,7 +3869,7 @@ glusterd_op_status_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         other_count++;
         node_count++;
     } else if ((cmd & GF_CLI_STATUS_BRICK) != 0) {
-        ret = dict_get_strn(dict, "brick", SLEN("brick"), &brick);
+        ret = dict_get_str(dict, "brick", &brick);
         if (ret)
             goto out;
 
@@ -3988,28 +3981,26 @@ glusterd_op_status_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_set_int32n(rsp_dict, "type", SLEN("type"), volinfo->type);
+    ret = dict_set_int32_sizen(rsp_dict, "type", volinfo->type);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
         goto out;
     }
 
-    ret = dict_set_int32n(rsp_dict, "brick-index-max", SLEN("brick-index-max"),
-                          brick_index);
+    ret = dict_set_int32_sizen(rsp_dict, "brick-index-max", brick_index);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=brick-index-max", NULL);
         goto out;
     }
-    ret = dict_set_int32n(rsp_dict, "other-count", SLEN("other-count"),
-                          other_count);
+    ret = dict_set_int32_sizen(rsp_dict, "other-count", other_count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=other-count", NULL);
         goto out;
     }
-    ret = dict_set_int32n(rsp_dict, "count", SLEN("count"), node_count);
+    ret = dict_set_int32_sizen(rsp_dict, "count", node_count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -4333,8 +4324,7 @@ glusterd_op_ac_lock(glusterd_op_sm_event_t *event, void *ctx)
         if (!ret)
             conf->mgmt_v3_lock_timeout = timeout + 120;
 
-        ret = dict_get_strn(lock_ctx->dict, "volname", SLEN("volname"),
-                            &volname);
+        ret = dict_get_str(lock_ctx->dict, "volname", &volname);
         if (ret)
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to acquire volname");
@@ -4346,8 +4336,7 @@ glusterd_op_ac_lock(glusterd_op_sm_event_t *event, void *ctx)
                        "Unable to acquire lock for %s", volname);
             goto out;
         }
-        ret = dict_get_strn(lock_ctx->dict, "globalname", SLEN("globalname"),
-                            &globalname);
+        ret = dict_get_str(lock_ctx->dict, "globalname", &globalname);
         if (!ret) {
             ret = glusterd_mgmt_v3_lock(globalname, lock_ctx->uuid, &op_errno,
                                         "global");
@@ -4389,8 +4378,7 @@ glusterd_op_ac_unlock(glusterd_op_sm_event_t *event, void *ctx)
         ret = glusterd_unlock(lock_ctx->uuid);
         glusterd_op_unlock_send_resp(lock_ctx->req, ret);
     } else {
-        ret = dict_get_strn(lock_ctx->dict, "volname", SLEN("volname"),
-                            &volname);
+        ret = dict_get_str(lock_ctx->dict, "volname", &volname);
         if (ret)
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to acquire volname");
@@ -4402,8 +4390,7 @@ glusterd_op_ac_unlock(glusterd_op_sm_event_t *event, void *ctx)
             goto out;
         }
 
-        ret = dict_get_strn(lock_ctx->dict, "globalname", SLEN("globalname"),
-                            &globalname);
+        ret = dict_get_str(lock_ctx->dict, "globalname", &globalname);
         if (!ret) {
             ret = glusterd_mgmt_v3_unlock(globalname, lock_ctx->uuid, "global");
             if (ret)
@@ -4496,7 +4483,7 @@ glusterd_dict_set_volid(dict_t *dict, char *volname, char **op_errstr)
         ret = -1;
         goto out;
     }
-    ret = dict_set_dynstrn(dict, "vol-id", SLEN("vol-id"), volid);
+    ret = dict_set_dynstr_sizen(dict, "vol-id", volid);
     if (ret) {
         snprintf(msg, sizeof(msg),
                  "Failed to set volume id of volume"
@@ -4591,7 +4578,7 @@ glusterd_op_build_payload(dict_t **req, char **op_errstr, dict_t *op_ctx)
     switch (op) {
         case GD_OP_CREATE_VOLUME: {
             ++glusterfs_port;
-            ret = dict_set_int32n(dict, "port", SLEN("port"), glusterfs_port);
+            ret = dict_set_int32_sizen(dict, "port", glusterfs_port);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set port in "
@@ -4614,7 +4601,7 @@ glusterd_op_build_payload(dict_t **req, char **op_errstr, dict_t *op_ctx)
         } break;
 
         case GD_OP_SET_VOLUME: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
@@ -4633,7 +4620,7 @@ glusterd_op_build_payload(dict_t **req, char **op_errstr, dict_t *op_ctx)
 
         case GD_OP_REMOVE_BRICK: {
             dict_t *dict = ctx;
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_DICT_GET_FAILED,
                        "volname is not present in "
@@ -4712,7 +4699,7 @@ glusterd_op_build_payload(dict_t **req, char **op_errstr, dict_t *op_ctx)
      * other special needs can all "fall through" to it.
      */
     if (do_common) {
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(dict, "volname", &volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_CRITICAL, -ret, GD_MSG_DICT_GET_FAILED,
                    "volname is not present in "
@@ -4982,7 +4969,7 @@ glusterd_op_check_peer_defrag_status(dict_t *dict, int count)
     int ret = -1;
     int i = 1;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -5140,15 +5127,13 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
                 goto out;
             }
 
-            ret = dict_get_int32n(op_ctx, "brick-index-max",
-                                  SLEN("brick-index-max"), &brick_index_max);
+            ret = dict_get_int32(op_ctx, "brick-index-max", &brick_index_max);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to get brick-index-max");
                 goto out;
             }
 
-            ret = dict_get_int32n(op_ctx, "other-count", SLEN("other-count"),
-                                  &other_count);
+            ret = dict_get_int32(op_ctx, "other-count", &other_count);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to get other-count");
                 goto out;
@@ -5161,7 +5146,7 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
              * rdma port in older key. Changing that value from here
              * to support backward compatibility
              */
-            ret = dict_get_strn(op_ctx, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(op_ctx, "volname", &volname);
             if (ret)
                 goto out;
 
@@ -5224,7 +5209,7 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
             if (!ret)
                 goto out;
 
-            ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &count);
+            ret = dict_get_int32(op_ctx, "count", &count);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to get brick count");
                 goto out;
@@ -5244,7 +5229,7 @@ glusterd_op_modify_op_ctx(glusterd_op_t op, void *ctx)
         case GD_OP_DEFRAG_BRICK_VOLUME:
         case GD_OP_SCRUB_STATUS:
         case GD_OP_SCRUB_ONDEMAND:
-            ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &count);
+            ret = dict_get_int32(op_ctx, "count", &count);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Failed to get count");
                 goto out;
@@ -5793,7 +5778,7 @@ glusterd_op_txn_complete(uuid_t *txn_id)
         else
             gf_msg_debug(this->name, 0, "Cleared local lock");
     } else {
-        ret = dict_get_strn(ctx, "volname", SLEN("volname"), &volname);
+        ret = dict_get_str(ctx, "volname", &volname);
         if (ret)
             gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                    "No Volume name present. "
@@ -6441,7 +6426,7 @@ glusterd_bricks_select_remove_brick(dict_t *dict, char **op_errstr,
     int32_t command = 0;
     int32_t force = 0;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -6457,21 +6442,21 @@ glusterd_bricks_select_remove_brick(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get count");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "command", SLEN("command"), &command);
+    ret = dict_get_int32(dict, "command", &command);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get command");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "force", SLEN("force"), &force);
+    ret = dict_get_int32(dict, "force", &force);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                "force flag is not set");
@@ -6543,7 +6528,7 @@ glusterd_bricks_select_profile_volume(dict_t *dict, char **op_errstr,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume name get failed");
@@ -6559,7 +6544,7 @@ glusterd_bricks_select_profile_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "op", SLEN("op"), &stats_op);
+    ret = dict_get_int32(dict, "op", &stats_op);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume profile op get failed");
@@ -6655,7 +6640,7 @@ glusterd_bricks_select_profile_volume(dict_t *dict, char **op_errstr,
                 goto out;
             }
 #endif
-            ret = dict_get_strn(dict, "brick", SLEN("brick"), &brick);
+            ret = dict_get_str(dict, "brick", &brick);
             if (!ret) {
                 ret = glusterd_volume_brickinfo_get_by_brick(
                     brick, volinfo, &brickinfo, _gf_true);
@@ -6769,12 +6754,10 @@ get_replica_index_for_per_replica_cmd(glusterd_volinfo_t *volinfo, dict_t *dict)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "per-replica-cmd-hostname",
-                        SLEN("per-replica-cmd-hostname"), &hostname);
+    ret = dict_get_str(dict, "per-replica-cmd-hostname", &hostname);
     if (ret)
         goto out;
-    ret = dict_get_strn(dict, "per-replica-cmd-path",
-                        SLEN("per-replica-cmd-path"), &path);
+    ret = dict_get_str(dict, "per-replica-cmd-path", &path);
     if (ret)
         goto out;
 
@@ -6807,8 +6790,7 @@ _select_hxlator_with_matching_brick(xlator_t *this, glusterd_volinfo_t *volinfo,
     glusterd_brickinfo_t *brickinfo = NULL;
     int hxl_children = 0;
 
-    if (!dict || dict_get_strn(dict, "per-replica-cmd-path",
-                               SLEN("per-replica-cmd-path"), &path))
+    if (!dict || dict_get_str(dict, "per-replica-cmd-path", &path))
         return -1;
 
     hxl_children = _get_hxl_children_count(volinfo);
@@ -6951,7 +6933,7 @@ glusterd_bricks_select_snap(dict_t *dict, char **op_errstr,
     glusterd_brickinfo_t *brickinfo = NULL;
     int brick_index = -1;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get"
@@ -7153,7 +7135,7 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
     int hxlator_count = 0;
     int index = 0;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume name get failed");
@@ -7169,8 +7151,7 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
-                          (int32_t *)&heal_op);
+    ret = dict_get_int32(dict, "heal-op", (int32_t *)&heal_op);
     if (ret || (heal_op == GF_SHD_OP_INVALID)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "heal op invalid");
@@ -7192,7 +7173,7 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_set_int32n(dict, "count", SLEN("count"), hxlator_count);
+    ret = dict_set_int32_sizen(dict, "count", hxlator_count);
     if (ret)
         goto out;
     pending_node = GF_CALLOC(1, sizeof(*pending_node),
@@ -7224,7 +7205,7 @@ glusterd_bricks_select_rebalance_volume(dict_t *dict, char **op_errstr,
     };
     glusterd_pending_node_t *pending_node = NULL;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "volume name get failed");
@@ -7276,7 +7257,7 @@ glusterd_bricks_select_status_volume(dict_t *dict, char **op_errstr,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_int32n(dict, "cmd", SLEN("cmd"), &cmd);
+    ret = dict_get_int32(dict, "cmd", &cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get status type");
@@ -7303,7 +7284,7 @@ glusterd_bricks_select_status_volume(dict_t *dict, char **op_errstr,
         default:
             goto out;
     }
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volname");
@@ -7315,7 +7296,7 @@ glusterd_bricks_select_status_volume(dict_t *dict, char **op_errstr,
     }
 
     if ((cmd & GF_CLI_STATUS_BRICK) != 0) {
-        ret = dict_get_strn(dict, "brick", SLEN("brick"), &brickname);
+        ret = dict_get_str(dict, "brick", &brickname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to get brick");
@@ -7513,7 +7494,7 @@ glusterd_bricks_select_scrub(dict_t *dict, char **op_errstr,
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get"
@@ -7569,7 +7550,7 @@ glusterd_bricks_select_barrier(dict_t *dict, struct cds_list_head *selected)
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get volname");

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -198,7 +198,7 @@ __glusterd_handle_quota(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get volume name");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -207,7 +207,7 @@ __glusterd_handle_quota(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         snprintf(msg, sizeof(msg), "Unable to get type of command");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -326,9 +326,8 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
         goto out;
     }
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0)
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0)
         volfileserver = "localhost";
 
     len = snprintf(vol_id, sizeof(vol_id), "client_per_brick/%s.%s.%s.%s.vol",
@@ -1435,7 +1434,7 @@ glusterd_quota_limit_usage(glusterd_volinfo_t *volinfo, dict_t *dict,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "path", SLEN("path"), &path);
+    ret = dict_get_str(dict, "path", &path);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch path");
@@ -1445,16 +1444,15 @@ glusterd_quota_limit_usage(glusterd_volinfo_t *volinfo, dict_t *dict,
     if (ret)
         goto out;
 
-    ret = dict_get_strn(dict, "hard-limit", SLEN("hard-limit"), &hard_limit);
+    ret = dict_get_str(dict, "hard-limit", &hard_limit);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch hard limit");
         goto out;
     }
 
-    if (dict_getn(dict, "soft-limit", SLEN("soft-limit"))) {
-        ret = dict_get_strn(dict, "soft-limit", SLEN("soft-limit"),
-                            &soft_limit);
+    if (dict_get_sizen(dict, "soft-limit")) {
+        ret = dict_get_str(dict, "soft-limit", &soft_limit);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to fetch "
@@ -1477,7 +1475,7 @@ glusterd_quota_limit_usage(glusterd_volinfo_t *volinfo, dict_t *dict,
             goto out;
     }
 
-    ret = dict_get_strn(dict, "gfid", SLEN("gfid"), &gfid_str);
+    ret = dict_get_str(dict, "gfid", &gfid_str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get gfid of path "
@@ -1569,7 +1567,7 @@ glusterd_quota_remove_limits(glusterd_volinfo_t *volinfo, dict_t *dict,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "path", SLEN("path"), &path);
+    ret = dict_get_str(dict, "path", &path);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch path");
@@ -1587,7 +1585,7 @@ glusterd_quota_remove_limits(glusterd_volinfo_t *volinfo, dict_t *dict,
             goto out;
     }
 
-    ret = dict_get_strn(dict, "gfid", SLEN("gfid"), &gfid_str);
+    ret = dict_get_str(dict, "gfid", &gfid_str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get gfid of path "
@@ -1625,7 +1623,7 @@ glusterd_set_quota_option(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
         return -1;
     }
 
-    ret = dict_get_strn(dict, "value", SLEN("value"), &value);
+    ret = dict_get_str(dict, "value", &value);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Option value absent.");
@@ -1710,7 +1708,7 @@ glusterd_op_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -1723,7 +1721,7 @@ glusterd_op_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
 
     if (!glusterd_is_quota_supported(type, op_errstr)) {
         ret = -1;
@@ -1899,7 +1897,7 @@ glusterd_get_gfid_from_brick(dict_t *dict, glusterd_volinfo_t *volinfo,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "path", SLEN("path"), &path);
+    ret = dict_get_str(dict, "path", &path);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get path");
@@ -1961,7 +1959,7 @@ glusterd_get_gfid_from_brick(dict_t *dict, glusterd_volinfo_t *volinfo,
         count++;
     }
 
-    ret = dict_set_int32n(rsp_dict, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(rsp_dict, "count", count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count");
@@ -2011,7 +2009,7 @@ _glusterd_validate_quota_opts(dict_t *dict, int type, char **errstr)
                "Unknown option: %s", key);
         goto out;
     }
-    ret = dict_get_strn(dict, "value", SLEN("value"), &value);
+    ret = dict_get_str(dict, "value", &value);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Value not found for key %s", key);
@@ -2084,9 +2082,8 @@ glusterd_create_quota_auxiliary_mount(xlator_t *this, char *volname, int type)
              volname);
     snprintf(qpid, 15, "%d", GF_CLIENT_PID_QUOTA_MOUNT);
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0)
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0)
         volfileserver = "localhost";
 
     synclock_unlock(&priv->big_lock);
@@ -2142,7 +2139,7 @@ glusterd_op_stage_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     GF_ASSERT(dict);
     GF_ASSERT(op_errstr);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -2163,7 +2160,7 @@ glusterd_op_stage_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         *op_errstr = gf_strdup(
             "Volume quota failed, internal error, "
@@ -2229,8 +2226,7 @@ glusterd_op_stage_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     switch (type) {
         case GF_QUOTA_OPTION_TYPE_LIMIT_USAGE:
-            ret = dict_get_strn(dict, "hard-limit", SLEN("hard-limit"),
-                                &hard_limit_str);
+            ret = dict_get_str(dict, "hard-limit", &hard_limit_str);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to get hard-limit from dict");

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -273,9 +273,8 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
 
     snprintf(volname, sizeof(volname), "rebalance/%s", volinfo->volname);
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0) {
         volfileserver = "localhost";
     }
 
@@ -301,9 +300,8 @@ glusterd_handle_defrag_start(glusterd_volinfo_t *volinfo, char *op_errstr,
     runner_argprintf(&runner, "%s", logfile);
     if (volinfo->memory_accounting)
         runner_add_arg(&runner, "--mem-accounting");
-    if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
-                      SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
-                      &localtime_logging) == 0) {
+    if (dict_get_str(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
+                     &localtime_logging) == 0) {
         if (strcmp(localtime_logging, "enable") == 0)
             runner_add_arg(&runner, "--localtime-logging");
     }
@@ -519,15 +517,14 @@ __glusterd_handle_defrag_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get volume name");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "rebalance-command", SLEN("rebalance-command"),
-                          (int32_t *)&cmd);
+    ret = dict_get_int32(dict, "rebalance-command", (int32_t *)&cmd);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get command");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
@@ -618,14 +615,13 @@ glusterd_set_rebalance_id_in_rsp_dict(dict_t *req_dict, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
     GF_ASSERT(req_dict);
 
-    ret = dict_get_strn(rsp_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(rsp_dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not found");
         goto out;
     }
 
-    ret = dict_get_int32n(rsp_dict, "rebalance-command",
-                          SLEN("rebalance-command"), &cmd);
+    ret = dict_get_int32(rsp_dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg_debug(this->name, 0, "cmd not found");
         goto out;
@@ -645,8 +641,7 @@ glusterd_set_rebalance_id_in_rsp_dict(dict_t *req_dict, dict_t *rsp_dict)
         (cmd == GF_DEFRAG_CMD_START_LAYOUT_FIX) ||
         (cmd == GF_DEFRAG_CMD_START_FORCE)) {
         if (is_origin_glusterd(rsp_dict)) {
-            ret = dict_get_strn(req_dict, GF_REBALANCE_TID_KEY,
-                                SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+            ret = dict_get_str(req_dict, GF_REBALANCE_TID_KEY, &task_id_str);
             if (ret) {
                 snprintf(msg, sizeof(msg), "Missing rebalance-id");
                 gf_msg(this->name, GF_LOG_WARNING, 0,
@@ -704,14 +699,13 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
     char *task_id_str = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not found");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "rebalance-command", SLEN("rebalance-command"),
-                          &cmd);
+    ret = dict_get_int32(dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg_debug(this->name, 0, "cmd not found");
         goto out;
@@ -757,8 +751,7 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
                     goto out;
                 }
             } else {
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     snprintf(msg, sizeof(msg), "Missing rebalance-id");
                     gf_msg(this->name, GF_LOG_WARNING, 0,
@@ -779,7 +772,7 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
         case GF_DEFRAG_CMD_STATUS:
         case GF_DEFRAG_CMD_STOP:
 
-            ret = dict_get_strn(dict, "cmd-str", SLEN("cmd-str"), &cmd_str);
+            ret = dict_get_str(dict, "cmd-str", &cmd_str);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to get "
@@ -850,14 +843,13 @@ glusterd_mgmt_v3_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     uint32_t commit_hash;
     int32_t is_force = 0;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not given");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "rebalance-command", SLEN("rebalance-command"),
-                          &cmd);
+    ret = dict_get_int32(dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg_debug(this->name, 0, "command not given");
         goto out;
@@ -875,7 +867,7 @@ glusterd_mgmt_v3_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         case GF_DEFRAG_CMD_START_LAYOUT_FIX:
         case GF_DEFRAG_CMD_START_FORCE:
 
-            ret = dict_get_int32n(dict, "force", SLEN("force"), &is_force);
+            ret = dict_get_int32(dict, "force", &is_force);
             if (ret)
                 is_force = 0;
             if (!is_force) {
@@ -885,8 +877,7 @@ glusterd_mgmt_v3_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                  */
                 volinfo->rebal.defrag_status = GF_DEFRAG_STATUS_NOT_STARTED;
 
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Missing rebalance"
@@ -924,8 +915,7 @@ glusterd_mgmt_v3_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                 volinfo->rebal.defrag_cmd = cmd;
                 volinfo->rebal.op = GD_OP_REBALANCE;
 
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Missing rebalance"
@@ -1008,14 +998,13 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
     dict_t *op_ctx = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not found");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "rebalance-command", SLEN("rebalance-command"),
-                          &cmd);
+    ret = dict_get_int32(dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg_debug(this->name, 0, "cmd not found");
         goto out;
@@ -1069,8 +1058,7 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
                     goto out;
                 }
             } else {
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     snprintf(msg, sizeof(msg), "Missing rebalance-id");
                     gf_msg(this->name, GF_LOG_WARNING, 0,
@@ -1091,7 +1079,7 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
         case GF_DEFRAG_CMD_STATUS:
         case GF_DEFRAG_CMD_STOP:
 
-            ret = dict_get_strn(dict, "cmd-str", SLEN("cmd-str"), &cmd_str);
+            ret = dict_get_str(dict, "cmd-str", &cmd_str);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to get "
@@ -1163,14 +1151,13 @@ glusterd_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     uint32_t commit_hash;
     int32_t is_force = 0;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg_debug(this->name, 0, "volname not given");
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "rebalance-command", SLEN("rebalance-command"),
-                          &cmd);
+    ret = dict_get_int32(dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg_debug(this->name, 0, "command not given");
         goto out;
@@ -1217,7 +1204,7 @@ glusterd_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         case GF_DEFRAG_CMD_START_LAYOUT_FIX:
         case GF_DEFRAG_CMD_START_FORCE:
 
-            ret = dict_get_int32n(dict, "force", SLEN("force"), &is_force);
+            ret = dict_get_int32(dict, "force", &is_force);
             if (ret)
                 is_force = 0;
             if (!is_force) {
@@ -1227,8 +1214,7 @@ glusterd_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                  */
                 volinfo->rebal.defrag_status = GF_DEFRAG_STATUS_NOT_STARTED;
 
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Missing rebalance"
@@ -1266,8 +1252,7 @@ glusterd_op_rebalance(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                 volinfo->rebal.defrag_cmd = cmd;
                 volinfo->rebal.op = GD_OP_REBALANCE;
 
-                ret = dict_get_strn(dict, GF_REBALANCE_TID_KEY,
-                                    SLEN(GF_REBALANCE_TID_KEY), &task_id_str);
+                ret = dict_get_str(dict, GF_REBALANCE_TID_KEY, &task_id_str);
                 if (ret) {
                     gf_msg_debug(this->name, 0,
                                  "Missing rebalance"
@@ -1348,7 +1333,7 @@ glusterd_defrag_event_notify_handle(dict_t *dict)
 
     GF_ASSERT(dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get volname");

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -80,14 +80,14 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Could not get volume name");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "operation", SLEN("operation"), &cli_op);
+    ret = dict_get_str(dict, "operation", &cli_op);
     if (ret) {
         gf_msg_debug(this->name, 0, "dict_get on operation failed");
         snprintf(msg, sizeof(msg), "Could not get operation");
@@ -107,7 +107,7 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "src-brick", SLEN("src-brick"), &src_brick);
+    ret = dict_get_str(dict, "src-brick", &src_brick);
 
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get src brick");
@@ -119,7 +119,7 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
     if (!strcmp(cli_op, "GF_RESET_OP_COMMIT") ||
         !strcmp(cli_op, "GF_RESET_OP_COMMIT_FORCE") ||
         !strcmp(cli_op, "GF_REPLACE_OP_COMMIT_FORCE")) {
-        ret = dict_get_strn(dict, "dst-brick", SLEN("dst-brick"), &dst_brick);
+        ret = dict_get_str(dict, "dst-brick", &dst_brick);
 
         if (ret) {
             snprintf(msg, sizeof(msg),
@@ -361,7 +361,7 @@ glusterd_op_stage_replace_brick(dict_t *dict, char **op_errstr,
             }
         }
 
-        ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"), 1);
+        ret = dict_set_int32_sizen(rsp_dict, "brick_count", 1);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set local_brick_count");
@@ -435,8 +435,7 @@ glusterd_op_perform_replace_brick(glusterd_volinfo_t *volinfo, char *old_brick,
      * introduced in gluster-3.6.0
      */
     if (conf->op_version >= GD_OP_VERSION_3_6_0) {
-        ret = dict_get_strn(dict, "brick1.mount_dir", SLEN("brick1.mount_dir"),
-                            &brick_mount_dir);
+        ret = dict_get_str(dict, "brick1.mount_dir", &brick_mount_dir);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_BRICK_MOUNTDIR_GET_FAIL,
@@ -499,7 +498,7 @@ glusterd_op_replace_brick(dict_t *dict, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "src-brick", SLEN("src-brick"), &src_brick);
+    ret = dict_get_str(dict, "src-brick", &src_brick);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get src brick");
@@ -508,7 +507,7 @@ glusterd_op_replace_brick(dict_t *dict, dict_t *rsp_dict)
 
     gf_msg_debug(this->name, 0, "src brick=%s", src_brick);
 
-    ret = dict_get_strn(dict, "dst-brick", SLEN("dst-brick"), &dst_brick);
+    ret = dict_get_str(dict, "dst-brick", &dst_brick);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get dst brick");
@@ -517,14 +516,14 @@ glusterd_op_replace_brick(dict_t *dict, dict_t *rsp_dict)
 
     gf_msg_debug(this->name, 0, "dst brick=%s", dst_brick);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
 
-    ret = dict_get_strn(dict, "operation", SLEN("operation"), &replace_op);
+    ret = dict_get_str(dict, "operation", &replace_op);
     if (ret) {
         gf_msg_debug(this->name, 0, "dict_get on operation failed");
         goto out;
@@ -649,8 +648,7 @@ glusterd_mgmt_v3_initiate_replace_brick_cmd_phases(rpcsvc_request_t *req,
         goto out;
     }
 
-    ret = dict_set_int32n(dict, "is_synctasked", SLEN("is_synctasked"),
-                          _gf_true);
+    ret = dict_set_int32_sizen(dict, "is_synctasked", _gf_true);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set synctasked flag to true.");

--- a/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
@@ -136,8 +136,7 @@ glusterd_reset_brick_prevalidate(dict_t *dict, char **op_errstr,
     volinfo->rep_brick.src_brick = src_brickinfo;
     volinfo->rep_brick.dst_brick = dst_brickinfo;
 
-    ret = dict_get_int32n(dict, "ignore-partition", SLEN("ignore-partition"),
-                          &ignore_partition);
+    ret = dict_get_int32(dict, "ignore-partition", &ignore_partition);
     ret = 0;
     if (glusterd_gf_is_local_addr(host)) {
         ret = glusterd_validate_and_create_brickpath(
@@ -198,7 +197,7 @@ glusterd_reset_brick_prevalidate(dict_t *dict, char **op_errstr,
         }
     }
 
-    ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"), 1);
+    ret = dict_set_int32_sizen(rsp_dict, "brick_count", 1);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count.");
@@ -231,13 +230,13 @@ glusterd_op_reset_brick(dict_t *dict, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "operation", SLEN("operation"), &op);
+    ret = dict_get_str(dict, "operation", &op);
     if (ret) {
         gf_msg_debug(this->name, 0, "dict_get on operation failed");
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -248,7 +247,7 @@ glusterd_op_reset_brick(dict_t *dict, dict_t *rsp_dict)
     if (ret)
         goto out;
 
-    ret = dict_get_strn(dict, "src-brick", SLEN("src-brick"), &src_brick);
+    ret = dict_get_str(dict, "src-brick", &src_brick);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get src brick");
@@ -277,7 +276,7 @@ glusterd_op_reset_brick(dict_t *dict, dict_t *rsp_dict)
 
     } else if (!strcmp(op, "GF_RESET_OP_COMMIT") ||
                !strcmp(op, "GF_RESET_OP_COMMIT_FORCE")) {
-        ret = dict_get_strn(dict, "dst-brick", SLEN("dst-brick"), &dst_brick);
+        ret = dict_get_str(dict, "dst-brick", &dst_brick);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to get dst brick");

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -58,7 +58,7 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
     switch (op) {
         case GD_OP_REMOVE_BRICK: {
             if (ctx)
-                ret = dict_get_strn(ctx, "errstr", SLEN("errstr"), &errstr);
+                ret = dict_get_str(ctx, "errstr", &errstr);
             break;
         }
         case GD_OP_RESET_VOLUME: {
@@ -69,7 +69,7 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
         case GD_OP_REBALANCE:
         case GD_OP_DEFRAG_BRICK_VOLUME: {
             if (ctx) {
-                ret = dict_get_int32n(ctx, "status", SLEN("status"), &status);
+                ret = dict_get_int32(ctx, "status", &status);
                 if (ret) {
                     gf_msg_trace(this->name, 0, "failed to get status");
                 }
@@ -79,16 +79,16 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
         case GD_OP_GSYNC_CREATE:
         case GD_OP_GSYNC_SET: {
             if (ctx) {
-                ret = dict_get_strn(ctx, "errstr", SLEN("errstr"), &errstr);
-                ret = dict_set_strn(ctx, "glusterd_workdir",
-                                    SLEN("glusterd_workdir"), conf->workdir);
+                ret = dict_get_str(ctx, "errstr", &errstr);
+                ret = dict_set_str_sizen(ctx, "glusterd_workdir",
+                                         conf->workdir);
                 /* swallow error here, that will be re-triggered in cli */
             }
             break;
         }
         case GD_OP_PROFILE_VOLUME: {
-            if (ctx && dict_get_int32n(ctx, "count", SLEN("count"), &count)) {
-                ret = dict_set_int32n(ctx, "count", SLEN("count"), 0);
+            if (ctx && dict_get_int32(ctx, "count", &count)) {
+                ret = dict_set_int32_sizen(ctx, "count", 0);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                            "failed to set count in dictionary");
@@ -147,14 +147,14 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
         }
         case GD_OP_COPY_FILE: {
             if (ctx)
-                ret = dict_get_strn(ctx, "errstr", SLEN("errstr"), &errstr);
+                ret = dict_get_str(ctx, "errstr", &errstr);
             break;
         }
         case GD_OP_SYS_EXEC: {
             if (ctx) {
-                ret = dict_get_strn(ctx, "errstr", SLEN("errstr"), &errstr);
-                ret = dict_set_strn(ctx, "glusterd_workdir",
-                                    SLEN("glusterd_workdir"), conf->workdir);
+                ret = dict_get_str(ctx, "errstr", &errstr);
+                ret = dict_set_str_sizen(ctx, "glusterd_workdir",
+                                         conf->workdir);
             }
             break;
         }
@@ -1439,13 +1439,13 @@ glusterd_rpc_probe(call_frame_t *frame, xlator_t *this, void *data)
 
     dict = data;
 
-    ret = dict_get_strn(dict, "hostname", SLEN("hostname"), &hostname);
+    ret = dict_get_str(dict, "hostname", &hostname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=hostname", NULL);
         goto out;
     }
-    ret = dict_get_int32n(dict, "port", SLEN("port"), &port);
+    ret = dict_get_int32(dict, "port", &port);
     if (ret) {
         gf_smsg(this->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=port", NULL);
@@ -1651,7 +1651,7 @@ glusterd_rpc_friend_update(call_frame_t *frame, xlator_t *this, void *data)
     if (ret)
         goto out;
     /* Don't want to send the pointer over */
-    dict_deln(friends, "peerinfo", SLEN("peerinfo"));
+    dict_del_sizen(friends, "peerinfo");
 
     ret = dict_allocate_and_serialize(friends, &req.friends.friends_val,
                                       &req.friends.friends_len);
@@ -1727,7 +1727,7 @@ glusterd_mgmt_v3_lock_peers(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     // peerinfo should not be in payload
-    dict_deln(dict, "peerinfo", SLEN("peerinfo"));
+    dict_del_sizen(dict, "peerinfo");
 
     glusterd_get_uuid(&req.uuid);
 
@@ -1799,7 +1799,7 @@ glusterd_mgmt_v3_unlock_peers(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     // peerinfo should not be in payload
-    dict_deln(dict, "peerinfo", SLEN("peerinfo"));
+    dict_del_sizen(dict, "peerinfo");
 
     glusterd_get_uuid(&req.uuid);
 
@@ -1905,7 +1905,7 @@ glusterd_stage_op(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     // peerinfo should not be in payload
-    dict_deln(dict, "peerinfo", SLEN("peerinfo"));
+    dict_del_sizen(dict, "peerinfo");
 
     glusterd_get_uuid(&req.uuid);
     req.op = glusterd_op_get_op();
@@ -1977,7 +1977,7 @@ glusterd_commit_op(call_frame_t *frame, xlator_t *this, void *data)
     }
 
     // peerinfo should not be in payload
-    dict_deln(dict, "peerinfo", SLEN("peerinfo"));
+    dict_del_sizen(dict, "peerinfo");
 
     glusterd_get_uuid(&req.uuid);
     req.op = glusterd_op_get_op();
@@ -2097,7 +2097,7 @@ __glusterd_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (GD_OP_STATUS_VOLUME == req_ctx->op) {
         node = frame->cookie;
         index = node->index;
-        ret = dict_set_int32n(dict, "index", SLEN("index"), index);
+        ret = dict_set_int32_sizen(dict, "index", index);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Error setting index on brick status rsp dict");

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -125,9 +125,8 @@ glusterd_shdsvc_init(void *data, glusterd_conn_t *mux_conn,
         goto out;
     }
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0) {
         volfileserver = "localhost";
     }
     ret = glusterd_proc_init(&(svc->proc), shd_svc_name, pidfile, logdir,

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -162,7 +162,7 @@ glusterd_broadcast_friend_delete(char *hostname, uuid_t uuid)
         goto out;
     }
 
-    ret = dict_set_int32n(friends, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(friends, "count", count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", key, NULL);
@@ -396,15 +396,14 @@ glusterd_ac_friend_probe(glusterd_friend_sm_event_t *event, void *ctx)
                     NULL);
             goto unlock;
         }
-        ret = dict_set_strn(dict, "hostname", SLEN("hostname"),
-                            probe_ctx->hostname);
+        ret = dict_set_str_sizen(dict, "hostname", probe_ctx->hostname);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=hostname", NULL);
             goto unlock;
         }
 
-        ret = dict_set_int32n(dict, "port", SLEN("port"), probe_ctx->port);
+        ret = dict_set_int32_sizen(dict, "port", probe_ctx->port);
         if (ret) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=port", NULL);
@@ -601,7 +600,7 @@ glusterd_ac_send_friend_update(glusterd_friend_sm_event_t *event, void *ctx)
             goto unlock;
     }
 
-    ret = dict_set_int32n(friends, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(friends, "count", count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -717,7 +716,7 @@ glusterd_ac_update_friend(glusterd_friend_sm_event_t *event, void *ctx)
             goto unlock;
     }
 
-    ret = dict_set_int32n(friends, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(friends, "count", count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -1052,8 +1051,7 @@ glusterd_ac_handle_friend_add_req(glusterd_friend_sm_event_t *event, void *ctx)
 
     new_event->ctx = new_ev_ctx;
 
-    ret = dict_get_strn(ev_ctx->vols, "hostname_in_cluster",
-                        SLEN("hostname_in_cluster"), &hostname);
+    ret = dict_get_str(ev_ctx->vols, "hostname_in_cluster", &hostname);
     if (ret || !hostname) {
         gf_msg_debug(this->name, 0, "Unable to fetch local hostname from peer");
     } else if (snprintf(local_node_hostname, sizeof(local_node_hostname), "%s",

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -3046,7 +3046,7 @@ glusterd_snap_quorum_check_for_clone(dict_t *dict, gf_boolean_t snap_volume,
     }
 
     if (snap_volume) {
-        ret = dict_get_str_sizen(dict, "snapname", &snapname);
+        ret = dict_get_str(dict, "snapname", &snapname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "failed to "
@@ -3088,7 +3088,7 @@ glusterd_snap_quorum_check_for_clone(dict_t *dict, gf_boolean_t snap_volume,
     }
 
     for (i = 1; i <= volcount; i++) {
-        ret = dict_get_str_sizen(dict, "clonename", &volname);
+        ret = dict_get_str(dict, "clonename", &volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "failed to "
@@ -3266,7 +3266,7 @@ glusterd_snap_quorum_check(dict_t *dict, gf_boolean_t snap_volume,
         goto out;
     }
 
-    ret = dict_get_int32_sizen(dict, "type", &snap_command);
+    ret = dict_get_int32(dict, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "unable to get the type of "

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -330,9 +330,8 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
      * in that case it's better to consider the default value.
      * Hence not erroring out if Key is not found.
      */
-    ret = dict_get_strn(conf->opts, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE,
-                        SLEN(GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE),
-                        &auto_delete);
+    ret = dict_get_str(conf->opts, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE,
+                       &auto_delete);
 
     ret = dict_set_dynstr_with_alloc(
         rsp_dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE, auto_delete);
@@ -346,8 +345,8 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
      * in that case it's better to consider the default value.
      * Hence not erroring out if Key is not found.
      */
-    ret = dict_get_strn(conf->opts, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
-                        SLEN(GLUSTERD_STORE_KEY_SNAP_ACTIVATE), &snap_activate);
+    ret = dict_get_str(conf->opts, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
+                       &snap_activate);
 
     ret = dict_set_dynstr_with_alloc(rsp_dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
                                      snap_activate);
@@ -688,7 +687,7 @@ glusterd_snapshot_restore(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get snap name");
@@ -845,7 +844,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get "
@@ -882,7 +881,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_set_strn(rsp_dict, "snapname", SLEN("snapname"), snapname);
+    ret = dict_set_str_sizen(rsp_dict, "snapname", snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set "
@@ -891,7 +890,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "volcount", SLEN("volcount"), &volcount);
+    ret = dict_get_int32(dict, "volcount", &volcount);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -1042,7 +1041,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
         }
     }
 
-    ret = dict_set_int32n(rsp_dict, "volcount", SLEN("volcount"), volcount);
+    ret = dict_set_int32_sizen(rsp_dict, "volcount", volcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set %s", key);
@@ -1157,8 +1156,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
 
     GF_ASSERT(conf);
 
-    ret = dict_get_int32n(dict, "config-command", SLEN("config-command"),
-                          &config_command);
+    ret = dict_get_int32(dict, "config-command", &config_command);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "failed to get config-command type");
         goto out;
@@ -1169,7 +1167,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (volname) {
         ret = glusterd_volinfo_find(volname, &volinfo);
         if (ret) {
@@ -1217,8 +1215,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    if (dict_getn(dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE,
-                  SLEN(GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE))) {
+    if (dict_get_sizen(dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE)) {
         req_auto_delete = dict_get_str_boolean(
             dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE, _gf_false);
         if (req_auto_delete < 0) {
@@ -1246,8 +1243,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
             *op_errno = EINVAL;
             goto out;
         }
-    } else if (dict_getn(dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
-                         SLEN(GLUSTERD_STORE_KEY_SNAP_ACTIVATE))) {
+    } else if (dict_get_sizen(dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE)) {
         req_snap_activate = dict_get_str_boolean(
             dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE, _gf_false);
         if (req_snap_activate < 0) {
@@ -1319,8 +1315,7 @@ glusterd_handle_snapshot_config(rpcsvc_request_t *req, glusterd_op_t op,
     /* TODO : Type of lock to be taken when we are setting
      * limits system wide
      */
-    ret = dict_get_int32n(dict, "config-command", SLEN("config-command"),
-                          &config_command);
+    ret = dict_get_int32(dict, "config-command", &config_command);
     if (ret) {
         snprintf(err_str, len, "Failed to get config-command type");
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -1328,13 +1323,12 @@ glusterd_handle_snapshot_config(rpcsvc_request_t *req, glusterd_op_t op,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     switch (config_command) {
         case GF_SNAP_CONFIG_TYPE_SET:
             if (!volname) {
-                ret = dict_set_int32n(dict, "hold_vol_locks",
-                                      SLEN("hold_vol_locks"), _gf_false);
+                ret = dict_set_int32_sizen(dict, "hold_vol_locks", _gf_false);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                            "Unable to set hold_vol_locks value "
@@ -1721,7 +1715,7 @@ glusterd_snap_pre_validate_use_rsp_dict(dict_t *dst, dict_t *src)
         goto out;
     }
 
-    ret = dict_get_int32n(dst, "type", SLEN("type"), &snap_command);
+    ret = dict_get_int32(dst, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "unable to get the type of "
@@ -2002,7 +1996,7 @@ glusterd_snapshot_clone_prevalidate(dict_t *dict, char **op_errstr,
     GF_ASSERT(dict);
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
-    ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &clonename);
+    ret = dict_get_str(dict, "clonename", &clonename);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to "
@@ -2010,7 +2004,7 @@ glusterd_snapshot_clone_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "Failed to get snapname");
         goto out;
@@ -2163,13 +2157,13 @@ glusterd_snapshot_create_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "Failed to get snapname");
         goto out;
     }
 
-    ret = dict_get_strn(dict, "description", SLEN("description"), &description);
+    ret = dict_get_str(dict, "description", &description);
     if (description && !(*description)) {
         /* description should have a non-null value */
         ret = -1;
@@ -2179,7 +2173,7 @@ glusterd_snapshot_create_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+    ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get flags");
@@ -3174,7 +3168,7 @@ glusterd_snapshot_get_all_snap_info(dict_t *dict)
         }
     }
 
-    ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), snapcount);
+    ret = dict_set_int32_sizen(dict, "snapcount", snapcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set snapcount");
@@ -3247,11 +3241,10 @@ glusterd_snapshot_get_info_by_volume(dict_t *dict, char *volname, char *err_str,
     }
 
     if (snap_limit > volinfo->snap_count)
-        ret = dict_set_int32n(dict, "snaps-available", SLEN("snaps-available"),
-                              snap_limit - volinfo->snap_count);
+        ret = dict_set_int32_sizen(dict, "snaps-available",
+                                   snap_limit - volinfo->snap_count);
     else
-        ret = dict_set_int32n(dict, "snaps-available", SLEN("snaps-available"),
-                              0);
+        ret = dict_set_int32_sizen(dict, "snaps-available", 0);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set available snaps");
@@ -3263,8 +3256,7 @@ glusterd_snapshot_get_info_by_volume(dict_t *dict, char *volname, char *err_str,
     if (!value)
         goto out;
 
-    ret = dict_set_dynstrn(dict, "origin-volname", SLEN("origin-volname"),
-                           value);
+    ret = dict_set_dynstr_sizen(dict, "origin-volname", value);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set parent "
@@ -3289,7 +3281,7 @@ glusterd_snapshot_get_info_by_volume(dict_t *dict, char *volname, char *err_str,
             goto out;
         }
     }
-    ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), snapcount);
+    ret = dict_set_int32_sizen(dict, "snapcount", snapcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set snapcount");
@@ -3329,7 +3321,7 @@ glusterd_handle_snapshot_info(rpcsvc_request_t *req, glusterd_op_t op,
     GF_VALIDATE_OR_GOTO(this->name, req, out);
     GF_VALIDATE_OR_GOTO(this->name, dict, out);
 
-    ret = dict_get_int32n(dict, "sub-cmd", SLEN("sub-cmd"), &cmd);
+    ret = dict_get_int32(dict, "sub-cmd", &cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get type "
@@ -3349,14 +3341,14 @@ glusterd_handle_snapshot_info(rpcsvc_request_t *req, glusterd_op_t op,
         }
 
         case GF_SNAP_INFO_TYPE_SNAP: {
-            ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+            ret = dict_get_str(dict, "snapname", &snapname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to get snap name");
                 goto out;
             }
 
-            ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), 1);
+            ret = dict_set_int32_sizen(dict, "snapcount", 1);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set snapcount");
@@ -3384,7 +3376,7 @@ glusterd_handle_snapshot_info(rpcsvc_request_t *req, glusterd_op_t op,
         }
 
         case GF_SNAP_INFO_TYPE_VOL: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOL_NOT_FOUND,
                        "Failed to get volname");
@@ -3466,7 +3458,7 @@ glusterd_snapshot_get_all_snapnames(dict_t *dict)
         }
     }
 
-    ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), snapcount);
+    ret = dict_set_int32_sizen(dict, "snapcount", snapcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set snapcount");
@@ -3513,7 +3505,7 @@ glusterd_snapshot_get_vol_snapnames(dict_t *dict, glusterd_volinfo_t *volinfo)
         }
     }
 
-    ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), snapcount);
+    ret = dict_set_int32_sizen(dict, "snapcount", snapcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set snapcount");
@@ -3541,7 +3533,7 @@ glusterd_handle_snapshot_list(rpcsvc_request_t *req, glusterd_op_t op,
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
     /* Ignore error for getting volname as it is optional */
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (NULL == volname) {
         ret = glusterd_snapshot_get_all_snapnames(dict);
@@ -3636,7 +3628,7 @@ glusterd_handle_snapshot_create(rpcsvc_request_t *req, glusterd_op_t op,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get the snapname");
@@ -3849,7 +3841,7 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
-    ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &clonename);
+    ret = dict_get_str(dict, "clonename", &clonename);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to "
@@ -3868,7 +3860,7 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get the snapname");
@@ -3893,7 +3885,7 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
     }
     uuid_ptr = NULL;
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get snapname name");
@@ -3998,7 +3990,7 @@ glusterd_handle_snapshot_restore(rpcsvc_request_t *req, glusterd_op_t op,
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to "
@@ -4037,7 +4029,7 @@ glusterd_handle_snapshot_restore(rpcsvc_request_t *req, glusterd_op_t op,
         buf = NULL;
     }
 
-    ret = dict_set_int32n(dict, "volcount", SLEN("volcount"), i);
+    ret = dict_set_int32_sizen(dict, "volcount", i);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save volume count");
@@ -4075,15 +4067,15 @@ glusterd_create_snap_object(dict_t *dict, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
 
     /* Fetch snapname, description, id and time from dict */
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch snapname");
         goto out;
     }
 
-    /* Ignore ret value for description*/
-    ret = dict_get_strn(dict, "description", SLEN("description"), &description);
+    /* Ignore ret value for description */
+    ret = dict_get_str(dict, "description", &description);
 
     ret = dict_get_bin(dict, "snap-id", (void **)&snap_id);
     if (ret) {
@@ -4211,8 +4203,7 @@ glusterd_add_missed_snaps_to_dict(dict_t *rsp_dict,
     }
 
     /* Fetch the missed_snap_count from the dict */
-    ret = dict_get_int32n(rsp_dict, "missed_snap_count",
-                          SLEN("missed_snap_count"), &missed_snap_count);
+    ret = dict_get_int32(rsp_dict, "missed_snap_count", &missed_snap_count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=missed_snap_count", NULL);
@@ -4233,8 +4224,8 @@ glusterd_add_missed_snaps_to_dict(dict_t *rsp_dict,
     missed_snap_count++;
 
     /* Setting the new missed_snap_count in the dict */
-    ret = dict_set_int32n(rsp_dict, "missed_snap_count",
-                          SLEN("missed_snap_count"), missed_snap_count);
+    ret = dict_set_int32_sizen(rsp_dict, "missed_snap_count",
+                               missed_snap_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set missed_snap_count for %s "
@@ -4871,7 +4862,7 @@ glusterd_do_snap_vol(glusterd_volinfo_t *origin_vol, glusterd_snap_t *snap,
 
     if (clone) {
         snap_vol->is_snap_volume = _gf_false;
-        ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &clonename);
+        ret = dict_get_str(dict, "clonename", &clonename);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Failed to get %s "
@@ -4957,7 +4948,7 @@ glusterd_do_snap_vol(glusterd_volinfo_t *origin_vol, glusterd_snap_t *snap,
      * before storing and generating the brick volfiles. Also update
      * the snap vol's version after removing the barrier key.
      */
-    dict_deln(snap_vol->dict, "features.barrier", SLEN("features.barrier"));
+    dict_del_sizen(snap_vol->dict, "features.barrier");
     gd_update_volume_op_versions(snap_vol);
 
     /* *
@@ -5133,7 +5124,7 @@ glusterd_snapshot_activate_deactivate_prevalidate(dict_t *dict,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Getting the snap name "
@@ -5154,9 +5145,9 @@ glusterd_snapshot_activate_deactivate_prevalidate(dict_t *dict,
         goto out;
     }
 
-    /*If its activation of snap then fetch the flags*/
+    /* If its activation of snap then fetch the flags */
     if (is_op_activate) {
-        ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+        ret = dict_get_int32(dict, "flags", &flags);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to get flags");
@@ -5228,7 +5219,7 @@ glusterd_handle_snapshot_delete_vol(dict_t *dict, char *err_str,
     GF_ASSERT(dict);
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get "
@@ -5296,7 +5287,7 @@ glusterd_handle_snapshot_delete_all(dict_t *dict)
         }
     }
 
-    ret = dict_set_int32n(dict, "snapcount", SLEN("snapcount"), i);
+    ret = dict_set_int32_sizen(dict, "snapcount", i);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save snapcount");
@@ -5330,7 +5321,7 @@ glusterd_handle_snapshot_delete_type_snap(rpcsvc_request_t *req,
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get snapname");
@@ -5417,7 +5408,7 @@ glusterd_handle_snapshot_delete(rpcsvc_request_t *req, glusterd_op_t op,
     GF_ASSERT(err_str);
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
-    ret = dict_get_int32n(dict, "sub-cmd", SLEN("sub-cmd"), &delete_cmd);
+    ret = dict_get_int32(dict, "sub-cmd", &delete_cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "Failed to get sub-cmd");
@@ -5497,7 +5488,7 @@ glusterd_snapshot_remove_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Getting the snap name "
@@ -5552,7 +5543,7 @@ glusterd_snapshot_status_prevalidate(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "sub-cmd", SLEN("sub-cmd"), &cmd);
+    ret = dict_get_int32(dict, "sub-cmd", &cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Could not fetch status cmd");
@@ -5565,7 +5556,7 @@ glusterd_snapshot_status_prevalidate(dict_t *dict, char **op_errstr,
         }
         case GF_SNAP_STATUS_TYPE_ITER:
         case GF_SNAP_STATUS_TYPE_SNAP: {
-            ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+            ret = dict_get_str(dict, "snapname", &snapname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Could not fetch snapname");
@@ -5589,7 +5580,7 @@ glusterd_snapshot_status_prevalidate(dict_t *dict, char **op_errstr,
             break;
         }
         case GF_SNAP_STATUS_TYPE_VOL: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Could not fetch volname");
@@ -5652,7 +5643,7 @@ glusterd_snapshot_activate_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Getting the snap name "
@@ -5660,7 +5651,7 @@ glusterd_snapshot_activate_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+    ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get flags");
@@ -5752,7 +5743,7 @@ glusterd_snapshot_deactivate_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Getting the snap name "
@@ -5848,7 +5839,7 @@ glusterd_snapshot_remove_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Getting the snap name "
@@ -5963,7 +5954,7 @@ glusterd_do_snap_cleanup(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     /* As of now snapshot of multiple volumes are not supported */
-    ret = dict_get_strn(dict, "volname1", SLEN("volname1"), &volname);
+    ret = dict_get_str(dict, "volname1", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get"
@@ -5971,7 +5962,7 @@ glusterd_do_snap_cleanup(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &name);
+    ret = dict_get_str(dict, "snapname", &name);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "getting the snap "
@@ -6024,8 +6015,7 @@ glusterd_snapshot_update_snaps_post_validate(dict_t *dict, char **op_errstr,
     GF_ASSERT(rsp_dict);
     GF_ASSERT(op_errstr);
 
-    ret = dict_get_int32n(dict, "missed_snap_count", SLEN("missed_snap_count"),
-                          &missed_snap_count);
+    ret = dict_get_int32(dict, "missed_snap_count", &missed_snap_count);
     if (ret) {
         gf_msg_debug(this->name, 0, "No missed snaps");
         ret = 0;
@@ -6068,8 +6058,7 @@ glusterd_take_brick_snapshot_task(void *opaque)
 
     /* Try and fetch clonename. If present set status with clonename *
      * else do so as snap-vol */
-    ret = dict_get_strn(snap_args->dict, "clonename", SLEN("clonename"),
-                        &clonename);
+    ret = dict_get_str(snap_args->dict, "clonename", &clonename);
     if (ret) {
         keylen = snprintf(key, sizeof(key), "snap-vol%d.brick%d.status",
                           snap_args->volcount, snap_args->brickorder);
@@ -6254,7 +6243,7 @@ glusterd_create_snap_object_for_clone(dict_t *dict, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
 
     /* Fetch snapname, description, id and time from dict */
-    ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &snapname);
+    ret = dict_get_str(dict, "clonename", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch clonename");
@@ -6312,7 +6301,7 @@ glusterd_snapshot_clone_commit(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &snapname);
+    ret = dict_get_str(dict, "clonename", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch clonename");
@@ -6335,7 +6324,7 @@ glusterd_snapshot_clone_commit(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
     tmp_name = NULL;
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &volname);
+    ret = dict_get_str(dict, "snapname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get snap name");
@@ -6486,7 +6475,7 @@ glusterd_snapshot_create_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch snapname");
@@ -6604,7 +6593,7 @@ glusterd_snapshot_create_commit(dict_t *dict, char **op_errstr,
     }
 
     /* Activate created bricks in case of activate-on-create config. */
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), &flags);
+    ret = dict_get_int32(dict, "flags", &flags);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get flags");
@@ -6672,8 +6661,8 @@ snap_max_hard_limit_set_commit(dict_t *dict, uint64_t value, char *volname,
         if (ret)
             goto out;
 
-        ret = dict_set_strn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
-                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+        ret = dict_set_str_sizen(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
+                                 next_version);
         if (ret)
             goto out;
 
@@ -6741,8 +6730,7 @@ glusterd_snapshot_config_commit(dict_t *dict, char **op_errstr,
 
     GF_ASSERT(conf);
 
-    ret = dict_get_int32n(dict, "config-command", SLEN("config-command"),
-                          &config_command);
+    ret = dict_get_int32(dict, "config-command", &config_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "failed to get config-command type");
@@ -6753,7 +6741,7 @@ glusterd_snapshot_config_commit(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     /* config values snap-max-hard-limit and snap-max-soft-limit are
      * optional and hence we are not erroring out if values are not
@@ -6790,9 +6778,8 @@ glusterd_snapshot_config_commit(dict_t *dict, char **op_errstr,
         goto done;
     }
 
-    if (!dict_get_strn(dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE,
-                       SLEN(GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE),
-                       &auto_delete)) {
+    if (!dict_get_str(dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE,
+                      &auto_delete)) {
         system_conf = _gf_true;
         ret = dict_set_dynstr_with_alloc(
             conf->opts, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE, auto_delete);
@@ -6802,9 +6789,8 @@ glusterd_snapshot_config_commit(dict_t *dict, char **op_errstr,
                    "save auto-delete value in conf->opts");
             goto out;
         }
-    } else if (!dict_get_strn(dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
-                              SLEN(GLUSTERD_STORE_KEY_SNAP_ACTIVATE),
-                              &snap_activate)) {
+    } else if (!dict_get_str(dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE,
+                             &snap_activate)) {
         system_conf = _gf_true;
         ret = dict_set_dynstr_with_alloc(
             conf->opts, GLUSTERD_STORE_KEY_SNAP_ACTIVATE, snap_activate);
@@ -6832,8 +6818,8 @@ done:
             goto out;
         }
 
-        ret = dict_set_strn(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
-                            SLEN(GLUSTERD_GLOBAL_OPT_VERSION), next_version);
+        ret = dict_set_str_sizen(conf->opts, GLUSTERD_GLOBAL_OPT_VERSION,
+                                 next_version);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0,
                    GD_MSG_GLOBAL_OP_VERSION_SET_FAIL,
@@ -7258,8 +7244,7 @@ glusterd_get_snap_status_of_volume(char **op_errstr, dict_t *rsp_dict,
         i++;
     }
 
-    ret = dict_set_int32n(rsp_dict, "status.snapcount",
-                          SLEN("status.snapcount"), i);
+    ret = dict_set_int32_sizen(rsp_dict, "status.snapcount", i);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to save snapcount");
@@ -7307,8 +7292,7 @@ glusterd_get_all_snapshot_status(dict_t *dict, char **op_errstr,
         i++;
     }
 
-    ret = dict_set_int32n(rsp_dict, "status.snapcount",
-                          SLEN("status.snapcount"), i);
+    ret = dict_set_int32_sizen(rsp_dict, "status.snapcount", i);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save snapcount");
@@ -7338,14 +7322,14 @@ glusterd_snapshot_status_commit(dict_t *dict, char **op_errstr,
     conf = this->private;
 
     GF_ASSERT(conf);
-    ret = dict_get_int32n(dict, "sub-cmd", SLEN("sub-cmd"), &cmd);
+    ret = dict_get_int32(dict, "sub-cmd", &cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get status cmd type");
         goto out;
     }
 
-    ret = dict_set_int32n(rsp_dict, "sub-cmd", SLEN("sub-cmd"), cmd);
+    ret = dict_set_int32_sizen(rsp_dict, "sub-cmd", cmd);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save status cmd in rsp dictionary");
@@ -7364,7 +7348,7 @@ glusterd_snapshot_status_commit(dict_t *dict, char **op_errstr,
         }
         case GF_SNAP_STATUS_TYPE_ITER:
         case GF_SNAP_STATUS_TYPE_SNAP: {
-            ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+            ret = dict_get_str(dict, "snapname", &snapname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to "
@@ -7396,8 +7380,7 @@ glusterd_snapshot_status_commit(dict_t *dict, char **op_errstr,
                 goto out;
             }
 
-            ret = dict_set_int32n(rsp_dict, "status.snapcount",
-                                  SLEN("status.snapcount"), 1);
+            ret = dict_set_int32_sizen(rsp_dict, "status.snapcount", 1);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Unable to "
@@ -7407,7 +7390,7 @@ glusterd_snapshot_status_commit(dict_t *dict, char **op_errstr,
             break;
         }
         case GF_SNAP_STATUS_TYPE_VOL: {
-            ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+            ret = dict_get_str(dict, "volname", &volname);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to"
@@ -7573,7 +7556,7 @@ glusterd_snapshot_clone_postvalidate(dict_t *dict, int32_t op_ret,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "clonename", SLEN("clonename"), &clonename);
+    ret = dict_get_str(dict, "clonename", &clonename);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch "
@@ -7604,7 +7587,7 @@ glusterd_snapshot_clone_postvalidate(dict_t *dict, int32_t op_ret,
      * needed in case of a clone                                    *
      */
     if (op_ret) {
-        ret = dict_get_int32n(dict, "cleanup", SLEN("cleanup"), &cleanup);
+        ret = dict_get_int32(dict, "cleanup", &cleanup);
         if (!ret && cleanup && snap) {
             glusterd_snap_remove(rsp_dict, snap, _gf_true, _gf_true, _gf_true);
         }
@@ -7656,7 +7639,7 @@ glusterd_snapshot_create_postvalidate(dict_t *dict, int32_t op_ret,
     GF_ASSERT(priv);
 
     if (op_ret) {
-        ret = dict_get_int32n(dict, "cleanup", SLEN("cleanup"), &cleanup);
+        ret = dict_get_int32(dict, "cleanup", &cleanup);
         if (!ret && cleanup) {
             ret = glusterd_do_snap_cleanup(dict, op_errstr, rsp_dict);
             if (ret) {
@@ -7675,7 +7658,7 @@ glusterd_snapshot_create_postvalidate(dict_t *dict, int32_t op_ret,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &snapname);
+    ret = dict_get_str(dict, "snapname", &snapname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch "
@@ -7732,7 +7715,7 @@ glusterd_snapshot_create_postvalidate(dict_t *dict, int32_t op_ret,
                      snap->snapname, uuid_utoa(snap->snap_id));
         }
 
-        ret = dict_get_strn(dict, "volname1", SLEN("volname1"), &volname);
+        ret = dict_get_str(dict, "volname1", &volname);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Failed to get volname.");
@@ -7816,7 +7799,7 @@ glusterd_snapshot(dict_t *dict, char **op_errstr, uint32_t *op_errno,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &snap_command);
+    ret = dict_get_int32(dict, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "unable to get the type of "
@@ -7867,8 +7850,7 @@ glusterd_snapshot(dict_t *dict, char **op_errstr, uint32_t *op_errno,
                     goto out;
                 }
 
-                ret = dict_get_strn(dict, "snapname", SLEN("snapname"),
-                                    &snap_name);
+                ret = dict_get_str(dict, "snapname", &snap_name);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                            "Failed to get snapname");
@@ -7959,7 +7941,7 @@ glusterd_snapshot_brickop(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     GF_ASSERT(dict);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &snap_command);
+    ret = dict_get_int32(dict, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "unable to get the type of "
@@ -7973,8 +7955,7 @@ glusterd_snapshot_brickop(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
             /* op_type with tell us whether its pre-commit operation
              * or post-commit
              */
-            ret = dict_get_strn(dict, "operation-type", SLEN("operation-type"),
-                                &op_type);
+            ret = dict_get_str(dict, "operation-type", &op_type);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Failed to fetch "
@@ -8023,7 +8004,7 @@ glusterd_snapshot_brickop(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                            "Unable to get volname");
                     goto out;
                 }
-                ret = dict_set_strn(dict, "volname", SLEN("volname"), volname);
+                ret = dict_set_str_sizen(dict, "volname", volname);
                 if (ret)
                     goto out;
 
@@ -8034,7 +8015,7 @@ glusterd_snapshot_brickop(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                 count++;
             }
 
-            dict_deln(dict, "volname", SLEN("volname"));
+            dict_del_sizen(dict, "volname");
             ret = 0;
             break;
         case GF_SNAP_OPTION_TYPE_DELETE:
@@ -8059,7 +8040,7 @@ glusterd_snapshot_prevalidate(dict_t *dict, char **op_errstr, dict_t *rsp_dict,
     GF_ASSERT(rsp_dict);
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &snap_command);
+    ret = dict_get_int32(dict, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "unable to get the type of "
@@ -8460,7 +8441,7 @@ glusterd_snapshot_restore_postop(dict_t *dict, int32_t op_ret, char **op_errstr,
     GF_ASSERT(dict);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &name);
+    ret = dict_get_str(dict, "snapname", &name);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "getting the snap "
@@ -8478,7 +8459,7 @@ glusterd_snapshot_restore_postop(dict_t *dict, int32_t op_ret, char **op_errstr,
     }
 
     /* TODO: fix this when multiple volume support will come */
-    ret = dict_get_strn(dict, "volname1", SLEN("volname1"), &volname);
+    ret = dict_get_str(dict, "volname1", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get volume name");
@@ -8492,7 +8473,7 @@ glusterd_snapshot_restore_postop(dict_t *dict, int32_t op_ret, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "snapname", SLEN("snapname"), &name);
+    ret = dict_get_str(dict, "snapname", &name);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "getting the snap "
@@ -8520,7 +8501,7 @@ glusterd_snapshot_restore_postop(dict_t *dict, int32_t op_ret, char **op_errstr,
             goto out;
         }
     } else { /* On failure revert snapshot restore */
-        ret = dict_get_int32n(dict, "cleanup", SLEN("cleanup"), &cleanup);
+        ret = dict_get_int32(dict, "cleanup", &cleanup);
         /* Perform cleanup only when required */
         if (ret || (0 == cleanup)) {
             /* Delete the backup copy of volume folder */
@@ -8586,7 +8567,7 @@ glusterd_snapshot_postvalidate(dict_t *dict, int32_t op_ret, char **op_errstr,
     GF_ASSERT(dict);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &snap_command);
+    ret = dict_get_int32(dict, "type", &snap_command);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND,
                "unable to get the type of "
@@ -8736,7 +8717,7 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
             ret = -1;
             goto out;
         }
-        ret = dict_set_dynstrn(dict, "host-uuid", SLEN("host-uuid"), host_uuid);
+        ret = dict_set_dynstr_sizen(dict, "host-uuid", host_uuid);
         if (ret) {
             GF_FREE(host_uuid);
             goto out;
@@ -8760,7 +8741,7 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
     if (ret < 0) {
         snprintf(err_str, sizeof(err_str), "Command type not found");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND, "%s",
@@ -9486,7 +9467,7 @@ glusterd_snapshot_get_volnames_uuids(dict_t *dict, char *volname,
         }
     }
 
-    ret = dict_set_int32n(dict, "snap-count", SLEN("snap-count"), snapcount);
+    ret = dict_set_int32_sizen(dict, "snap-count", snapcount);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set snapcount");

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -99,9 +99,8 @@ glusterd_svc_init_common(glusterd_svc_t *svc, char *svc_name, char *workdir,
     glusterd_svc_build_logfile_path(svc_name, logdir, logfile, sizeof(logfile));
     glusterd_svc_build_volfileid_path(svc_name, volfileid, sizeof(volfileid));
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &volfileserver) != 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &volfileserver) != 0) {
         volfileserver = "localhost";
     }
 
@@ -202,15 +201,13 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
                         svc->proc.volfileid, "-p", svc->proc.pidfile, "-l",
                         svc->proc.logfile, "-S", svc->conn.sockpath, NULL);
 
-        if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
-                          SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
-                          &localtime_logging) == 0) {
+        if (dict_get_str(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
+                         &localtime_logging) == 0) {
             if (strcmp(localtime_logging, "enable") == 0)
                 runner_add_arg(&runner, "--localtime-logging");
         }
-        if (dict_get_strn(priv->opts, GLUSTERD_DAEMON_LOG_LEVEL_KEY,
-                          SLEN(GLUSTERD_DAEMON_LOG_LEVEL_KEY),
-                          &log_level) == 0) {
+        if (dict_get_str(priv->opts, GLUSTERD_DAEMON_LOG_LEVEL_KEY,
+                         &log_level) == 0) {
             snprintf(daemon_log_level, 30, "--log-level=%s", log_level);
             runner_add_arg(&runner, daemon_log_level);
         }
@@ -487,8 +484,7 @@ glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
     if (ret)
         goto out;
 
-    ret = dict_set_int32n(options, "transport.socket.ignore-enoent",
-                          SLEN("transport.socket.ignore-enoent"), 1);
+    ret = dict_set_int32_sizen(options, "transport.socket.ignore-enoent", 1);
     if (ret)
         goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -238,7 +238,7 @@ glusterd_append_gsync_status(dict_t *dst, dict_t *src)
     int ret = 0;
     char *stop_msg = NULL;
 
-    ret = dict_get_strn(src, "gsync-status", SLEN("gsync-status"), &stop_msg);
+    ret = dict_get_str(src, "gsync-status", &stop_msg);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=gsync-status", NULL);
@@ -276,11 +276,11 @@ glusterd_append_status_dicts(dict_t *dst, dict_t *src)
     if (src == NULL)
         goto out;
 
-    ret = dict_get_int32n(dst, "gsync-count", SLEN("gsync-count"), &dst_count);
+    ret = dict_get_int32(dst, "gsync-count", &dst_count);
     if (ret)
         dst_count = 0;
 
-    ret = dict_get_int32n(src, "gsync-count", SLEN("gsync-count"), &src_count);
+    ret = dict_get_int32(src, "gsync-count", &src_count);
     if (ret || !src_count) {
         gf_msg_debug("glusterd", 0, "Source brick empty");
         ret = 0;
@@ -315,8 +315,7 @@ glusterd_append_status_dicts(dict_t *dst, dict_t *src)
         }
     }
 
-    ret = dict_set_int32n(dst, "gsync-count", SLEN("gsync-count"),
-                          dst_count + src_count);
+    ret = dict_set_int32_sizen(dst, "gsync-count", dst_count + src_count);
 
 out:
     gf_msg_debug("glusterd", 0, "Returning %d", ret);
@@ -351,8 +350,7 @@ glusterd_gsync_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict, char *op_errstr)
         if (ret)
             goto out;
 
-        ret = dict_get_strn(rsp_dict, "conf_path", SLEN("conf_path"),
-                            &conf_path);
+        ret = dict_get_str(rsp_dict, "conf_path", &conf_path);
         if (!ret && conf_path) {
             ret = dict_set_dynstr_with_alloc(ctx, "conf_path", conf_path);
             if (ret) {
@@ -384,15 +382,13 @@ glusterd_max_opversion_use_rsp_dict(dict_t *dst, dict_t *src)
     GF_VALIDATE_OR_GOTO(THIS->name, dst, out);
     GF_VALIDATE_OR_GOTO(THIS->name, src, out);
 
-    ret = dict_get_int32n(dst, "max-opversion", SLEN("max-opversion"),
-                          &max_opversion);
+    ret = dict_get_int32(dst, "max-opversion", &max_opversion);
     if (ret)
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Maximum supported op-version not set in destination "
                "dictionary");
 
-    ret = dict_get_int32n(src, "max-opversion", SLEN("max-opversion"),
-                          &src_max_opversion);
+    ret = dict_get_int32(src, "max-opversion", &src_max_opversion);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get maximum supported op-version from source");
@@ -402,8 +398,7 @@ glusterd_max_opversion_use_rsp_dict(dict_t *dst, dict_t *src)
     if (max_opversion == -1 || src_max_opversion < max_opversion)
         max_opversion = src_max_opversion;
 
-    ret = dict_set_int32n(dst, "max-opversion", SLEN("max-opversion"),
-                          max_opversion);
+    ret = dict_set_int32_sizen(dst, "max-opversion", max_opversion);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set max op-version");
@@ -442,7 +437,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(aggr, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(aggr, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -456,9 +451,9 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(aggr, "count", SLEN("count"), &dst_count);
+    ret = dict_get_int32(aggr, "count", &dst_count);
 
-    ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &src_count);
+    ret = dict_get_int32(rsp_dict, "count", &src_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get count value");
@@ -466,7 +461,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_set_int32n(aggr, "count", SLEN("count"), src_count + dst_count);
+    ret = dict_set_int32_sizen(aggr, "count", src_count + dst_count);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count in dictonary");
@@ -574,8 +569,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "bitrot_log_file", SLEN("bitrot_log_file"),
-                        &bitd_log);
+    ret = dict_get_str(rsp_dict, "bitrot_log_file", &bitd_log);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(aggr, "bitrot_log_file", bitd_log);
         if (ret) {
@@ -586,8 +580,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "scrub_log_file", SLEN("scrub_log_file"),
-                        &scrub_log);
+    ret = dict_get_str(rsp_dict, "scrub_log_file", &scrub_log);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(aggr, "scrub_log_file", scrub_log);
         if (ret) {
@@ -598,8 +591,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "features.scrub-freq",
-                        SLEN("features.scrub-freq"), &scrub_freq);
+    ret = dict_get_str(rsp_dict, "features.scrub-freq", &scrub_freq);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(aggr, "features.scrub-freq",
                                          scrub_freq);
@@ -611,8 +603,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "features.scrub-throttle",
-                        SLEN("features.scrub-throttle"), &scrub_impact);
+    ret = dict_get_str(rsp_dict, "features.scrub-throttle", &scrub_impact);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(aggr, "features.scrub-throttle",
                                          scrub_impact);
@@ -624,8 +615,7 @@ glusterd_volume_bitrot_scrub_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "features.scrub", SLEN("features.scrub"),
-                        &scrub_state);
+    ret = dict_get_str(rsp_dict, "features.scrub", &scrub_state);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(aggr, "features.scrub", scrub_state);
         if (ret) {
@@ -659,11 +649,9 @@ glusterd_sys_exec_output_rsp_dict(dict_t *dst, dict_t *src)
         goto out;
     }
 
-    ret = dict_get_int32n(dst, "output_count", SLEN("output_count"),
-                          &dst_output_count);
+    ret = dict_get_int32(dst, "output_count", &dst_output_count);
 
-    ret = dict_get_int32n(src, "output_count", SLEN("output_count"),
-                          &src_output_count);
+    ret = dict_get_int32(src, "output_count", &src_output_count);
     if (ret) {
         gf_msg_debug("glusterd", 0, "No output from source");
         ret = 0;
@@ -698,8 +686,8 @@ glusterd_sys_exec_output_rsp_dict(dict_t *dst, dict_t *src)
         }
     }
 
-    ret = dict_set_int32n(dst, "output_count", SLEN("output_count"),
-                          dst_output_count + src_output_count);
+    ret = dict_set_int32_sizen(dst, "output_count",
+                               dst_output_count + src_output_count);
 out:
     gf_msg_debug("glusterd", 0, "Returning %d", ret);
     return ret;
@@ -778,7 +766,7 @@ glusterd_volume_quota_copy_to_op_ctx_dict(dict_t *dict, dict_t *rsp_dict)
     xlator_t *this = THIS;
     int type = GF_QUOTA_OPTION_TYPE_NONE;
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get quota opcode");
@@ -794,7 +782,7 @@ glusterd_volume_quota_copy_to_op_ctx_dict(dict_t *dict, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &rsp_dict_count);
+    ret = dict_get_int32(rsp_dict, "count", &rsp_dict_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get the count of "
@@ -802,7 +790,7 @@ glusterd_volume_quota_copy_to_op_ctx_dict(dict_t *dict, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(dict, "count", &count);
     if (ret)
         /* The key "count" is absent in op_ctx when this function is
          * called after self-staging on the originator. This must not
@@ -840,7 +828,7 @@ glusterd_volume_quota_copy_to_op_ctx_dict(dict_t *dict, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_set_int32n(dict, "count", SLEN("count"), rsp_dict_count + count);
+    ret = dict_set_int32_sizen(dict, "count", rsp_dict_count + count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set aggregated "
@@ -1901,7 +1889,7 @@ glusterd_validate_and_set_gfid(dict_t *op_ctx, dict_t *req_dict,
     char *uuid1_str_dup = NULL;
     char *uuid2_str = NULL;
 
-    ret = dict_get_int32n(op_ctx, "type", SLEN("type"), &op_code);
+    ret = dict_get_int32(op_ctx, "type", &op_code);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get quota opcode");
@@ -1916,14 +1904,14 @@ glusterd_validate_and_set_gfid(dict_t *op_ctx, dict_t *req_dict,
         goto out;
     }
 
-    ret = dict_get_strn(op_ctx, "path", SLEN("path"), &path);
+    ret = dict_get_str(op_ctx, "path", &path);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get path");
         goto out;
     }
 
-    ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &count);
+    ret = dict_get_int32(op_ctx, "count", &count);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get count");
@@ -1992,7 +1980,7 @@ glusterd_validate_and_set_gfid(dict_t *op_ctx, dict_t *req_dict,
             goto out;
         }
 
-        ret = dict_set_dynstrn(req_dict, "gfid", SLEN("gfid"), uuid1_str_dup);
+        ret = dict_set_dynstr_sizen(req_dict, "gfid", uuid1_str_dup);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Failed to set gfid");

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -169,9 +169,7 @@ is_brick_mx_enabled(void)
 
     priv = THIS->private;
 
-    ret = dict_get_strn(priv->opts, GLUSTERD_BRICK_MULTIPLEX_KEY,
-                        SLEN(GLUSTERD_BRICK_MULTIPLEX_KEY), &value);
-
+    ret = dict_get_str(priv->opts, GLUSTERD_BRICK_MULTIPLEX_KEY, &value);
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
@@ -196,9 +194,7 @@ is_brick_graceful_cleanup_enabled(dict_t *opts)
     int ret = 0;
     gf_boolean_t enabled = _gf_false;
 
-    ret = dict_get_strn(opts, GLUSTER_BRICK_GRACEFUL_CLEANUP,
-                        SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), &value);
-
+    ret = dict_get_str(opts, GLUSTER_BRICK_GRACEFUL_CLEANUP, &value);
     if (!ret)
         ret = gf_string2boolean(value, &enabled);
 
@@ -305,8 +301,7 @@ get_mux_limit_per_process(int *mux_limit)
         goto out;
     }
 
-    ret = dict_get_strn(priv->opts, GLUSTERD_BRICKMUX_LIMIT_KEY,
-                        SLEN(GLUSTERD_BRICKMUX_LIMIT_KEY), &value);
+    ret = dict_get_str(priv->opts, GLUSTERD_BRICKMUX_LIMIT_KEY, &value);
     if (ret) {
         value = GLUSTERD_BRICKMUX_LIMIT_DFLT_VALUE;
     }
@@ -341,8 +336,7 @@ get_gd_vol_thread_limit(int *thread_limit)
         goto out;
     }
 
-    ret = dict_get_strn(priv->opts, GLUSTERD_VOL_CNT_PER_THRD,
-                        SLEN(GLUSTERD_VOL_CNT_PER_THRD), &value);
+    ret = dict_get_str(priv->opts, GLUSTERD_VOL_CNT_PER_THRD, &value);
     if (ret) {
         value = GLUSTERD_VOL_CNT_PER_THRD_DEFAULT_VALUE;
     }
@@ -1897,9 +1891,8 @@ retry:
                     "--xlator-option", glusterd_uuid, "--process-name", "brick",
                     NULL);
 
-    if (dict_get_strn(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
-                      SLEN(GLUSTERD_LOCALTIME_LOGGING_KEY),
-                      &localtime_logging) == 0) {
+    if (dict_get_str(priv->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
+                     &localtime_logging) == 0) {
         if (strcmp(localtime_logging, "enable") == 0)
             runner_add_arg(&runner, "--localtime-logging");
     }
@@ -1965,9 +1958,8 @@ retry:
                          volinfo->volname, rdma_port);
     }
 
-    if (dict_get_strn(volinfo->dict, VKEY_CONFIG_GLOBAL_THREADING,
-                      SLEN(VKEY_CONFIG_GLOBAL_THREADING),
-                      &global_threading) == 0) {
+    if (dict_get_str(volinfo->dict, VKEY_CONFIG_GLOBAL_THREADING,
+                     &global_threading) == 0) {
         if ((gf_string2boolean(global_threading, &threading) == 0) &&
             threading) {
             runner_add_arg(&runner, "--global-threading");
@@ -1987,9 +1979,8 @@ retry:
     runner_argprintf(&runner, "%s-server.listen-port=%d", volinfo->volname,
                      port);
 
-    if (dict_get_strn(this->options, "transport.socket.bind-address",
-                      SLEN("transport.socket.bind-address"),
-                      &bind_address) == 0) {
+    if (dict_get_str(this->options, "transport.socket.bind-address",
+                     &bind_address) == 0) {
         runner_add_arg(&runner, "--xlator-option");
         runner_argprintf(&runner, "transport.socket.bind-address=%s",
                          bind_address);
@@ -3447,7 +3438,7 @@ glusterd_add_volumes_to_export_dict(dict_t *peer_data, char **buf,
                "Finished dictionary population in all threads");
     }
 
-    ret = dict_set_int32n(peer_data, "count", SLEN("count"), volcnt);
+    ret = dict_set_int32_sizen(peer_data, "count", volcnt);
     if (ret)
         goto out;
 
@@ -3458,8 +3449,7 @@ glusterd_add_volumes_to_export_dict(dict_t *peer_data, char **buf,
     ctx.val_name = "val";
     dict_foreach(priv->opts, _add_dict_to_prdict, &ctx);
     ctx.opt_count--;
-    ret = dict_set_int32n(peer_data, "global-opt-count",
-                          SLEN("global-opt-count"), ctx.opt_count);
+    ret = dict_set_int32_sizen(peer_data, "global-opt-count", ctx.opt_count);
     if (ret)
         goto out;
 
@@ -4986,7 +4976,7 @@ glusterd_import_friend_volumes_synctask(void *opaque)
         goto out;
 
     peer_data = arg->peer_data;
-    ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
+    ret = dict_get_int32(peer_data, "count", &count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
@@ -5043,7 +5033,7 @@ glusterd_import_friend_volumes(dict_t *peer_data)
 
     GF_ASSERT(peer_data);
 
-    ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
+    ret = dict_get_int32(peer_data, "count", &count);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
@@ -5068,8 +5058,7 @@ glusterd_get_global_server_quorum_ratio(dict_t *opts, double *quorum)
     int ret = -1;
     char *quorum_str = NULL;
 
-    ret = dict_get_strn(opts, GLUSTERD_QUORUM_RATIO_KEY,
-                        SLEN(GLUSTERD_QUORUM_RATIO_KEY), &quorum_str);
+    ret = dict_get_str(opts, GLUSTERD_QUORUM_RATIO_KEY, &quorum_str);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_DEBUG, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_QUORUM_RATIO_KEY, NULL);
@@ -5085,8 +5074,7 @@ glusterd_get_global_opt_version(dict_t *opts, uint32_t *version)
     int ret = -1;
     char *version_str = NULL;
 
-    ret = dict_get_strn(opts, GLUSTERD_GLOBAL_OPT_VERSION,
-                        SLEN(GLUSTERD_GLOBAL_OPT_VERSION), &version_str);
+    ret = dict_get_str(opts, GLUSTERD_GLOBAL_OPT_VERSION, &version_str);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=%s", GLUSTERD_GLOBAL_OPT_VERSION, NULL);
@@ -5130,8 +5118,7 @@ glusterd_import_global_opts(dict_t *friend_data)
 
     conf = this->private;
 
-    ret = dict_get_int32n(friend_data, "global-opt-count",
-                          SLEN("global-opt-count"), &count);
+    ret = dict_get_int32(friend_data, "global-opt-count", &count);
     if (ret) {
         // old version peer
         gf_smsg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
@@ -5210,7 +5197,7 @@ glusterd_compare_friend_data(dict_t *peer_data, dict_t *cmp, int32_t *status,
         goto out;
     }
 
-    ret = dict_get_int32n(peer_data, "count", SLEN("count"), &count);
+    ret = dict_get_int32(peer_data, "count", &count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
@@ -5661,8 +5648,8 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
             ret = -ENOMEM;
             goto err;
         }
-        ret = dict_set_strn(dict, GLUSTER_BRICK_GRACEFUL_CLEANUP,
-                            SLEN(GLUSTER_BRICK_GRACEFUL_CLEANUP), "enable");
+        ret = dict_set_str_sizen(dict, GLUSTER_BRICK_GRACEFUL_CLEANUP,
+                                 "enable");
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                    "Unable to set cluster.brick-graceful-cleanup key");
@@ -8821,7 +8808,7 @@ glusterd_validate_volume_id(dict_t *op_dict, glusterd_volinfo_t *volinfo)
     };
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(op_dict, "vol-id", SLEN("vol-id"), &volid_str);
+    ret = dict_get_str(op_dict, "vol-id", &volid_str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get volume id for "
@@ -8882,8 +8869,7 @@ glusterd_defrag_volume_status_update(glusterd_volinfo_t *volinfo,
     if (ret)
         gf_msg_trace(this->name, 0, "failed to get lookedup file count");
 
-    ret = dict_get_int32n(rsp_dict, "status", SLEN("status"),
-                          (int32_t *)&status);
+    ret = dict_get_int32(rsp_dict, "status", (int32_t *)&status);
     if (ret)
         gf_msg_trace(this->name, 0, "failed to get status");
 
@@ -9076,10 +9062,9 @@ glusterd_volset_help(dict_t *dict, char **op_errstr)
         }
     }
 
-    if (dict_getn(dict, "help", SLEN("help"))) {
+    if (dict_get_sizen(dict, "help")) {
         xml_out = _gf_false;
-
-    } else if (dict_getn(dict, "help-xml", SLEN("help-xml"))) {
+    } else if (dict_get_sizen(dict, "help-xml")) {
         xml_out = _gf_true;
 #if (HAVE_LIB_XML)
         ret = 0;
@@ -9120,7 +9105,7 @@ glusterd_to_cli(rpcsvc_request_t *req, gf_cli_rsp *arg, struct iovec *payload,
     op_ret = arg->op_ret;
     op_errstr = arg->op_errstr;
 
-    ret = dict_get_strn(dict, "cmd-str", SLEN("cmd-str"), &cmd);
+    ret = dict_get_str(dict, "cmd-str", &cmd);
     if (ret)
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get command "
@@ -9157,8 +9142,7 @@ glusterd_aggr_brick_mount_dirs(dict_t *aggr, dict_t *rsp_dict)
     GF_ASSERT(aggr);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
-                          &brick_count);
+    ret = dict_get_int32(rsp_dict, "brick_count", &brick_count);
     if (ret) {
         gf_msg_debug(this->name, 0, "No brick_count present");
         ret = 0;
@@ -9210,14 +9194,12 @@ glusterd_rb_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     }
 
     if (rsp_dict) {
-        ret = dict_get_int32n(rsp_dict, "src-brick-port",
-                              SLEN("src-brick-port"), &src_port);
+        ret = dict_get_int32(rsp_dict, "src-brick-port", &src_port);
         if (ret == 0) {
             gf_msg_debug("glusterd", 0, "src-brick-port=%d found", src_port);
         }
 
-        ret = dict_get_int32n(rsp_dict, "dst-brick-port",
-                              SLEN("dst-brick-port"), &dst_port);
+        ret = dict_get_int32(rsp_dict, "dst-brick-port", &dst_port);
         if (ret == 0) {
             gf_msg_debug("glusterd", 0, "dst-brick-port=%d found", dst_port);
         }
@@ -9232,8 +9214,7 @@ glusterd_rb_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     }
 
     if (src_port) {
-        ret = dict_set_int32n(ctx, "src-brick-port", SLEN("src-brick-port"),
-                              src_port);
+        ret = dict_set_int32_sizen(ctx, "src-brick-port", src_port);
         if (ret) {
             gf_msg_debug("glusterd", 0, "Could not set src-brick");
             goto out;
@@ -9241,8 +9222,7 @@ glusterd_rb_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     }
 
     if (dst_port) {
-        ret = dict_set_int32n(ctx, "dst-brick-port", SLEN("dst-brick-port"),
-                              dst_port);
+        ret = dict_set_int32_sizen(ctx, "dst-brick-port", dst_port);
         if (ret) {
             gf_msg_debug("glusterd", 0, "Could not set dst-brick");
             goto out;
@@ -9304,7 +9284,7 @@ glusterd_profile_volume_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
 
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &brick_count);
+    ret = dict_get_int32(rsp_dict, "count", &brick_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=count", NULL);
@@ -9321,12 +9301,11 @@ glusterd_profile_volume_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(ctx_dict, "count", SLEN("count"), &count);
+    ret = dict_get_int32(ctx_dict, "count", &count);
     rsp_ctx.count = count;
     rsp_ctx.dict = ctx_dict;
     dict_foreach(rsp_dict, _profile_volume_add_friend_rsp, &rsp_ctx);
-    ret = dict_set_int32n(ctx_dict, "count", SLEN("count"),
-                          count + brick_count);
+    ret = dict_set_int32_sizen(ctx_dict, "count", count + brick_count);
 out:
     return ret;
 }
@@ -9420,7 +9399,7 @@ glusterd_volume_status_aggregate_tasks_status(dict_t *ctx_dict,
     GF_ASSERT(ctx_dict);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_int32n(rsp_dict, "tasks", SLEN("tasks"), &remote_count);
+    ret = dict_get_int32(rsp_dict, "tasks", &remote_count);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get remote task count");
@@ -9429,7 +9408,7 @@ glusterd_volume_status_aggregate_tasks_status(dict_t *ctx_dict,
     /* Local count will not be present when this is called for the first
      * time with the origins rsp_dict
      */
-    ret = dict_get_int32n(ctx_dict, "tasks", SLEN("tasks"), &local_count);
+    ret = dict_get_int32(ctx_dict, "tasks", &local_count);
     if (ret) {
         ret = dict_foreach(
             rsp_dict, glusterd_volume_status_copy_tasks_to_ctx_dict, ctx_dict);
@@ -9591,7 +9570,7 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
         ctx_dict = glusterd_op_get_ctx();
     }
 
-    ret = dict_get_int32n(ctx_dict, "cmd", SLEN("cmd"), &cmd);
+    ret = dict_get_int32(ctx_dict, "cmd", &cmd);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "Key=cmd",
                 NULL);
@@ -9599,11 +9578,9 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
     }
 
     if (cmd & GF_CLI_STATUS_ALL && is_origin_glusterd(ctx_dict)) {
-        ret = dict_get_int32n(rsp_dict, "vol_count", SLEN("vol_count"),
-                              &vol_count);
+        ret = dict_get_int32(rsp_dict, "vol_count", &vol_count);
         if (ret == 0) {
-            ret = dict_set_int32n(ctx_dict, "vol_count", SLEN("vol_count"),
-                                  vol_count);
+            ret = dict_set_int32_sizen(ctx_dict, "vol_count", vol_count);
             if (ret) {
                 gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                         "Key=vol_count", NULL);
@@ -9636,7 +9613,7 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
     if ((cmd & GF_CLI_STATUS_TASKS) != 0)
         goto aggregate_tasks;
 
-    ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &rsp_node_count);
+    ret = dict_get_int32(rsp_dict, "count", &rsp_node_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED, "Key=count",
                 NULL);
@@ -9644,27 +9621,24 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(rsp_dict, "other-count", SLEN("other-count"),
-                          &rsp_other_count);
+    ret = dict_get_int32(rsp_dict, "other-count", &rsp_other_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=other-count", NULL);
         goto out;
     }
 
-    ret = dict_get_int32n(ctx_dict, "count", SLEN("count"), &node_count);
-    ret = dict_get_int32n(ctx_dict, "other-count", SLEN("other-count"),
-                          &other_count);
-    if (!dict_getn(ctx_dict, "brick-index-max", SLEN("brick-index-max"))) {
-        ret = dict_get_int32n(rsp_dict, "brick-index-max",
-                              SLEN("brick-index-max"), &brick_index_max);
+    ret = dict_get_int32(ctx_dict, "count", &node_count);
+    ret = dict_get_int32(ctx_dict, "other-count", &other_count);
+    if (!dict_get_sizen(ctx_dict, "brick-index-max")) {
+        ret = dict_get_int32(rsp_dict, "brick-index-max", &brick_index_max);
         if (ret) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                     "Key=brick-index-max", NULL);
             goto out;
         }
-        ret = dict_set_int32n(ctx_dict, "brick-index-max",
-                              SLEN("brick-index-max"), brick_index_max);
+        ret = dict_set_int32_sizen(ctx_dict, "brick-index-max",
+                                   brick_index_max);
         if (ret) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                     "Key=brick-index-max", NULL);
@@ -9672,8 +9646,7 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
         }
 
     } else {
-        ret = dict_get_int32n(ctx_dict, "brick-index-max",
-                              SLEN("brick-index-max"), &brick_index_max);
+        ret = dict_get_int32(ctx_dict, "brick-index-max", &brick_index_max);
         if (ret) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                     "Key=brick-index-max", NULL);
@@ -9688,23 +9661,22 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
 
     dict_foreach(rsp_dict, glusterd_volume_status_add_peer_rsp, &rsp_ctx);
 
-    ret = dict_set_int32n(ctx_dict, "count", SLEN("count"),
-                          node_count + rsp_node_count);
+    ret = dict_set_int32_sizen(ctx_dict, "count", node_count + rsp_node_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
 
-    ret = dict_set_int32n(ctx_dict, "other-count", SLEN("other-count"),
-                          (other_count + rsp_other_count));
+    ret = dict_set_int32_sizen(ctx_dict, "other-count",
+                               other_count + rsp_other_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=other-count", NULL);
         goto out;
     }
 
-    ret = dict_get_strn(ctx_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(ctx_dict, "volname", &volname);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                 "Key=volname", NULL);
@@ -9718,15 +9690,14 @@ glusterd_volume_status_copy_to_op_ctx_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_set_int32n(ctx_dict, "hot_brick_count", SLEN("hot_brick_count"),
-                          hot_brick_count);
+    ret = dict_set_int32_sizen(ctx_dict, "hot_brick_count", hot_brick_count);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=hot_brick_count", NULL);
         goto out;
     }
 
-    ret = dict_set_int32n(ctx_dict, "type", SLEN("type"), type);
+    ret = dict_set_int32_sizen(ctx_dict, "type", type);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=type", NULL);
@@ -9770,23 +9741,23 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_set_strn(aggr, "bitrot_log_file", SLEN("bitrot_log_file"),
-                        priv->bitd_svc.proc.logfile);
+    ret = dict_set_str_sizen(aggr, "bitrot_log_file",
+                             priv->bitd_svc.proc.logfile);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set bitrot log file location");
         goto out;
     }
 
-    ret = dict_set_strn(aggr, "scrub_log_file", SLEN("scrub_log_file"),
-                        priv->scrub_svc.proc.logfile);
+    ret = dict_set_str_sizen(aggr, "scrub_log_file",
+                             priv->scrub_svc.proc.logfile);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set scrubber log file location");
         goto out;
     }
 
-    ret = dict_get_strn(aggr, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(aggr, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -9800,10 +9771,10 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_int32n(aggr, "count", SLEN("count"), &i);
+    ret = dict_get_int32(aggr, "count", &i);
     i++;
 
-    ret = dict_set_int32n(aggr, "count", SLEN("count"), i);
+    ret = dict_set_int32_sizen(aggr, "count", i);
     if (ret)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count");
@@ -9816,11 +9787,9 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "failed to set node-uuid");
 
-    ret = dict_get_strn(volinfo->dict, "features.scrub-freq",
-                        SLEN("features.scrub-freq"), &scrub_freq);
+    ret = dict_get_str(volinfo->dict, "features.scrub-freq", &scrub_freq);
     if (!ret) {
-        ret = dict_set_strn(aggr, "features.scrub-freq",
-                            SLEN("features.scrub-freq"), scrub_freq);
+        ret = dict_set_str_sizen(aggr, "features.scrub-freq", scrub_freq);
         if (ret) {
             gf_msg_debug(this->name, 0,
                          "Failed to set "
@@ -9842,11 +9811,9 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(volinfo->dict, "features.scrub-throttle",
-                        SLEN("features.scrub-throttle"), &scrub_impact);
+    ret = dict_get_str(volinfo->dict, "features.scrub-throttle", &scrub_impact);
     if (!ret) {
-        ret = dict_set_strn(aggr, "features.scrub-throttle",
-                            SLEN("features.scrub-throttle"), scrub_impact);
+        ret = dict_set_str_sizen(aggr, "features.scrub-throttle", scrub_impact);
         if (ret) {
             gf_msg_debug(this->name, 0,
                          "Failed to set "
@@ -9868,11 +9835,9 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(volinfo->dict, "features.scrub", SLEN("features.scrub"),
-                        &scrub_state);
+    ret = dict_get_str(volinfo->dict, "features.scrub", &scrub_state);
     if (!ret) {
-        ret = dict_set_strn(aggr, "features.scrub", SLEN("features.scrub"),
-                            scrub_state);
+        ret = dict_set_str_sizen(aggr, "features.scrub", scrub_state);
         if (ret) {
             gf_msg_debug(this->name, 0,
                          "Failed to set "
@@ -9913,8 +9878,7 @@ glusterd_bitrot_volume_node_rsp(dict_t *aggr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_get_strn(rsp_dict, "last-scrub-time", SLEN("last-scrub-time"),
-                        &last_scrub_time);
+    ret = dict_get_str(rsp_dict, "last-scrub-time", &last_scrub_time);
     if (!ret) {
         keylen = snprintf(key, sizeof(key), "last-scrub-time-%d", i);
 
@@ -10005,7 +9969,7 @@ glusterd_volume_rebalance_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         goto out;
     }
 
-    ret = dict_get_strn(ctx_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(ctx_dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -10017,7 +9981,7 @@ glusterd_volume_rebalance_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
     if (ret)
         goto out;
 
-    ret = dict_get_int32n(rsp_dict, "count", SLEN("count"), &index);
+    ret = dict_get_int32(rsp_dict, "count", &index);
     if (ret)
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "failed to get index from rsp dict");
@@ -10040,10 +10004,9 @@ glusterd_volume_rebalance_use_rsp_dict(dict_t *aggr, dict_t *rsp_dict)
         RCU_READ_UNLOCK;
 
         /* Setting the largest index value as the total count. */
-        ret = dict_get_int32n(ctx_dict, "count", SLEN("count"), &count);
+        ret = dict_get_int32(ctx_dict, "count", &count);
         if (count < current_index) {
-            ret = dict_set_int32n(ctx_dict, "count", SLEN("count"),
-                                  current_index);
+            ret = dict_set_int32_sizen(ctx_dict, "count", current_index);
             if (ret)
                 gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set count");
@@ -10330,14 +10293,14 @@ glusterd_heal_volume_brick_rsp(dict_t *req_dict, dict_t *rsp_dict,
     GF_ASSERT(op_ctx);
     GF_ASSERT(op_errstr);
 
-    ret = dict_get_strn(req_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(req_dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
         goto out;
     }
 
-    ret = dict_get_int32n(req_dict, "heal-op", SLEN("heal-op"), &heal_op);
+    ret = dict_get_int32(req_dict, "heal-op", &heal_op);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get heal_op");
@@ -10392,24 +10355,24 @@ glusterd_status_volume_brick_rsp(dict_t *rsp_dict, dict_t *op_ctx,
     GF_ASSERT(op_ctx);
     GF_ASSERT(op_errstr);
 
-    ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &count);
+    ret = dict_get_int32(op_ctx, "count", &count);
     if (ret) {
         count = 0;
     } else {
         count++;
     }
-    ret = dict_get_int32n(rsp_dict, "index", SLEN("index"), &index);
+    ret = dict_get_int32(rsp_dict, "index", &index);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Couldn't get node index");
         goto out;
     }
-    dict_deln(rsp_dict, "index", SLEN("index"));
+    dict_del_sizen(rsp_dict, "index");
 
     rsp_ctx.count = index;
     rsp_ctx.dict = op_ctx;
     dict_foreach(rsp_dict, _status_volume_add_brick_rsp, &rsp_ctx);
-    ret = dict_set_int32n(op_ctx, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(op_ctx, "count", count);
 
 out:
     return ret;
@@ -10436,14 +10399,12 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
     GF_ASSERT(op_ctx);
     GF_ASSERT(op_errstr);
 
-    ret = dict_get_int32n(rsp_dict, "clientcount", SLEN("clientcount"),
-                          &client_count);
+    ret = dict_get_int32(rsp_dict, "clientcount", &client_count);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                "Couldn't get node index");
     }
-    ret = dict_set_int32n(op_ctx, "client-count", SLEN("client-count"),
-                          client_count);
+    ret = dict_set_int32_sizen(op_ctx, "client-count", client_count);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Couldn't get node index");
@@ -10464,8 +10425,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
                    "Couldn't set client name");
         }
         if (!strncmp(process, "fuse", 4)) {
-            ret = dict_get_int32n(op_ctx, "fuse-count", SLEN("fuse-count"),
-                                  &count);
+            ret = dict_get_int32(op_ctx, "fuse-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get fuse-count");
@@ -10473,8 +10433,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
             fuse_count++;
             continue;
         } else if (!strncmp(process, "gfapi", 5)) {
-            ret = dict_get_int32n(op_ctx, "gfapi-count", SLEN("gfapi-count"),
-                                  &count);
+            ret = dict_get_int32(op_ctx, "gfapi-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get gfapi-count");
@@ -10483,8 +10442,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
             continue;
 
         } else if (!strcmp(process, "rebalance")) {
-            ret = dict_get_int32n(op_ctx, "rebalance-count",
-                                  SLEN("rebalance-count"), &count);
+            ret = dict_get_int32(op_ctx, "rebalance-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get rebalance-count");
@@ -10492,8 +10450,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
             rebalance_count++;
             continue;
         } else if (!strcmp(process, "glustershd")) {
-            ret = dict_get_int32n(op_ctx, "glustershd-count",
-                                  SLEN("glustershd-count"), &count);
+            ret = dict_get_int32(op_ctx, "glustershd-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get glustershd-count");
@@ -10501,8 +10458,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
             glustershd_count++;
             continue;
         } else if (!strcmp(process, "quotad")) {
-            ret = dict_get_int32n(op_ctx, "quotad-count", SLEN("quotad-count"),
-                                  &count);
+            ret = dict_get_int32(op_ctx, "quotad-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get quotad-count");
@@ -10510,8 +10466,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
             quotad_count++;
             continue;
         } else if (!strcmp(process, "snapd")) {
-            ret = dict_get_int32n(op_ctx, "snapd-count", SLEN("snapd-count"),
-                                  &count);
+            ret = dict_get_int32(op_ctx, "snapd-count", &count);
             if (ret) {
                 gf_msg(THIS->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                        "Couldn't get snapd-count");
@@ -10521,8 +10476,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
     }
 
     if (fuse_count) {
-        ret = dict_set_int32n(op_ctx, "fuse-count", SLEN("fuse-count"),
-                              fuse_count);
+        ret = dict_set_int32_sizen(op_ctx, "fuse-count", fuse_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set fuse-count");
@@ -10530,8 +10484,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
         }
     }
     if (gfapi_count) {
-        ret = dict_set_int32n(op_ctx, "gfapi-count", SLEN("gfapi-count"),
-                              gfapi_count);
+        ret = dict_set_int32_sizen(op_ctx, "gfapi-count", gfapi_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set gfapi-count");
@@ -10539,8 +10492,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
         }
     }
     if (rebalance_count) {
-        ret = dict_set_int32n(op_ctx, "rebalance-count",
-                              SLEN("rebalance-count"), rebalance_count);
+        ret = dict_set_int32_sizen(op_ctx, "rebalance-count", rebalance_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set rebalance-count");
@@ -10548,8 +10500,8 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
         }
     }
     if (glustershd_count) {
-        ret = dict_set_int32n(op_ctx, "glustershd-count",
-                              SLEN("glustershd-count"), glustershd_count);
+        ret = dict_set_int32_sizen(op_ctx, "glustershd-count",
+                                   glustershd_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set glustershd-count");
@@ -10557,8 +10509,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
         }
     }
     if (quotad_count) {
-        ret = dict_set_int32n(op_ctx, "quotad-count", SLEN("quotad-count"),
-                              quotad_count);
+        ret = dict_set_int32_sizen(op_ctx, "quotad-count", quotad_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set quotad-count");
@@ -10566,8 +10517,7 @@ glusterd_status_volume_client_list(dict_t *rsp_dict, dict_t *op_ctx,
         }
     }
     if (snapd_count) {
-        ret = dict_set_int32n(op_ctx, "snapd-count", SLEN("snapd-count"),
-                              snapd_count);
+        ret = dict_set_int32_sizen(op_ctx, "snapd-count", snapd_count);
         if (ret) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set snapd-count");
@@ -10648,7 +10598,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
 
     GF_ASSERT(req_dict);
 
-    ret = dict_get_strn(req_dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(req_dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -10657,8 +10607,7 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
 
     ret = glusterd_volinfo_find(volname, &volinfo);
 
-    ret = dict_get_int32n(req_dict, "rebalance-command",
-                          SLEN("rebalance-command"), &cmd);
+    ret = dict_get_int32(req_dict, "rebalance-command", &cmd);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                "Unable to get the cmd");
@@ -10674,10 +10623,10 @@ glusterd_defrag_volume_node_rsp(dict_t *req_dict, dict_t *rsp_dict,
         goto out;
     }
 
-    ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &i);
+    ret = dict_get_int32(op_ctx, "count", &i);
     i++;
 
-    ret = dict_set_int32n(op_ctx, "count", SLEN("count"), i);
+    ret = dict_set_int32_sizen(op_ctx, "count", i);
     if (ret)
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count");
@@ -10722,7 +10671,7 @@ glusterd_profile_volume_brick_rsp(void *pending_entry, dict_t *rsp_dict,
     GF_ASSERT(op_errstr);
     GF_ASSERT(pending_entry);
 
-    ret = dict_get_int32n(op_ctx, "count", SLEN("count"), &count);
+    ret = dict_get_int32(op_ctx, "count", &count);
     if (ret) {
         count = 1;
     } else {
@@ -10743,7 +10692,7 @@ glusterd_profile_volume_brick_rsp(void *pending_entry, dict_t *rsp_dict,
     rsp_ctx.count = count;
     rsp_ctx.dict = op_ctx;
     dict_foreach(rsp_dict, _profile_volume_add_brick_rsp, &rsp_ctx);
-    ret = dict_set_int32n(op_ctx, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(op_ctx, "count", count);
     return ret;
 }
 
@@ -10763,7 +10712,7 @@ glusterd_handle_node_rsp(dict_t *req_dict, void *pending_entry,
                                                     op_ctx, op_errstr, type);
             break;
         case GD_OP_STATUS_VOLUME:
-            ret = dict_get_int32n(req_dict, "cmd", SLEN("cmd"), &cmd);
+            ret = dict_get_int32(req_dict, "cmd", &cmd);
             if (!ret && (cmd & GF_CLI_STATUS_CLIENT_LIST)) {
                 ret = glusterd_status_volume_client_list(rsp_dict, op_ctx,
                                                          op_errstr);
@@ -11041,8 +10990,7 @@ gd_should_i_start_rebalance(glusterd_volinfo_t *volinfo)
             }
             break;
         case GD_OP_REMOVE_BRICK:
-            ret = dict_get_int32n(volinfo->rebal.dict, "count", SLEN("count"),
-                                  &count);
+            ret = dict_get_int32(volinfo->rebal.dict, "count", &count);
             if (ret) {
                 goto out;
             }
@@ -11479,7 +11427,7 @@ glusterd_get_global_max_op_version(rpcsvc_request_t *req, dict_t *ctx,
 
     ret = glusterd_mgmt_v3_initiate_all_phases(req, GD_OP_MAX_OPVERSION, ctx);
 
-    ret = dict_get_strn(ctx, "max-opversion", SLEN("max-opversion"), &def_val);
+    ret = dict_get_str(ctx, "max-opversion", &def_val);
     if (ret) {
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get max-opversion value from"
@@ -11536,7 +11484,7 @@ glusterd_get_global_options_for_all_vols(rpcsvc_request_t *req, dict_t *ctx,
 
     GF_VALIDATE_OR_GOTO(this->name, ctx, out);
 
-    ret = dict_get_strn(ctx, "key", SLEN("key"), &key);
+    ret = dict_get_str(ctx, "key", &key);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get option key from dictionary");
@@ -11626,7 +11574,7 @@ glusterd_get_global_options_for_all_vols(rpcsvc_request_t *req, dict_t *ctx,
             break;
     }
 
-    ret = dict_set_int32n(ctx, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(ctx, "count", count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count in dictionary");
@@ -11761,7 +11709,7 @@ glusterd_get_default_val_for_volopt(dict_t *ctx, gf_boolean_t all_opts,
     if (!all_opts && !key_found)
         goto out;
 
-    ret = dict_set_int32n(ctx, "count", SLEN("count"), count);
+    ret = dict_set_int32_sizen(ctx, "count", count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set count "
@@ -11933,7 +11881,7 @@ glusterd_get_volopt_content(dict_t *ctx, gf_boolean_t xml_out)
 #endif
     }
 
-    ret = dict_set_dynstrn(ctx, "help-str", SLEN("help-str"), output);
+    ret = dict_set_dynstr_sizen(ctx, "help-str", output);
     if (ret >= 0) {
         output = NULL;
     }
@@ -12063,9 +12011,8 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
 
     switch (op) {
         case GD_OP_REPLACE_BRICK:
-            if (dict_get_strn(this->options, "transport.socket.bind-address",
-                              SLEN("transport.socket.bind-address"),
-                              &volfileserver) != 0)
+            if (dict_get_str(this->options, "transport.socket.bind-address",
+                             &volfileserver) != 0)
                 volfileserver = "localhost";
 
             snprintf(logfile, sizeof(logfile), "%s/%s-replace-brick-mount.log",
@@ -12193,8 +12140,7 @@ rb_update_dstbrick_port(glusterd_brickinfo_t *dst_brickinfo, dict_t *rsp_dict,
     int dict_ret = 0;
     int dst_port = 0;
 
-    dict_ret = dict_get_int32n(req_dict, "dst-brick-port",
-                               SLEN("dst-brick-port"), &dst_port);
+    dict_ret = dict_get_int32(req_dict, "dst-brick-port", &dst_port);
     if (!dict_ret)
         dst_brickinfo->port = dst_port;
 
@@ -12203,8 +12149,8 @@ rb_update_dstbrick_port(glusterd_brickinfo_t *dst_brickinfo, dict_t *rsp_dict,
                "adding dst-brick port no %d", dst_port);
 
         if (rsp_dict) {
-            ret = dict_set_int32n(rsp_dict, "dst-brick-port",
-                                  SLEN("dst-brick-port"), dst_brickinfo->port);
+            ret = dict_set_int32_sizen(rsp_dict, "dst-brick-port",
+                                       dst_brickinfo->port);
             if (ret) {
                 gf_msg_debug("glusterd", 0,
                              "Could not set dst-brick port no in rsp dict");
@@ -12213,8 +12159,8 @@ rb_update_dstbrick_port(glusterd_brickinfo_t *dst_brickinfo, dict_t *rsp_dict,
         }
 
         if (req_dict && !dict_ret) {
-            ret = dict_set_int32n(req_dict, "dst-brick-port",
-                                  SLEN("dst-brick-port"), dst_brickinfo->port);
+            ret = dict_set_int32_sizen(req_dict, "dst-brick-port",
+                                       dst_brickinfo->port);
             if (ret) {
                 gf_msg_debug("glusterd", 0, "Could not set dst-brick port no");
                 goto out;
@@ -12246,7 +12192,7 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = dict_get_strn(dict, "operation", SLEN("operation"), op);
+    ret = dict_get_str(dict, "operation", op);
     if (ret) {
         gf_msg_debug(this->name, 0, "dict get on operation type failed");
         goto out;
@@ -12256,7 +12202,7 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
     if (*gd_op < 0)
         goto out;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), volname);
+    ret = dict_get_str(dict, "volname", volname);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -12316,8 +12262,7 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
         }
     }
 
-    ret = dict_get_strn(dict, "src-brick", SLEN("src-brick"), src_brick);
-
+    ret = dict_get_str(dict, "src-brick", src_brick);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get src brick");
@@ -12342,9 +12287,8 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
     if (glusterd_gf_is_local_addr((*src_brickinfo)->hostname)) {
         gf_msg_debug(this->name, 0, "I AM THE SOURCE HOST");
         if ((*src_brickinfo)->port && rsp_dict) {
-            ret = dict_set_int32n(rsp_dict, "src-brick-port",
-                                  SLEN("src-brick-port"),
-                                  (*src_brickinfo)->port);
+            ret = dict_set_int32_sizen(rsp_dict, "src-brick-port",
+                                       (*src_brickinfo)->port);
             if (ret) {
                 gf_msg_debug(this->name, 0, "Could not set src-brick-port=%d",
                              (*src_brickinfo)->port);
@@ -12372,7 +12316,7 @@ glusterd_get_dst_brick_info(char **dst_brick, char *volname, char **op_errstr,
     xlator_t *this = THIS;
     int ret = 0;
 
-    ret = dict_get_strn(dict, "dst-brick", SLEN("dst-brick"), dst_brick);
+    ret = dict_get_str(dict, "dst-brick", dst_brick);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -12622,7 +12566,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     CDS_INIT_LIST_HEAD(&pre_list->list);
 
     if (!(*volname)) {
-        ret = dict_get_strn(dict, "volname", SLEN("volname"), &(*volname));
+        ret = dict_get_str(dict, "volname", &(*volname));
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to get volume name");
@@ -12667,7 +12611,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     }
 
     if (!(*brick_list)) {
-        ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &(*brick_list));
+        ret = dict_get_str(dict, "bricks", &(*brick_list));
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Bricks check : Could not "
@@ -12677,7 +12621,7 @@ glusterd_check_brick_order(dict_t *dict, char *err_str, int32_t type,
     }
 
     if (!(*brick_count)) {
-        ret = dict_get_int32n(dict, "count", SLEN("count"), &(*brick_count));
+        ret = dict_get_int32(dict, "count", &(*brick_count));
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Bricks check : Could not "
@@ -12873,7 +12817,7 @@ glusterd_add_peers_to_auth_list(char *volname)
         goto out;
     }
 
-    ret = dict_get_str_sizen(volinfo->dict, "auth.allow", &auth_allow_list);
+    ret = dict_get_str(volinfo->dict, "auth.allow", &auth_allow_list);
     if (ret) {
         gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "auth allow list is not set");
@@ -12957,8 +12901,7 @@ glusterd_replace_old_auth_allow_list(char *volname)
         goto out;
     }
 
-    ret = dict_get_str_sizen(volinfo->dict, "old.auth.allow",
-                             &old_auth_allow_list);
+    ret = dict_get_str(volinfo->dict, "old.auth.allow", &old_auth_allow_list);
     if (ret) {
         gf_msg(this->name, GF_LOG_INFO, -ret, GD_MSG_DICT_GET_FAILED,
                "old auth allow list is not set, no need to replace the list");

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -52,7 +52,7 @@ struct check_and_add_user_xlator_t {
     do {                                                                       \
         char *_value = NULL;                                                   \
                                                                                \
-        if (dict_get_str_sizen(set_dict, CLI_OPT, &_value) == 0) {             \
+        if (dict_get_str(set_dict, CLI_OPT, &_value) == 0) {                   \
             if (xlator_set_fixed_option(XL, "transport.socket." XLATOR_OPT,    \
                                         _value) != 0) {                        \
                 gf_msg("glusterd", GF_LOG_WARNING, errno,                      \
@@ -1164,12 +1164,12 @@ get_transport_type(glusterd_volinfo_t *volinfo, dict_t *set_dict, char *transt,
     char *tt = NULL;
 
     if (is_nfs == _gf_false) {
-        ret = dict_get_str_sizen(set_dict, "client-transport-type", &tt);
+        ret = dict_get_str(set_dict, "client-transport-type", &tt);
         if (ret)
             get_vol_transport_type(volinfo, transt);
     } else {
 #ifdef BUILD_GNFS
-        ret = dict_get_str_sizen(set_dict, "nfs.transport-type", &tt);
+        ret = dict_get_str(set_dict, "nfs.transport-type", &tt);
         if (ret)
             get_vol_nfs_transport_type(volinfo, transt);
 #endif
@@ -1485,14 +1485,14 @@ volgen_graph_set_xl_options(volgen_graph_t *graph, dict_t *dict)
     char *loglevel = NULL;
     xlator_t *trav = NULL;
 
-    ret = dict_get_str_sizen(dict, "xlator", &xlator);
+    ret = dict_get_str(dict, "xlator", &xlator);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=xlator", NULL);
         goto out;
     }
 
-    ret = dict_get_str_sizen(dict, "loglevel", &loglevel);
+    ret = dict_get_str(dict, "loglevel", &loglevel);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=loglevel", NULL);
@@ -2459,8 +2459,8 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     RPC_SET_OPT(xl, SSL_DH_PARAM_OPT, "ssl-dh-param", return -1);
     RPC_SET_OPT(xl, SSL_EC_CURVE_OPT, "ssl-ec-curve", return -1);
 
-    if (dict_get_str_sizen(volinfo->dict, "transport.address-family",
-                           &address_family_data) == 0) {
+    if (dict_get_str(volinfo->dict, "transport.address-family",
+                     &address_family_data) == 0) {
         ret = xlator_set_fixed_option(xl, "transport.address-family",
                                       address_family_data);
         if (ret) {
@@ -2505,7 +2505,7 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
             return -1;
     }
 
-    if (dict_get_str_sizen(volinfo->dict, "auth.ssl-allow", &ssl_user) == 0) {
+    if (dict_get_str(volinfo->dict, "auth.ssl-allow", &ssl_user) == 0) {
         len = snprintf(key, sizeof(key), "auth.login.%s.ssl-allow",
                        brickinfo->path);
         if ((len < 0) || (len >= sizeof(key))) {
@@ -2822,11 +2822,11 @@ server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         i--;
     }
 
-    ret = dict_get_str_sizen(set_dict, "xlator", &xlator);
+    ret = dict_get_str(set_dict, "xlator", &xlator);
 
     /* got a cli log level request */
     if (!ret) {
-        ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
+        ret = dict_get_str(set_dict, "loglevel", &loglevel);
         if (ret) {
             gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
@@ -3207,8 +3207,8 @@ volgen_graph_build_client(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (ret)
         goto err;
 
-    if (dict_get_str_sizen(volinfo->dict, "transport.address-family",
-                           &address_family_data) == 0) {
+    if (dict_get_str(volinfo->dict, "transport.address-family",
+                     &address_family_data) == 0) {
         ret = xlator_set_fixed_option(xl, "transport.address-family",
                                       address_family_data);
         if (ret) {
@@ -3238,7 +3238,7 @@ volgen_graph_build_client(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         }
     }
 
-    if (dict_get_str_sizen(set_dict, "client.ssl", &ssl_str) == 0) {
+    if (dict_get_str(set_dict, "client.ssl", &ssl_str) == 0) {
         if (gf_string2boolean(ssl_str, &ssl_bool) == 0) {
             if (ssl_bool) {
                 ret = xlator_set_fixed_option(
@@ -4047,7 +4047,7 @@ client_graph_set_rda_options(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
      * glusterd_volinfo_get, so that we consider key value of the in
      * progress volume set option.
      */
-    ret = dict_get_str_sizen(set_dict, VKEY_RDA_CACHE_LIMIT, &rda_cache_s);
+    ret = dict_get_str(set_dict, VKEY_RDA_CACHE_LIMIT, &rda_cache_s);
     if (ret < 0) {
         ret = glusterd_volinfo_get(volinfo, VKEY_RDA_CACHE_LIMIT, &rda_cache_s);
         if (ret < 0)
@@ -4060,7 +4060,7 @@ client_graph_set_rda_options(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         goto out;
     }
 
-    ret = dict_get_str_sizen(set_dict, VKEY_RDA_REQUEST_SIZE, &rda_req_s);
+    ret = dict_get_str(set_dict, VKEY_RDA_REQUEST_SIZE, &rda_req_s);
     if (ret < 0) {
         ret = glusterd_volinfo_get(volinfo, VKEY_RDA_REQUEST_SIZE, &rda_req_s);
         if (ret < 0)
@@ -4370,9 +4370,9 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* Do not allow changing read-after-open option if root-squash is
        enabled.
     */
-    ret = dict_get_str_sizen(set_dict, "performance.read-after-open", &tmp);
+    ret = dict_get_str(set_dict, "performance.read-after-open", &tmp);
     if (!ret) {
-        ret = dict_get_str_sizen(volinfo->dict, "server.root-squash", &tmp);
+        ret = dict_get_str(volinfo->dict, "server.root-squash", &tmp);
         if (!ret) {
             ob = _gf_false;
             ret = gf_string2boolean(tmp, &ob);
@@ -4395,15 +4395,15 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
        root-squash is enabled, open-behind's option to read after
        open is done is also enabled.
     */
-    ret = dict_get_str_sizen(set_dict, "server.root-squash", &tmp);
+    ret = dict_get_str(set_dict, "server.root-squash", &tmp);
     if (!ret) {
         ret = gf_string2boolean(tmp, &var);
         if (ret)
             goto out;
 
         if (var) {
-            ret = dict_get_str_sizen(volinfo->dict,
-                                     "performance.read-after-open", &tmp);
+            ret = dict_get_str(volinfo->dict, "performance.read-after-open",
+                               &tmp);
             if (!ret) {
                 ret = gf_string2boolean(tmp, &ob);
                 /* go ahead with turning read-after-open on
@@ -4425,8 +4425,8 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
                option was not set before turning on root-squash.
             */
             ob = _gf_false;
-            ret = dict_get_str_sizen(volinfo->dict,
-                                     "performance.read-after-open", &tmp);
+            ret = dict_get_str(volinfo->dict, "performance.read-after-open",
+                               &tmp);
             if (!ret) {
                 ret = gf_string2boolean(tmp, &ob);
 
@@ -5610,7 +5610,7 @@ glusterd_generate_client_per_brick_volfile(glusterd_volinfo_t *volinfo)
         goto free_dict;
     }
 
-    if (dict_get_str_sizen(volinfo->dict, "client.ssl", &ssl_str) == 0) {
+    if (dict_get_str(volinfo->dict, "client.ssl", &ssl_str) == 0) {
         if (gf_string2boolean(ssl_str, &ssl_bool) == 0) {
             if (ssl_bool) {
                 if (dict_set_dynstr_with_alloc(dict, "client.ssl", "on") != 0) {
@@ -5875,9 +5875,9 @@ glusterd_snapdsvc_generate_volfile(volgen_graph_t *graph,
     if (!set_dict)
         return -1;
 
-    ret = dict_get_str_sizen(set_dict, "xlator", &xlator);
+    ret = dict_get_str(set_dict, "xlator", &xlator);
     if (!ret) {
-        ret = dict_get_str_sizen(set_dict, "loglevel", &loglevel);
+        ret = dict_get_str(set_dict, "loglevel", &loglevel);
         if (ret) {
             gf_msg("glusterd", GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                    "could not get both"
@@ -5912,7 +5912,7 @@ glusterd_snapdsvc_generate_volfile(volgen_graph_t *graph,
     if (ret)
         return -1;
 
-    if (dict_get_str_sizen(set_dict, "server.ssl", &ssl_str) == 0) {
+    if (dict_get_str(set_dict, "server.ssl", &ssl_str) == 0) {
         if (gf_string2boolean(ssl_str, &ssl_bool) == 0) {
             if (ssl_bool) {
                 ret = xlator_set_fixed_option(
@@ -6467,7 +6467,7 @@ validate_nfsopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
     graph.errstr = op_errstr;
 
     get_vol_transport_type(volinfo, transport_type);
-    ret = dict_get_str_sizen(val_dict, "nfs.transport-type", &tt);
+    ret = dict_get_str(val_dict, "nfs.transport-type", &tt);
     if (!ret) {
         if (volinfo->transport_type != GF_TRANSPORT_BOTH_TCP_RDMA) {
             snprintf(err_str, sizeof(err_str),

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -111,8 +111,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
-
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get volume "
@@ -131,7 +130,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
+    ret = dict_get_int32(dict, "count", &brick_count);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get brick count"
@@ -142,7 +141,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+    ret = dict_get_int32(dict, "type", &type);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get type of "
@@ -153,7 +152,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "transport", SLEN("transport"), &trans_type);
+    ret = dict_get_str(dict, "transport", &trans_type);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get "
@@ -164,8 +163,8 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(this->options, "transport.address-family",
-                        SLEN("transport.address-family"), &address_family_str);
+    ret = dict_get_str(this->options, "transport.address-family",
+                       &address_family_str);
 
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(dict, "transport.address-family",
@@ -192,7 +191,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
             }
         }
     }
-    ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+    ret = dict_get_str(dict, "bricks", &bricks);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get bricks for "
@@ -203,8 +202,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "thin-arbiter-count",
-                          SLEN("thin-arbiter-count"), &thin_arbiter_count);
+    ret = dict_get_int32(dict, "thin-arbiter-count", &thin_arbiter_count);
     if (thin_arbiter_count && conf->op_version < GD_OP_VERSION_7_0) {
         snprintf(err_str, sizeof(err_str),
                  "Cannot execute command. "
@@ -218,7 +216,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    if (!dict_getn(dict, "force", SLEN("force"))) {
+    if (!dict_get_sizen(dict, "force")) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get 'force' flag");
         goto out;
@@ -226,7 +224,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
 
     gf_uuid_generate(volume_id);
     free_ptr = gf_strdup(uuid_utoa(volume_id));
-    ret = dict_set_dynstrn(dict, "volume-id", SLEN("volume-id"), free_ptr);
+    ret = dict_set_dynstr_sizen(dict, "volume-id", free_ptr);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to set volume "
@@ -242,8 +240,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
 
     gf_uuid_generate(tmp_uuid);
     username = gf_strdup(uuid_utoa(tmp_uuid));
-    ret = dict_set_dynstrn(dict, "internal-username", SLEN("internal-username"),
-                           username);
+    ret = dict_set_dynstr_sizen(dict, "internal-username", username);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set username for "
@@ -254,8 +251,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
 
     gf_uuid_generate(tmp_uuid);
     password = gf_strdup(uuid_utoa(tmp_uuid));
-    ret = dict_set_dynstrn(dict, "internal-password", SLEN("internal-password"),
-                           password);
+    ret = dict_set_dynstr_sizen(dict, "internal-password", password);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set password for "
@@ -338,7 +334,7 @@ __glusterd_handle_cli_start_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(errstr, sizeof(errstr), "Unable to get volume name");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s",
@@ -427,7 +423,7 @@ __glusterd_handle_cli_stop_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &dup_volname);
+    ret = dict_get_str(dict, "volname", &dup_volname);
 
     if (ret) {
         snprintf(err_str, sizeof(err_str),
@@ -519,7 +515,7 @@ __glusterd_handle_cli_delete_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to get volume "
@@ -563,8 +559,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
     char *key = NULL;
     char *value = NULL;
 
-    ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
-                          (int32_t *)&heal_op);
+    ret = dict_get_int32(dict, "heal-op", (int32_t *)&heal_op);
     if (ret || (heal_op == GF_SHD_OP_INVALID)) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=heal-op", NULL);
@@ -612,21 +607,21 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
         }
     }
 
-    ret = dict_set_strn(dict, "key1", SLEN("key1"), key);
+    ret = dict_set_str_sizen(dict, "key1", key);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
 
-    ret = dict_set_strn(dict, "value1", SLEN("value1"), value);
+    ret = dict_set_str_sizen(dict, "value1", value);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=value1", NULL);
         goto out;
     }
 
-    ret = dict_set_int32n(dict, "count", SLEN("count"), 1);
+    ret = dict_set_int32_sizen(dict, "count", 1);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -716,7 +711,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
         }
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(op_errstr, sizeof(op_errstr),
                  "Unable to find "
@@ -757,7 +752,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
     if (ret)
         goto out;
 
-    ret = dict_set_int32n(dict, "count", SLEN("count"), volinfo->brick_count);
+    ret = dict_set_int32_sizen(dict, "count", volinfo->brick_count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
@@ -830,7 +825,7 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
             goto out;
         }
     }
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "Unable to get the volume name");
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s",
@@ -838,7 +833,7 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "options", SLEN("options"), &options);
+    ret = dict_get_str(dict, "options", &options);
     if (ret) {
         snprintf(err_str, sizeof(err_str), "Unable to get options");
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s",
@@ -846,7 +841,7 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "option_cnt", SLEN("option_cnt"), &option_cnt);
+    ret = dict_get_int32(dict, "option_cnt", &option_cnt);
     if (ret) {
         snprintf(err_str, sizeof(err_str),
                  "Unable to get option "
@@ -922,7 +917,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
     GF_ASSERT(priv);
     GF_ASSERT(rsp_dict);
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -936,7 +931,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &brick_count);
+    ret = dict_get_int32(dict, "count", &brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick count "
@@ -945,7 +940,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volume-id", SLEN("volume-id"), &volume_uuid_str);
+    ret = dict_get_str(dict, "volume-id", &volume_uuid_str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume id of "
@@ -963,7 +958,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+    ret = dict_get_str(dict, "bricks", &bricks);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get bricks for "
@@ -988,7 +983,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
      * force at the end of command not given then check brick order.
      */
     if (is_origin_glusterd(dict)) {
-        ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
+        ret = dict_get_int32(dict, "type", &type);
         if (ret) {
             snprintf(msg, sizeof(msg),
                      "Unable to get type of "
@@ -1001,8 +996,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
 
         if (!is_force) {
             if (type == GF_CLUSTER_TYPE_REPLICATE) {
-                ret = dict_get_int32n(dict, "replica-count",
-                                      SLEN("replica-count"), &replica_count);
+                ret = dict_get_int32(dict, "replica-count", &replica_count);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                            "Bricks check : Could"
@@ -1016,8 +1010,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
                                                  &bricks, &brick_count,
                                                  replica_count, 0);
             } else if (type == GF_CLUSTER_TYPE_DISPERSE) {
-                ret = dict_get_int32n(dict, "disperse-count",
-                                      SLEN("disperse-count"), &disperse_count);
+                ret = dict_get_int32(dict, "disperse-count", &disperse_count);
                 if (ret) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                            "Bricks check : Could"
@@ -1121,8 +1114,7 @@ glusterd_op_stage_create_volume(dict_t *dict, char **op_errstr,
         brick_info = NULL;
     }
 
-    ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
-                          local_brick_count);
+    ret = dict_set_int32_sizen(rsp_dict, "brick_count", local_brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count");
@@ -1163,14 +1155,14 @@ glusterd_op_stop_volume_args_get(dict_t *dict, char **volname, int *flags)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), volname);
+    ret = dict_get_str(dict, "volname", volname);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "flags", SLEN("flags"), flags);
+    ret = dict_get_int32(dict, "flags", flags);
     if (ret) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=flags", NULL);
@@ -1191,21 +1183,21 @@ glusterd_op_statedump_volume_args_get(dict_t *dict, char **volname,
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), volname);
+    ret = dict_get_str(dict, "volname", volname);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "options", SLEN("options"), options);
+    ret = dict_get_str(dict, "options", options);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=options", NULL);
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "option_cnt", SLEN("option_cnt"), option_cnt);
+    ret = dict_get_int32(dict, "option_cnt", option_cnt);
     if (ret) {
         gf_smsg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=option_cnt", NULL);
@@ -1395,8 +1387,7 @@ glusterd_op_stage_start_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         }
     }
 
-    ret = dict_set_int32n(rsp_dict, "brick_count", SLEN("brick_count"),
-                          local_brick_count);
+    ret = dict_set_int32_sizen(rsp_dict, "brick_count", local_brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Failed to set local_brick_count");
@@ -1510,7 +1501,7 @@ glusterd_op_stage_delete_volume(dict_t *dict, char **op_errstr)
     char msg[2048] = {0};
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -1585,8 +1576,7 @@ glusterd_handle_heal_cmd(xlator_t *this, glusterd_volinfo_t *volinfo,
         "Self-heal daemon is not running. "
         "Check self-heal daemon log file.";
 
-    ret = dict_get_int32n(dict, "heal-op", SLEN("heal-op"),
-                          (int32_t *)&heal_op);
+    ret = dict_get_int32(dict, "heal-op", (int32_t *)&heal_op);
     if (ret) {
         ret = -1;
         *op_errstr = gf_strdup("Heal operation not specified");
@@ -1689,7 +1679,7 @@ glusterd_op_stage_heal_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -1830,7 +1820,7 @@ glusterd_op_stage_clearlocks_volume(dict_t *dict, char **op_errstr)
         0,
     };
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get volume name");
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
@@ -1838,7 +1828,7 @@ glusterd_op_stage_clearlocks_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "path", SLEN("path"), &path);
+    ret = dict_get_str(dict, "path", &path);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get path");
         gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
@@ -1846,7 +1836,7 @@ glusterd_op_stage_clearlocks_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "kind", SLEN("kind"), &kind);
+    ret = dict_get_str(dict, "kind", &kind);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get kind");
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
@@ -1854,7 +1844,7 @@ glusterd_op_stage_clearlocks_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "type", SLEN("type"), &type);
+    ret = dict_get_str(dict, "type", &type);
     if (ret) {
         snprintf(msg, sizeof(msg), "Failed to get type");
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s", msg);
@@ -1936,7 +1926,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
@@ -1952,7 +1942,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
 
     GF_ASSERT(volinfo->volname);
 
-    ret = dict_get_int32n(dict, "type", SLEN("type"), &volinfo->type);
+    ret = dict_get_int32(dict, "type", &volinfo->type);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get type of volume"
@@ -1961,7 +1951,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "count", SLEN("count"), &volinfo->brick_count);
+    ret = dict_get_int32(dict, "count", &volinfo->brick_count);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get brick count of"
@@ -1970,14 +1960,14 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_int32n(dict, "port", SLEN("port"), &volinfo->port);
+    ret = dict_get_int32(dict, "port", &volinfo->port);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get port");
         goto out;
     }
 
-    ret = dict_get_strn(dict, "bricks", SLEN("bricks"), &bricks);
+    ret = dict_get_str(dict, "bricks", &bricks);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get bricks for "
@@ -1997,9 +1987,8 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
          * replicate volumes
          */
         if (priv->op_version >= GD_OP_VERSION_3_12_2) {
-            ret = dict_set_nstrn(volinfo->dict, "performance.client-io-threads",
-                                 SLEN("performance.client-io-threads"), "off",
-                                 SLEN("off"));
+            ret = dict_set_sizen_str_sizen(
+                volinfo->dict, "performance.client-io-threads", "off");
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                        "Failed to set "
@@ -2007,8 +1996,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
                 goto out;
             }
         }
-        ret = dict_get_int32n(dict, "replica-count", SLEN("replica-count"),
-                              &volinfo->replica_count);
+        ret = dict_get_int32(dict, "replica-count", &volinfo->replica_count);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Failed to get "
@@ -2018,13 +2006,11 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         }
 
         /* coverity[unused_value] arbiter count is optional */
-        ret = dict_get_int32n(dict, "arbiter-count", SLEN("arbiter-count"),
-                              &volinfo->arbiter_count);
-        ret = dict_get_int32n(dict, "thin-arbiter-count",
-                              SLEN("thin-arbiter-count"),
-                              &volinfo->thin_arbiter_count);
+        ret = dict_get_int32(dict, "arbiter-count", &volinfo->arbiter_count);
+        ret = dict_get_int32(dict, "thin-arbiter-count",
+                             &volinfo->thin_arbiter_count);
         if (volinfo->thin_arbiter_count) {
-            ret = dict_get_strn(dict, "ta-brick", SLEN("ta-brick"), &ta_bricks);
+            ret = dict_get_str(dict, "ta-brick", &ta_bricks);
             if (ret) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                        "Unable to get thin arbiter brick for "
@@ -2035,8 +2021,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         }
 
     } else if (GF_CLUSTER_TYPE_DISPERSE == volinfo->type) {
-        ret = dict_get_int32n(dict, "disperse-count", SLEN("disperse-count"),
-                              &volinfo->disperse_count);
+        ret = dict_get_int32(dict, "disperse-count", &volinfo->disperse_count);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Failed to get "
@@ -2044,9 +2029,8 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
                    volname);
             goto out;
         }
-        ret = dict_get_int32n(dict, "redundancy-count",
-                              SLEN("redundancy-count"),
-                              &volinfo->redundancy_count);
+        ret = dict_get_int32(dict, "redundancy-count",
+                             &volinfo->redundancy_count);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Failed to get "
@@ -2076,14 +2060,14 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
     if (volinfo->dist_leaf_count > 1)
         volinfo->sub_count = volinfo->dist_leaf_count;
 
-    ret = dict_get_strn(dict, "transport", SLEN("transport"), &trans_type);
+    ret = dict_get_str(dict, "transport", &trans_type);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get transport type of volume %s", volname);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "volume-id", SLEN("volume-id"), &str);
+    ret = dict_get_str(dict, "volume-id", &str);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume-id of volume %s", volname);
@@ -2096,8 +2080,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "internal-username", SLEN("internal-username"),
-                        &username);
+    ret = dict_get_str(dict, "internal-username", &username);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "unable to get internal username of volume %s", volname);
@@ -2105,8 +2088,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
     }
     glusterd_auth_set_username(volinfo, username);
 
-    ret = dict_get_strn(dict, "internal-password", SLEN("internal-password"),
-                        &password);
+    ret = dict_get_str(dict, "internal-password", &password);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "unable to get internal password of volume %s", volname);
@@ -2228,9 +2210,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         goto out;
     }
 
-    ret = dict_get_strn(dict, "transport.address-family",
-                        SLEN("transport.address-family"), &address_family_str);
-
+    ret = dict_get_str(dict, "transport.address-family", &address_family_str);
     if (!ret) {
         ret = dict_set_dynstr_with_alloc(
             volinfo->dict, "transport.address-family", address_family_str);
@@ -2543,7 +2523,7 @@ glusterd_op_delete_volume(dict_t *dict)
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to get volume name");
@@ -2925,7 +2905,7 @@ glusterd_op_clearlocks_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     glusterd_volinfo_t *volinfo = NULL;
     xlator_t *this = THIS;
 
-    ret = dict_get_strn(dict, "volname", SLEN("volname"), &volname);
+    ret = dict_get_str(dict, "volname", &volname);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                 "Key=volname", NULL);
@@ -2933,28 +2913,28 @@ glusterd_op_clearlocks_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
     gf_msg_debug("glusterd", 0, "Performing clearlocks on volume %s", volname);
 
-    ret = dict_get_strn(dict, "path", SLEN("path"), &path);
+    ret = dict_get_str(dict, "path", &path);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "Key=path",
                 NULL);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "kind", SLEN("kind"), &kind);
+    ret = dict_get_str(dict, "kind", &kind);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "Key=kind",
                 NULL);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "type", SLEN("type"), &type);
+    ret = dict_get_str(dict, "type", &type);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "Key=type",
                 NULL);
         goto out;
     }
 
-    ret = dict_get_strn(dict, "opts", SLEN("opts"), &opts);
+    ret = dict_get_str(dict, "opts", &opts);
     if (ret)
         ret = 0;
 
@@ -3023,8 +3003,7 @@ glusterd_op_clearlocks_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     free_ptr = gf_strdup(result);
-    if (dict_set_dynstrn(rsp_dict, "lk-summary", SLEN("lk-summary"),
-                         free_ptr)) {
+    if (dict_set_dynstr_sizen(rsp_dict, "lk-summary", free_ptr)) {
         GF_FREE(free_ptr);
         snprintf(msg, sizeof(msg),
                  "Failed to set clear-locks "


### PR DESCRIPTION
Refactor to prefer `dict_set_XXX_sizen()` and `dict_get_YYY()`
dict API functions to avoid a lot of explicit `SLEN()` calls,
adjust style and comments. No (expected) functional changes.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Suggested-by: Yaniv Kaul <ykaul@redhat.com>
Updates: #1000
