### PR TITLE
glusterd: remove unused declarations

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
@@ -30,8 +30,4 @@ glusterd_bitdsvc_stop(glusterd_svc_t *svc, int sig);
 int
 glusterd_bitdsvc_reconfigure();
 
-void
-glusterd_bitdsvc_build_volfile_path(char *server, char *workdir, char *volfile,
-                                    size_t len);
-
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
@@ -38,10 +38,6 @@ glusterd_gfproxydsvc_stop(glusterd_svc_t *svc, int sig);
 int
 glusterd_gfproxydsvc_reconfigure(glusterd_volinfo_t *volinfo);
 
-void
-glusterd_gfproxydsvc_build_volfile_path(char *server, char *workdir,
-                                        char *volfile, size_t len);
-
 int
 glusterd_gfproxydsvc_restart();
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-nfs-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-nfs-svc.h
@@ -18,9 +18,6 @@ void
 glusterd_nfssvc_build(glusterd_svc_t *svc);
 
 int
-glusterd_nfssvc_init(glusterd_svc_t *svc);
-
-int
 glusterd_nfssvc_reconfigure();
 
 #endif /* BUILD_GNFS */

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -242,10 +242,6 @@ glusterd_brick_op_build_payload(glusterd_op_t op,
 int
 glusterd_node_op_build_payload(glusterd_op_t op, gd1_mgmt_brick_op_req **req,
                                dict_t *dict);
-int32_t
-glusterd_handle_brick_rsp(void *pending_entry, glusterd_op_t op,
-                          dict_t *rsp_dict, dict_t *ctx_dict, char **op_errstr,
-                          gd_node_type type);
 
 dict_t *
 glusterd_op_init_commit_rsp_dict(glusterd_op_t op);
@@ -253,17 +249,6 @@ glusterd_op_init_commit_rsp_dict(glusterd_op_t op);
 void
 glusterd_op_modify_op_ctx(glusterd_op_t op, void *op_ctx);
 
-int
-glusterd_set_detach_bricks(dict_t *dict, glusterd_volinfo_t *volinfo);
-
-int32_t
-glusterd_volume_stats_read_perf(char *brick_path, int32_t blk_size,
-                                int32_t blk_count, double *throughput,
-                                double *time);
-int32_t
-glusterd_volume_stats_write_perf(char *brick_path, int32_t blk_size,
-                                 int32_t blk_count, double *throughput,
-                                 double *time);
 gf_boolean_t
 glusterd_is_volume_started(glusterd_volinfo_t *volinfo);
 

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
@@ -35,8 +35,4 @@ glusterd_scrubsvc_stop(glusterd_svc_t *svc, int sig);
 int
 glusterd_scrubsvc_reconfigure();
 
-void
-glusterd_scrubsvc_build_volfile_path(char *server, char *workdir, char *volfile,
-                                     size_t len);
-
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.h
@@ -69,10 +69,6 @@ glusterd_bricks_snapshot_restore(dict_t *rsp_dict, glusterd_volinfo_t *snap_vol,
 gf_boolean_t
 glusterd_snapshot_probe(char *path, glusterd_brickinfo_t *brickinfo);
 
-int32_t
-glusterd_snapshot_mount(glusterd_brickinfo_t *brickinfo,
-                        char *brick_mount_path);
-
 int
 glusterd_snapshot_umount(glusterd_volinfo_t *snap_vol,
                          glusterd_brickinfo_t *brickinfo, int32_t brick_count);
@@ -129,9 +125,6 @@ gd_restore_snap_volume(dict_t *dict, dict_t *rsp_dict,
                        glusterd_volinfo_t *orig_vol,
                        glusterd_volinfo_t *snap_vol, int32_t volcount,
                        gf_boolean_t retain_origin_path);
-
-int32_t
-glusterd_umount(const char *path, gf_boolean_t remove);
 
 int32_t
 glusterd_snap_unmount(xlator_t *this, glusterd_volinfo_t *volinfo);
@@ -197,14 +190,8 @@ int
 glusterd_snapshot_restore_cleanup(dict_t *rsp_dict, char *volname,
                                   glusterd_snap_t *snap);
 
-void
-glusterd_get_snapd_dir(glusterd_volinfo_t *volinfo, char *path, int path_len);
-
 int
 glusterd_is_snapd_enabled(glusterd_volinfo_t *volinfo);
-
-int32_t
-glusterd_check_and_set_config_limit(glusterd_conf_t *priv);
 
 int32_t
 glusterd_is_snap_soft_limit_reached(glusterd_volinfo_t *volinfo, dict_t *dict);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -445,9 +445,6 @@ int
 glusterd_copy_uuid_to_dict(uuid_t uuid, dict_t *dict, char *key,
                            const int keylen);
 
-gf_boolean_t
-glusterd_is_same_address(char *name1, char *name2);
-
 void
 gd_update_volume_op_versions(glusterd_volinfo_t *volinfo);
 

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.h
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.h
@@ -205,12 +205,6 @@ glusterd_create_volfiles_and_notify_services(glusterd_volinfo_t *volinfo);
 int
 glusterd_generate_client_per_brick_volfile(glusterd_volinfo_t *volinfo);
 
-void
-glusterd_get_nfs_filepath(char *filename);
-
-void
-glusterd_get_shd_filepath(char *filename);
-
 int
 build_shd_graph(glusterd_volinfo_t *volinfo, volgen_graph_t *graph,
                 dict_t *mod_dict);
@@ -235,10 +229,6 @@ build_scrub_graph(volgen_graph_t *graph, dict_t *mod_dict);
 int
 glusterd_delete_volfile(glusterd_volinfo_t *volinfo,
                         glusterd_brickinfo_t *brickinfo);
-int
-glusterd_delete_snap_volfile(glusterd_volinfo_t *volinfo,
-                             glusterd_volinfo_t *snap_volinfo,
-                             glusterd_brickinfo_t *brickinfo);
 
 int
 glusterd_volinfo_get(glusterd_volinfo_t *volinfo, char *key, char **value);
@@ -249,9 +239,6 @@ glusterd_volinfo_get_boolean(glusterd_volinfo_t *volinfo, char *key);
 int
 glusterd_validate_globalopts(glusterd_volinfo_t *volinfo, dict_t *val_dict,
                              char **op_errstr);
-
-int
-glusterd_validate_localopts(dict_t *val_dict, char **op_errstr);
 
 gf_boolean_t
 glusterd_check_globaloption(char *key);

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -979,12 +979,6 @@ glusterd_list_add_snapvol(glusterd_volinfo_t *origin_vol,
                           glusterd_volinfo_t *snap_vol);
 
 glusterd_snap_t *
-glusterd_remove_snap_by_id(uuid_t snap_id);
-
-glusterd_snap_t *
-glusterd_remove_snap_by_name(char *snap_name);
-
-glusterd_snap_t *
 glusterd_find_snap_by_name(char *snap_name);
 
 glusterd_snap_t *


### PR DESCRIPTION
Drop prototypes of functions which are no longer exists.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000