### PR TITLE
rpc, afr, dht, posix: remove unused declarations

### DIFF
--- a/rpc/rpc-lib/src/rpcsvc.h
+++ b/rpc/rpc-lib/src/rpcsvc.h
@@ -553,14 +553,6 @@ rpcsvc_transport_privport_check(rpcsvc_t *svc, char *volname, uint16_t port);
 #define rpcsvc_request_seterr(req, err) ((req)->rpc_err = (int)(err))
 #define rpcsvc_request_set_autherr(req, err) ((req)->auth_err = (int)(err))
 
-extern int
-rpcsvc_submit_vectors(rpcsvc_request_t *req);
-
-extern int
-rpcsvc_request_attach_vector(rpcsvc_request_t *req, struct iovec msgvec,
-                             struct iobuf *iob, struct iobref *ioref,
-                             int finalvector);
-
 typedef int (*auth_init_trans)(rpc_transport_t *trans, void *priv);
 typedef int (*auth_init_request)(rpcsvc_request_t *req, void *priv);
 typedef int (*auth_request_authenticate)(rpcsvc_request_t *req, void *priv);
@@ -607,9 +599,6 @@ rpcsvc_auth_init(rpcsvc_t *svc, dict_t *options);
 
 extern int
 rpcsvc_auth_reconf(rpcsvc_t *svc, dict_t *options);
-
-extern int
-rpcsvc_auth_transport_init(rpc_transport_t *xprt);
 
 extern int
 rpcsvc_authenticate(rpcsvc_request_t *req);

--- a/xlators/cluster/afr/src/afr-inode-write.h
+++ b/xlators/cluster/afr/src/afr-inode-write.h
@@ -12,22 +12,6 @@
 #define __INODE_WRITE_H__
 
 int32_t
-afr_chmod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
-          dict_t *xdata);
-
-int32_t
-afr_chown(call_frame_t *frame, xlator_t *this, loc_t *loc, uid_t uid, gid_t gid,
-          dict_t *xdata);
-
-int
-afr_fchown(call_frame_t *frame, xlator_t *this, fd_t *fd, uid_t uid, gid_t gid,
-           dict_t *xdata);
-
-int32_t
-afr_fchmod(call_frame_t *frame, xlator_t *this, fd_t *fd, mode_t mode,
-           dict_t *xdata);
-
-int32_t
 afr_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
            int32_t count, off_t offset, uint32_t flags, struct iobref *iobref,
            dict_t *xdata);
@@ -39,10 +23,6 @@ afr_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 int32_t
 afr_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
               dict_t *xdata);
-
-int32_t
-afr_utimens(call_frame_t *frame, xlator_t *this, loc_t *loc,
-            struct timespec tv[2], dict_t *xdata);
 
 int
 afr_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *buf,

--- a/xlators/cluster/afr/src/afr-self-heald.h
+++ b/xlators/cluster/afr/src/afr-self-heald.h
@@ -66,10 +66,6 @@ int
 afr_xl_op(xlator_t *this, dict_t *input, dict_t *output);
 
 int
-afr_shd_gfid_to_path(xlator_t *this, xlator_t *subvol, uuid_t gfid,
-                     char **path_p);
-
-int
 afr_shd_entry_purge(xlator_t *subvol, inode_t *inode, char *name,
                     ia_type_t type);
 #endif /* !_AFR_SELF_HEALD_H */

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -728,8 +728,6 @@ xlator_t *
 dht_layout_search(xlator_t *this, dht_layout_t *layout, const char *name);
 int32_t
 dht_migration_get_dst_subvol(xlator_t *this, dht_local_t *local);
-int32_t
-dht_migration_needed(xlator_t *this);
 int
 dht_layout_normalize(xlator_t *this, loc_t *loc, dht_layout_t *layout);
 void

--- a/xlators/cluster/dht/src/dht-lock.h
+++ b/xlators/cluster/dht/src/dht-lock.h
@@ -67,11 +67,6 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
                                    xlator_t *this, int32_t op_ret,
                                    int32_t op_errno, dict_t *xdata);
 
-int32_t
-dht_blocking_entrylk_after_inodelk_rename(call_frame_t *frame, void *cookie,
-                                          xlator_t *this, int32_t op_ret,
-                                          int32_t op_errno, dict_t *xdata);
-
 void
 dht_unlock_namespace(call_frame_t *, dht_dir_transaction_t *);
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -501,9 +501,6 @@ int
 posix_forget(xlator_t *this, inode_t *inode);
 
 int32_t
-posix_discover(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata);
-
-int32_t
 posix_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata);
 
 int


### PR DESCRIPTION
Drop prototypes of functions which are no longer exists.

Signed-off-by: Dmitry Antipov dantipov@cloudlinux.com
Updates: #1000