### PR TITLE
glusterd: do not return address of local variable

### DIFF
--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-lvm-snapshot.c
@@ -31,15 +31,14 @@
 
 extern char snap_mount_dir[VALID_GLUSTERD_PATHMAX];
 
-int32_t
+static int32_t
 glusterd_origin_device(char *device, char **origin_device)
 {
     int ret = -1;
-    char msg[1024] = "";
+    char msg[4096] = "";
     char origin_name[PATH_MAX] = "";
     char *ptr = NULL;
     char *snap_device = NULL;
-    char origin_dev[PATH_MAX] = "";
     xlator_t *this = NULL;
     runner_t runner = {
         0,
@@ -83,15 +82,14 @@ glusterd_origin_device(char *device, char **origin_device)
     runner_end(&runner);
 
     snap_device = gf_strdup(device);
-    len = snprintf(origin_dev, sizeof(origin_dev), "%s/%s",
-                   dirname(snap_device), origin_name);
+    len = gf_asprintf(origin_device, "%s/%s", dirname(snap_device),
+                      origin_name);
 
-    if ((len < 0) || (len >= sizeof(origin_dev))) {
+    if (len < 0) {
         ret = -1;
         goto out;
     }
 
-    *origin_device = origin_dev;
     ret = 0;
 
 out:


### PR DESCRIPTION
Fix the following warning recently found with GCC 12:
```
snapshot/glusterd-lvm-snapshot.c: In function 'glusterd_origin_device':
snapshot/glusterd-lvm-snapshot.c:94:20: warning: storing the address of local variable 'origin_dev' in '*origin_device' [-Wdangling-pointer=]
   94 |     *origin_device = origin_dev;
      |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~
snapshot/glusterd-lvm-snapshot.c:42:10: note: 'origin_dev' declared here
   42 |     char origin_dev[PATH_MAX] = "";
      |          ^~~~~~~~~~
snapshot/glusterd-lvm-snapshot.c:42:10: note: 'origin_device' declared here
```
After marking `glusterd_origin_device()` as static, it becomes a subject
for inlining at `-O2` at least, and the following warning is also fixed:
```
snapshot/glusterd-lvm-snapshot.c: In function 'glusterd_lvm_snapshot_create_clone':
snapshot/glusterd-lvm-snapshot.c:52:66: warning: '%s' directive output may be truncated writing up to 3775 bytes into a region of size 991 [-Wformat-truncation=]
   52 |     snprintf(msg, sizeof(msg), "Get origin device for the device %s", device);
      |                                                                  ^~
In function 'glusterd_origin_device',
    inlined from 'glusterd_lvm_snapshot_create_clone' at snapshot/glusterd-lvm-snapshot.c:327:19:
snapshot/glusterd-lvm-snapshot.c:52:5: note: 'snprintf' output between 34 and 3809 bytes into a destination of size 1024
   52 |     snprintf(msg, sizeof(msg), "Get origin device for the device %s", device);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000