### PR TITLE
io_uring: fix issues in the implementation

### DIFF
--- a/libglusterfs/src/glusterfs/gf-io-common.h
+++ b/libglusterfs/src/glusterfs/gf-io-common.h
@@ -92,7 +92,7 @@
 #define gf_res_err(_err)                                                       \
     ({                                                                         \
         int32_t __gf_res_err = -(_err);                                        \
-        if (__gf_res_err < 0) {                                                \
+        if (__gf_res_err > 0) {                                                \
             GF_LOG_E("io", LG_MSG_IO_BAD_RETURN(-__gf_res_err));               \
             __gf_res_err = -EUCLEAN;                                           \
         }                                                                      \

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -595,6 +595,8 @@ gf_get_index_by_elem
 gf_global_mem_acct_enable_set
 gfid_to_ino
 gf_inode_type_to_str
+gf_io
+gf_io_data_wait
 gf_io_run
 gf_is_ip_in_net
 gf_is_local_addr


### PR DESCRIPTION
Some changes in the io_uring structures caused issues in recent linux
versions. This patch addresses them.

Also, an incorrect check in macro gf_res_err() caused unexpected error
messages.

Finally some io-framework related symbols have been published so that
other xlators can correctly use it.

Change-Id: Id471a9d2ec72a05ff05c38da57cc50c9b50e5b68
Updates: #2123
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

