### PR TITLE
glusterd: reduce pressure to THIS

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -48,11 +48,12 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     char msg[256] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -242,7 +242,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
         0,
     };
     glusterd_volinfo_t *volinfo = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     int total_bricks = 0;
     int32_t replica_count = 0;
     int32_t arbiter_count = 0;
@@ -250,7 +250,8 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 
@@ -611,10 +612,12 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
     char vol_type[256] = "";
     int32_t replica_count = 0;
     char *volname = 0;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     int cmd = -1;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -91,10 +91,11 @@ __glusterd_handle_sys_exec(rpcsvc_request_t *req)
     char err_str[64] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     priv = this->private;
     GF_ASSERT(priv);
 
@@ -172,10 +173,11 @@ __glusterd_handle_copy_file(rpcsvc_request_t *req)
     char err_str[64] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     priv = this->private;
     GF_ASSERT(priv);
 
@@ -256,10 +258,11 @@ __glusterd_handle_gsync_set(rpcsvc_request_t *req)
     char err_str[64] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     priv = this->private;
     GF_ASSERT(priv);
 

--- a/xlators/mgmt/glusterd/src/glusterd-log-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-log-ops.c
@@ -30,9 +30,11 @@ __glusterd_handle_log_rotate(rpcsvc_request_t *req)
     char msg[64] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
@@ -27,9 +27,12 @@ glusterd_mgmt_v3_lock_send_resp(rpcsvc_request_t *req, int32_t status,
     gd1_mgmt_v3_lock_rsp rsp = {
         {0},
     };
+    xlator_t *this = NULL;
     int ret = -1;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     if (rsp.op_ret)
@@ -40,7 +43,7 @@ glusterd_mgmt_v3_lock_send_resp(rpcsvc_request_t *req, int32_t status,
     ret = glusterd_submit_reply(req, &rsp, NULL, 0, NULL,
                                 (xdrproc_t)xdr_gd1_mgmt_v3_lock_rsp);
 
-    gf_msg_debug(THIS->name, 0, "Responded to mgmt_v3 lock, ret: %d", ret);
+    gf_msg_debug(this->name, 0, "Responded to mgmt_v3 lock, ret: %d", ret);
 
     return ret;
 }
@@ -51,10 +54,12 @@ glusterd_synctasked_mgmt_v3_lock(rpcsvc_request_t *req,
                                  glusterd_op_lock_ctx_t *ctx)
 {
     int32_t ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(ctx);
     GF_ASSERT(ctx->dict);
 
@@ -76,12 +81,14 @@ glusterd_op_state_machine_mgmt_v3_lock(rpcsvc_request_t *req,
                                        glusterd_op_lock_ctx_t *ctx)
 {
     int32_t ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_op_info_t txn_op_info = {
         GD_OP_STATE_DEFAULT,
     };
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     glusterd_txn_opinfo_init(&txn_op_info, 0, &lock_req->op, ctx->dict, req);
 
@@ -113,15 +120,17 @@ glusterd_handle_mgmt_v3_lock_fn(rpcsvc_request_t *req)
     };
     int32_t ret = -1;
     glusterd_op_lock_ctx_t *ctx = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_synctasked = _gf_false;
     gf_boolean_t free_ctx = _gf_false;
     glusterd_conf_t *conf = NULL;
     time_t timeout = 0;
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
-    GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &lock_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_lock_req);
@@ -232,9 +241,11 @@ glusterd_mgmt_v3_pre_validate_send_resp(rpcsvc_request_t *req, int32_t op,
         {0},
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     glusterd_get_uuid(&rsp.uuid);
@@ -269,13 +280,15 @@ glusterd_handle_pre_validate_fn(rpcsvc_request_t *req)
     gd1_mgmt_v3_pre_val_req op_req = {
         {0},
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char *op_errstr = NULL;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_pre_val_req);
@@ -357,9 +370,11 @@ glusterd_mgmt_v3_brick_op_send_resp(rpcsvc_request_t *req, int32_t op,
         {0},
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     glusterd_get_uuid(&rsp.uuid);
@@ -393,12 +408,14 @@ glusterd_handle_brick_op_fn(rpcsvc_request_t *req)
     gd1_mgmt_v3_brick_op_req op_req = {
         {0},
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char *op_errstr = NULL;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_brick_op_req);
@@ -480,9 +497,11 @@ glusterd_mgmt_v3_commit_send_resp(rpcsvc_request_t *req, int32_t op,
         {0},
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     glusterd_get_uuid(&rsp.uuid);
@@ -517,13 +536,15 @@ glusterd_handle_commit_fn(rpcsvc_request_t *req)
     gd1_mgmt_v3_commit_req op_req = {
         {0},
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char *op_errstr = NULL;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_commit_req);
@@ -606,9 +627,11 @@ glusterd_mgmt_v3_post_commit_send_resp(rpcsvc_request_t *req, int32_t op,
         {0},
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     glusterd_get_uuid(&rsp.uuid);
@@ -643,13 +666,15 @@ glusterd_handle_post_commit_fn(rpcsvc_request_t *req)
     gd1_mgmt_v3_post_commit_req op_req = {
         {0},
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char *op_errstr = NULL;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_post_commit_req);
@@ -732,9 +757,11 @@ glusterd_mgmt_v3_post_validate_send_resp(rpcsvc_request_t *req, int32_t op,
         {0},
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     glusterd_get_uuid(&rsp.uuid);
@@ -768,12 +795,14 @@ glusterd_handle_post_validate_fn(rpcsvc_request_t *req)
     gd1_mgmt_v3_post_val_req op_req = {
         {0},
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char *op_errstr = NULL;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_post_val_req);
@@ -853,9 +882,12 @@ glusterd_mgmt_v3_unlock_send_resp(rpcsvc_request_t *req, int32_t status)
     gd1_mgmt_v3_unlock_rsp rsp = {
         {0},
     };
+    xlator_t *this = NULL;
     int ret = -1;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     rsp.op_ret = status;
     if (rsp.op_ret)
@@ -866,7 +898,7 @@ glusterd_mgmt_v3_unlock_send_resp(rpcsvc_request_t *req, int32_t status)
     ret = glusterd_submit_reply(req, &rsp, NULL, 0, NULL,
                                 (xdrproc_t)xdr_gd1_mgmt_v3_unlock_rsp);
 
-    gf_msg_debug(THIS->name, 0, "Responded to mgmt_v3 unlock, ret: %d", ret);
+    gf_msg_debug(this->name, 0, "Responded to mgmt_v3 unlock, ret: %d", ret);
 
     return ret;
 }
@@ -877,9 +909,11 @@ glusterd_syctasked_mgmt_v3_unlock(rpcsvc_request_t *req,
                                   glusterd_op_lock_ctx_t *ctx)
 {
     int32_t ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(ctx);
 
     /* Trying to release multiple mgmt_v3 locks */
@@ -901,9 +935,11 @@ glusterd_op_state_machine_mgmt_v3_unlock(rpcsvc_request_t *req,
                                          glusterd_op_lock_ctx_t *ctx)
 {
     int32_t ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = glusterd_op_sm_inject_event(GD_OP_EVENT_UNLOCK, &lock_req->txn_id,
                                       ctx);
@@ -926,11 +962,13 @@ glusterd_handle_mgmt_v3_unlock_fn(rpcsvc_request_t *req)
     };
     int32_t ret = -1;
     glusterd_op_lock_ctx_t *ctx = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_synctasked = _gf_false;
     gf_boolean_t free_ctx = _gf_false;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &lock_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_unlock_req);

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -2399,16 +2399,18 @@ glusterd_mgmt_v3_initiate_all_phases_with_brickop_phase(rpcsvc_request_t *req,
     dict_t *tmp_dict = NULL;
     glusterd_conf_t *conf = NULL;
     char *op_errstr = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_acquired = _gf_false;
     uuid_t *originator_uuid = NULL;
     uint32_t txn_generation = 0;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
-    GF_ASSERT(dict);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
+    GF_ASSERT(dict);
 
     /* Save the peer list generation */
     txn_generation = conf->generation;
@@ -2563,16 +2565,18 @@ glusterd_mgmt_v3_initiate_all_phases(rpcsvc_request_t *req, glusterd_op_t op,
     dict_t *tmp_dict = NULL;
     glusterd_conf_t *conf = NULL;
     char *op_errstr = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_acquired = _gf_false;
     uuid_t *originator_uuid = NULL;
     uint32_t txn_generation = 0;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
-    GF_ASSERT(dict);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
+    GF_ASSERT(dict);
 
     /* Save the peer list generation */
     txn_generation = conf->generation;
@@ -2790,7 +2794,7 @@ glusterd_mgmt_v3_initiate_snap_phases(rpcsvc_request_t *req, glusterd_op_t op,
     dict_t *tmp_dict = NULL;
     glusterd_conf_t *conf = NULL;
     char *op_errstr = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_acquired = _gf_false;
     uuid_t *originator_uuid = NULL;
     gf_boolean_t success = _gf_false;
@@ -2799,9 +2803,11 @@ glusterd_mgmt_v3_initiate_snap_phases(rpcsvc_request_t *req, glusterd_op_t op,
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
-    GF_ASSERT(dict);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
+    GF_ASSERT(dict);
 
     /* Save the peer list generation */
     txn_generation = conf->generation;

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -408,7 +408,11 @@ __gluster_pmap_portbybrick(rpcsvc_request_t *req)
         0,
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
+
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &args,
                          (xdrproc_t)xdr_pmap_port_by_brick_req);
@@ -541,8 +545,12 @@ __gluster_pmap_signin(rpcsvc_request_t *req)
         0,
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_brickinfo_t *brickinfo = NULL;
+
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_pmap_signin_req);
     if (ret < 0) {
@@ -583,14 +591,17 @@ __gluster_pmap_signout(rpcsvc_request_t *req)
         0,
     };
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     glusterd_volinfo_t *volinfo = NULL;
     glusterd_brickinfo_t *brickinfo = NULL;
     char pidfile[PATH_MAX] = {0};
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, conf, fail);
+    GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_pmap_signout_req);
     if (ret < 0) {

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -165,10 +165,12 @@ __glusterd_handle_quota(rpcsvc_request_t *req)
     char msg[2048] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -485,10 +485,11 @@ __glusterd_handle_defrag_volume(rpcsvc_request_t *req)
     char msg[2048] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     priv = this->private;
     GF_ASSERT(priv);
 

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -44,11 +44,14 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
     char msg[256] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
+    GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
@@ -622,14 +625,16 @@ glusterd_mgmt_v3_initiate_replace_brick_cmd_phases(rpcsvc_request_t *req,
     dict_t *req_dict = NULL;
     dict_t *tmp_dict = NULL;
     uuid_t *originator_uuid = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     gf_boolean_t is_acquired = _gf_false;
 
     GF_ASSERT(req);
-    GF_ASSERT(dict);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
+    GF_ASSERT(dict);
 
     txn_generation = conf->generation;
     originator_uuid = GF_MALLOC(sizeof(uuid_t), gf_common_mt_uuid_t);

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -47,10 +47,12 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
     gf_cli_rsp rsp = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
-
     GF_ASSERT(conf);
 
     ctx = op_ctx;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -1306,11 +1306,13 @@ glusterd_handle_snapshot_config(rpcsvc_request_t *req, glusterd_op_t op,
 {
     int32_t ret = -1;
     char *volname = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     int config_command = 0;
 
-    GF_VALIDATE_OR_GOTO(this->name, req, out);
-    GF_VALIDATE_OR_GOTO(this->name, dict, out);
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
+    GF_ASSERT(dict);
 
     /* TODO : Type of lock to be taken when we are setting
      * limits system wide
@@ -3315,11 +3317,13 @@ glusterd_handle_snapshot_info(rpcsvc_request_t *req, glusterd_op_t op,
     char *volname = NULL;
     char *snapname = NULL;
     glusterd_snap_t *snap = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     int32_t cmd = GF_SNAP_INFO_TYPE_ALL;
 
-    GF_VALIDATE_OR_GOTO(this->name, req, out);
-    GF_VALIDATE_OR_GOTO(this->name, dict, out);
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
+    GF_ASSERT(dict);
 
     ret = dict_get_int32(dict, "sub-cmd", &cmd);
     if (ret) {
@@ -3526,11 +3530,13 @@ glusterd_handle_snapshot_list(rpcsvc_request_t *req, glusterd_op_t op,
     int ret = -1;
     char *volname = NULL;
     glusterd_volinfo_t *volinfo = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
-    GF_VALIDATE_OR_GOTO(this->name, req, out);
-    GF_VALIDATE_OR_GOTO(this->name, dict, out);
-    GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
+    GF_ASSERT(dict);
+    GF_ASSERT(op_errno);
 
     /* Ignore error for getting volname as it is optional */
     ret = dict_get_str(dict, "volname", &volname);
@@ -3597,7 +3603,7 @@ glusterd_handle_snapshot_create(rpcsvc_request_t *req, glusterd_op_t op,
     char *volname = NULL;
     char *snapname = NULL;
     int64_t volcount = 0;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char key[64] = "";
     int keylen;
     char *username = NULL;
@@ -3610,7 +3616,10 @@ glusterd_handle_snapshot_create(rpcsvc_request_t *req, glusterd_op_t op,
     char new_snapname[GLUSTERD_MAX_SNAP_NAME] = "";
     char gmt_snaptime[GLUSTERD_MAX_SNAP_NAME] = "";
     time_t snap_time;
+
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
@@ -3789,14 +3798,17 @@ glusterd_handle_snapshot_status(rpcsvc_request_t *req, glusterd_op_t op,
                                 dict_t *dict, char *err_str, size_t len)
 {
     int ret = -1;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
     ret = glusterd_mgmt_v3_initiate_snap_phases(req, op, dict);
     if (ret) {
-        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_INIT_FAIL,
+        gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_INIT_FAIL,
                "Failed to initiate "
                "snap phases");
         goto out;
@@ -3826,7 +3838,7 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
     int ret = -1;
     char *clonename = NULL;
     char *snapname = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char key[64] = "";
     int keylen;
     char *username = NULL;
@@ -3838,6 +3850,8 @@ glusterd_handle_snapshot_clone(rpcsvc_request_t *req, glusterd_op_t op,
     char snap_volname[GD_VOLUME_NAME_MAX] = "";
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
@@ -3976,17 +3990,18 @@ glusterd_handle_snapshot_restore(rpcsvc_request_t *req, glusterd_op_t op,
     char *snapname = NULL;
     char *buf = NULL;
     glusterd_conf_t *conf = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_snap_t *snap = NULL;
     glusterd_volinfo_t *snap_volinfo = NULL;
     int32_t i = 0;
     char key[64] = "";
     int keylen;
 
-    conf = this->private;
-
-    GF_ASSERT(conf);
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
+    conf = this->private;
+    GF_ASSERT(conf);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
@@ -5315,9 +5330,11 @@ glusterd_handle_snapshot_delete_type_snap(rpcsvc_request_t *req,
     glusterd_snap_t *snap = NULL;
     glusterd_volinfo_t *snap_vol = NULL;
     glusterd_volinfo_t *tmp = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
 
@@ -5400,13 +5417,15 @@ glusterd_handle_snapshot_delete(rpcsvc_request_t *req, glusterd_op_t op,
                                 size_t len)
 {
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     int32_t delete_cmd = -1;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     GF_ASSERT(dict);
     GF_ASSERT(err_str);
-    GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
+    GF_ASSERT(op_errno);
 
     ret = dict_get_int32(dict, "sub-cmd", &delete_cmd);
     if (ret) {
@@ -8675,11 +8694,12 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
     glusterd_conf_t *conf = NULL;
     char *host_uuid = NULL;
     char err_str[2048] = "";
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     uint32_t op_errno = 0;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -2283,10 +2283,14 @@ gd_unlock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, int *op_ret,
     uuid_t tmp_uuid = {0};
     int peer_cnt = 0;
     int ret = -1;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     struct syncargs args = {0};
     int32_t global = 0;
     char *type = NULL;
+
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     /* If the lock has not been held during this
      * transaction, do not send unlock requests */
@@ -2417,7 +2421,10 @@ gd_get_brick_count(struct cds_list_head *bricks)
 {
     glusterd_pending_node_t *pending_node = NULL;
     int npeers = 0;
-    cds_list_for_each_entry(pending_node, bricks, list) { npeers++; }
+    cds_list_for_each_entry(pending_node, bricks, list)
+    {
+        npeers++;
+    }
     return npeers;
 }
 
@@ -2538,7 +2545,7 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
     char *tmp = NULL;
     char *global = NULL;
     char *volname = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     gf_boolean_t is_acquired = _gf_false;
     gf_boolean_t is_global = _gf_false;
     uuid_t *txn_id = NULL;
@@ -2549,6 +2556,9 @@ gd_sync_task_begin(dict_t *op_ctx, rpcsvc_request_t *req)
     gf_boolean_t cluster_lock = _gf_false;
     time_t timeout = 0;
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -54,7 +54,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
     gf_cli_rsp rsp = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
     char *free_ptr = NULL;
     char *trans_type = NULL;
@@ -74,9 +74,10 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
     glusterd_volinfo_t *volinfo = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
-    GF_VALIDATE_OR_GOTO(this->name, conf, out);
+    GF_ASSERT(conf);
 
     ret = -1;
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
@@ -299,13 +300,15 @@ __glusterd_handle_cli_start_volume(rpcsvc_request_t *req)
     char errstr[2048] = {
         0,
     };
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
-
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
+
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
         snprintf(errstr, sizeof(errstr),
@@ -386,13 +389,15 @@ __glusterd_handle_cli_stop_volume(rpcsvc_request_t *req)
     char *dup_volname = NULL;
     dict_t *dict = NULL;
     glusterd_op_t cli_op = GD_OP_STOP_VOLUME;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char err_str[64] = {
         0,
     };
     glusterd_conf_t *conf = NULL;
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     conf = this->private;
     GF_ASSERT(conf);
 
@@ -479,6 +484,7 @@ __glusterd_handle_cli_delete_volume(rpcsvc_request_t *req)
         },
     };
     glusterd_op_t cli_op = GD_OP_DELETE_VOLUME;
+    xlator_t *this = NULL;
     dict_t *dict = NULL;
     char *volname = NULL;
     char err_str[64] = {
@@ -486,6 +492,8 @@ __glusterd_handle_cli_delete_volume(rpcsvc_request_t *req)
     };
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
@@ -555,13 +563,18 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
                                             glusterd_volinfo_t *volinfo)
 {
     gf_xl_afr_op_t heal_op = GF_SHD_OP_INVALID;
+    xlator_t *this = NULL;
     int ret = 0;
     char *key = NULL;
     char *value = NULL;
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
+
     ret = dict_get_int32(dict, "heal-op", (int32_t *)&heal_op);
     if (ret || (heal_op == GF_SHD_OP_INVALID)) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_GET_FAILED,
                 "Key=heal-op", NULL);
         ret = -1;
         goto out;
@@ -601,7 +614,7 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
         key = "cluster.granular-entry-heal";
         ret = dict_set_int8(dict, "is-special-key", 1);
         if (ret) {
-            gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+            gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                     "Key=is-special-key", NULL);
             goto out;
         }
@@ -609,21 +622,21 @@ glusterd_handle_heal_options_enable_disable(rpcsvc_request_t *req, dict_t *dict,
 
     ret = dict_set_str_sizen(dict, "key1", key);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=key1", NULL);
         goto out;
     }
 
     ret = dict_set_str_sizen(dict, "value1", value);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=value1", NULL);
         goto out;
     }
 
     ret = dict_set_int32_sizen(dict, "count", 1);
     if (ret) {
-        gf_smsg(THIS->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
+        gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=count", NULL);
         goto out;
     }
@@ -678,12 +691,14 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
     glusterd_op_t cli_op = GD_OP_HEAL_VOLUME;
     char *volname = NULL;
     glusterd_volinfo_t *volinfo = NULL;
-    xlator_t *this = THIS;
+    xlator_t *this = NULL;
     char op_errstr[2048] = {
         0,
     };
 
     GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
     if (ret < 0) {
@@ -795,12 +810,14 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
     char err_str[128] = {
         0,
     };
+    xlator_t *this = NULL;
     glusterd_conf_t *priv = NULL;
 
+    GF_ASSERT(req);
+    this = req->trans->xl;
+    GF_ASSERT(this);
     priv = THIS->private;
     GF_ASSERT(priv);
-
-    GF_ASSERT(req);
 
     ret = -1;
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);


### PR DESCRIPTION
Prefer transport-internal `xlator` pointer over
`THIS` in RPC request handlers, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000