### PR TITLE
nfs: fix `is_nfs_export_available` check and `mount_nfs` commands failure on s390x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1305,6 +1305,18 @@ fi
 
 AC_SUBST(GF_DISTRIBUTION)
 
+AC_CHECK_FILE([/etc/os-release])
+
+if test "x$ac_cv_file__etc_os_release" = "xyes"; then
+   AC_CANONICAL_HOST
+
+   if test "x${host_cpu}" = "xs390x" || test "x${host_cpu}" = "xs390" ; then
+      if grep "Red Hat Enterprise Linux 8\|SUSE Linux Enterprise Server 15" /etc/os-release ; then
+         AC_DEFINE(REDHAT8_OR_SLES15_ON_S390X, 1, [Red Hat 8 or SLES 15 on s390x])
+      fi
+   fi
+fi
+
 GF_HOST_OS=""
 GF_LDFLAGS="${GF_LDFLAGS} -rdynamic"
 

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -1679,9 +1679,15 @@ nfs_start_rpc_poller(struct nfs_state *state)
  *     all registered services, from any thread.
  */
 #ifdef HAVE_LIBTIRPC
+#ifdef REDHAT8_OR_SLES15_ON_S390X
+    if (uatomic_xchg(&state->svc_running, 1)) {
+        return;
+    }
+#else
     if (uatomic_xchg(&state->svc_running, true)) {
         return;
     }
+#endif
 #endif
 
     svc_run();

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -103,7 +103,11 @@ struct nfs_state {
     gf_boolean_t rdirplus;
 
 #ifdef HAVE_LIBTIRPC
+#ifdef REDHAT8_OR_SLES15_ON_S390X
+    int svc_running;
+#else
     bool svc_running;
+#endif
 #endif
 };
 


### PR DESCRIPTION
Fixes: #3604 , #3302

This PR is to fix `is_nfs_export_available` check and `mount_nfs` commands failure in RHEL 8.x and SLES 15 on s390x.

To achieve this, this PR first detects the OS and Host arch in `configure.ac`, then makes the appropriate data type adjustment for `svc_running` in `xlators/nfs/server/src/nfs.c` and `xlators/nfs/server/src/nfs.h` when the building environment is RHEL 8.x or SLES 15 on s390x.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>

