### PR TITLE
configure.ac: Fix `AC_PROG_LEX` warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -541,7 +541,7 @@ AC_ARG_WITH([server],
 AM_CONDITIONAL([WITH_SERVER], [test x$with_server = xyes])
 
 # LEX needs a check
-AC_PROG_LEX
+AC_PROG_LEX([noyywrap])
 if test  "x${LEX}" != "xflex" -a "x${FLEX}" != "xlex"; then
    AC_MSG_ERROR([Flex or lex required to build glusterfs.])
 fi


### PR DESCRIPTION
With autoconf 2.70, the following warnings are emitted:

```
configure.ac:544: warning: AC_PROG_LEX without either yywrap or noyywrap
is obsolete
./lib/autoconf/programs.m4:716: _AC_PROG_LEX is expanded from...
./lib/autoconf/programs.m4:709: AC_PROG_LEX is expanded from...
configure.ac:544: the top level
```

Autoconf [docs](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/autoconf.html#index-AC_005fPROG_005fLEX-1) now states:

> Prior to Autoconf 2.70, AC_PROG_LEX did not take any arguments, and its behavior was different from either of the above possibilities: it would search for a library that defines yywrap, and would set LEXLIB to that library if it finds one. However, if a library that defines this function could not be found, LEXLIB would be left empty and LEX would not be reset. This behavior was due to a bug, but several packages came to depend on it, so AC_PROG_LEX still does this if neither the yywrap nor the noyywrap option is given.
> 
> Usage of AC_PROG_LEX without choosing one of the yywrap or noyywrap options is deprecated. It is usually better to use noyywrap and define the yywrap function yourself, as this almost always renders the LEXLIB unnecessary. 

The behaviour of the argument on autoconf < 2.70 is to ignore the argument, so there are no issues with adding the option.