### PR TITLE
api: Fix return from `glfs_h_open()` to honour `O_DIRECTORY` flag

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -451,25 +451,9 @@ retry:
     if (ret)
         goto out;
 
-    if (IA_ISDIR(iatt.ia_type)) {
-        if ((flags & (O_RDWR | O_WRONLY)) ||
-            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
-            ret = -1;
-            errno = EISDIR;
-            goto out;
-        }
-    } else {
-        if (flags & O_DIRECTORY) {
-            ret = -1;
-            errno = ENOTDIR;
-            goto out;
-        }
-        if (!IA_ISREG(iatt.ia_type)) {
-            ret = -1;
-            errno = EINVAL;
-            goto out;
-        }
-    }
+    ret = validate_open_flags(flags, iatt.ia_type);
+    if (ret)
+        goto out;
 
     if (glfd->fd) {
         /* Retry. Safe to touch glfd->fd as we

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -653,18 +653,9 @@ pub_glfs_h_open(struct glfs *fs, struct glfs_object *object, int flags)
         goto out;
     }
 
-    /* check types to open */
-    if (IA_ISDIR(inode->ia_type)) {
-        ret = -1;
-        errno = EISDIR;
+    ret = validate_open_flags(flags, inode->ia_type);
+    if (ret)
         goto out;
-    }
-
-    if (!IA_ISREG(inode->ia_type)) {
-        ret = -1;
-        errno = EINVAL;
-        goto out;
-    }
 
     glfd = glfs_fd_new(fs);
     if (!glfd) {

--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -714,6 +714,9 @@ get_fop_attr_thrd_key(dict_t **fop_attr);
 void
 unset_fop_attr(dict_t **fop_attr);
 
+int
+validate_open_flags(int flags, ia_type_t ia_type);
+
 /*
   SYNOPSIS
   glfs_statx: Fetch extended file attributes for the given path.

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -642,6 +642,30 @@ unset_fop_attr(dict_t **fop_attr)
     }
 }
 
+int
+validate_open_flags(int flags, ia_type_t ia_type)
+{
+    int ret = 0;
+
+    if (IA_ISDIR(ia_type)) {
+        if ((flags & (O_RDWR | O_WRONLY)) ||
+            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
+            ret = -1;
+            errno = EISDIR;
+        }
+    } else {
+        if (flags & O_DIRECTORY) {
+            ret = -1;
+            errno = ENOTDIR;
+        } else if (!IA_ISREG(ia_type)) {
+            ret = -1;
+            errno = EINVAL;
+        }
+    }
+
+    return ret;
+}
+
 GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_from_glfd, 3.4.0)
 struct glfs *
 pub_glfs_from_glfd(struct glfs_fd *glfd)


### PR DESCRIPTION
This is more or less the same change done previously for _glfs_open()_. See description from https://github.com/gluster/glusterfs/pull/3307 and corresponding commit https://github.com/gluster/glusterfs/commit/754a8a8e8ec8ea3a9949ecfd4e3ce149e0bd99b8 for more details.

