### PR TITLE
posix-acl*: remove unused variables, move functions to static

### DIFF
--- a/xlators/system/posix-acl/src/posix-acl-xattr.h
+++ b/xlators/system/posix-acl/src/posix-acl-xattr.h
@@ -15,13 +15,12 @@
 #include <glusterfs/glusterfs-acl.h>
 
 struct posix_acl *
-posix_acl_from_xattr(xlator_t *this, const char *buf, int size);
+posix_acl_from_xattr(const char *buf, int size);
 
 int
-posix_acl_to_xattr(xlator_t *this, struct posix_acl *acl, char *buf, int size);
+posix_acl_to_xattr(struct posix_acl *acl, char *buf, int size);
 
 int
-posix_acl_matches_xattr(xlator_t *this, struct posix_acl *acl, const char *buf,
-                        int size);
+posix_acl_matches_xattr(struct posix_acl *acl, const char *buf, int size);
 
 #endif /* !_POSIX_ACL_XATTR_H */

--- a/xlators/system/posix-acl/src/posix-acl.h
+++ b/xlators/system/posix-acl/src/posix-acl.h
@@ -12,20 +12,6 @@
 #define _POSIX_ACL_H
 
 struct posix_acl *
-posix_acl_new(xlator_t *this, int entry_count);
-struct posix_acl *
-posix_acl_ref(xlator_t *this, struct posix_acl *acl);
-void
-posix_acl_unref(xlator_t *this, struct posix_acl *acl);
-void
-posix_acl_destroy(xlator_t *this, struct posix_acl *acl);
-struct posix_acl_ctx *
-posix_acl_ctx_get(inode_t *inode, xlator_t *this);
-int
-posix_acl_get(inode_t *inode, xlator_t *this, struct posix_acl **acl_access_p,
-              struct posix_acl **acl_default_p);
-int
-posix_acl_set(inode_t *inode, xlator_t *this, struct posix_acl *acl_access,
-              struct posix_acl *acl_default);
+posix_acl_new(int entry_count);
 
 #endif /* !_POSIX_ACL_H */


### PR DESCRIPTION
Remove unused variables, move functions to static, remove the use of 'THIS'.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

