### PR TITLE
glusterd: regenerate all volfiles durring upgrade/ op-version change

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -8083,27 +8083,11 @@ glusterd_recreate_volfiles(glusterd_conf_t *conf)
 
     cds_list_for_each_entry(volinfo, &conf->volumes, vol_list)
     {
-        ret = generate_brick_volfiles(volinfo);
+        ret = glusterd_create_volfiles(volinfo);
         if (ret) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_VOLFILE_CREATE_FAIL,
                    "Failed to "
-                   "regenerate brick volfiles for %s",
-                   volinfo->volname);
-            op_ret = ret;
-        }
-        ret = generate_client_volfiles(volinfo, GF_CLIENT_TRUSTED);
-        if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_VOLFILE_CREATE_FAIL,
-                   "Failed to "
-                   "regenerate trusted client volfiles for %s",
-                   volinfo->volname);
-            op_ret = ret;
-        }
-        ret = generate_client_volfiles(volinfo, GF_CLIENT_OTHER);
-        if (ret) {
-            gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_VOLFILE_CREATE_FAIL,
-                   "Failed to "
-                   "regenerate client volfiles for %s",
+                   "regenerate volfile(s) for %s",
                    volinfo->volname);
             op_ret = ret;
         }


### PR DESCRIPTION
When we invoke glusterd with the upgrade flags (glusterd --xlator-option
*.upgrade=on -N') or bump up the cluster-op version after an upgrade,
glusterd_recreate_volfiles() gets called. This function regenerates some
volfiles but misses out on others..

glusterd_create_volfiles() already exists which generates all volfiles.
Use that and reduce code duplication.

Updates: #1000
Change-Id: I74fba4e60f5120853782867c9c8d8605ee510396
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

