### PR TITLE
Fix showing wrong distCount in XML output

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -737,18 +737,17 @@ gf_cli_print_number_of_bricks(int type, int brick_count, int dist_count,
     if (type == GF_CLUSTER_TYPE_NONE) {
         cli_out("Number of Bricks: %d", brick_count);
     } else if (type == GF_CLUSTER_TYPE_DISPERSE) {
-        cli_out("Number of Bricks: %d x (%d + %d) = %d",
-                (brick_count / dist_count), disperse_count - redundancy_count,
-                redundancy_count, brick_count);
+        cli_out("Number of Bricks: %d x (%d + %d) = %d", dist_count,
+                disperse_count - redundancy_count, redundancy_count,
+                brick_count);
     } else {
         /* For replicate, dist_count is good enough */
         if (arbiter_count == 0) {
-            cli_out("Number of Bricks: %d x %d = %d",
-                    (brick_count / dist_count), dist_count, brick_count);
+            cli_out("Number of Bricks: %d x %d = %d", dist_count, replica_count,
+                    brick_count);
         } else {
-            cli_out("Number of Bricks: %d x (%d + %d) = %d",
-                    (brick_count / dist_count), dist_count - arbiter_count,
-                    arbiter_count, brick_count);
+            cli_out("Number of Bricks: %d x (%d + %d) = %d", dist_count,
+                    replica_count - arbiter_count, arbiter_count, brick_count);
         }
     }
 }
@@ -912,6 +911,11 @@ xml_output:
 
         keylen = snprintf(key, sizeof(key), "volume%d.dist_count", i);
         ret = dict_get_int32n(dict, key, keylen, &dist_count);
+        if (ret)
+            goto out;
+
+        keylen = snprintf(key, sizeof(key), "volume%d.replica_count", i);
+        ret = dict_get_int32n(dict, key, keylen, &replica_count);
         if (ret)
             goto out;
 

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -2503,9 +2503,8 @@ cli_xml_output_vol_info(cli_local_t *local, dict_t *dict)
         ret = dict_get_int32(dict, key, &dist_count);
         if (ret)
             goto out;
-        ret = xmlTextWriterWriteFormatElement(local->writer,
-                                              (xmlChar *)"distCount", "%d",
-                                              (brick_count / dist_count));
+        ret = xmlTextWriterWriteFormatElement(
+            local->writer, (xmlChar *)"distCount", "%d", dist_count);
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         snprintf(key, sizeof(key), "volume%d.replica_count", i);

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -446,7 +446,8 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
     }
 
     keylen = snprintf(key, sizeof(key), "volume%d.dist_count", count);
-    ret = dict_set_int32n(volumes, key, keylen, volinfo->dist_leaf_count);
+    ret = dict_set_int32n(volumes, key, keylen,
+                          volinfo->brick_count / volinfo->dist_leaf_count);
     if (ret) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, GD_MSG_DICT_SET_FAILED,
                 "Key=%s", key, NULL);


### PR DESCRIPTION
While reading from the Volinfo, `distCount` is set to `dist_leaf_count`
instead of `brick_count / dist_leaf_count`.

Fixes: #3662
Change-Id: I6e909d0ba82658bab60181a39d124ccc84da4418
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>

