### PR TITLE
glusterfsd: handle port in volfile server

### DIFF
--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -45,20 +45,76 @@ server_getspec(rpcsvc_request_t *req)
     gf_getspec_rsp rsp = {
         0,
     };
+    struct stat stbuf = {
+        0,
+    };
+    char volpath[PATH_MAX] = {
+        0,
+    };
+    int32_t spec_fd = -1;
+    xlator_t *this = req->svc->xl;
+    server_conf_t *conf = this->private;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_getspec_req);
     if (ret < 0) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         op_errno = EINVAL;
-        goto fail;
+        rsp.spec = "<this method is not in use, use glusterd for getspec>";
+        rsp.op_errno = gf_errno_to_error(op_errno);
+        rsp.op_ret = -1;
+        goto out;
     }
 
-    op_errno = ENOSYS;
-fail:
-    rsp.spec = "<this method is not in use, use glusterd for getspec>";
-    rsp.op_errno = gf_errno_to_error(op_errno);
-    rsp.op_ret = -1;
+    char *volid = args.key;
+    ret = snprintf(volpath, PATH_MAX - 1, "%s/%s.vol", conf->volfile_dir,
+                   volid);
+    if (ret == -1) {
+        gf_msg(this->name, GF_LOG_ERROR, errno, 0, "failed to copy volfile");
+        goto out;
+    }
+
+    ret = sys_stat(volpath, &stbuf);
+    if (ret < 0) {
+        goto out;
+    }
+
+    spec_fd = open(volpath, O_RDONLY);
+    if (spec_fd < 0) {
+        gf_msg("glusterd", GF_LOG_ERROR, errno, 0, "Unable to open %s (%s)",
+               volpath, strerror(errno));
+        goto out;
+    }
+    ret = stbuf.st_size;
+
+    if (ret > 0) {
+        rsp.spec = CALLOC(ret + 1, sizeof(char));
+        if (!rsp.spec) {
+            gf_msg(this->name, GF_LOG_ERROR, errno, 0, "no memory");
+            ret = -1;
+            op_errno = ENOMEM;
+            goto out;
+        }
+        ret = sys_read(spec_fd, rsp.spec, ret);
+    }
+
+out:
+    if (spec_fd >= 0)
+        sys_close(spec_fd);
+
+    rsp.op_ret = ret;
+    if (rsp.op_ret < 0) {
+        if (!op_errno)
+            op_errno = ENOENT;
+        gf_msg(this->name, GF_LOG_ERROR, op_errno, 0,
+               "Failed to mount the volume");
+    }
+
+    if (op_errno)
+        rsp.op_errno = gf_errno_to_error(op_errno);
+
+    if (!rsp.spec)
+        rsp.spec = strdup("");
 
     server_submit_reply(NULL, req, &rsp, NULL, 0, NULL,
                         (xdrproc_t)xdr_gf_getspec_rsp);

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -60,6 +60,7 @@ struct server_conf {
                              * (say *.allow | *.reject) are
                              * tweeked */
     char *conf_dir;
+    char *volfile_dir;
     struct _volfile_ctx *volfile;
     dict_t *auth_modules;
     struct list_head xprt_list;


### PR DESCRIPTION
this PR allows `--volfile-server` option to glusterfsd to have port in it - `node:port` (or `[ipv6addr]:port`) 

Depends on #3668 
