### PR TITLE
ec: fix the setxattr of simple-quota limit

### DIFF
--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -755,6 +755,20 @@ ec_setxattr(call_frame_t *frame, xlator_t *this, uintptr_t target,
         }
     }
 
+    ec_t *ec = fop->xl->private;
+    int64_t val = 0;
+    int ret = dict_get_int64(fop->dict, SQUOTA_LIMIT_KEY, &val);
+    if (IS_SUCCESS(ret)) {
+        /* divide the total usage to priv->fragments */
+        int64_t new_value = val / ec->fragments;
+        ret = dict_set_int64(fop->dict, SQUOTA_LIMIT_KEY, new_value);
+        if (IS_ERROR(ret)) {
+            /* Add a trace log */
+            gf_msg(ec->xl->name, GF_LOG_DEBUG, ENOMEM,
+                   EC_MSG_FILE_DESC_REF_FAIL,
+                   "Failed to update the simple-quota limit");
+        }
+    }
     error = 0;
 
 out:

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -763,10 +763,10 @@ ec_setxattr(call_frame_t *frame, xlator_t *this, uintptr_t target,
         int64_t new_value = val / ec->fragments;
         ret = dict_set_int64(fop->dict, SQUOTA_LIMIT_KEY, new_value);
         if (IS_ERROR(ret)) {
-            /* Add a trace log */
-            gf_msg(ec->xl->name, GF_LOG_DEBUG, ENOMEM,
-                   EC_MSG_FILE_DESC_REF_FAIL,
+            /* Add a debug log */
+            gf_msg(ec->xl->name, GF_LOG_DEBUG, ENOMEM, EC_MSG_DICT_REF_FAIL,
                    "Failed to update the simple-quota limit");
+            goto out;
         }
     }
     error = 0;


### PR DESCRIPTION
Simple-quota works on the idea that each brick knows what its capacity at the directory level are. In EC, the brick doesn't have full data but reduced by a factor of fragments. Thus, in this special case, while sending the limit itself, good to handle the fragment size part.

Updates: #3638 
Change-Id: Id341de5afe59a7348c5eb15c51555243363550ef
Signed-off-by: Amar Tumballi <amar@dhiway.com>

