### PR TITLE
dht: Wind a lock(inodelk/entrylk) fop as a internal fop

### DIFF
--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -191,6 +191,8 @@ dht_lock_frame(call_frame_t *parent_frame)
     if (lock_frame)
         set_lk_owner_from_ptr(&lock_frame->root->lk_owner, parent_frame->root);
 
+    /* Set negative pid to conisder lock fop as an internal fop */
+    lock_frame->pid = GF_CLIENT_PID_NO_ROOT_SQUASH;
     return lock_frame;
 }
 


### PR DESCRIPTION
Set negative pid while wind a lock fop by dht

Change-Id: Ib9f9aeb15629753ab337f647b9592399eb5730bc
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

