### PR TITLE
multiple files: unify and improve the check for . and .. entries

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -3993,21 +3993,21 @@ glfd_entry_refresh(struct glfs_fd *glfd, int plus)
             {
                 if ((!entry->inode && (!IA_ISDIR(entry->d_stat.ia_type))) ||
                     ((entry->d_stat.ia_ctime == 0) &&
-                     strcmp(entry->d_name, ".") &&
-                     strcmp(entry->d_name, ".."))) {
-                    /* entry->inode for directories will be
-                     * always set to null to force a lookup
-                     * on the dentry. Hence to not degrade
-                     * readdir performance, we skip lookups
-                     * for directory entries. Also we will have
-                     * proper stat if directory present on
-                     * hashed subvolume.
-                     *
-                     * In addition, if the stat is invalid, force
-                     * lookup to fetch proper stat.
-                     */
-                    gf_fill_iatt_for_dirent(entry, fd->inode, subvol);
-                }
+                     inode_dir_or_parentdir(entry)))
+                    {
+                        /* entry->inode for directories will be
+                         * always set to null to force a lookup
+                         * on the dentry. Hence to not degrade
+                         * readdir performance, we skip lookups
+                         * for directory entries. Also we will have
+                         * proper stat if directory present on
+                         * hashed subvolume.
+                         *
+                         * In addition, if the stat is invalid, force
+                         * lookup to fetch proper stat.
+                         */
+                        gf_fill_iatt_for_dirent(entry, fd->inode, subvol);
+                    }
             }
 
             gf_link_inodes_from_dirent(fd->inode, &entries);

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -3993,7 +3993,7 @@ glfd_entry_refresh(struct glfs_fd *glfd, int plus)
             {
                 if ((!entry->inode && (!IA_ISDIR(entry->d_stat.ia_type))) ||
                     ((entry->d_stat.ia_ctime == 0) &&
-                     inode_dir_or_parentdir(entry)))
+                     !inode_dir_or_parentdir(entry)))
                     {
                         /* entry->inode for directories will be
                          * always set to null to force a lookup

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -754,8 +754,8 @@ glfsh_heal_entries(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
     list_for_each_entry_safe(entry, tmp, &entries->list, list)
     {
         *offset = entry->d_off;
-        if ((strcmp(entry->d_name, ".") == 0) ||
-            (strcmp(entry->d_name, "..") == 0))
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(entry))
             continue;
         snprintf(file, sizeof(file), "gfid:%s", entry->d_name);
         ret = glfsh_heal_splitbrain_file(fs, top_subvol, rootloc, file,
@@ -788,8 +788,8 @@ glfsh_process_entries(xlator_t *xl, fd_t *fd, gf_dirent_t *entries,
     list_for_each_entry_safe(entry, tmp, &entries->list, list)
     {
         *offset = entry->d_off;
-        if ((strcmp(entry->d_name, ".") == 0) ||
-            (strcmp(entry->d_name, "..") == 0))
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(entry))
             continue;
 
         if (dict) {

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -56,7 +56,7 @@ struct _gf_dirent {
 static inline gf_boolean_t
 inode_dir_or_parentdir(gf_dirent_t *entry)
 {
-    return ((entry->d_name[0] == '.') &&
+    return ((entry->d_len <= 2) && (entry->d_name[0] == '.') &&
             ((entry->d_name[1] == 0) || (entry->d_name[1] == '.')));
 }
 

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -56,8 +56,8 @@ struct _gf_dirent {
 static inline gf_boolean_t
 inode_dir_or_parentdir(gf_dirent_t *entry)
 {
-    return (entry->d_len <= 2 && (strcmp(entry->d_name, ".") == 0 ||
-                                  strcmp(entry->d_name, "..") == 0));
+    return ((entry->d_name[0] == '.') &&
+            ((entry->d_name[1] == 0) || (entry->d_name[1] == '.')));
 }
 
 gf_dirent_t *

--- a/libglusterfs/src/glusterfs/gf-dirent.h
+++ b/libglusterfs/src/glusterfs/gf-dirent.h
@@ -53,6 +53,13 @@ struct _gf_dirent {
 
 #define DT_ISDIR(mode) (mode == DT_DIR)
 
+static inline gf_boolean_t
+inode_dir_or_parentdir(gf_dirent_t *entry)
+{
+    return (entry->d_len <= 2 && (strcmp(entry->d_name, ".") == 0 ||
+                                  strcmp(entry->d_name, "..") == 0));
+}
+
 gf_dirent_t *
 gf_dirent_for_name(const char *name);
 gf_dirent_t *

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -115,8 +115,8 @@ syncop_ftw(xlator_t *subvol, loc_t *loc, int pid, void *data,
         list_for_each_entry(entry, &entries.list, list)
         {
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             gf_link_inode_from_dirent(fd->inode, entry);
@@ -198,8 +198,8 @@ syncop_ftw_throttle(xlator_t *subvol, loc_t *loc, int pid, void *data,
         list_for_each_entry(entry, &entries.list, list)
         {
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             if (++tmp >= count) {
@@ -396,7 +396,8 @@ syncop_mt_dir_scan(call_frame_t *frame, xlator_t *subvol, loc_t *loc, int pid,
                 goto out;
 
             list_del_init(&entry->list);
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry)) {
                 gf_dirent_entry_free(entry);
                 continue;
             }
@@ -485,8 +486,8 @@ syncop_dir_scan(xlator_t *subvol, loc_t *loc, int pid, void *data,
         list_for_each_entry(entry, &entries.list, list)
         {
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             ret |= fn(subvol, entry, loc, data);

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -949,8 +949,8 @@ afr_selfheal_entry_do_subvol(call_frame_t *frame, xlator_t *this, fd_t *fd,
         list_for_each_entry(entry, &entries.list, list)
         {
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             ret = afr_selfheal_entry_dirent(iter_frame, this, fd, entry->d_name,

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -10390,9 +10390,8 @@ dht_rmdir_is_subvol_empty(call_frame_t *frame, xlator_t *this,
 
     list_for_each_entry(trav, &entries->list, list)
     {
-        if (strcmp(trav->d_name, ".") == 0)
-            continue;
-        if (strcmp(trav->d_name, "..") == 0)
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(trav))
             continue;
         if (check_is_linkfile(NULL, (&trav->d_stat), trav->dict,
                               conf->link_xattr_name)) {
@@ -10430,9 +10429,8 @@ dht_rmdir_is_subvol_empty(call_frame_t *frame, xlator_t *this,
 
     list_for_each_entry(trav, &entries->list, list)
     {
-        if (strcmp(trav->d_name, ".") == 0)
-            continue;
-        if (strcmp(trav->d_name, "..") == 0)
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(trav))
             continue;
 
         lookup_frame = copy_frame(frame);

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3128,7 +3128,8 @@ gf_defrag_get_entry(xlator_t *this, int i, dht_container_t **container,
         dir_dfmeta->iterator[i] = dir_dfmeta->iterator[i]->next;
 
         dir_dfmeta->offset_var[i].offset = df_entry->d_off;
-        if (!strcmp(df_entry->d_name, ".") || !strcmp(df_entry->d_name, ".."))
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(df_entry))
             continue;
 
         if (IA_ISDIR(df_entry->d_stat.ia_type)) {
@@ -3676,8 +3677,8 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
             }
 
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             if ((DT_DIR != entry->d_type) && (DT_UNKNOWN != entry->d_type)) {

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -2758,8 +2758,8 @@ br_stub_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     list_for_each_entry(entry, &entries->list, list)
     {
-        if ((strcmp(entry->d_name, ".") == 0) ||
-            (strcmp(entry->d_name, "..") == 0))
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(entry))
             continue;
 
         if (!IA_ISREG(entry->d_stat.ia_type))

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1694,7 +1694,8 @@ index_get_gfid_type(void *opaque)
 
     list_for_each_entry(entry, &args->entries->list, list)
     {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+        /* skip . and .. */
+        if (inode_dir_or_parentdir(entry))
             continue;
 
         loc_wipe(&loc);

--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1903,8 +1903,8 @@ mq_update_dirty_inode_task(void *opaque)
         list_for_each_entry(entry, &entries.list, list)
         {
             offset = entry->d_off;
-
-            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            /* skip . and .. */
+            if (inode_dir_or_parentdir(entry))
                 continue;
 
             memset(&contri, 0, sizeof(contri));

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -3086,8 +3086,8 @@ marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     list_for_each_entry(entry, &entries->list, list)
     {
-        if ((strcmp(entry->d_name, ".") == 0) ||
-            (strcmp(entry->d_name, "..") == 0) || entry->inode == NULL)
+        /* skip . and .. */
+        if (entry->inode == NULL || inode_dir_or_parentdir(entry))
             continue;
 
         if (no_found_entry)

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -1048,7 +1048,10 @@ quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
         goto out;
     }
 
-    list_for_each_entry(entry, parents, next) { parent_count++; }
+    list_for_each_entry(entry, parents, next)
+    {
+        parent_count++;
+    }
 
     LOCK(&par_local->lock);
     {
@@ -4547,8 +4550,8 @@ quota_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     list_for_each_entry(entry, &entries->list, list)
     {
-        if ((strcmp(entry->d_name, ".") == 0) ||
-            (strcmp(entry->d_name, "..") == 0) || entry->inode == NULL)
+        /* skip . and .. */
+        if (entry->inode == NULL || inode_dir_or_parentdir(entry))
             continue;
 
         gf_uuid_copy(loc.gfid, entry->d_stat.ia_gfid);

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -3793,8 +3793,8 @@ shard_delete_shards(void *opaque)
             list_for_each_entry(entry, &entries.list, list)
             {
                 offset = entry->d_off;
-
-                if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+                /* skip . and .. */
+                if (inode_dir_or_parentdir(entry))
                     continue;
 
                 if (!entry->inode) {

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1576,7 +1576,8 @@ svs_readdirp_fill(xlator_t *this, inode_t *parent, svs_inode_t *parent_ctx,
     GF_VALIDATE_OR_GOTO(this->name, parent_ctx, out);
     GF_VALIDATE_OR_GOTO(this->name, entry, out);
 
-    if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+    /* skip . and .. */
+    if (inode_dir_or_parentdir(entry))
         goto out;
 
     inode = inode_grep(parent->table, parent, entry->d_name);

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3779,7 +3779,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         feo->nodeid = inode_to_fuse_nodeid(linked_inode);
 
-        if (!(inode_dir_or_parentdir(entry))) {
+        if (!inode_dir_or_parentdir(entry)) {
             inode_lookup(linked_inode);
         }
 

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3779,8 +3779,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         feo->nodeid = inode_to_fuse_nodeid(linked_inode);
 
-        if (!((strcmp(entry->d_name, ".") == 0) ||
-              (strcmp(entry->d_name, "..") == 0))) {
+        if (!(inode_dir_or_parentdir(entry))) {
             inode_lookup(linked_inode);
         }
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -308,8 +308,7 @@ __rda_fill_readdirp(xlator_t *this, gf_dirent_t *entries, size_t request_size,
         if (size + dirent_size > request_size)
             break;
 
-        if (dirent->inode && (!((strcmp(dirent->d_name, ".") == 0) ||
-                                (strcmp(dirent->d_name, "..") == 0)))) {
+        if (dirent->inode && !(inode_dir_or_parentdir(dirent))) {
             rda_inode_ctx_get_iatt(dirent->inode, this, &dirent->d_stat);
         }
 
@@ -504,8 +503,7 @@ rda_fill_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             /* must preserve entry order */
             list_add_tail(&dirent->list, &ctx->entries.list);
             if (dirent->inode) {
-                if (!((strcmp(dirent->d_name, ".") == 0) ||
-                      (strcmp(dirent->d_name, "..") == 0))) {
+                if (!(inode_dir_or_parentdir(dirent))) {
                     /* If ctxp->stat is invalidated, don't update it
                      * with dirent->d_stat as we don't have
                      * generation number of the inode when readdirp

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -308,7 +308,7 @@ __rda_fill_readdirp(xlator_t *this, gf_dirent_t *entries, size_t request_size,
         if (size + dirent_size > request_size)
             break;
 
-        if (dirent->inode && !(inode_dir_or_parentdir(dirent))) {
+        if (dirent->inode && !inode_dir_or_parentdir(dirent)) {
             rda_inode_ctx_get_iatt(dirent->inode, this, &dirent->d_stat);
         }
 
@@ -503,7 +503,7 @@ rda_fill_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             /* must preserve entry order */
             list_add_tail(&dirent->list, &ctx->entries.list);
             if (dirent->inode) {
-                if (!(inode_dir_or_parentdir(dirent))) {
+                if (!inode_dir_or_parentdir(dirent)) {
                     /* If ctxp->stat is invalidated, don't update it
                      * with dirent->d_stat as we don't have
                      * generation number of the inode when readdirp


### PR DESCRIPTION
in gf_dirent structure

- Check if the name length is <=2 and only then call strcmp()
- Reuse across codebase.

Mostly useful in readdir(p) loops.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

