### PR TITLE
dht: Cleanup linkto file by rebalance daemon while (hashed|cached) subvol are same

### DIFF
--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -3172,9 +3172,11 @@ gf_defrag_get_entry(xlator_t *this, int i, dht_container_t **container,
                                  " %s on subvol: %s status is %d",
                                  df_entry->d_name, conf->local_subvols[i]->name,
                                  ret);
-                    continue;
+                    break;
                 }
             }
+            if (j < conf->subvolume_cnt)
+                continue;
         }
         /*Build Container Structure */
 


### PR DESCRIPTION
The rebalance damon has skipped linkto files if it has found hashed
and cached subvol are same. Even It has skipped to cleanup linkto files
on decommissioned brick also. Due to this behavior If a user has tried
to run rmdir it gives an error ENOTEMPTY. Though the issue was already resolved
by the patch (https://review.gluster.org/#/c/glusterfs/+/17065/) but the
patch has scope of improvement. This approach slows the RMDIR performance.
I have observed if we do skip readdirp  during rmdir the performance has
improved significantly. To improve the RMDIR performance first we need
to clean up link files during rebalance and for specific to rmdir
optimization I will send a separate patch.

Solution: Cleanup linkto file in case of decommissioned brick and
          if rebalance has been found hashed and cached subvol
          are the same.

Fixes: #3683
Change-Id: Ib9d70bcd1e36b25e8a3e2b86ed1ea928676e76e3
Credits: Xavi Hernandez <xhernandez@redhat.com>
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

