### PR TITLE
dht: call dht_lookup_directory only for directories

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -2369,9 +2369,6 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                              NULL);
             return 0;
         }
-        /* A hack */
-        dht_lookup_directory(frame, this, &local->loc);
-        return 0;
     }
 
     if (local->dir_count) {
@@ -3094,8 +3091,7 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
              * heal this so check if this is a directory on the other subvols.
              */
             if ((op_errno == ENOTCONN) || (op_errno == ENODATA)) {
-                dht_lookup_directory(frame, this, &local->loc);
-                return 0;
+                goto is_dir_check;
             }
         }
         gf_msg_debug(this->name, op_errno, "%s: Lookup on subvolume %s failed",
@@ -3122,6 +3118,7 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         }
     }
 
+is_dir_check:
     is_dir = check_is_dir(inode, stbuf, xattr);
     if (is_dir) {
         /* A directory is present on all subvols, send the lookup to


### PR DESCRIPTION
Problem:
When two clients simultaneously create and unlink the same file in a
loop (stress testing), the client doing the unlink was hung and
unresponsive to CTRL-C. On examining, it was observed that when
dht_lookup_cbk() failed with ENODATA (since the other client had created the
file but not yet set the gfid), it was triggering a recursive loop of
lookups (on the client doing the unlink):

dht_lookup_cbk  ───────────► dht_lookup_directory ──►dht_lookup_dir_cbk───►dht_lookup_everywhere ───► dht_lookup_everywhere_done
                                    ▲                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    └─────────────────────────────────────────────────────────────────────────▼
Fix:
I'm not sure of the cases that necessiate a "recursive" call of
dht_lookup_directory() but it definitely doesn't make sense to call it
for a regular file. This patch tries to call dht_lookup_directory() only
for directories.

Note: Even with this fix, there are ESTALE/ENODATA errors seen on the
mount but there is no hang whatsoever. CTRL-c promptly returns.

Fixes: #3688
Change-Id: Ide178f75edc15c3af76328f2922e1852d69144f0
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

