### PR TITLE
fd/inode/xlator.c: remove some redundant 'THIS' assignments

### DIFF
--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -444,17 +444,6 @@ fd_destroy(fd_t *fd, gf_boolean_t bound)
     int i = 0;
     xlator_t *old_THIS = NULL;
 
-    if (fd == NULL) {
-        gf_msg_callingfn("xlator", GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG,
-                         "invalid argument");
-        goto out;
-    }
-
-    if (fd->inode == NULL) {
-        gf_msg_callingfn("xlator", GF_LOG_ERROR, 0, LG_MSG_FD_INODE_NULL,
-                         "fd->inode is NULL");
-        goto out;
-    }
     if (!fd->_ctx)
         goto out;
 
@@ -467,10 +456,12 @@ fd_destroy(fd_t *fd, gf_boolean_t bound)
                         old_THIS = THIS;
                     THIS = xl;
                     xl->cbks->releasedir(xl, fd);
-                    THIS = old_THIS;
                 }
             }
         }
+        if (old_THIS)
+            THIS = old_THIS;
+
     } else {
         for (i = 0; i < fd->xl_count; i++) {
             if (fd->_ctx[i].key) {
@@ -480,10 +471,11 @@ fd_destroy(fd_t *fd, gf_boolean_t bound)
                         old_THIS = THIS;
                     THIS = xl;
                     xl->cbks->release(xl, fd);
-                    THIS = old_THIS;
                 }
             }
         }
+        if (old_THIS)
+            THIS = old_THIS;
     }
 
     LOCK_DESTROY(&fd->lock);

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -366,10 +366,11 @@ __inode_ctx_free(inode_t *inode)
                     old_THIS = THIS;
                 THIS = xl;
                 xl->cbks->forget(xl, inode);
-                THIS = old_THIS;
             }
         }
     }
+    if (old_THIS)
+        THIS = old_THIS;
 
     GF_FREE(inode->_ctx);
     inode->_ctx = NULL;

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -483,14 +483,16 @@ xlator_foreach(xlator_t *this, void (*fn)(xlator_t *each, void *data),
         first = first->prev;
 
     while (first) {
-        old_THIS = THIS;
+        if (!old_THIS)
+            old_THIS = THIS;
         THIS = first;
 
         fn(first, data);
 
-        THIS = old_THIS;
         first = first->next;
     }
+    if (old_THIS)
+        THIS = old_THIS;
 
 out:
     return;


### PR DESCRIPTION
We can just save it once and restore it once, in those loops.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

