### PR TITLE
test: ./tests/bugs/posix/bug-1651445.t is failing while running test suite

### DIFF
--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2188,8 +2188,13 @@ out:
         pthread_mutex_unlock(&ctx->write_atomic_lock);
         locked = _gf_false;
     }
-
-    if (op_errno == ENOSPC && priv->disk_space_full && !check_space_error) {
+    /* Check overwrite in case if errorno is ENOSPC, there could be
+       a situation the disk_space_check thread is not set disk_space_flag
+       because the thread is already waiting on sleep and other thread has
+       already consumed free disk space, at the same time if another client try
+       to overwrite the data it would get failed.
+    */
+    if (op_errno == ENOSPC && !check_space_error) {
         ret = posix_fd_ctx_get(fd, this, &pfd, &op_errno);
         if (ret < 0) {
             gf_msg(this->name, GF_LOG_WARNING, ret, P_MSG_PFD_NULL,


### PR DESCRIPTION
The ./tests/bugs/posix/bug-1651445.t is getting failed continuously
while running test suite. The test case is failing after reaching a
situation while brick is throwing an ENOSPC error and after cleanup, as the
test case is trying to create a file it is failing. The file creation is
failing because the flag (disk_space_full) is reset after every 5s by
a thread posix_ctx_disk_thread_proc.

Solution: After cleanup data wait for 5s to reset the flag. Earlier
          the test case did the same but it was changed by the patch(#3637).
Fixes: #3695
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: Ifa0310ba9266651557e29480f5ea476016726e41

