### PR TITLE
tests: do not zero first sectors of LV, do not discard on mkfs.xfs

### DIFF
--- a/tests/snapshot.rc
+++ b/tests/snapshot.rc
@@ -142,13 +142,13 @@ function _create_lv() {
     local virtualsize="150M"
 
     wipefs -a "${dir}/${LVM_PREFIX}_loop"
-    /sbin/pvcreate $dir/${LVM_PREFIX}_loop
-    /sbin/vgcreate ${!vg} $dir/${LVM_PREFIX}_loop
+    /sbin/pvcreate --zero n $dir/${LVM_PREFIX}_loop
+    /sbin/vgcreate --zero n ${!vg} $dir/${LVM_PREFIX}_loop
 
-    /sbin/lvcreate -L ${thinpoolsize} -T ${!vg}/thinpool
+    /sbin/lvcreate --zero n -L ${thinpoolsize} -T ${!vg}/thinpool
     /sbin/lvcreate -V ${virtualsize} -T ${!vg}/thinpool -n brick_lvm
 
-    mkfs.xfs -f /dev/${!vg}/brick_lvm
+    mkfs.xfs -K -f /dev/${!vg}/brick_lvm
 }
 
 function _mount_lv() {


### PR DESCRIPTION
There's no need to zero the first sectors of the PV, VG, LV or discard the FS on creation.
They were all just created and are empty anyway.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

