### PR TITLE
dht: break out of recursive loop for lookups.

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -2370,6 +2370,7 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
             return 0;
         }
         /* A hack */
+        local->gfid_missing = _gf_false;
         dht_lookup_directory(frame, this, &local->loc);
         return 0;
     }


### PR DESCRIPTION
Problem:
When two clients simultaneously create and unlink the same file in a
loop (stress testing), the client doing the unlink was hung and
unresponsive to CTRL-C. On examining, it was observed that when
dht_lookup_cbk() failed with ENODATA (since the other client had created the
file but not yet set the gfid), it was triggering a recursive loop of
lookups (on the client doing the unlink):

```
dht_lookup_cbk  ───────────► dht_lookup_directory ──►dht_lookup_dir_cbk───►dht_lookup_everywhere ───► dht_lookup_everywhere_done
                                    ▲                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    │                                                                         │
                                    └─────────────────────────────────────────────────────────────────────────▼
```

Fix:
Set unset `local->gfid_missing` before "hacking" dht_lookup_everywhere_done()
to again call dht_lookup_directory().

From my limited understanding of dht code, this fix seems to not break
commit 2e4f6f24e4e2656cbb431e9ea34150acb6896a33 and also does not break
gluster behaviour of how a fuse mount will assign a gfid to a file
that is directly created on the brick.

Note: Even with this fix, there are ESTALE/ENODATA errors seen on the
mount but there is no hang whatsoever. CTRL-c promptly returns.

Fixes: #3688
Change-Id: I60e2a3c83542dae59c90e4e295dbc2ea2848537f
Signed-off-by: Ravishankar N <ravishankar.n@pavilion.io>

