### PR TITLE
basic_mount-nfs-auth.t: ensure rpcbind is running

### DIFF
--- a/tests/000-flaky/basic_mount-nfs-auth.t
+++ b/tests/000-flaky/basic_mount-nfs-auth.t
@@ -17,6 +17,9 @@ TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume info
 
+# Ensure port mapper is up and running. Silently continue if it fails.
+sudo systemctl start rpcbind || true
+
 H0IP=$(ip addr show |grep -w inet |grep -v 127.0.0.1|awk '{ print $2 }'| cut -d "/" -f 1)
 H0IP6=$(host $HOSTNAME | grep IPv6 | awk '{print $NF}')
 


### PR DESCRIPTION
At least on my Fedora, the issue with this test not working properly was due to rpcbind not running.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

