### PR TITLE
gfapi: Add support for 'AT_EMPTY_PATH' flag

### DIFF
--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -755,3 +755,9 @@ glfs_iatt_from_statx(struct iatt *, const struct glfs_stat *)
 int
 glfs_setfspid(struct glfs *, pid_t) GFAPI_PRIVATE(glfs_setfspid, 6.1);
 #endif /* !_GLFS_INTERNAL_H */
+
+/* This function is of use when filepath is not present to
+ * resolve and to fill loc.
+ */
+void
+fd_to_loc(struct glfs_fd *glfd, loc_t *loc);

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -1226,3 +1226,11 @@ out:
     GF_FREE(lpath);
     return target_object;
 }
+
+void
+fd_to_loc(struct glfs_fd *glfd, loc_t *loc)
+{
+    loc->inode = inode_ref(glfd->fd->inode);
+    loc->parent = inode_parent(glfd->fd->inode, NULL, NULL);
+    uuid_copy(loc->gfid, glfd->fd->inode->gfid);
+}

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -160,6 +160,9 @@ trap(void);
 /* Advisory buffer size for formatted timestamps (see gf_time_fmt) */
 #define GF_TIMESTR_SIZE 256
 
+/* Allow empty relative pathname */
+#define AT_EMPTY_PATH 0x1000
+
 /*
  * we could have initialized these as +ve values and treated
  * them as negative while comparing etc.. (which would have


### PR DESCRIPTION
Add support for `AT_EMPTY_PATH` flag for the following fops,

- [x] glfs_fstatat
- [x] glfs_linkat
- [x] glfs_fchownat

Acc. to man pages,
`If pathname is an empty string, operate on the file referred to by dirfd (which may
have  been  obtained using the open(2) O_PATH flag).`

Here fstatat & fchownat can have directory file referred by dirfd, unlinkat cannot.

Updates: https://github.com/gluster/glusterfs/issues/2717
Sponsored-By: iXsystems, Inc https://www.ixsystems.com/

Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>

