### PR TITLE
afr-no-fsync.t: disable cluster.lookup-optimize and skip initial FSYN…

### DIFF
--- a/tests/basic/afr/afr-no-fsync.t
+++ b/tests/basic/afr/afr-no-fsync.t
@@ -19,6 +19,6 @@ TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
 sleep 5
 TEST $CLI volume profile $V0 start
 TEST dd if=/dev/zero of=$M0/a bs=1M count=500
-TEST ! "$CLI volume profile $V0 info incremental | fgrep FSYNC"
+TEST ! "$CLI volume profile $V0 info incremental | fgrep -w FSYNC"
 
 cleanup;

--- a/tests/basic/afr/afr-no-fsync.t
+++ b/tests/basic/afr/afr-no-fsync.t
@@ -1,5 +1,6 @@
 #!/bin/bash
 #Tests that sequential write workload doesn't lead to FSYNCs
+#Unrelated FSYNCDIR are filtered
 
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc
@@ -11,10 +12,13 @@ TEST pidof glusterd
 TEST $CLI volume create $V0 replica 3 $H0:$B0/brick{0,1,3}
 TEST $CLI volume set $V0 features.shard on
 TEST $CLI volume set $V0 performance.flush-behind off
+TEST $CLI volume set $V0 cluster.lookup-optimize off
 TEST $CLI volume start $V0
-TEST $CLI volume profile $V0 start
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
+# Let some FSYNCDIR from internal directories complete, before profiling.
+sleep 5
+TEST $CLI volume profile $V0 start
 TEST dd if=/dev/zero of=$M0/a bs=1M count=500
-TEST ! "$CLI volume profile $V0 info incremental | grep FSYNC"
+TEST ! "$CLI volume profile $V0 info incremental | fgrep FSYNC"
 
 cleanup;


### PR DESCRIPTION
…CDIR

Per #2253 we need to disable lookup-optimize feature.

More importantly, there are some FSYNCDIR (4 of them) that appear for some reason too soon.
Re-order the profile start - give 5 seconds for those to be done with and then start profiling.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

