### PR TITLE
Marker: Optimize the size of the stack

### DIFF
--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1116,8 +1116,8 @@ mq_synctask1(xlator_t *this, synctask_fn_t task, gf_boolean_t spawn, loc_t *loc,
     }
 
     if (spawn) {
-        ret = synctask_new1(this->ctx->env, 1024 * 16, task,
-                            mq_synctask_cleanup, NULL, args);
+        ret = synctask_new1(this->ctx->env, 0, task, mq_synctask_cleanup, NULL,
+                            args);
         if (ret) {
             gf_log(this->name, GF_LOG_ERROR,
                    "Failed to spawn "


### PR DESCRIPTION
When the stack size is set 0,  writing small files according to the following steps will not cause the brick process to crash.
And the fuse process is running normally.

(1) create the volume with replica 3 and set quota.
gluster volume create volume-5G replica 3 gluster-0.gluster-svc.default.svc.cluster.local:/data/glusterfs0 gluster-1.gluster-svc.default.svc.cluster.local:/data/glusterfs1 gluster-2.gluster-svc.default.svc.cluster.local:/data/glusterfs2 force
gluster volume start volume-5G
gluster volume quota volume-5G enable
gluster volume quota volume-5G limit-usage / $((510241024*1024))

(2) Mount the volume to the specified directory.
glusterfs --volfile-id=volume-5G --volfile-server=gluster-2.gluster-svc.default.svc.cluster.local /root/data

(3) Run script to write file.
```bash
#!/bin/sh
tmp_dir2=/root/data
for i in {1..1000000};do
mkdir ${tmp_dir2}/${i}
dd if=/dev/zero of=${tmp_dir2}/${i}/${i}.log bs=`shuf -n 1 -i 0-16k` count=1 &>/dev/null
done
```

Fixes: #3710 

Signed-off-by: JamesWSWu <wu.shiwei@zte.com.cn>

