### PR TITLE
syncop functions: no need to copy iatt structs if you are not going t…

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1832,21 +1832,8 @@ glfs_pwritev_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    if (prestat) {
-        if (poststat)
-            ret = syncop_writev(subvol, fd, &iov, 1, offset, iobref, flags,
-                                &preiatt, &postiatt, fop_attr, NULL);
-        else
-            ret = syncop_writev(subvol, fd, &iov, 1, offset, iobref, flags,
-                                &preiatt, NULL, fop_attr, NULL);
-    } else {
-        if (poststat)
-            ret = syncop_writev(subvol, fd, &iov, 1, offset, iobref, flags,
-                                NULL, &postiatt, fop_attr, NULL);
-        else
-            ret = syncop_writev(subvol, fd, &iov, 1, offset, iobref, flags,
-                                NULL, NULL, fop_attr, NULL);
-    }
+    ret = syncop_writev(subvol, fd, &iov, 1, offset, iobref, flags, &preiatt,
+                        &postiatt, fop_attr, NULL);
     DECODE_SYNCOP_ERR(ret);
 
     if (ret >= 0) {

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -507,7 +507,7 @@ glfsh_print_heal_op_status(int ret, uint64_t num_entries,
     return glfsh_output->print_heal_op_status(ret, num_entries, fmt_str);
 }
 
-int
+static int
 glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
                         int32_t *op_errno, char *vgfid)
 {
@@ -515,7 +515,6 @@ glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
     int ret = 0;
     dict_t *xattr = NULL;
     struct iatt iattr = {0};
-    struct iatt parent = {0};
 
     ret = syncop_getxattr(xl, rootloc, &xattr, vgfid, NULL, NULL);
     if (ret < 0) {
@@ -532,7 +531,7 @@ glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
     gf_uuid_copy(dirloc->gfid, index_gfid);
     dirloc->path = "";
     dirloc->inode = inode_new(rootloc->inode->table);
-    ret = syncop_lookup(xl, dirloc, &iattr, &parent, NULL, NULL);
+    ret = syncop_lookup(xl, dirloc, &iattr, NULL, NULL, NULL);
     dirloc->path = NULL;
     if (ret < 0) {
         *op_errno = -ret;

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -662,8 +662,8 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
             goto out;
         }
     } else {
-        ret = syncop_create(to, loc, O_RDWR, DHT_LINKFILE_MODE, fd, &new_stbuf,
-                            dict, NULL);
+        ret = syncop_create(to, loc, O_RDWR, DHT_LINKFILE_MODE, fd, NULL, dict,
+                            NULL);
         if (ret < 0) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                    "failed to create %s on %s", loc->path, to->name);
@@ -4176,12 +4176,6 @@ gf_defrag_start_crawl(void *data)
     loc_t loc = {
         0,
     };
-    struct iatt iatt = {
-        0,
-    };
-    struct iatt parent = {
-        0,
-    };
     int thread_index = 0;
     pthread_t *tid = NULL;
     pthread_t filecnt_thread;
@@ -4213,7 +4207,7 @@ gf_defrag_start_crawl(void *data)
 
     /* fix-layout on '/' first */
 
-    ret = syncop_lookup(this, &loc, &iatt, &parent, NULL, NULL);
+    ret = syncop_lookup(this, &loc, NULL, NULL, NULL, NULL);
 
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_REBALANCE_START_FAILED,

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -290,9 +290,6 @@ br_scrubber_scrub_begin(xlator_t *this, struct br_fsscan_entry *fsentry)
     struct iatt iatt = {
         0,
     };
-    struct iatt parent_buf = {
-        0,
-    };
     pid_t pid = 0;
     br_child_t *child = NULL;
     unsigned char *md = NULL;
@@ -328,7 +325,7 @@ br_scrubber_scrub_begin(xlator_t *this, struct br_fsscan_entry *fsentry)
 
     syncopctx_setfspid(&pid);
 
-    ret = syncop_lookup(child->xl, &loc, &iatt, &parent_buf, NULL, NULL);
+    ret = syncop_lookup(child->xl, &loc, &iatt, NULL, NULL, NULL);
     if (ret) {
         br_log_object_path(this, "lookup", loc.path, -ret);
         goto out;

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -940,9 +940,6 @@ bitd_oneshot_crawl(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     struct iatt iatt = {
         0,
     };
-    struct iatt parent_buf = {
-        0,
-    };
     dict_t *xattr = NULL;
     int32_t ret = -1;
     inode_t *linked_inode = NULL;
@@ -959,7 +956,7 @@ bitd_oneshot_crawl(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     if (!ret)
         goto out;
 
-    ret = syncop_lookup(child->xl, &loc, &iatt, &parent_buf, NULL, NULL);
+    ret = syncop_lookup(child->xl, &loc, &iatt, NULL, NULL, NULL);
     if (ret) {
         br_log_object_path(this, "lookup", loc.path, -ret);
         goto out;
@@ -1273,12 +1270,6 @@ br_brick_connect(xlator_t *this, br_child_t *child)
     loc_t loc = {
         0,
     };
-    struct iatt buf = {
-        0,
-    };
-    struct iatt parent = {
-        0,
-    };
     br_stub_init_t *stub = NULL;
     dict_t *xattr = NULL;
     int op_errno = 0;
@@ -1294,7 +1285,7 @@ br_brick_connect(xlator_t *this, br_child_t *child)
     gf_uuid_copy(loc.gfid, loc.inode->gfid);
     loc.path = gf_strdup("/");
 
-    ret = syncop_lookup(child->xl, &loc, &buf, &parent, NULL, NULL);
+    ret = syncop_lookup(child->xl, &loc, NULL, NULL, NULL, NULL);
     if (ret) {
         op_errno = -ret;
         ret = -1;

--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -380,9 +380,6 @@ mq_are_xattrs_set(xlator_t *this, loc_t *loc, gf_boolean_t *contri_set,
     quota_meta_t meta = {
         0,
     };
-    struct iatt stbuf = {
-        0,
-    };
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
 
@@ -396,7 +393,7 @@ mq_are_xattrs_set(xlator_t *this, loc_t *loc, gf_boolean_t *contri_set,
     if (ret < 0)
         goto out;
 
-    ret = syncop_lookup(FIRST_CHILD(this), loc, &stbuf, NULL, dict, &rsp_dict);
+    ret = syncop_lookup(FIRST_CHILD(this), loc, NULL, NULL, dict, &rsp_dict);
     if (ret < 0) {
         gf_log_callingfn(
             this->name,
@@ -527,9 +524,6 @@ mq_get_dirty(xlator_t *this, loc_t *loc, int32_t *dirty)
     int8_t value = 0;
     dict_t *dict = NULL;
     dict_t *rsp_dict = NULL;
-    struct iatt stbuf = {
-        0,
-    };
 
     dict = dict_new();
     if (dict == NULL) {
@@ -543,7 +537,7 @@ mq_get_dirty(xlator_t *this, loc_t *loc, int32_t *dirty)
         goto out;
     }
 
-    ret = syncop_lookup(FIRST_CHILD(this), loc, &stbuf, NULL, dict, &rsp_dict);
+    ret = syncop_lookup(FIRST_CHILD(this), loc, NULL, NULL, dict, &rsp_dict);
     if (ret < 0) {
         gf_log_callingfn(
             this->name,

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -5344,9 +5344,6 @@ fuse_first_lookup(xlator_t *this)
     dict_t *dict = NULL;
     static uuid_t gfid = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
     int ret = -1;
-    struct iatt iatt = {
-        0,
-    };
 
     priv = this->private;
 
@@ -5366,7 +5363,7 @@ fuse_first_lookup(xlator_t *this)
         goto out;
     }
 
-    ret = syncop_lookup(xl, &loc, &iatt, NULL, dict, NULL);
+    ret = syncop_lookup(xl, &loc, NULL, NULL, dict, NULL);
     DECODE_SYNCOP_ERR(ret);
     if (ret < 0) {
         gf_log(this->name, GF_LOG_ERROR, "first lookup on root failed (%s)",

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -130,9 +130,6 @@ server_first_lookup(xlator_t *this, client_t *client, dict_t *reply)
     loc_t loc = {
         0,
     };
-    struct iatt iatt = {
-        0,
-    };
     dict_t *dict = NULL;
     int ret = 0;
     xlator_t *xl = client->bound_xl;
@@ -149,7 +146,7 @@ server_first_lookup(xlator_t *this, client_t *client, dict_t *reply)
     loc.parent = NULL;
     gf_uuid_copy(loc.gfid, loc.inode->gfid);
 
-    ret = syncop_lookup(xl, &loc, &iatt, NULL, NULL, NULL);
+    ret = syncop_lookup(xl, &loc, NULL, NULL, NULL, NULL);
     if (ret < 0)
         gf_log(xl->name, GF_LOG_ERROR, "lookup on root failed: %s",
                strerror(errno));


### PR DESCRIPTION
…o use them later on.

They are optional anyway, so if the caller does not intend on using them later on, just pass NULL instead
and skip copying them.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

