### PR TITLE
events: webhooks.json's format may be wrong

### DIFF
--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -78,8 +78,10 @@ def create_custom_config_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(CUSTOM_CONFIG_FILE):
-        with open(CUSTOM_CONFIG_FILE, "w") as f:
+        with open(CUSTOM_CONFIG_FILE + ".tmp2", "w") as f:
             f.write("{}")
+
+        os.rename(CUSTOM_CONFIG_FILE + ".tmp2", CUSTOM_CONFIG_FILE)
 
 
 def create_webhooks_file_if_not_exists(args):
@@ -91,8 +93,10 @@ def create_webhooks_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(WEBHOOKS_FILE):
-        with open(WEBHOOKS_FILE, "w") as f:
+        with open(WEBHOOKS_FILE + ".tmp1", "w") as f:
             f.write("{}")
+
+        os.rename(WEBHOOKS_FILE + ".tmp1", WEBHOOKS_FILE)
 
 
 def boolify(value):


### PR DESCRIPTION
Description of problem:
I have 3-replica volume, and each on different node.
each node I run cmd :
gluster-eventsapi webhook-add http://210.0.1.228:1110/storage/v1/tenants/admin/glusterevent
gluster-eventsapi config-set port 24009

Occasionality, I find webhooks.json under /var/lib/glusterd/events is in wrong format. And gluster-eventsapi will fail due to
json.load(open(WEBHOOKS_FILE)).

cat webhooks.json
{}http://210.0.1.228:1110/storage/v1/tenants/admin/glusterevent": {"token": "", "secret": ""}}

The exact command to reproduce the issue:
3-replica volume, on each node run
gluster-eventsapi webhook-add http://210.0.1.228:1110/storage/v1/tenants/admin/glusterevent
gluster-eventsapi config-set port 24009