### PR TITLE
posix: Handle `glusterfs.get_real_filename` virtual xattr in `fgetxattr()`

### DIFF
--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -4186,6 +4186,10 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         0,
     };
     dict_t *xattr_rsp = NULL;
+    char *path = NULL;
+    loc_t loc = {
+        0,
+    };
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -4211,6 +4215,44 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         op_ret = -1;
         op_errno = ENOMEM;
         goto out;
+    }
+
+    if (fd->inode && name &&
+        (strncmp(name, GF_XATTR_GET_REAL_FILENAME_KEY,
+                 SLEN(GF_XATTR_GET_REAL_FILENAME_KEY)) == 0)) {
+        ret = inode_path(fd->inode, NULL, &path);
+        if (ret < 0) {
+            op_ret = -1;
+            op_errno = -ret;
+            goto out;
+        }
+
+        loc.path = path;
+        loc.inode = inode_ref(fd->inode);
+        gf_uuid_copy(loc.gfid, fd->inode->gfid);
+
+        ret = posix_xattr_get_real_filename(frame, this, &loc, name, dict,
+                                            xdata);
+        if (ret < 0) {
+            op_ret = -1;
+            op_errno = -ret;
+            if (op_errno == ENOATTR) {
+                gf_msg_debug(this->name, 0,
+                             "Failed to get "
+                             "real filename (%s, %s)",
+                             loc.path, name);
+            } else {
+                gf_msg(this->name, GF_LOG_WARNING, op_errno,
+                       P_MSG_GETTING_FILENAME_FAILED,
+                       "Failed to get real filename (%s, %s):", loc.path, name);
+            }
+            loc_wipe(&loc);
+            goto out;
+        }
+
+        size = ret;
+        loc_wipe(&loc);
+        goto done;
     }
 
     if (name && !strcmp(name, GLUSTERFS_OPEN_FD_COUNT)) {


### PR DESCRIPTION
Treat the special case of `glusterfs.get_real_filename:<name>` xattr in _fgetxattr()_ in the same way as _getxattr()_. This fixes the mismatch in error code returned for those calls.

fixes #3725 

