### PR TITLE
fd_ctx_get() and fd_ctx_del() should just return the value

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -5859,7 +5859,7 @@ glfs_recall_lease_fd(struct glfs *fs, struct gf_upcall *up_data)
     {
         list_for_each_entry(fd, &inode->fd_list, inode_list)
         {
-            ret = fd_ctx_get(fd, subvol, &value);
+            value = fd_ctx_get(fd, subvol);
             glfd = (struct glfs_fd *)(uintptr_t)value;
             if (glfd) {
                 gf_msg_trace(THIS->name, 0, "glfd (%p) has held lease", glfd);

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -5823,7 +5823,6 @@ glfs_recall_lease_fd(struct glfs *fs, struct gf_upcall *up_data)
     struct glfs_fd *tmp = NULL;
     struct list_head glfd_list;
     fd_t *fd = NULL;
-    uint64_t value = 0;
     struct glfs_lease lease = {
         0,
     };
@@ -5859,8 +5858,7 @@ glfs_recall_lease_fd(struct glfs *fs, struct gf_upcall *up_data)
     {
         list_for_each_entry(fd, &inode->fd_list, inode_list)
         {
-            value = fd_ctx_get(fd, subvol);
-            glfd = (struct glfs_fd *)(uintptr_t)value;
+            glfd = fd_ctx_get_ptr(fd, subvol);
             if (glfd) {
                 gf_msg_trace(THIS->name, 0, "glfd (%p) has held lease", glfd);
                 GF_REF_GET(glfd);

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -939,41 +939,38 @@ fd_ctx_get(fd_t *fd, xlator_t *xlator)
     return ret;
 }
 
-static int
-__fd_ctx_del(fd_t *fd, xlator_t *xlator, uint64_t *value)
+static uint64_t
+__fd_ctx_del(fd_t *fd, xlator_t *xlator)
 {
     int index = 0;
+    uint64_t value = 0;
 
     if (!fd || !xlator)
         return -1;
 
     for (index = 0; index < fd->xl_count; index++) {
         if (fd->_ctx[index].xl_key == xlator) {
-            if (value)
-                *value = fd->_ctx[index].value1;
+            value = fd->_ctx[index].value1;
             fd->_ctx[index].key = 0;
             fd->_ctx[index].value1 = 0;
-            return 0;
         }
     }
 
-    return -1;
+    return value;
 }
 
-int
-fd_ctx_del(fd_t *fd, xlator_t *xlator, uint64_t *value)
+uint64_t
+fd_ctx_del(fd_t *fd, xlator_t *xlator)
 {
-    int ret = 0;
+    uint64_t ret = 0;
 
-    if (!fd)
-        return -1;
-
-    LOCK(&fd->lock);
-    {
-        ret = __fd_ctx_del(fd, xlator, value);
+    if (fd) {
+        LOCK(&fd->lock);
+        {
+            ret = __fd_ctx_del(fd, xlator);
+        }
+        UNLOCK(&fd->lock);
     }
-    UNLOCK(&fd->lock);
-
     return ret;
 }
 

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -948,13 +948,14 @@ __fd_ctx_del(fd_t *fd, xlator_t *xlator)
 
     for (index = 0; index < fd->xl_count; index++) {
         if (fd->_ctx[index].xl_key == xlator) {
-            fd->_ctx[index].key = 0;
             value = fd->_ctx[index].value1;
+            fd->_ctx[index].key = 0;
             fd->_ctx[index].value1 = 0;
+            return value;
         }
     }
 
-    return value;
+    return 0;
 }
 
 uint64_t

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -848,8 +848,7 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value)
                 set_idx = index;
             /* don't break, to check if key already exists
                further on */
-        }
-        else if (fd->_ctx[index].xl_key == xlator) {
+        } else if (fd->_ctx[index].xl_key == xlator) {
             set_idx = index;
             goto set_value;
         }
@@ -910,7 +909,6 @@ uint64_t
 __fd_ctx_get(fd_t *fd, xlator_t *xlator)
 {
     int index = 0;
-    int ret = 0;
 
     if (!fd || !xlator)
         return 0;

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -815,10 +815,10 @@ fd_lookup_anonymous(inode_t *inode, int32_t flags)
     return fd;
 }
 
-int
+uint8_t
 fd_list_empty(inode_t *inode)
 {
-    int empty = 0;
+    uint8_t empty = 0;
 
     LOCK(&inode->lock);
     {
@@ -848,9 +848,10 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value)
                 set_idx = index;
             /* don't break, to check if key already exists
                further on */
-        } else if (fd->_ctx[index].xl_key == xlator) {
+        }
+        if (fd->_ctx[index].xl_key == xlator) {
             set_idx = index;
-            goto set_value;
+            break;
         }
     }
 
@@ -878,7 +879,6 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value)
     }
 
     fd->_ctx[set_idx].xl_key = xlator;
-set_value:
     fd->_ctx[set_idx].value1 = value;
 
 out:
@@ -944,12 +944,12 @@ __fd_ctx_del(fd_t *fd, xlator_t *xlator)
     uint64_t value = 0;
 
     if (!fd || !xlator)
-        return -1;
+        return 0;
 
     for (index = 0; index < fd->xl_count; index++) {
         if (fd->_ctx[index].xl_key == xlator) {
-            value = fd->_ctx[index].value1;
             fd->_ctx[index].key = 0;
+            value = fd->_ctx[index].value1;
             fd->_ctx[index].value1 = 0;
         }
     }

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -146,6 +146,7 @@ fd_ctx_get(fd_t *fd, xlator_t *xlator);
 
 uint64_t
 fd_ctx_del(fd_t *fd, xlator_t *xlator);
+#define fd_ctx_del_ptr(_fd, _xl) (void *)(uintptr_t)fd_ctx_del(_fd, _xl)
 
 int
 __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -142,7 +142,7 @@ fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
 uint64_t
 fd_ctx_get(fd_t *fd, xlator_t *xlator);
-#define fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t)fd_ctx_get(_fd, _xl)
+#define fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t) fd_ctx_get(_fd, _xl)
 
 uint64_t
 fd_ctx_del(fd_t *fd, xlator_t *xlator);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -38,14 +38,14 @@ struct _fd_ctx {
 struct _fd {
     uint64_t pid;
     int32_t flags;
-    gf_atomic_t refcount;
+    gf_atomic_uint32_t refcount;
     struct list_head inode_list;
     struct _inode *inode;
     gf_lock_t lock; /* used ONLY for manipulating
                        'struct _fd_ctx' array (_ctx).*/
     struct _fd_ctx *_ctx;
-    int xl_count; /* Number of xl referred in this fd */
     struct fd_lk_ctx *lk_ctx;
+    int xl_count; /* Number of xl referred in this fd */
     gf_boolean_t anonymous; /* fd which does not have counterpart open
                                fd on backend (server for client, posix
                                for server). */

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -131,7 +131,7 @@ fd_anonymous(inode_t *inode);
 fd_t *
 fd_anonymous_with_flags(inode_t *inode, int32_t flags);
 
-int
+uint8_t
 fd_list_empty(struct _inode *inode);
 
 fd_t *

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -75,6 +75,8 @@ typedef struct _fdtable fdtable_t;
  */
 #define GF_FDENTRY_ALLOCATED -2
 
+#define fd_is_anonymous(_fd) (((_fd) && (_fd)->anonymous))
+
 #include "glusterfs/logging.h"
 #include "glusterfs/xlator.h"
 
@@ -129,10 +131,7 @@ fd_anonymous(inode_t *inode);
 fd_t *
 fd_anonymous_with_flags(inode_t *inode, int32_t flags);
 
-gf_boolean_t
-fd_is_anonymous(fd_t *fd);
-
-uint8_t
+int
 fd_list_empty(struct _inode *inode);
 
 fd_t *
@@ -141,20 +140,17 @@ fd_bind(fd_t *fd);
 int
 fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
-int
-fd_ctx_get(fd_t *fd, xlator_t *xlator, uint64_t *value);
+uint64_t
+fd_ctx_get(fd_t *fd, xlator_t *xlator);
 
 int
 fd_ctx_del(fd_t *fd, xlator_t *xlator, uint64_t *value);
 
 int
-__fd_ctx_del(fd_t *fd, xlator_t *xlator, uint64_t *value);
-
-int
 __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
-int
-__fd_ctx_get(fd_t *fd, xlator_t *xlator, uint64_t *value);
+uint64_t
+__fd_ctx_get(fd_t *fd, xlator_t *xlator);
 
 void
 fd_ctx_dump(fd_t *fd, char *prefix);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -143,8 +143,8 @@ fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 uint64_t
 fd_ctx_get(fd_t *fd, xlator_t *xlator);
 
-int
-fd_ctx_del(fd_t *fd, xlator_t *xlator, uint64_t *value);
+uint64_t
+fd_ctx_del(fd_t *fd, xlator_t *xlator);
 
 int
 __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -142,6 +142,7 @@ fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
 uint64_t
 fd_ctx_get(fd_t *fd, xlator_t *xlator);
+#define fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t)fd_ctx_get(_fd, _xl)
 
 uint64_t
 fd_ctx_del(fd_t *fd, xlator_t *xlator);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -142,7 +142,7 @@ fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
 uint64_t
 fd_ctx_get(fd_t *fd, xlator_t *xlator);
-#define fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t) fd_ctx_get(_fd, _xl)
+#define fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t)fd_ctx_get(_fd, _xl)
 
 uint64_t
 fd_ctx_del(fd_t *fd, xlator_t *xlator);
@@ -152,6 +152,7 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value);
 
 uint64_t
 __fd_ctx_get(fd_t *fd, xlator_t *xlator);
+#define __fd_ctx_get_ptr(_fd, _xl) (void *)(uintptr_t)__fd_ctx_get(_fd, _xl)
 
 void
 fd_ctx_dump(fd_t *fd, char *prefix);

--- a/libglusterfs/src/glusterfs/fd.h
+++ b/libglusterfs/src/glusterfs/fd.h
@@ -45,7 +45,7 @@ struct _fd {
                        'struct _fd_ctx' array (_ctx).*/
     struct _fd_ctx *_ctx;
     struct fd_lk_ctx *lk_ctx;
-    int xl_count; /* Number of xl referred in this fd */
+    int xl_count;           /* Number of xl referred in this fd */
     gf_boolean_t anonymous; /* fd which does not have counterpart open
                                fd on backend (server for client, posix
                                for server). */
@@ -74,8 +74,6 @@ typedef struct _fdtable fdtable_t;
  * the next_free value in an fdentry that has been allocated
  */
 #define GF_FDENTRY_ALLOCATED -2
-
-#define fd_is_anonymous(_fd) (((_fd) && (_fd)->anonymous))
 
 #include "glusterfs/logging.h"
 #include "glusterfs/xlator.h"
@@ -130,6 +128,9 @@ fd_anonymous(inode_t *inode);
 
 fd_t *
 fd_anonymous_with_flags(inode_t *inode, int32_t flags);
+
+gf_boolean_t
+fd_is_anonymous(fd_t *fd);
 
 uint8_t
 fd_list_empty(struct _inode *inode);

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -455,6 +455,7 @@ __fd_ctx_get
 fd_ctx_get
 __fd_ctx_set
 fd_ctx_set
+fd_is_anonymous
 fd_list_empty
 fd_lk_ctx_empty
 fd_lk_ctx_ref

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -449,14 +449,12 @@ fd_bind
 fd_close
 fd_create
 fd_create_uint64
-__fd_ctx_del
 fd_ctx_del
 fd_ctx_dump
 __fd_ctx_get
 fd_ctx_get
 __fd_ctx_set
 fd_ctx_set
-fd_is_anonymous
 fd_list_empty
 fd_lk_ctx_empty
 fd_lk_ctx_ref

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4122,7 +4122,6 @@ static afr_fd_ctx_t *
 __afr_fd_ctx_get(fd_t *fd, xlator_t *this)
 {
     uint64_t ctx = 0;
-    int ret = 0;
     afr_fd_ctx_t *fd_ctx = NULL;
 
     ctx = __fd_ctx_get(fd, this);

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4052,11 +4052,9 @@ _afr_cleanup_fd_ctx(xlator_t *this, afr_fd_ctx_t *fd_ctx)
 void
 afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd)
 {
-    uint64_t ctx = 0;
     afr_fd_ctx_t *fd_ctx = NULL;
 
-    ctx = fd_ctx_get(fd, this);
-    fd_ctx = (afr_fd_ctx_t *)(long)ctx;
+    fd_ctx = fd_ctx_get_ptr(fd, this);
     if (fd_ctx)
         _afr_cleanup_fd_ctx(this, fd_ctx);
 }

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4116,15 +4116,12 @@ out:
 static afr_fd_ctx_t *
 __afr_fd_ctx_get(fd_t *fd, xlator_t *this)
 {
-    uint64_t ctx = 0;
     afr_fd_ctx_t *fd_ctx = NULL;
 
-    ctx = __fd_ctx_get(fd, this);
+    fd_ctx = __fd_ctx_get_ptr(fd, this);
 
-    if (!ctx) {
+    if (!fd_ctx) {
         fd_ctx = __afr_fd_ctx_set(this, fd);
-    } else {
-        fd_ctx = (afr_fd_ctx_t *)(long)ctx;
     }
     return fd_ctx;
 }

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4049,25 +4049,19 @@ _afr_cleanup_fd_ctx(xlator_t *this, afr_fd_ctx_t *fd_ctx)
     return;
 }
 
-int
+void
 afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd)
 {
     uint64_t ctx = 0;
     afr_fd_ctx_t *fd_ctx = NULL;
-    int ret = 0;
 
-    ret = fd_ctx_get(fd, this, &ctx);
-    if (ret < 0)
-        goto out;
-
-    fd_ctx = (afr_fd_ctx_t *)(long)ctx;
-
-    if (fd_ctx) {
-        _afr_cleanup_fd_ctx(this, fd_ctx);
+    ctx = fd_ctx_get(fd, this);
+    if (ctx) {
+        fd_ctx = (afr_fd_ctx_t *)(long)ctx;
+        if (fd_ctx) {
+            _afr_cleanup_fd_ctx(this, fd_ctx);
+        }
     }
-
-out:
-    return 0;
 }
 
 int
@@ -4131,9 +4125,9 @@ __afr_fd_ctx_get(fd_t *fd, xlator_t *this)
     int ret = 0;
     afr_fd_ctx_t *fd_ctx = NULL;
 
-    ret = __fd_ctx_get(fd, this, &ctx);
+    ctx = __fd_ctx_get(fd, this);
 
-    if (ret < 0) {
+    if (!ctx) {
         fd_ctx = __afr_fd_ctx_set(this, fd);
     } else {
         fd_ctx = (afr_fd_ctx_t *)(long)ctx;

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4056,12 +4056,9 @@ afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd)
     afr_fd_ctx_t *fd_ctx = NULL;
 
     ctx = fd_ctx_get(fd, this);
-    if (ctx) {
-        fd_ctx = (afr_fd_ctx_t *)(long)ctx;
-        if (fd_ctx) {
-            _afr_cleanup_fd_ctx(this, fd_ctx);
-        }
-    }
+    fd_ctx = (afr_fd_ctx_t *)(long)ctx;
+    if (fd_ctx)
+        _afr_cleanup_fd_ctx(this, fd_ctx);
 }
 
 int

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -528,7 +528,6 @@ afr_lock_blocking(call_frame_t *frame, xlator_t *this, int cookie)
     afr_local_t *local = NULL;
     afr_private_t *priv = NULL;
     uint64_t ctx = 0;
-    int ret = 0;
     int child_index = 0;
     int lockee_num = 0;
 

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -539,9 +539,9 @@ afr_lock_blocking(call_frame_t *frame, xlator_t *this, int cookie)
     lockee_num = cookie / priv->child_count;
 
     if (local->fd) {
-        ret = fd_ctx_get(local->fd, this, &ctx);
+        ctx = fd_ctx_get(local->fd, this);
 
-        if (ret < 0) {
+        if (!ctx) {
             gf_msg(this->name, GF_LOG_INFO, 0, AFR_MSG_FD_CTX_GET_FAILED,
                    "unable to get fd ctx for fd=%p", local->fd);
 

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -1014,7 +1014,7 @@ int
 afr_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
          fd_t *fd, dict_t *xdata);
 
-int
+void
 afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd);
 
 #define AFR_STACK_UNWIND(fop, frame, op_ret, op_errno, params...)              \

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -76,7 +76,6 @@ int
 dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
 {
     dht_fd_ctx_t *fd_ctx = NULL;
-    uint64_t value = 0;
     int ret = -1;
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
@@ -84,9 +83,8 @@ dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
 
     LOCK(&fd->lock);
     {
-        value = __fd_ctx_get(fd, this);
-        if (value) {
-            fd_ctx = (dht_fd_ctx_t *)(uintptr_t)value;
+        fd_ctx = __fd_ctx_get_ptr(fd, this);
+        if (fd_ctx) {
             if (fd_ctx->opened_on_dst == (uint64_t)(uintptr_t)dst) {
                 /* This could happen due to racing
                  * check_progress tasks*/
@@ -114,16 +112,14 @@ static dht_fd_ctx_t *
 dht_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     dht_fd_ctx_t *fd_ctx = NULL;
-    uint64_t tmp_val = 0;
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     LOCK(&fd->lock);
     {
-        tmp_val = __fd_ctx_get(fd, this);
-        if (tmp_val) {
-            fd_ctx = (dht_fd_ctx_t *)(uintptr_t)tmp_val;
+        fd_ctx = __fd_ctx_get_ptr(fd, this);
+        if (fd_ctx) {
             GF_REF_GET(fd_ctx);
         }
     }

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -22,19 +22,13 @@ int32_t
 dht_fd_ctx_destroy(xlator_t *this, fd_t *fd)
 {
     dht_fd_ctx_t *fd_ctx = NULL;
-    uint64_t value = 0;
     int32_t ret = -1;
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     ret = 0;
-    value = fd_ctx_del(fd, this);
-    if (!value) {
-        goto out;
-    }
-
-    fd_ctx = (dht_fd_ctx_t *)(uintptr_t)value;
+    fd_ctx = fd_ctx_del_ptr(fd, this);
     if (fd_ctx) {
         GF_REF_PUT(fd_ctx);
     }

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -28,8 +28,8 @@ dht_fd_ctx_destroy(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("dht", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = fd_ctx_del(fd, this, &value);
-    if (ret) {
+    value = fd_ctx_del(fd, this);
+    if (!value) {
         goto out;
     }
 
@@ -114,7 +114,6 @@ static dht_fd_ctx_t *
 dht_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     dht_fd_ctx_t *fd_ctx = NULL;
-    int ret = -1;
     uint64_t tmp_val = 0;
 
     GF_VALIDATE_OR_GOTO("dht", this, out);
@@ -123,14 +122,11 @@ dht_fd_ctx_get(xlator_t *this, fd_t *fd)
     LOCK(&fd->lock);
     {
         tmp_val = __fd_ctx_get(fd, this);
-        if (tmp_val == 0) {
-            goto unlock;
+        if (tmp_val) {
+            fd_ctx = (dht_fd_ctx_t *)(uintptr_t)tmp_val;
+            GF_REF_GET(fd_ctx);
         }
-
-        fd_ctx = (dht_fd_ctx_t *)(uintptr_t)tmp_val;
-        GF_REF_GET(fd_ctx);
     }
-unlock:
     UNLOCK(&fd->lock);
 
 out:

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -28,6 +28,7 @@ dht_fd_ctx_destroy(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("dht", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
+    ret = 0;
     value = fd_ctx_del(fd, this);
     if (!value) {
         goto out;

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -84,8 +84,8 @@ dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
 
     LOCK(&fd->lock);
     {
-        ret = __fd_ctx_get(fd, this, &value);
-        if (ret && value) {
+        value = __fd_ctx_get(fd, this);
+        if (value) {
             fd_ctx = (dht_fd_ctx_t *)(uintptr_t)value;
             if (fd_ctx->opened_on_dst == (uint64_t)(uintptr_t)dst) {
                 /* This could happen due to racing
@@ -122,8 +122,8 @@ dht_fd_ctx_get(xlator_t *this, fd_t *fd)
 
     LOCK(&fd->lock);
     {
-        ret = __fd_ctx_get(fd, this, &tmp_val);
-        if ((ret < 0) || (tmp_val == 0)) {
+        tmp_val = __fd_ctx_get(fd, this);
+        if (tmp_val == 0) {
             goto unlock;
         }
 

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -76,6 +76,7 @@ dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
     GF_VALIDATE_OR_GOTO("dht", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
+    ret = 0;
     LOCK(&fd->lock);
     {
         fd_ctx = __fd_ctx_get_ptr(fd, this);

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -755,8 +755,8 @@ __ec_fd_get(fd_t *fd, xlator_t *xl)
     uint64_t value = 0;
     ec_t *ec = xl->private;
 
-    value = __fd_ctx_get(fd, xl);
-    if (value == 0) {
+    ctx = __fd_ctx_get_ptr(fd, xl);
+    if (!ctx) {
         ctx = GF_MALLOC(sizeof(*ctx) + (sizeof(ec_fd_status_t) * ec->nodes),
                         ec_mt_ec_fd_t);
         if (ctx != NULL) {
@@ -782,8 +782,6 @@ __ec_fd_get(fd_t *fd, xlator_t *xl)
                 ctx->bad_version = ictx->bad_version;
             }
         }
-    } else {
-        ctx = (ec_fd_t *)(uintptr_t)value;
     }
 
     /* Treat anonymous fd specially */

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -755,7 +755,8 @@ __ec_fd_get(fd_t *fd, xlator_t *xl)
     uint64_t value = 0;
     ec_t *ec = xl->private;
 
-    if ((__fd_ctx_get(fd, xl, &value) != 0) || (value == 0)) {
+    value = __fd_ctx_get(fd, xl);
+    if (value == 0) {
         ctx = GF_MALLOC(sizeof(*ctx) + (sizeof(ec_fd_status_t) * ec->nodes),
                         ec_mt_ec_fd_t);
         if (ctx != NULL) {

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -1499,12 +1499,10 @@ ec_gf_forget(xlator_t *this, inode_t *inode)
 void
 ec_gf_release_fd(xlator_t *this, fd_t *fd)
 {
-    uint64_t value = 0;
     ec_fd_t *ctx = NULL;
 
-    value = fd_ctx_del(fd, this);
-    if (value) {
-        ctx = (ec_fd_t *)(uintptr_t)value;
+    ctx = fd_ctx_del_ptr(fd, this);
+    if (ctx) {
         loc_wipe(&ctx->loc);
         GF_FREE(ctx);
     }

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -1502,7 +1502,8 @@ ec_gf_release_fd(xlator_t *this, fd_t *fd)
     uint64_t value = 0;
     ec_fd_t *ctx = NULL;
 
-    if ((fd_ctx_del(fd, this, &value) == 0) && (value != 0)) {
+    value = fd_ctx_del(fd, this);
+    if (value) {
         ctx = (ec_fd_t *)(uintptr_t)value;
         loc_wipe(&ctx->loc);
         GF_FREE(ctx);

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -313,9 +313,9 @@ ios_fd_ctx_get(fd_t *fd, xlator_t *this, struct ios_fd **iosfd)
     unsigned long iosfdlong = 0;
     int ret = 0;
 
-    ret = fd_ctx_get(fd, this, &iosfd64);
+    iosfd64 = fd_ctx_get(fd, this);
     iosfdlong = iosfd64;
-    if (ret != -1)
+    if (iosfdlong)
         *iosfd = (void *)iosfdlong;
 
     return ret;

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -307,21 +307,6 @@ is_fop_latency_started(call_frame_t *frame)
     } while (0)
 
 static int
-ios_fd_ctx_get(fd_t *fd, xlator_t *this, struct ios_fd **iosfd)
-{
-    uint64_t iosfd64 = 0;
-    unsigned long iosfdlong = 0;
-    int ret = 0;
-
-    iosfd64 = fd_ctx_get(fd, this);
-    iosfdlong = iosfd64;
-    if (iosfdlong)
-        *iosfd = (void *)iosfdlong;
-
-    return ret;
-}
-
-static int
 ios_fd_ctx_set(fd_t *fd, xlator_t *this, struct ios_fd *iosfd)
 {
     uint64_t iosfd64 = 0;
@@ -466,7 +451,6 @@ ios_bump_read(xlator_t *this, fd_t *fd, size_t len)
 
     conf = this->private;
     lb2 = log_base2(len);
-    ios_fd_ctx_get(fd, this, &iosfd);
     if (!conf)
         return;
 
@@ -475,6 +459,7 @@ ios_bump_read(xlator_t *this, fd_t *fd, size_t len)
     GF_ATOMIC_INC(conf->cumulative.block_count_read[lb2]);
     GF_ATOMIC_INC(conf->incremental.block_count_read[lb2]);
 
+    iosfd = fd_ctx_get_ptr(fd, this);
     if (iosfd) {
         GF_ATOMIC_ADD(iosfd->data_read, len);
         GF_ATOMIC_INC(iosfd->block_count_read[lb2]);
@@ -490,7 +475,6 @@ ios_bump_write(xlator_t *this, fd_t *fd, size_t len)
 
     conf = this->private;
     lb2 = log_base2(len);
-    ios_fd_ctx_get(fd, this, &iosfd);
     if (!conf)
         return;
 
@@ -499,6 +483,7 @@ ios_bump_write(xlator_t *this, fd_t *fd, size_t len)
     GF_ATOMIC_INC(conf->cumulative.block_count_write[lb2]);
     GF_ATOMIC_INC(conf->incremental.block_count_write[lb2]);
 
+    iosfd = fd_ctx_get_ptr(fd, this);
     if (iosfd) {
         GF_ATOMIC_ADD(iosfd->data_written, len);
         GF_ATOMIC_INC(iosfd->block_count_write[lb2]);
@@ -3564,7 +3549,7 @@ io_stats_release(xlator_t *this, fd_t *fd)
         UNLOCK(&conf->lock);
     }
 
-    ios_fd_ctx_get(fd, this, &iosfd);
+    iosfd = fd_ctx_get_ptr(fd, this);
     if (iosfd) {
         io_stats_dump_fd(this, iosfd);
 

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -44,14 +44,14 @@ br_stub_fd_t *
 __br_stub_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     br_stub_fd_t *br_stub_fd = NULL;
-    uint64_t value = 0;
 
-    GF_VALIDATE_OR_GOTO("bit-rot-stub", this, out);
-    GF_VALIDATE_OR_GOTO(this->name, fd, out);
-
-    value = __fd_ctx_get(fd, this);
-    if (value)
-        br_stub_fd = (br_stub_fd_t *)((long)value);
+    br_stub_fd = __fd_ctx_get_ptr(fd, this);
+    if (!br_stub_fd) {
+        /* check if one of the parameters was null and provide meaningful error
+         */
+        GF_VALIDATE_OR_GOTO("bit-rot-stub", this, out);
+        GF_VALIDATE_OR_GOTO(this->name, fd, out);
+    }
 
 out:
     return br_stub_fd;

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -45,16 +45,13 @@ __br_stub_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     br_stub_fd_t *br_stub_fd = NULL;
     uint64_t value = 0;
-    int ret = -1;
 
     GF_VALIDATE_OR_GOTO("bit-rot-stub", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     value = __fd_ctx_get(fd, this);
-    if (!value)
-        return NULL;
-
-    br_stub_fd = (br_stub_fd_t *)((long)value);
+    if (value)
+        br_stub_fd = (br_stub_fd_t *)((long)value);
 
 out:
     return br_stub_fd;

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -50,8 +50,8 @@ __br_stub_fd_ctx_get(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("bit-rot-stub", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = __fd_ctx_get(fd, this, &value);
-    if (ret)
+    value = __fd_ctx_get(fd, this);
+    if (!value)
         return NULL;
 
     br_stub_fd = (br_stub_fd_t *)((long)value);

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -3453,9 +3453,10 @@ unblock:
     }
 
     tmp = fd_ctx_del(fd, this);
-    br_stub_fd = (br_stub_fd_t *)(long)tmp;
-
-    GF_FREE(br_stub_fd);
+    if (tmp) {
+        br_stub_fd = (br_stub_fd_t *)(long)tmp;
+        GF_FREE(br_stub_fd);
+    }
 
     return 0;
 }

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -3411,7 +3411,6 @@ br_stub_release(xlator_t *this, fd_t *fd)
     inode_t *inode = NULL;
     unsigned long releaseversion = 0;
     br_stub_inode_ctx_t *ctx = NULL;
-    uint64_t tmp = 0;
     br_stub_fd_t *br_stub_fd = NULL;
     int32_t signinfo = 0;
 
@@ -3452,9 +3451,8 @@ unblock:
         br_stub_send_ipc_fop(this, fd, releaseversion, signinfo);
     }
 
-    tmp = fd_ctx_del(fd, this);
-    if (tmp) {
-        br_stub_fd = (br_stub_fd_t *)(long)tmp;
+    br_stub_fd = fd_ctx_del_ptr(fd, this);
+    if (br_stub_fd) {
         GF_FREE(br_stub_fd);
     }
 
@@ -3465,14 +3463,12 @@ int32_t
 br_stub_releasedir(xlator_t *this, fd_t *fd)
 {
     br_stub_fd_t *fctx = NULL;
-    uint64_t ctx = 0;
     int ret = 0;
 
-    ctx = fd_ctx_del(fd, this);
-    if (!ctx)
+    fctx = fd_ctx_del_ptr(fd, this);
+    if (!fctx)
         goto out;
 
-    fctx = (br_stub_fd_t *)(long)ctx;
     if (fctx->bad_object.dir) {
         ret = sys_closedir(fctx->bad_object.dir);
         if (ret)

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -3452,7 +3452,7 @@ unblock:
         br_stub_send_ipc_fop(this, fd, releaseversion, signinfo);
     }
 
-    ret = fd_ctx_del(fd, this, &tmp);
+    tmp = fd_ctx_del(fd, this);
     br_stub_fd = (br_stub_fd_t *)(long)tmp;
 
     GF_FREE(br_stub_fd);
@@ -3467,8 +3467,8 @@ br_stub_releasedir(xlator_t *this, fd_t *fd)
     uint64_t ctx = 0;
     int ret = 0;
 
-    ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
+    ctx = fd_ctx_del(fd, this);
+    if (!ctx)
         goto out;
 
     fctx = (br_stub_fd_t *)(long)ctx;

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -1885,7 +1885,7 @@ changelog_release(xlator_t *this, fd_t *fd)
     gf_uuid_copy(ev.u.release.gfid, fd->inode->gfid);
     changelog_dispatch_event(this, priv, &ev);
 
-    (void)fd_ctx_del(fd, this, NULL);
+    (void)fd_ctx_del(fd, this);
 
     return 0;
 }

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -2571,8 +2571,8 @@ index_releasedir(xlator_t *this, fd_t *fd)
     uint64_t ctx = 0;
     int ret = 0;
 
-    ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
+    ctx = fd_ctx_del(fd, this);
+    if (!ctx)
         goto out;
 
     fctx = (index_fd_ctx_t *)(long)ctx;
@@ -2593,15 +2593,13 @@ index_release(xlator_t *this, fd_t *fd)
 {
     index_fd_ctx_t *fctx = NULL;
     uint64_t ctx = 0;
-    int ret = 0;
 
-    ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
-        goto out;
+    ctx = fd_ctx_del(fd, this);
+    if (ctx) {
+        fctx = (index_fd_ctx_t *)(long)ctx;
+        GF_FREE(fctx);
+    }
 
-    fctx = (index_fd_ctx_t *)(long)ctx;
-    GF_FREE(fctx);
-out:
     return 0;
 }
 

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -2566,14 +2566,12 @@ int32_t
 index_releasedir(xlator_t *this, fd_t *fd)
 {
     index_fd_ctx_t *fctx = NULL;
-    uint64_t ctx = 0;
     int ret = 0;
 
-    ctx = fd_ctx_del(fd, this);
-    if (!ctx)
+    fctx = fd_ctx_del_ptr(fd, this);
+    if (!fctx)
         goto out;
 
-    fctx = (index_fd_ctx_t *)(long)ctx;
     if (fctx->dir) {
         ret = sys_closedir(fctx->dir);
         if (ret)
@@ -2590,11 +2588,9 @@ int32_t
 index_release(xlator_t *this, fd_t *fd)
 {
     index_fd_ctx_t *fctx = NULL;
-    uint64_t ctx = 0;
 
-    ctx = fd_ctx_del(fd, this);
-    if (ctx) {
-        fctx = (index_fd_ctx_t *)(long)ctx;
+    fctx = fd_ctx_del_ptr(fd, this);
+    if (fctx) {
         GF_FREE(fctx);
     }
 

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1134,12 +1134,10 @@ __index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
 {
     int ret = 0;
     index_fd_ctx_t *fctx = NULL;
-    uint64_t tmpctx = 0;
     char dirpath[PATH_MAX] = {0};
 
-    tmpctx = __fd_ctx_get(fd, this);
-    if (tmpctx) {
-        fctx = (index_fd_ctx_t *)(long)tmpctx;
+    fctx = __fd_ctx_get(fd, this);
+    if (fctx) {
         *ctx = fctx;
         goto out;
     }

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1137,8 +1137,8 @@ __index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
     uint64_t tmpctx = 0;
     char dirpath[PATH_MAX] = {0};
 
-    ret = __fd_ctx_get(fd, this, &tmpctx);
-    if (!ret) {
+    tmpctx = __fd_ctx_get(fd, this);
+    if (tmpctx) {
         fctx = (index_fd_ctx_t *)(long)tmpctx;
         *ctx = fctx;
         goto out;

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -1136,7 +1136,7 @@ __index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
     index_fd_ctx_t *fctx = NULL;
     char dirpath[PATH_MAX] = {0};
 
-    fctx = __fd_ctx_get(fd, this);
+    fctx = __fd_ctx_get_ptr(fd, this);
     if (fctx) {
         *ctx = fctx;
         goto out;

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -678,7 +678,6 @@ __is_lease_grantable(xlator_t *this, lease_inode_ctx_t *lease_ctx,
     fd_t *iter_fd = NULL;
     gf_boolean_t grant = _gf_false;
     lease_fd_ctx_t *fd_ctx = NULL;
-    uint64_t ctx = 0;
 
     GF_VALIDATE_OR_GOTO("leases", lease_ctx, out);
     GF_VALIDATE_OR_GOTO("leases", lease, out);
@@ -704,15 +703,14 @@ __is_lease_grantable(xlator_t *this, lease_inode_ctx_t *lease_ctx,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            ctx = fd_ctx_get(iter_fd, this);
-            if (!ctx) {
+            fd_ctx = fd_ctx_get_ptr(iter_fd, this);
+            if (!fd_ctx) {
                 grant = _gf_false;
                 UNLOCK(&inode->lock);
                 gf_msg(this->name, GF_LOG_ERROR, 0, LEASE_MSG_INVAL_FD_CTX,
                        "Unable to get fd ctx");
                 goto out;
             }
-            fd_ctx = (lease_fd_ctx_t *)(long)ctx;
 
             /* Check for open fd conflict, note that open fds from
              * the same lease id is not checked for conflict, as it is

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -677,7 +677,6 @@ __is_lease_grantable(xlator_t *this, lease_inode_ctx_t *lease_ctx,
     int32_t flags = 0;
     fd_t *iter_fd = NULL;
     gf_boolean_t grant = _gf_false;
-    int ret = 0;
     lease_fd_ctx_t *fd_ctx = NULL;
     uint64_t ctx = 0;
 
@@ -705,8 +704,8 @@ __is_lease_grantable(xlator_t *this, lease_inode_ctx_t *lease_ctx,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            ret = fd_ctx_get(iter_fd, this, &ctx);
-            if (ret < 0) {
+            ctx = fd_ctx_get(iter_fd, this);
+            if (!ctx) {
                 grant = _gf_false;
                 UNLOCK(&inode->lock);
                 gf_msg(this->name, GF_LOG_ERROR, 0, LEASE_MSG_INVAL_FD_CTX,

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -1065,8 +1065,8 @@ leases_release(xlator_t *this, fd_t *fd)
 
     gf_log(this->name, GF_LOG_TRACE, "Releasing all leases with fd %p", fd);
 
-    ret = fd_ctx_del(fd, this, &tmp);
-    if (ret) {
+    tmp = fd_ctx_del(fd, this);
+    if (!tmp) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         goto out;
     }

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -1066,8 +1066,8 @@ leases_release(xlator_t *this, fd_t *fd)
     if (!fd_ctx) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         goto out;
-    } else
-        GF_FREE(fd_ctx);
+    }
+    GF_FREE(fd_ctx);
 
     ret = 0;
 out:

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -1072,6 +1072,8 @@ leases_release(xlator_t *this, fd_t *fd)
     fd_ctx = (lease_fd_ctx_t *)(long)tmp;
     if (fd_ctx)
         GF_FREE(fd_ctx);
+
+    ret = 0;
 out:
     return ret;
 }

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -1054,7 +1054,6 @@ static int
 leases_release(xlator_t *this, fd_t *fd)
 {
     int ret = -1;
-    uint64_t tmp = 0;
     lease_fd_ctx_t *fd_ctx = NULL;
 
     if (fd == NULL) {
@@ -1063,14 +1062,11 @@ leases_release(xlator_t *this, fd_t *fd)
 
     gf_log(this->name, GF_LOG_TRACE, "Releasing all leases with fd %p", fd);
 
-    tmp = fd_ctx_del(fd, this);
-    if (!tmp) {
+    fd_ctx = fd_ctx_del_ptr(fd, this);
+    if (!fd_ctx) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         goto out;
-    }
-
-    fd_ctx = (lease_fd_ctx_t *)(long)tmp;
-    if (fd_ctx)
+    } else
         GF_FREE(fd_ctx);
 
     ret = 0;

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -848,7 +848,6 @@ leases_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     char *lease_id = NULL;
     int ret = 0;
     lease_fd_ctx_t *fd_ctx = NULL;
-    uint64_t ctx = 0;
 
     EXIT_IF_LEASES_OFF(this, out);
     EXIT_IF_INTERNAL_FOP(frame, xdata, out);
@@ -880,9 +879,8 @@ out:
      *                      OR
      *     - Find why release is not called post the last close call
      */
-    ctx = fd_ctx_get(fd, this);
-    if (ctx) {
-        fd_ctx = (lease_fd_ctx_t *)(long)ctx;
+    fd_ctx = fd_ctx_get_ptr(fd, this);
+    if (fd_ctx) {
         if (fd_ctx->client_uid) {
             GF_FREE(fd_ctx->client_uid);
             fd_ctx->client_uid = NULL;

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -880,8 +880,8 @@ out:
      *                      OR
      *     - Find why release is not called post the last close call
      */
-    ret = fd_ctx_get(fd, this, &ctx);
-    if (ret == 0) {
+    ctx = fd_ctx_get(fd, this);
+    if (ctx) {
         fd_ctx = (lease_fd_ctx_t *)(long)ctx;
         if (fd_ctx->client_uid) {
             GF_FREE(fd_ctx->client_uid);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -312,7 +312,10 @@ __get_posixlk_count(pl_inode_t *pl_inode)
     posix_lock_t *lock = NULL;
     int32_t count = 0;
 
-    list_for_each_entry(lock, &pl_inode->ext_list, list) { count++; }
+    list_for_each_entry(lock, &pl_inode->ext_list, list)
+    {
+        count++;
+    }
 
     return count;
 }
@@ -2973,7 +2976,6 @@ pl_release(xlator_t *this, fd_t *fd)
     pl_inode_t *pl_inode = NULL;
     uint64_t tmp_pl_inode = 0;
     int ret = -1;
-    uint64_t tmp = 0;
     pl_fdctx_t *fdctx = NULL;
 
     if (fd == NULL) {
@@ -2994,15 +2996,13 @@ pl_release(xlator_t *this, fd_t *fd)
     pl_update_refkeeper(this, fd->inode);
 
 clean:
-    tmp = fd_ctx_del(fd, this);
-    if (!tmp) {
+    fdctx = fd_ctx_del_ptr(fd, this);
+    if (!fdctx) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         ret = -1;
         goto out;
     }
     ret = 0;
-
-    fdctx = (pl_fdctx_t *)(long)tmp;
 
     GF_FREE(fdctx);
 out:
@@ -3013,20 +3013,17 @@ int
 pl_releasedir(xlator_t *this, fd_t *fd)
 {
     int ret = -1;
-    uint64_t tmp = 0;
     pl_fdctx_t *fdctx = NULL;
 
     if (fd == NULL) {
         goto out;
     }
 
-    tmp = fd_ctx_del(fd, this);
-    if (!tmp) {
+    fdctx = fd_ctx_del_ptr(fd, this);
+    if (!fdctx) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         goto out;
     }
-
-    fdctx = (pl_fdctx_t *)(long)tmp;
 
     GF_FREE(fdctx);
     ret = 0;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2996,9 +2996,10 @@ pl_release(xlator_t *this, fd_t *fd)
     pl_update_refkeeper(this, fd->inode);
 
 clean:
-    ret = fd_ctx_del(fd, this, &tmp);
-    if (ret) {
+    tmp = fd_ctx_del(fd, this);
+    if (!tmp) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
+        ret = -1;
         goto out;
     }
 
@@ -3020,8 +3021,8 @@ pl_releasedir(xlator_t *this, fd_t *fd)
         goto out;
     }
 
-    ret = fd_ctx_del(fd, this, &tmp);
-    if (ret) {
+    tmp = fd_ctx_del(fd, this);
+    if (!tmp) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get fdctx");
         goto out;
     }
@@ -3029,6 +3030,7 @@ pl_releasedir(xlator_t *this, fd_t *fd)
     fdctx = (pl_fdctx_t *)(long)tmp;
 
     GF_FREE(fdctx);
+    ret = 0;
 out:
     return ret;
 }

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -3000,6 +3000,7 @@ clean:
         ret = -1;
         goto out;
     }
+    ret = 0;
 
     fdctx = (pl_fdctx_t *)(long)tmp;
 

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2538,7 +2538,6 @@ static int
 pl_getlk_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd,
             posix_lock_t *reqlock)
 {
-    uint64_t tmp = 0;
     pl_fdctx_t *fdctx = NULL;
     int ret = 0;
 
@@ -2553,8 +2552,7 @@ pl_getlk_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd,
 
         gf_log(this->name, GF_LOG_DEBUG, "There are active locks on fd");
 
-        tmp = fd_ctx_get(fd, this);
-        fdctx = (pl_fdctx_t *)(long)tmp;
+        fdctx = fd_ctx_get_ptr(fd, this);
 
         if (list_empty(&fdctx->locks_list)) {
             gf_log(this->name, GF_LOG_TRACE,

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -607,8 +607,8 @@ pl_check_n_create_fdctx(xlator_t *this, fd_t *fd)
 
     LOCK(&fd->lock);
     {
-        ret = __fd_ctx_get(fd, this, &tmp);
-        if ((ret != 0) || (tmp == 0)) {
+        tmp = __fd_ctx_get(fd, this);
+        if (tmp == 0) {
             fdctx = pl_new_fdctx();
             if (fdctx == NULL) {
                 goto unlock;
@@ -2553,7 +2553,7 @@ pl_getlk_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd,
 
         gf_log(this->name, GF_LOG_DEBUG, "There are active locks on fd");
 
-        ret = fd_ctx_get(fd, this, &tmp);
+        tmp = fd_ctx_get(fd, this);
         fdctx = (pl_fdctx_t *)(long)tmp;
 
         if (list_empty(&fdctx->locks_list)) {

--- a/xlators/features/read-only/src/worm.c
+++ b/xlators/features/read-only/src/worm.c
@@ -618,12 +618,9 @@ worm_release(xlator_t *this, fd_t *fd)
             goto out;
         }
 
-        ret = fd_ctx_get(fd, this, &value);
-        if (ret) {
-            gf_log(this->name, GF_LOG_DEBUG, "Failed to get the fd ctx");
-        }
+        value = fd_ctx_get(fd, this);
         if (!value) {
-            goto out;
+            gf_log(this->name, GF_LOG_DEBUG, "Failed to get the fd ctx");
         }
 
         ret = dict_set_int8(dict, "trusted.worm_file", 1);

--- a/xlators/features/read-only/src/worm.c
+++ b/xlators/features/read-only/src/worm.c
@@ -621,6 +621,7 @@ worm_release(xlator_t *this, fd_t *fd)
         value = fd_ctx_get(fd, this);
         if (!value) {
             gf_log(this->name, GF_LOG_DEBUG, "Failed to get the fd ctx");
+            goto out;
         }
 
         ret = dict_set_int8(dict, "trusted.worm_file", 1);

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -6091,9 +6091,9 @@ shard_fsync_shards_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                             SHARD_MASK_TIMES);
     }
     UNLOCK(&frame->lock);
-    fd_ctx_get(anon_fd, this, &fsync_count);
 out:
     if (anon_fd && (base_inode != anon_fd->inode)) {
+        fsync_count = fd_ctx_get(anon_fd, this);
         LOCK(&base_inode->lock);
         LOCK(&anon_fd->inode->lock);
         {

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -2400,13 +2400,12 @@ gf_svc_releasedir(xlator_t *this, fd_t *fd)
 {
     svc_fd_t *sfd = NULL;
     uint64_t tmp_pfd = 0;
-    int ret = 0;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    tmp_pfd = fd_ctx_del(fd, this);
+    if (!tmp_pfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -127,16 +127,13 @@ __svc_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     svc_fd_t *svc_fd = NULL;
     uint64_t value = 0;
-    int ret = -1;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = __fd_ctx_get(fd, this, &value);
-    if (ret)
-        return NULL;
-
-    svc_fd = (svc_fd_t *)((long)value);
+    value = __fd_ctx_get(fd, this);
+    if (value)
+        svc_fd = (svc_fd_t *)((long)value);
 
 out:
     return svc_fd;

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -126,14 +126,12 @@ static svc_fd_t *
 __svc_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     svc_fd_t *svc_fd = NULL;
-    uint64_t value = 0;
 
-    GF_VALIDATE_OR_GOTO("snapview-client", this, out);
-    GF_VALIDATE_OR_GOTO(this->name, fd, out);
-
-    value = __fd_ctx_get(fd, this);
-    if (value)
-        svc_fd = (svc_fd_t *)((long)value);
+    svc_fd = __fd_ctx_get_ptr(fd, this);
+    if (!svc_fd) {
+        GF_VALIDATE_OR_GOTO("snapview-client", this, out);
+        GF_VALIDATE_OR_GOTO(this->name, fd, out);
+    }
 
 out:
     return svc_fd;
@@ -1912,8 +1910,7 @@ gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, this->private, out);
 
-   private
-    = this->private;
+    private = this->private;
     local = frame->local;
 
     loc = &local->loc;
@@ -2600,8 +2597,7 @@ init(xlator_t *this)
                      "volfile");
     }
 
-   private
-    = GF_CALLOC(1, sizeof(*private), gf_svc_mt_svc_private_t);
+    private = GF_CALLOC(1, sizeof(*private), gf_svc_mt_svc_private_t);
     if (!private)
         goto out;
 
@@ -2614,8 +2610,7 @@ init(xlator_t *this)
         goto out;
     }
 
-   private
-    ->path = gf_strdup(path);
+    private->path = gf_strdup(path);
     if (!private->path) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_NO_MEMORY,
                 "entry-point-path=%s", path, NULL);
@@ -2634,8 +2629,7 @@ init(xlator_t *this)
         goto out;
     }
 
-   private
-    ->special_dir = gf_strdup(special_dir);
+    private->special_dir = gf_strdup(special_dir);
     if (!private->special_dir) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_NO_MEMORY,
                 "special-directory=%s", special_dir, NULL);

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -2396,18 +2396,16 @@ static int32_t
 gf_svc_releasedir(xlator_t *this, fd_t *fd)
 {
     svc_fd_t *sfd = NULL;
-    uint64_t tmp_pfd = 0;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    tmp_pfd = fd_ctx_del(fd, this);
-    if (!tmp_pfd) {
+    sfd = fd_ctx_del_ptr(fd, this);
+    if (!sfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }
 
-    sfd = (svc_fd_t *)(long)tmp_pfd;
     GF_FREE(sfd);
 
 out:

--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -160,14 +160,12 @@ svs_fd_t *
 __svs_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     svs_fd_t *svs_fd = NULL;
-    uint64_t value = 0;
 
-    GF_VALIDATE_OR_GOTO("snapview-server", this, out);
-    GF_VALIDATE_OR_GOTO(this->name, fd, out);
-
-    value = __fd_ctx_get(fd, this);
-    if (value)
-        svs_fd = (svs_fd_t *)((long)value);
+    svs_fd = __fd_ctx_get_ptr(fd, this);
+    if (!svs_fd) {
+        GF_VALIDATE_OR_GOTO("snapview-server", this, out);
+        GF_VALIDATE_OR_GOTO(this->name, fd, out);
+    }
 
 out:
     return svs_fd;

--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -161,16 +161,13 @@ __svs_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     svs_fd_t *svs_fd = NULL;
     uint64_t value = 0;
-    int ret = -1;
 
     GF_VALIDATE_OR_GOTO("snapview-server", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = __fd_ctx_get(fd, this, &value);
-    if (ret)
-        return NULL;
-
-    svs_fd = (svs_fd_t *)((long)value);
+    value = __fd_ctx_get(fd, this);
+    if (value)
+        svs_fd = (svs_fd_t *)((long)value);
 
 out:
     return svs_fd;

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1224,9 +1224,10 @@ svs_releasedir(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("snapview-server", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    tmp_pfd = fd_ctx_del(fd, this);
+    if (tmp_pfd == 0) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
+        ret = -1;
         goto out;
     }
 
@@ -1261,7 +1262,6 @@ svs_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
     int32_t op_ret = -1;
     int32_t op_errno = 0;
-    int ret = -1;
     uint64_t value = 0;
     svs_inode_t *inode_ctx = NULL;
     call_stack_t *root = NULL;
@@ -1318,9 +1318,10 @@ svs_release(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("snapview-server", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    tmp_pfd = fd_ctx_del(fd, this);
+    if (tmp_pfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
+        ret = -1;
         goto out;
     }
 

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1289,8 +1289,8 @@ svs_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         goto out;
     }
 
-    ret = fd_ctx_get(fd, this, &value);
-    if (ret < 0 && inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
+    value = fd_ctx_get(fd, this);
+    if (!value && inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
         op_errno = EINVAL;
         gf_msg(this->name, GF_LOG_WARNING, op_errno,
                SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1215,7 +1215,6 @@ static int32_t
 svs_releasedir(xlator_t *this, fd_t *fd)
 {
     svs_fd_t *sfd = NULL;
-    uint64_t tmp_pfd = 0;
     int ret = 0;
     svs_inode_t *svs_inode = NULL;
     glfs_t *fs = NULL;
@@ -1224,8 +1223,8 @@ svs_releasedir(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("snapview-server", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    tmp_pfd = fd_ctx_del(fd, this);
-    if (tmp_pfd == 0) {
+    sfd = fd_ctx_del_ptr(fd, this);
+    if (!sfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         ret = -1;
         goto out;
@@ -1238,7 +1237,6 @@ svs_releasedir(xlator_t *this, fd_t *fd)
         fs = svs_inode->fs; /* should inode->lock be held for this? */
         SVS_CHECK_VALID_SNAPSHOT_HANDLE(fs, this);
         if (fs) {
-            sfd = (svs_fd_t *)(long)tmp_pfd;
             if (sfd->fd) {
                 ret = glfs_close(sfd->fd);
                 if (ret)
@@ -1310,7 +1308,6 @@ static int32_t
 svs_release(xlator_t *this, fd_t *fd)
 {
     svs_fd_t *sfd = NULL;
-    uint64_t tmp_pfd = 0;
     int ret = 0;
     inode_t *inode = NULL;
     svs_inode_t *svs_inode = NULL;
@@ -1319,8 +1316,8 @@ svs_release(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO("snapview-server", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    tmp_pfd = fd_ctx_del(fd, this);
-    if (!tmp_pfd) {
+    sfd = fd_ctx_del_ptr(fd, this);
+    if (!sfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         ret = -1;
         goto out;
@@ -1333,7 +1330,6 @@ svs_release(xlator_t *this, fd_t *fd)
         fs = svs_inode->fs; /* should inode->lock be held for this? */
         SVS_CHECK_VALID_SNAPSHOT_HANDLE(fs, this);
         if (fs) {
-            sfd = (svs_fd_t *)(long)tmp_pfd;
             if (sfd->fd) {
                 ret = glfs_close(sfd->fd);
                 if (ret)

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1319,7 +1319,7 @@ svs_release(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     tmp_pfd = fd_ctx_del(fd, this);
-    if (tmp_pfd) {
+    if (!tmp_pfd) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         ret = -1;
         goto out;

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1294,7 +1294,7 @@ svs_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         if (!value) {
             op_errno = EINVAL;
             gf_msg(this->name, GF_LOG_WARNING, op_errno,
-                SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);
+                   SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);
             goto out;
         }
     }

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1289,14 +1289,15 @@ svs_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         goto out;
     }
 
-    value = fd_ctx_get(fd, this);
-    if (!value && inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
-        op_errno = EINVAL;
-        gf_msg(this->name, GF_LOG_WARNING, op_errno,
-               SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);
-        goto out;
+    if (inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
+        value = fd_ctx_get(fd, this);
+        if (!value) {
+            op_errno = EINVAL;
+            gf_msg(this->name, GF_LOG_WARNING, op_errno,
+                SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);
+            goto out;
+        }
     }
-
     op_ret = 0;
 
 out:

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -16,20 +16,16 @@
 meta_fd_t *
 meta_fd_get(fd_t *fd, xlator_t *this)
 {
-    uint64_t value = 0;
     meta_fd_t *meta_fd = NULL;
 
     LOCK(&fd->lock);
     {
-        value = __fd_ctx_get(fd, this);
-        if (!value) {
+        meta_fd = __fd_ctx_get_ptr(fd, this);
+        if (!meta_fd) {
             meta_fd = GF_CALLOC(1, sizeof(*meta_fd), gf_meta_mt_fd_t);
             if (!meta_fd)
                 goto unlock;
-            value = (long)meta_fd;
-            __fd_ctx_set(fd, this, value);
-        } else {
-            meta_fd = (void *)(uintptr_t)value;
+            __fd_ctx_set(fd, this, (long)meta_fd);
         }
     }
 unlock:

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -40,7 +40,7 @@ meta_fd_release(fd_t *fd, xlator_t *this)
     meta_fd_t *meta_fd = NULL;
     int i = 0;
 
-    meta_fd = fd_ctx_get_ptr(fd, this);
+    meta_fd = fd_ctx_del_ptr(fd, this);
 
     if (meta_fd) {
         if (meta_fd->dirents) {

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -21,14 +21,13 @@ meta_fd_get(fd_t *fd, xlator_t *this)
 
     LOCK(&fd->lock);
     {
-        if (__fd_ctx_get(fd, this, &value) < 0) {
-            if (!value) {
-                meta_fd = GF_CALLOC(1, sizeof(*meta_fd), gf_meta_mt_fd_t);
-                if (!meta_fd)
-                    goto unlock;
-                value = (long)meta_fd;
-                __fd_ctx_set(fd, this, value);
-            }
+        value = __fd_ctx_get(fd, this);
+        if (!value) {
+            meta_fd = GF_CALLOC(1, sizeof(*meta_fd), gf_meta_mt_fd_t);
+            if (!meta_fd)
+                goto unlock;
+            value = (long)meta_fd;
+            __fd_ctx_set(fd, this, value);
         } else {
             meta_fd = (void *)(uintptr_t)value;
         }
@@ -46,7 +45,7 @@ meta_fd_release(fd_t *fd, xlator_t *this)
     meta_fd_t *meta_fd = NULL;
     int i = 0;
 
-    fd_ctx_get(fd, this, &value);
+    value = fd_ctx_get(fd, this);
     meta_fd = (void *)(uintptr_t)value;
 
     if (meta_fd && meta_fd->dirents) {

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -41,20 +41,17 @@ unlock:
 int
 meta_fd_release(fd_t *fd, xlator_t *this)
 {
-    uint64_t value = 0;
     meta_fd_t *meta_fd = NULL;
     int i = 0;
 
-    value = fd_ctx_get(fd, this);
-    meta_fd = (void *)(uintptr_t)value;
-
-    if (meta_fd && meta_fd->dirents) {
-        for (i = 0; i < meta_fd->size; i++)
-            GF_FREE((void *)meta_fd->dirents[i].name);
-        GF_FREE(meta_fd->dirents);
-    }
+    meta_fd = fd_ctx_get_ptr(fd, this);
 
     if (meta_fd) {
+        if (meta_fd->dirents) {
+            for (i = 0; i < meta_fd->size; i++)
+                GF_FREE((void *)meta_fd->dirents[i].name);
+            GF_FREE(meta_fd->dirents);
+        }
         GF_FREE(meta_fd->data);
         GF_FREE(meta_fd);
     }

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -126,11 +126,10 @@ fuse_fd_ctx_destroy(xlator_t *this, fd_t *fd)
 {
     fd_t *activefd = NULL;
     uint64_t val = 0;
-    int ret = 0;
     fuse_fd_ctx_t *fdctx = NULL;
 
-    ret = fd_ctx_del(fd, this, &val);
-    if (!ret) {
+    val = fd_ctx_del(fd, this);
+    if (val) {
         fdctx = (fuse_fd_ctx_t *)(unsigned long)val;
         if (fdctx) {
             activefd = fdctx->activefd;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -78,13 +78,10 @@ fuse_forget_cbk(xlator_t *this, inode_t *inode)
 fuse_fd_ctx_t *
 __fuse_fd_ctx_check_n_create(xlator_t *this, fd_t *fd)
 {
-    uint64_t val = 0;
     int32_t ret = 0;
     fuse_fd_ctx_t *fd_ctx = NULL;
 
-    val = __fd_ctx_get(fd, this);
-
-    fd_ctx = (fuse_fd_ctx_t *)(unsigned long)val;
+    fd_ctx = __fd_ctx_get_ptr(fd, this);
 
     if (fd_ctx == NULL) {
         fd_ctx = GF_CALLOC(1, sizeof(*fd_ctx), gf_fuse_mt_fd_ctx_t);
@@ -6354,8 +6351,7 @@ fuse_priv_dump(xlator_t *this)
     if (!this)
         return -1;
 
-   private
-    = this->private;
+    private = this->private;
 
     if (!private)
         return -1;
@@ -6503,8 +6499,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
     glusterfs_graph_t *graph = NULL;
     struct pollfd pfd = {0};
 
-   private
-    = this->private;
+    private = this->private;
 
     graph = data;
 
@@ -6529,8 +6524,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
                 (event == GF_EVENT_CHILD_DOWN)) {
                 pthread_mutex_lock(&private->sync_mutex);
                 {
-                   private
-                    ->event_recvd = 1;
+                    private->event_recvd = 1;
                     pthread_cond_broadcast(&private->sync_cond);
                 }
                 pthread_mutex_unlock(&private->sync_mutex);
@@ -6539,18 +6533,16 @@ notify(xlator_t *this, int32_t event, void *data, ...)
             pthread_mutex_lock(&private->sync_mutex);
             {
                 if (!private->fuse_thread_started) {
-                   private
-                    ->fuse_thread_started = 1;
+                    private->fuse_thread_started = 1;
                     start_thread = _gf_true;
                 }
             }
             pthread_mutex_unlock(&private->sync_mutex);
 
             if (start_thread) {
-               private
-                ->fuse_thread = GF_CALLOC(private->reader_thread_count,
-                                          sizeof(pthread_t),
-                                          gf_fuse_mt_pthread_t);
+                private->fuse_thread = GF_CALLOC(private->reader_thread_count,
+                                                 sizeof(pthread_t),
+                                                 gf_fuse_mt_pthread_t);
                 for (i = 0; i < private->reader_thread_count; i++) {
                     ret = gf_thread_create(&private->fuse_thread[i], NULL,
                                            fuse_thread_proc, this, "fuseproc");
@@ -6584,8 +6576,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
                         if (fuse_get_mount_status(this) != 0) {
                             goto auth_fail_unlock;
                         }
-                       private
-                        ->mount_finished = _gf_true;
+                        private->mount_finished = _gf_true;
                     } else if (pfd.revents) {
                         gf_log(this->name, GF_LOG_ERROR,
                                "mount pipe closed without status");

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -122,20 +122,16 @@ static void
 fuse_fd_ctx_destroy(xlator_t *this, fd_t *fd)
 {
     fd_t *activefd = NULL;
-    uint64_t val = 0;
     fuse_fd_ctx_t *fdctx = NULL;
 
-    val = fd_ctx_del(fd, this);
-    if (val) {
-        fdctx = (fuse_fd_ctx_t *)(unsigned long)val;
-        if (fdctx) {
-            activefd = fdctx->activefd;
-            if (activefd) {
-                fd_unref(activefd);
-            }
-
-            GF_FREE(fdctx);
+    fdctx = fd_ctx_del_ptr(fd, this);
+    if (fdctx) {
+        activefd = fdctx->activefd;
+        if (activefd) {
+            fd_unref(activefd);
         }
+
+        GF_FREE(fdctx);
     }
 }
 

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -82,7 +82,7 @@ __fuse_fd_ctx_check_n_create(xlator_t *this, fd_t *fd)
     int32_t ret = 0;
     fuse_fd_ctx_t *fd_ctx = NULL;
 
-    ret = __fd_ctx_get(fd, this, &val);
+    val = __fd_ctx_get(fd, this);
 
     fd_ctx = (fuse_fd_ctx_t *)(unsigned long)val;
 
@@ -148,16 +148,11 @@ fuse_fd_ctx_get(xlator_t *this, fd_t *fd)
 {
     fuse_fd_ctx_t *fdctx = NULL;
     uint64_t value = 0;
-    int ret = 0;
 
-    ret = fd_ctx_get(fd, this, &value);
-    if (ret < 0) {
-        goto out;
-    }
+    value = fd_ctx_get(fd, this);
+    if (value)
+        fdctx = (fuse_fd_ctx_t *)(unsigned long)value;
 
-    fdctx = (fuse_fd_ctx_t *)(unsigned long)value;
-
-out:
     return fdctx;
 }
 

--- a/xlators/mount/fuse/src/fuse-resolve.c
+++ b/xlators/mount/fuse/src/fuse-resolve.c
@@ -22,9 +22,6 @@ int
 fuse_migrate_fd(xlator_t *this, fd_t *fd, xlator_t *old_subvol,
                 xlator_t *new_subvol);
 
-fuse_fd_ctx_t *
-fuse_fd_ctx_get(xlator_t *this, fd_t *fd);
-
 static int
 fuse_resolve_loc_touchup(fuse_state_t *state)
 {
@@ -370,7 +367,7 @@ fuse_migrate_fd_task(void *data)
 
     basefd = state->fd;
 
-    basefd_ctx = fuse_fd_ctx_get(state->this, basefd);
+    basefd_ctx = fd_ctx_get_ptr(basefd, state->this);
     if (!basefd_ctx)
         goto out;
 
@@ -411,7 +408,7 @@ fuse_migrate_fd_error(xlator_t *this, fd_t *fd)
     fuse_fd_ctx_t *fdctx = NULL;
     char error = 0;
 
-    fdctx = fuse_fd_ctx_get(this, fd);
+    fdctx = fd_ctx_get_ptr(fd, this);
     if (fdctx != NULL) {
         if (fdctx->migration_failed) {
             error = 1;
@@ -452,7 +449,7 @@ fuse_resolve_fd(fuse_state_t *state)
     this = state->this;
 
     basefd = resolve->fd;
-    basefd_ctx = fuse_fd_ctx_get(this, basefd);
+    basefd_ctx = fd_ctx_get_ptr(basefd, this);
     if (basefd_ctx == NULL) {
         gf_log(state->this->name, GF_LOG_WARNING,
                "fdctx is NULL for basefd (ptr:%p inode-gfid:%s), "

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -513,7 +513,7 @@ static void
 __nfs3_call_state_wipe(nfs3_call_state_t *cs)
 {
     if (cs->fd) {
-        gf_msg_trace(GF_NFS3, 0, "fd 0x%lx ref: %" PRId64, (long)cs->fd,
+        gf_msg_trace(GF_NFS3, 0, "fd 0x%lx ref: %" PRIu32, (long)cs->fd,
                      GF_ATOMIC_GET(cs->fd->refcount));
         fd_unref(cs->fd);
     }

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -1109,6 +1109,7 @@ ioc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     uint32_t weight = 0;
     ioc_table_t *table = NULL;
     int32_t op_errno = EINVAL;
+    uint64_t fd_ctx = 0;
 
     if (!this) {
         goto out;
@@ -1157,7 +1158,8 @@ ioc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
     ioc_inode_unlock(ioc_inode);
 
-    if (!fd_ctx_get(fd, this, NULL)) {
+    fd_ctx = fd_ctx_get(fd, this);
+    if (fd_ctx) {
         /* disable caching for this fd, go ahead with normal readv */
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->readv, fd, size, offset, flags,

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -286,9 +286,10 @@ ob_open_and_resume_fd(xlator_t *xl, fd_t *fd, int32_t open_count,
                       bool synchronous, bool trigger, ob_inode_t **pob_inode,
                       fd_t **pfd)
 {
-    uint64_t err;
+    uint64_t err = 0;
 
-    if ((fd_ctx_get(fd, xl, &err) == 0) && (err != 0)) {
+    err = fd_ctx_get(fd, xl);
+    if (err) {
         return (ob_state_t)-err;
     }
 
@@ -888,7 +889,8 @@ ob_fdctx_dump(xlator_t *this, fd_t *fd)
     if (ret)
         return 0;
 
-    if ((__fd_ctx_get(fd, this, &value) == 0) && (value != 0)) {
+    value = __fd_ctx_get(fd, this);
+    if (value) {
         error = (int32_t)value;
     }
 

--- a/xlators/performance/read-ahead/src/page.c
+++ b/xlators/performance/read-ahead/src/page.c
@@ -140,7 +140,7 @@ ra_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local = frame->local;
     fd = local->fd;
 
-    fd_ctx_get(fd, this, &tmp_file);
+    tmp_file = fd_ctx_get(fd, this);
 
     file = (ra_file_t *)(long)tmp_file;
     pending_offset = local->pending_offset;
@@ -436,7 +436,7 @@ ra_frame_unwind(call_frame_t *frame)
     }
 
     fd = local->fd;
-    fd_ctx_get(fd, frame->this, &tmp_file);
+    tmp_file = fd_ctx_get(fd, frame->this);
     file = (ra_file_t *)(long)tmp_file;
 
     STACK_UNWIND_STRICT(readv, frame, local->op_ret, local->op_errno, vector,

--- a/xlators/performance/read-ahead/src/page.c
+++ b/xlators/performance/read-ahead/src/page.c
@@ -132,7 +132,6 @@ ra_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     ra_page_t *page = NULL;
     ra_waitq_t *waitq = NULL;
     fd_t *fd = NULL;
-    uint64_t tmp_file = 0;
     gf_boolean_t stale = _gf_false;
 
     GF_ASSERT(frame);
@@ -140,9 +139,8 @@ ra_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local = frame->local;
     fd = local->fd;
 
-    tmp_file = fd_ctx_get(fd, this);
+    file = fd_ctx_get_ptr(fd, this);
 
-    file = (ra_file_t *)(long)tmp_file;
     pending_offset = local->pending_offset;
 
     if (file == NULL) {
@@ -379,7 +377,6 @@ ra_frame_unwind(call_frame_t *frame)
     ra_fill_t *next = NULL;
     fd_t *fd = NULL;
     ra_file_t *file = NULL;
-    uint64_t tmp_file = 0;
 
     GF_VALIDATE_OR_GOTO("read-ahead", frame, out);
 
@@ -436,8 +433,7 @@ ra_frame_unwind(call_frame_t *frame)
     }
 
     fd = local->fd;
-    tmp_file = fd_ctx_get(fd, frame->this);
-    file = (ra_file_t *)(long)tmp_file;
+    file = fd_ctx_get_ptr(fd, frame->this);
 
     STACK_UNWIND_STRICT(readv, frame, local->op_ret, local->op_errno, vector,
                         count, &file->stbuf, iobref, NULL);

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -444,7 +444,6 @@ ra_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     ra_conf_t *conf = NULL;
     int op_errno = EINVAL;
     char expected_offset = 1;
-    uint64_t tmp_file = 0;
 
     GF_ASSERT(frame);
     GF_VALIDATE_OR_GOTO(frame->this->name, this, unwind);
@@ -456,8 +455,7 @@ ra_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                  "NEW REQ at offset=%" PRId64 " for size=%" GF_PRI_SIZET "",
                  offset, size);
 
-    tmp_file = fd_ctx_get(fd, this);
-    file = (ra_file_t *)(long)tmp_file;
+    file = fd_ctx_get_ptr(fd, this);
 
     if (!file || file->disabled) {
         goto disabled;
@@ -612,7 +610,6 @@ ra_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
           dict_t *xdata)
 {
     ra_file_t *file = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
     inode_t *inode = NULL;
     fd_t *iter_fd = NULL;
@@ -627,10 +624,7 @@ ra_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            tmp_file = 0;
-            tmp_file = fd_ctx_get(iter_fd, this);
-            file = (ra_file_t *)(long)tmp_file;
-
+            file = fd_ctx_get_ptr(iter_fd, this);
             if (!file)
                 continue;
 
@@ -685,7 +679,6 @@ ra_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     ra_file_t *file = NULL;
     fd_t *iter_fd = NULL;
     inode_t *inode = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
 
     GF_ASSERT(frame);
@@ -698,10 +691,7 @@ ra_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            tmp_file = 0;
-            tmp_file = fd_ctx_get(iter_fd, this);
-            file = (ra_file_t *)(long)tmp_file;
-
+            file = fd_ctx_get_ptr(iter_fd, this);
             if (!file)
                 continue;
             /*
@@ -766,15 +756,12 @@ ra_fdctx_dump(xlator_t *this, fd_t *fd)
     ra_file_t *file = NULL;
     ra_page_t *page = NULL;
     int32_t ret = 0, i = 0;
-    uint64_t tmp_file = 0;
     char *path = NULL;
     char key_prefix[GF_DUMP_MAX_BUF_LEN] = {
         0,
     };
 
-    tmp_file = fd_ctx_get(fd, this);
-    file = (ra_file_t *)(long)tmp_file;
-
+    file = fd_ctx_get_ptr(fd, this);
     if (file == NULL) {
         ret = 0;
         goto out;
@@ -822,7 +809,6 @@ ra_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     ra_file_t *file = NULL;
     fd_t *iter_fd = NULL;
     inode_t *inode = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
     ra_conf_t *conf = NULL;
 
@@ -839,10 +825,7 @@ ra_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         {
             list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
             {
-                tmp_file = 0;
-                tmp_file = fd_ctx_get(iter_fd, this);
-                file = (ra_file_t *)(long)tmp_file;
-
+                file = fd_ctx_get_ptr(iter_fd, this);
                 if (!file)
                     continue;
                 flush_region(frame, file, 0, file->pages.prev->offset + 1, 0);
@@ -867,7 +850,6 @@ ra_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     ra_file_t *file = NULL;
     fd_t *iter_fd = NULL;
     inode_t *inode = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
 
     GF_ASSERT(frame);
@@ -880,9 +862,7 @@ ra_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            tmp_file = 0;
-            tmp_file = fd_ctx_get(iter_fd, this);
-            file = (ra_file_t *)(long)tmp_file;
+            file = fd_ctx_get_ptr(iter_fd, this);
             if (!file)
                 continue;
             /*
@@ -926,7 +906,6 @@ ra_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     ra_file_t *file = NULL;
     fd_t *iter_fd = NULL;
     inode_t *inode = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
 
     GF_ASSERT(frame);
@@ -939,9 +918,7 @@ ra_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            tmp_file = 0;
-            tmp_file = fd_ctx_get(iter_fd, this);
-            file = (ra_file_t *)(long)tmp_file;
+            file = fd_ctx_get_ptr(iter_fd, this);
             if (!file)
                 continue;
 
@@ -978,7 +955,6 @@ ra_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     ra_file_t *file = NULL;
     fd_t *iter_fd = NULL;
     inode_t *inode = NULL;
-    uint64_t tmp_file = 0;
     int32_t op_errno = EINVAL;
 
     GF_ASSERT(frame);
@@ -991,9 +967,7 @@ ra_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     {
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
-            tmp_file = 0;
-            tmp_file = fd_ctx_get(iter_fd, this);
-            file = (ra_file_t *)(long)tmp_file;
+            file = fd_ctx_get_ptr(iter_fd, this);
             if (!file)
                 continue;
 

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -457,7 +457,7 @@ ra_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                  "NEW REQ at offset=%" PRId64 " for size=%" GF_PRI_SIZET "",
                  offset, size);
 
-    fd_ctx_get(fd, this, &tmp_file);
+    tmp_file = fd_ctx_get(fd, this);
     file = (ra_file_t *)(long)tmp_file;
 
     if (!file || file->disabled) {
@@ -629,7 +629,7 @@ ra_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             tmp_file = 0;
-            fd_ctx_get(iter_fd, this, &tmp_file);
+            tmp_file = fd_ctx_get(iter_fd, this);
             file = (ra_file_t *)(long)tmp_file;
 
             if (!file)
@@ -700,7 +700,7 @@ ra_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             tmp_file = 0;
-            fd_ctx_get(iter_fd, this, &tmp_file);
+            tmp_file = fd_ctx_get(iter_fd, this);
             file = (ra_file_t *)(long)tmp_file;
 
             if (!file)
@@ -773,7 +773,7 @@ ra_fdctx_dump(xlator_t *this, fd_t *fd)
         0,
     };
 
-    fd_ctx_get(fd, this, &tmp_file);
+    tmp_file = fd_ctx_get(fd, this);
     file = (ra_file_t *)(long)tmp_file;
 
     if (file == NULL) {
@@ -841,7 +841,7 @@ ra_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
             list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
             {
                 tmp_file = 0;
-                fd_ctx_get(iter_fd, this, &tmp_file);
+                tmp_file = fd_ctx_get(iter_fd, this);
                 file = (ra_file_t *)(long)tmp_file;
 
                 if (!file)
@@ -882,7 +882,7 @@ ra_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             tmp_file = 0;
-            fd_ctx_get(iter_fd, this, &tmp_file);
+            tmp_file = fd_ctx_get(iter_fd, this);
             file = (ra_file_t *)(long)tmp_file;
             if (!file)
                 continue;
@@ -941,7 +941,7 @@ ra_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             tmp_file = 0;
-            fd_ctx_get(iter_fd, this, &tmp_file);
+            tmp_file = fd_ctx_get(iter_fd, this);
             file = (ra_file_t *)(long)tmp_file;
             if (!file)
                 continue;
@@ -993,7 +993,7 @@ ra_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             tmp_file = 0;
-            fd_ctx_get(iter_fd, this, &tmp_file);
+            tmp_file = fd_ctx_get(iter_fd, this);
             file = (ra_file_t *)(long)tmp_file;
             if (!file)
                 continue;

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -234,14 +234,13 @@ int
 ra_release(xlator_t *this, fd_t *fd)
 {
     uint64_t tmp_file = 0;
-    int ret = 0;
 
     GF_VALIDATE_OR_GOTO("read-ahead", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    ret = fd_ctx_del(fd, this, &tmp_file);
+    tmp_file = fd_ctx_del(fd, this);
 
-    if (!ret) {
+    if (tmp_file) {
         ra_file_destroy((ra_file_t *)(long)tmp_file);
     }
 

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -233,15 +233,15 @@ flush_region(call_frame_t *frame, ra_file_t *file, off_t offset, off_t size,
 int
 ra_release(xlator_t *this, fd_t *fd)
 {
-    uint64_t tmp_file = 0;
+    ra_file_t *tmp_file = NULL;
 
     GF_VALIDATE_OR_GOTO("read-ahead", this, out);
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
-    tmp_file = fd_ctx_del(fd, this);
+    tmp_file = fd_ctx_del_ptr(fd, this);
 
     if (tmp_file) {
-        ra_file_destroy((ra_file_t *)(long)tmp_file);
+        ra_file_destroy(tmp_file);
     }
 
 out:

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -50,13 +50,12 @@ rda_local_wipe(struct rda_local *local)
 static struct rda_fd_ctx *
 get_rda_fd_ctx(fd_t *fd, xlator_t *this)
 {
-    uint64_t val;
     struct rda_fd_ctx *ctx;
 
     LOCK(&fd->lock);
 
-    val = __fd_ctx_get(fd, this);
-    if (!val) {
+    ctx = __fd_ctx_get_ptr(fd, this);
+    if (!ctx) {
         ctx = GF_CALLOC(1, sizeof(struct rda_fd_ctx), gf_rda_mt_rda_fd_ctx);
         if (!ctx)
             goto out;
@@ -72,8 +71,6 @@ get_rda_fd_ctx(fd_t *fd, xlator_t *this)
             ctx = NULL;
             goto out;
         }
-    } else {
-        ctx = (struct rda_fd_ctx *)(uintptr_t)val;
     }
 out:
     UNLOCK(&fd->lock);

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -1114,14 +1114,9 @@ rda_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 static int32_t
 rda_releasedir(xlator_t *this, fd_t *fd)
 {
-    uint64_t val;
     struct rda_fd_ctx *ctx;
 
-    val = fd_ctx_del(fd, this);
-    if (val == 0)
-        return -1;
-
-    ctx = (struct rda_fd_ctx *)(uintptr_t)val;
+    ctx = fd_ctx_del_ptr(fd, this);
     if (!ctx)
         return 0;
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -208,7 +208,6 @@ rda_mark_inode_dirty(xlator_t *this, inode_t *inode)
 {
     inode_t *parent = NULL;
     fd_t *fd = NULL;
-    uint64_t val = 0;
     int32_t ret = 0;
     struct rda_fd_ctx *fd_ctx = NULL;
     char gfid[GF_UUID_BUF_SIZE] = {0};
@@ -219,12 +218,10 @@ rda_mark_inode_dirty(xlator_t *this, inode_t *inode)
         {
             list_for_each_entry(fd, &parent->fd_list, inode_list)
             {
-                val = 0;
-                val = fd_ctx_get(fd, this);
-                if (val == 0)
+                fd_ctx = fd_ctx_get_ptr(fd, this);
+                if (!fd_ctx)
                     continue;
 
-                fd_ctx = (void *)(uintptr_t)val;
                 if (!GF_ATOMIC_GET(fd_ctx->prefetching))
                     continue;
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -1123,7 +1123,8 @@ rda_releasedir(xlator_t *this, fd_t *fd)
     uint64_t val;
     struct rda_fd_ctx *ctx;
 
-    if (fd_ctx_del(fd, this, &val) < 0)
+    val = fd_ctx_del(fd, this);
+    if (val == 0)
         return -1;
 
     ctx = (struct rda_fd_ctx *)(uintptr_t)val;

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -55,7 +55,8 @@ get_rda_fd_ctx(fd_t *fd, xlator_t *this)
 
     LOCK(&fd->lock);
 
-    if (__fd_ctx_get(fd, this, &val) < 0) {
+    val = __fd_ctx_get(fd, this);
+    if (!val) {
         ctx = GF_CALLOC(1, sizeof(struct rda_fd_ctx), gf_rda_mt_rda_fd_ctx);
         if (!ctx)
             goto out;
@@ -219,7 +220,7 @@ rda_mark_inode_dirty(xlator_t *this, inode_t *inode)
             list_for_each_entry(fd, &parent->fd_list, inode_list)
             {
                 val = 0;
-                fd_ctx_get(fd, this, &val);
+                val = fd_ctx_get(fd, this);
                 if (val == 0)
                     continue;
 

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -55,10 +55,10 @@ typedef struct wb_inode {
                                which arrive later (which overlap, etc.)
                                are issued only after their dependencies
                                in this list are "fulfilled".
-
+ 
                                Server acks for entries in this list
                                shrinks the window.
-
+ 
                                The sum total of all req->write_size
                                of entries in this list must be kept less
                                than the permitted window size.
@@ -92,14 +92,14 @@ typedef struct wb_inode {
                                     the current 'state' of liability. Every
                                     new addition to the liability list bumps
                                     the generation number.
-
+               
                                     a newly arrived request is only required
                                     to perform causal checks against the entries
                                     in the liability list which were present
                                     at the time of its addition. the generation
                                     number at the time of its addition is stored
                                     in the request and used during checks.
-
+               
                                     the liability list can grow while the request
                                     waits in the todo list waiting for its
                                     dependent operations to complete. however

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -2770,9 +2770,7 @@ wb_forget(xlator_t *this, inode_t *inode)
 int
 wb_release(xlator_t *this, fd_t *fd)
 {
-    uint64_t tmp = 0;
-
-    (void)fd_ctx_del(fd, this, &tmp);
+    (void)fd_ctx_del(fd, this);
 
     return 0;
 }

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -58,15 +58,16 @@ out:
 clnt_fd_ctx_t *
 this_fd_get_ctx(fd_t *file, xlator_t *this)
 {
-    uint64_t ctxaddr = 0;
+    clnt_fd_ctx_t *ctxaddr = NULL;
 
-    GF_VALIDATE_OR_GOTO("client", this, out);
-    GF_VALIDATE_OR_GOTO(this->name, file, out);
-
-    ctxaddr = fd_ctx_get(file, this);
+    ctxaddr = fd_ctx_get_ptr(file, this);
+    if (!ctxaddr) { /* check that we did not pass NULL to either this or file */
+        GF_VALIDATE_OR_GOTO("client", this, out);
+        GF_VALIDATE_OR_GOTO(this->name, file, out);
+    }
 
 out:
-    return (clnt_fd_ctx_t *)(unsigned long)ctxaddr;
+    return ctxaddr;
 }
 
 void

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -44,16 +44,16 @@ out:
 clnt_fd_ctx_t *
 this_fd_del_ctx(fd_t *file, xlator_t *this)
 {
-    uint64_t ctxaddr = 0;
+    clnt_fd_ctx_t *ctxaddr = NULL;
 
-    ctxaddr = fd_ctx_del(file, this);
+    ctxaddr = fd_ctx_del_ptr(file, this);
     if (!ctxaddr) { /* check that we did not pass NULL to either this or file */
         GF_VALIDATE_OR_GOTO("client", this, out);
         GF_VALIDATE_OR_GOTO(this->name, file, out);
     }
 
 out:
-    return (clnt_fd_ctx_t *)(unsigned long)ctxaddr;
+    return ctxaddr;
 }
 
 clnt_fd_ctx_t *

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -44,17 +44,12 @@ out:
 clnt_fd_ctx_t *
 this_fd_del_ctx(fd_t *file, xlator_t *this)
 {
-    int dict_ret = -1;
     uint64_t ctxaddr = 0;
 
     GF_VALIDATE_OR_GOTO("client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, file, out);
 
-    dict_ret = fd_ctx_del(file, this, &ctxaddr);
-
-    if (dict_ret < 0) {
-        ctxaddr = 0;
-    }
+    ctxaddr = fd_ctx_del(file, this);
 
 out:
     return (clnt_fd_ctx_t *)(unsigned long)ctxaddr;

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -46,10 +46,11 @@ this_fd_del_ctx(fd_t *file, xlator_t *this)
 {
     uint64_t ctxaddr = 0;
 
-    GF_VALIDATE_OR_GOTO("client", this, out);
-    GF_VALIDATE_OR_GOTO(this->name, file, out);
-
     ctxaddr = fd_ctx_del(file, this);
+    if (!ctxaddr) { /* check that we did not pass NULL to either this or file */
+        GF_VALIDATE_OR_GOTO("client", this, out);
+        GF_VALIDATE_OR_GOTO(this->name, file, out);
+    }
 
 out:
     return (clnt_fd_ctx_t *)(unsigned long)ctxaddr;

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -63,17 +63,12 @@ out:
 clnt_fd_ctx_t *
 this_fd_get_ctx(fd_t *file, xlator_t *this)
 {
-    int dict_ret = -1;
     uint64_t ctxaddr = 0;
 
     GF_VALIDATE_OR_GOTO("client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, file, out);
 
-    dict_ret = fd_ctx_get(file, this, &ctxaddr);
-
-    if (dict_ret < 0) {
-        ctxaddr = 0;
-    }
+    ctxaddr = fd_ctx_get(file, this);
 
 out:
     return (clnt_fd_ctx_t *)(unsigned long)ctxaddr;
@@ -88,8 +83,8 @@ this_fd_set_ctx(fd_t *file, xlator_t *this, loc_t *loc, clnt_fd_ctx_t *ctx)
     GF_VALIDATE_OR_GOTO("client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, file, out);
 
-    ret = fd_ctx_get(file, this, &oldaddr);
-    if (ret >= 0) {
+    oldaddr = fd_ctx_get(file, this);
+    if (oldaddr) {
         if (loc)
             gf_smsg(this->name, GF_LOG_INFO, 0, PC_MSG_FD_DUPLICATE_TRY,
                     "path=%s", loc->path, "gfid=%s",

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1819,7 +1819,6 @@ static int
 __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
                    int *op_errno_p)
 {
-    uint64_t tmp_pfd = 0;
     struct posix_fd *pfd = NULL;
     int ret = -1;
     char *real_path = NULL;
@@ -1830,14 +1829,10 @@ __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
 
     struct posix_private *priv = NULL;
 
-    priv = this->private;
-
-    tmp_pfd = __fd_ctx_get(fd, this);
-    if (tmp_pfd) {
-        pfd = (void *)(long)tmp_pfd;
+    pfd = __fd_ctx_get_ptr(fd, this);
+    if (pfd) {
         goto out;
-    }
-    if (!fd_is_anonymous(fd)) {
+    } else if (!fd_is_anonymous(fd)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_READ_FAILED,
                "Failed to get fd context for a non-anonymous fd, "
                "gfid: %s",
@@ -1883,6 +1878,7 @@ __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
     if (fd->inode->ia_type == IA_IFREG) {
         _fd = open(real_path, fd->flags);
         if ((_fd == -1) && (errno == ENOENT)) {
+            priv = this->private;
             POSIX_GET_FILE_UNLINK_PATH(priv->base_path, fd->inode->gfid,
                                        unlink_path);
             _fd = open(unlink_path, fd->flags);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1832,8 +1832,8 @@ __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
 
     priv = this->private;
 
-    ret = __fd_ctx_get(fd, this, &tmp_pfd);
-    if (ret == 0) {
+    tmp_pfd = __fd_ctx_get(fd, this);
+    if (tmp_pfd) {
         pfd = (void *)(long)tmp_pfd;
         goto out;
     }

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1833,7 +1833,8 @@ __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
     if (pfd) {
         ret = 0;
         goto out;
-    } else if (!fd_is_anonymous(fd)) {
+    }
+    if (!fd_is_anonymous(fd)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_READ_FAILED,
                "Failed to get fd context for a non-anonymous fd, "
                "gfid: %s",

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1831,6 +1831,7 @@ __posix_fd_ctx_get(fd_t *fd, xlator_t *this, struct posix_fd **pfd_p,
 
     pfd = __fd_ctx_get_ptr(fd, this);
     if (pfd) {
+        ret = 0;
         goto out;
     } else if (!fd_is_anonymous(fd)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_READ_FAILED,

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1430,18 +1430,16 @@ int32_t
 posix_releasedir(xlator_t *this, fd_t *fd)
 {
     struct posix_fd *pfd = NULL;
-    uint64_t tmp_pfd = 0;
 
     VALIDATE_OR_GOTO(this, out);
     VALIDATE_OR_GOTO(fd, out);
 
-    tmp_pfd = fd_ctx_del(fd, this);
-    if (tmp_pfd == 0) {
+    pfd = fd_ctx_del_ptr(fd, this);
+    if (pfd == NULL) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }
 
-    pfd = (struct posix_fd *)(long)tmp_pfd;
     if (!pfd->dir) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_PFD_NULL,
                "pfd->dir is NULL for fd=%p", fd);
@@ -2650,7 +2648,6 @@ int32_t
 posix_release(xlator_t *this, fd_t *fd)
 {
     struct posix_fd *pfd = NULL;
-    uint64_t tmp_pfd = 0;
 
     VALIDATE_OR_GOTO(this, out);
     VALIDATE_OR_GOTO(fd, out);
@@ -2658,14 +2655,13 @@ posix_release(xlator_t *this, fd_t *fd)
     if (fd->inode->active_fd_count == 0)
         posix_unlink_renamed_file(this, fd->inode);
 
-    tmp_pfd = fd_ctx_del(fd, this);
-    if (tmp_pfd == 0) {
+    pfd = fd_ctx_del_ptr(fd, this);
+    if (pfd == NULL) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_PFD_NULL,
                "pfd is NULL from fd=%p", fd);
         goto out;
     }
 
-    pfd = (struct posix_fd *)(long)tmp_pfd;
     if (pfd->dir) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_DIR_NOT_NULL,
                "pfd->dir is %p (not NULL) for file fd=%p", pfd->dir, fd);
@@ -6023,7 +6019,10 @@ posix_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         if (op_ret >= 0) {
             op_ret = 0;
 
-            list_for_each_entry(entry, &entries.list, list) { op_ret++; }
+            list_for_each_entry(entry, &entries.list, list)
+            {
+                op_ret++;
+            }
         }
 
         STACK_UNWIND_STRICT(readdirp, frame, op_ret, op_errno, &entries, NULL);

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1431,13 +1431,12 @@ posix_releasedir(xlator_t *this, fd_t *fd)
 {
     struct posix_fd *pfd = NULL;
     uint64_t tmp_pfd = 0;
-    int ret = 0;
 
     VALIDATE_OR_GOTO(this, out);
     VALIDATE_OR_GOTO(fd, out);
 
-    ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    tmp_pfd = fd_ctx_del(fd, this);
+    if (tmp_pfd == 0) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }
@@ -2651,7 +2650,6 @@ int32_t
 posix_release(xlator_t *this, fd_t *fd)
 {
     struct posix_fd *pfd = NULL;
-    int ret = -1;
     uint64_t tmp_pfd = 0;
 
     VALIDATE_OR_GOTO(this, out);
@@ -2660,8 +2658,8 @@ posix_release(xlator_t *this, fd_t *fd)
     if (fd->inode->active_fd_count == 0)
         posix_unlink_renamed_file(this, fd->inode);
 
-    ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    tmp_pfd = fd_ctx_del(fd, this);
+    if (tmp_pfd == 0) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_PFD_NULL,
                "pfd is NULL from fd=%p", fd);
         goto out;


### PR DESCRIPTION
NULL is quite useless or an error message anyway, there's no need to check for 'ret'.

Also fixes https://github.com/gluster/glusterfs/issues/3729 