### PR TITLE
io-stats: Introduce FOP_HITS_PER_SEC in profile data

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -5687,7 +5687,7 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
     cli_out("%12s: %" PRId64 " seconds", "End time", end_time);
     cli_out("%12s: %" PRId64 " bytes", "Data Read", r_count);
     cli_out("%12s: %" PRId64 " bytes", "Data Written", w_count);
-    cli_out("%12s: %" PRId64, "FOPS/S", fop_hits_per_sec);
+    cli_out("%12s: %" PRId64 " ", "fops/s", fop_hits_per_sec);
 
     cli_out(" ");
 }

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -5496,6 +5496,9 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
     int ret = 0;
     double total_percentage_latency = 0;
     uint64_t fop_hits_per_sec = 0;
+    time_t timestamp = 0;
+    char tdate[64];
+    struct tm *gtime = NULL;
 
     for (i = 0; i < 32; i++) {
         snprintf(key, sizeof(key), "%d-%d-read-%" PRIu32, count, interval,
@@ -5683,8 +5686,14 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
     }
 
     cli_out(" ");
-    cli_out("%12s: %" PRId64 " seconds", "Start time", start_time);
-    cli_out("%12s: %" PRId64 " seconds", "End time", end_time);
+    timestamp = start_time;
+    gtime = gmtime(&timestamp);
+    strftime(tdate, sizeof(tdate), "%a, %d %b %Y %H:%M:%S +0000", gtime);
+    cli_out("%12s: %s", "Start time", tdate);
+    timestamp = end_time;
+    gtime = gmtime(&timestamp);
+    strftime(tdate, sizeof(tdate), "%a, %d %b %Y %H:%M:%S +0000", gtime);
+    cli_out("%12s: %s", "End time", tdate);
     cli_out("%12s: %" PRId64 " bytes", "Data Read", r_count);
     cli_out("%12s: %" PRId64 " bytes", "Data Written", w_count);
     cli_out("%12s: %" PRId64 " fops/s", "Throughput", fop_hits_per_sec);

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -5687,7 +5687,7 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
     cli_out("%12s: %" PRId64 " seconds", "End time", end_time);
     cli_out("%12s: %" PRId64 " bytes", "Data Read", r_count);
     cli_out("%12s: %" PRId64 " bytes", "Data Written", w_count);
-    cli_out("%12s: %" PRId64 " ", "fops/s", fop_hits_per_sec);
+    cli_out("%12s: %" PRId64 " fops/s", "Throughput", fop_hits_per_sec);
 
     cli_out(" ");
 }


### PR DESCRIPTION
1) Currently, glusterfs profile does not provide any
metrics to measure what is the fops handling rate per second?
Sometimes a user/developer can be interested to monitor this value.
2) During testing i have observed the client profile is printing latency
in microsec even time difference is captured in nanosecond.

Solution: 1) Analyze the FOP_HITS_PER_SEC during profile capture
             based on the last time duration interval divided by a
             total number of fop hits during that duration.
2) Correct the format to print the latency in nanosecond.

Fixes: #3734
Change-Id: Id0f043493854724d32d81dbe09e254d4d19ffdbb
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

