### PR TITLE
Fix qemu-img crash on a distributed volume (#3720)

### DIFF
--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -5398,7 +5398,7 @@ client4_0_seek(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(seek, frame, -1, op_errno, 0, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;


### PR DESCRIPTION
Fix 'qemu-img' crash discovered as follows:

$ gluster volume info test0

Volume Name: test0
Type: Distribute
Volume ID: dc5607a7-fadc-42fd-a532-de0b791097ef
Status: Started
Snapshot Count: 0
Number of Bricks: 3
Transport-type: tcp
Bricks:
Brick1: 192.168.222.111:/pool/0
Brick2: 192.168.222.111:/pool/1
Brick3: 192.168.222.111:/pool/2
Options Reconfigured:
storage.fips-mode-rchecksum: on
transport.address-family: inet
nfs.disable: on

$ qemu-img info gluster://192.168.222.111/test0/test0.img
[2022-08-17 08:15:46.704459 +0000] I [io-stats.c:3797:ios_sample_buf_size_configure]
0-test0: Configure ios_sample_buf  size is 1024 because ios_sample_interval is 0
Segmentation fault (core dumped)

$ gdb -q qemu-img core
...
Program terminated with signal SIGSEGV, Segmentation fault.
#0  dict_ref (this=this@entry=0x48003278) at dict.c:655
655	    GF_ATOMIC_INC(this->refcount);
...
(gdb) p *this
Cannot access memory at address 0x48003278
(gdb) bt 4
#0  dict_ref (this=this@entry=0x48003278) at dict.c:655
#1  0x00007fb96f34e695 in syncop_seek_cbk (frame=frame@entry=0x55a04de5a2c8, cookie=0x7ffea4b96340,
    this=<optimized out>, op_ret=op_ret@entry=-1, op_errno=op_errno@entry=77, offset=offset@entry=0,
    xdata=0x48003278) at syncop.c:3167
#2  0x00007fb9669e7a42 in io_stats_seek_cbk (frame=frame@entry=0x55a04de5a3b8, cookie=<optimized out>,
    this=<optimized out>, op_ret=op_ret@entry=-1, op_errno=op_errno@entry=77, offset=offset@entry=0,
    xdata=0x48003278) at io-stats.c:2610
#3  0x00007fb96f39d47d in default_seek_cbk (frame=0x55a04de5b698, cookie=<optimized out>,
    this=<optimized out>, op_ret=-1, op_errno=77, offset=0, xdata=0x48003278) at defaults.c:1615
#4  0x00007fb96c174f47 in client4_0_seek (frame=0x7fb948000eb8, this=<optimized out>, data=<optimized out>)
    at client-rpc-fops_v2.c:5299
(More stack frames follow...)

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000

