### PR TITLE
geo-rep: rsync tries to sync trusted.SGI_ACL_FILE

### DIFF
--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -674,7 +674,7 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0) ||
-        (fnmatch("trusted.SGI_ACL_FILE", key, FNM_PERIOD) == 0)))
+          (fnmatch("trusted.SGI_ACL_FILE", key, FNM_PERIOD) == 0)))
         ret = -1;
 
 out:

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -674,7 +674,7 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0) ||
-          (fnmatch("trusted.SGI_ACL_FILE", key, FNM_PERIOD) == 0)))
+          (fnmatch("trusted.SGI_*", key, FNM_PERIOD) == 0)))
         ret = -1;
 
 out:

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -673,7 +673,8 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("glusterfs.gfid.newfile", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||
-          (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0)))
+          (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0)) ||
+        (fnmatch("trusted.SGI_ACL_FILE", key, FNM_PERIOD) == 0)))
         ret = -1;
 
 out:

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -673,7 +673,7 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("glusterfs.gfid.newfile", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||
-          (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0)) ||
+          (fnmatch("*.glusterfs.shard.file-size", key, FNM_PERIOD) == 0) ||
         (fnmatch("trusted.SGI_ACL_FILE", key, FNM_PERIOD) == 0)))
         ret = -1;
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -134,7 +134,7 @@ posix_handle_georep_xattrs(call_frame_t *frame, const char *name, int *op_errno,
                                          "*.glusterfs.lockinfo",
                                          "*.glusterfs.*.entry_stime",
                                          "*.glusterfs.volume-mark.*",
-                                         "trusted.SGI_ACL_FILE",
+                                         "trusted.SGI_*",
                                          NULL};
 
     if (!name) {

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -129,10 +129,13 @@ posix_handle_georep_xattrs(call_frame_t *frame, const char *name, int *op_errno,
     int ret = 0;
     int pid = 1;
     gf_boolean_t filter_xattr = _gf_true;
-    static const char *georep_xattr[] = {
-        "*.glusterfs.*.stime",       "*.glusterfs.*.xtime",
-        "*.glusterfs.lockinfo",      "*.glusterfs.*.entry_stime",
-        "*.glusterfs.volume-mark.*", NULL};
+    static const char *georep_xattr[] = {"*.glusterfs.*.stime",
+                                         "*.glusterfs.*.xtime",
+                                         "*.glusterfs.lockinfo",
+                                         "*.glusterfs.*.entry_stime",
+                                         "*.glusterfs.volume-mark.*",
+                                         "trusted.SGI_ACL_FILE",
+                                         NULL};
 
     if (!name) {
         /* No need to do anything here */


### PR DESCRIPTION
trusted.SGI_ACL_FILE is one of the internal xattrs
and hence should not be synced by rsync.

So add trusted.SGI_ACL_FILE among the list of xattrs that
are to be avoided by rsync to fix the same.

Fixes:#3738
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

