### PR TITLE
[rpc-transport] Skip `inet_pton` when address family is already known

### DIFF
--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -322,6 +322,8 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     uint16_t remote_port = GF_DEFAULT_SOCKET_LISTEN_PORT;
     struct addrinfo *addr_info = NULL;
     int32_t ret = 0;
+    struct in6_addr serveraddr_ipv6;
+    struct in_addr serveraddr_ipv4;
 
     remote_host_data = dict_get_sizen(options, "remote-host");
     if (remote_host_data == NULL) {
@@ -364,8 +366,6 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     /* Need to update transport-address family if address-family is not provided
        to command-line arguments
     */
-    struct in6_addr serveraddr_ipv6;
-    struct in_addr serveraddr_ipv4;
     if (inet_pton(AF_INET6, remote_host, &serveraddr_ipv6)) {
         sockaddr->sa_family = AF_INET6;
     } else if (inet_pton(AF_INET, remote_host, &serveraddr_ipv4)) {

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -357,6 +357,18 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
         }
     }
 
+    // If transport-address family is already present in cmdline args, resolve
+    // right away. If family is set to AF_UNSPEC, we try and guess the family
+    switch (sockaddr->sa_family) {
+        case AF_INET:
+        case AF_INET6:
+            goto resolve;
+            break;
+
+        default:
+            break;
+    }
+
     /* Need to update transport-address family if address-family is not provided
        to command-line arguments
     */
@@ -370,6 +382,7 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
 
     /* TODO: gf_resolve is a blocking call. kick in some
        non blocking dns techniques */
+resolve:
     ret = gf_resolve_ip6(remote_host, remote_port, sockaddr->sa_family,
                          &this->dnscache, &addr_info);
     if (ret == -1) {

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -322,8 +322,6 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
     uint16_t remote_port = GF_DEFAULT_SOCKET_LISTEN_PORT;
     struct addrinfo *addr_info = NULL;
     int32_t ret = 0;
-    struct in6_addr serveraddr_ipv6;
-    struct in_addr serveraddr_ipv4;
 
     remote_host_data = dict_get_sizen(options, "remote-host");
     if (remote_host_data == NULL) {
@@ -359,19 +357,15 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
 
     // If transport-address family is already present in cmdline args, resolve
     // right away. If family is set to AF_UNSPEC, we try and guess the family
-    switch (sockaddr->sa_family) {
-        case AF_INET:
-        case AF_INET6:
-            goto resolve;
-            break;
-
-        default:
-            break;
+    if (sockaddr->sa_family == AF_INET || sockaddr->sa_family == AF_INET6) {
+        goto resolve;
     }
 
     /* Need to update transport-address family if address-family is not provided
        to command-line arguments
     */
+    struct in6_addr serveraddr_ipv6;
+    struct in_addr serveraddr_ipv4;
     if (inet_pton(AF_INET6, remote_host, &serveraddr_ipv6)) {
         sockaddr->sa_family = AF_INET6;
     } else if (inet_pton(AF_INET, remote_host, &serveraddr_ipv4)) {


### PR DESCRIPTION
from the cmdline args. We only do this in the case of family being
`AF_INET` or `AF_INET6` as `AF_UNSPEC` is set when the options are not
provided explicitly.

Signed-off-by: black.dragon74 <nickk.2974@gmail.com>

