### PR TITLE
dht: fix use after free issue in dht_setxattr_mds_cbk

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -3963,28 +3963,29 @@ dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     for (i = 0; i < conf->subvolume_cnt; i++) {
         if (mds_subvol && (mds_subvol == conf->subvolumes[i]))
             continue;
-        if (local->fop == GF_FOP_SETXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->setxattr, &local->loc,
-                       local->xattr, local->flags, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_FSETXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->fsetxattr, local->fd,
-                       local->xattr, local->flags, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_REMOVEXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->removexattr, &local->loc,
-                       local->key, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_FREMOVEXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->fremovexattr, local->fd,
-                       local->key, local->xattr_req);
+        switch (local->fop) {
+            case GF_FOP_SETXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->setxattr, &local->loc,
+                           local->xattr, local->flags, local->xattr_req);
+                break;
+            case GF_FOP_FSETXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->fsetxattr, local->fd,
+                           local->xattr, local->flags, local->xattr_req);
+                break;
+            case GF_FOP_REMOVEXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->removexattr, &local->loc,
+                           local->key, local->xattr_req);
+                break;
+            case GF_FOP_FREMOVEXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->fremovexattr, local->fd,
+                           local->key, local->xattr_req);
+                break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
It is a day one bug when a feature was implemented, the
issue was not caught earlier because the client crash
depends on the environment.The client was crashing because
during wind it was not passing cookie and in cbk it
was trying to access cookie.

Solution: Pass a xlator_t as a cookie during STACK_WIND_COOKIE
          to avoid a crash.

Fixes: #3732
Change-Id: I5fd75e90a94d852093dfa40fb37d4211b4e9fdfb
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

