### PR TITLE
protocol/server: fix the server_getspec to serve the volfiles

### DIFF
--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1599,6 +1599,7 @@ volfile_init(glusterfs_ctx_t *ctx)
     }
 
     ret = glusterfs_process_volfp(ctx, fp);
+    fp = NULL; /* this is freed inside the function (both success & failure) */
     if (ret)
         goto out;
 
@@ -1625,6 +1626,9 @@ volfile_init(glusterfs_ctx_t *ctx)
 
     ret = 0;
 out:
+    if (fp)
+        fclose(fp);
+
     if (volfile)
         GF_FREE(volfile);
     return ret;

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1494,6 +1494,142 @@ cleanup_and_exit(int signum)
     }
 }
 
+static FILE *
+get_volfp(glusterfs_ctx_t *ctx)
+{
+    cmd_args_t *cmd_args = NULL;
+    FILE *specfp = NULL;
+
+    cmd_args = &ctx->cmd_args;
+
+    if ((specfp = fopen(cmd_args->volfile, "r")) == NULL) {
+        gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_9,
+                "volume_file=%s", cmd_args->volfile, NULL);
+        return NULL;
+    }
+
+    gf_msg_debug("glusterfsd", 0, "loading volume file %s", cmd_args->volfile);
+
+    return specfp;
+}
+
+static int
+volfile_init(glusterfs_ctx_t *ctx)
+{
+    int ret = -1;
+    char *volfile = NULL;
+    gf_volfile_t *volfile_obj = NULL;
+    gf_volfile_t *volfile_tmp = NULL;
+    struct stat stbuf = {
+        0,
+    };
+    char sha256_hash[SHA256_DIGEST_LENGTH] = {
+        0,
+    };
+
+    cmd_args_t *cmd_args = &ctx->cmd_args;
+    FILE *fp = get_volfp(ctx);
+    if (!fp) {
+        gf_smsg("glusterfsd", GF_LOG_ERROR, 0, glusterfsd_msg_28, NULL);
+        goto out;
+    }
+    ret = sys_stat(cmd_args->volfile, &stbuf);
+    if (IS_ERROR(ret)) {
+        gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_9,
+                "volume_file=%s", cmd_args->volfile, NULL);
+        goto out;
+    }
+
+    volfile = GF_MALLOC(stbuf.st_size, gf_common_mt_char);
+    if (!volfile) {
+        gf_smsg("glusterfsd", GF_LOG_ERROR, ENOMEM, glusterfsd_msg_9,
+                "volume_file=%s", cmd_args->volfile, NULL);
+        ret = -1;
+        goto out;
+    }
+    ret = fread(volfile, stbuf.st_size, 1, fp);
+    if (IS_ERROR(ret)) {
+        gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_9,
+                "volume_file=%s", cmd_args->volfile, NULL);
+        goto out;
+    }
+    glusterfs_compute_sha256((const unsigned char *)volfile, stbuf.st_size,
+                             sha256_hash);
+    LOCK(&ctx->volfile_lock);
+    {
+        list_for_each_entry(volfile_obj, &ctx->volfile_list, volfile_list)
+        {
+            if (!memcmp(sha256_hash, volfile_obj->volfile_checksum,
+                        sizeof(volfile_obj->volfile_checksum))) {
+                UNLOCK(&ctx->volfile_lock);
+                ret = 0;
+                gf_smsg(THIS->name, GF_LOG_INFO, 0, glusterfsd_msg_40, NULL);
+                goto out;
+            }
+            volfile_tmp = volfile_obj;
+            break;
+        }
+    }
+    UNLOCK(&ctx->volfile_lock);
+
+    /*  Check if only options have changed. No need to reload the
+     *  volfile if topology hasn't changed.
+     *  glusterfs_volfile_reconfigure returns 3 possible return states
+     *  return 0          =======> reconfiguration of options has succeeded
+     *  return 1          =======> the graph has to be reconstructed and all
+     * the xlators should be inited return -1(or -ve) =======> Some Internal
+     * Error occurred during the operation
+     */
+
+    if (volfile_tmp) {
+        ret = glusterfs_volfile_reconfigure(fp, ctx);
+        if (ret == 0) {
+            gf_msg_debug("glusterfsd-mgmt", 0,
+                         "No need to re-load volfile, reconfigure done");
+            memcpy(volfile_tmp->volfile_checksum, sha256_hash,
+                   sizeof(volfile_tmp->volfile_checksum));
+            goto out;
+        } else {
+            gf_msg("glusterfsd-mgmt", GF_LOG_INFO, 0, 0,
+                   "reconfigure failed, continuing with init");
+        }
+    } else {
+        gf_msg("glusterfsd-mgmt", GF_LOG_INFO, 0, 0,
+               "volume not found, continuing with init");
+    }
+
+    ret = glusterfs_process_volfp(ctx, fp);
+    if (ret)
+        goto out;
+
+    LOCK(&ctx->volfile_lock);
+    {
+        if (!volfile_tmp) {
+            volfile_tmp = GF_CALLOC(1, sizeof(gf_volfile_t),
+                                    gf_common_volfile_t);
+            if (!volfile_tmp) {
+                ret = -1;
+                goto out;
+            }
+
+            INIT_LIST_HEAD(&volfile_tmp->volfile_list);
+            volfile_tmp->graph = ctx->active;
+            list_add(&volfile_tmp->volfile_list, &ctx->volfile_list);
+            snprintf(volfile_tmp->vol_id, sizeof(volfile_tmp->vol_id), "%s",
+                     cmd_args->volfile_id);
+        }
+        memcpy(volfile_tmp->volfile_checksum, sha256_hash,
+               sizeof(volfile_tmp->volfile_checksum));
+    }
+    UNLOCK(&ctx->volfile_lock);
+
+    ret = 0;
+out:
+    if (volfile)
+        GF_FREE(volfile);
+    return ret;
+}
+
 static void
 reincarnate(int signum)
 {
@@ -1509,6 +1645,8 @@ reincarnate(int signum)
     if (cmd_args->volfile_server) {
         gf_smsg("glusterfsd", GF_LOG_INFO, 0, glusterfsd_msg_11, NULL);
         ret = glusterfs_volfile_fetch(ctx);
+    } else {
+        ret = volfile_init(ctx);
     }
 
     /* Also, SIGHUP should do logrotate */
@@ -1516,6 +1654,10 @@ reincarnate(int signum)
 
     if (ret < 0)
         gf_smsg("glusterfsd", GF_LOG_ERROR, 0, glusterfsd_msg_12, NULL);
+
+    /* Notify all xlators */
+    if (ctx->active)
+        xlator_notify(ctx->active->top, GF_EVENT_SIGHUP, NULL);
 
     return;
 }
@@ -2538,29 +2680,9 @@ out:
     return ret;
 }
 
-static FILE *
-get_volfp(glusterfs_ctx_t *ctx)
-{
-    cmd_args_t *cmd_args = NULL;
-    FILE *specfp = NULL;
-
-    cmd_args = &ctx->cmd_args;
-
-    if ((specfp = fopen(cmd_args->volfile, "r")) == NULL) {
-        gf_smsg("glusterfsd", GF_LOG_ERROR, errno, glusterfsd_msg_9,
-                "volume_file=%s", cmd_args->volfile, NULL);
-        return NULL;
-    }
-
-    gf_msg_debug("glusterfsd", 0, "loading volume file %s", cmd_args->volfile);
-
-    return specfp;
-}
-
 static int
 glusterfs_volumes_init(glusterfs_ctx_t *ctx)
 {
-    FILE *fp = NULL;
     cmd_args_t *cmd_args = NULL;
     int ret = 0;
 
@@ -2578,18 +2700,7 @@ glusterfs_volumes_init(glusterfs_ctx_t *ctx)
         return ret;
     }
 
-    fp = get_volfp(ctx);
-
-    if (!fp) {
-        gf_smsg("glusterfsd", GF_LOG_ERROR, 0, glusterfsd_msg_28, NULL);
-        ret = -1;
-        goto out;
-    }
-
-    ret = glusterfs_process_volfp(ctx, fp);
-    if (ret)
-        goto out;
-
+    ret = volfile_init(ctx);
 out:
     emancipate(ctx, ret);
     return ret;

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3042,8 +3042,21 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
     }
 
     INIT_LIST_HEAD(&server->list);
+    server->port = port;
 
-    server->volfile_server = gf_strdup(host);
+    char *duphost = gf_strdup(host);
+    if (duphost) {
+        char *lastptr = rindex(duphost, ':');
+        if (lastptr) {
+            *lastptr = '\0';
+            long port_argument = strtol(lastptr + 1, NULL, 0);
+            if (!port_argument) {
+                port_argument = port;
+            }
+            server->port = port_argument;
+        }
+    }
+    server->volfile_server = gf_strdup(duphost);
     if (!server->volfile_server) {
         errno = ENOMEM;
         goto out;
@@ -3054,8 +3067,6 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
         errno = ENOMEM;
         goto out;
     }
-
-    server->port = port;
 
     if (!cmd_args->volfile_server) {
         cmd_args->volfile_server = server->volfile_server;
@@ -3082,6 +3093,8 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
     ret = 0;
 out:
     if (-1 == ret) {
+        if (duphost)
+            GF_FREE(duphost);
         if (server) {
             GF_FREE(server->volfile_server);
             GF_FREE(server->transport);
@@ -4298,7 +4311,7 @@ gf_set_nofile(rlim_t high, rlim_t low)
 {
     int n, ret = -1;
     struct rlimit lim;
-    rlim_t r[2] = { high, low };
+    rlim_t r[2] = {high, low};
 
     for (n = 0; n < 2; n++)
         if (r[n] != 0) {
@@ -4350,15 +4363,19 @@ gf_rebalance_thread_count(char *str, char **errmsg)
         if (count > 0 && count <= lim)
             return count;
         else {
-            if (gf_asprintf(errmsg, "number of rebalance threads should be "
-                            "in range from 1 to %d, not %d", lim, count) < 0)
+            if (gf_asprintf(errmsg,
+                            "number of rebalance threads should be "
+                            "in range from 1 to %d, not %d",
+                            lim, count) < 0)
                 *errmsg = NULL;
             return -1;
         }
     }
-    if (gf_asprintf(errmsg, "number of rebalance threads should "
+    if (gf_asprintf(errmsg,
+                    "number of rebalance threads should "
                     "be {lazy|normal|aggressive} or a number in "
-                    "range from 1 to %d, not %s", lim, str) < 0)
+                    "range from 1 to %d, not %s",
+                    lim, str) < 0)
         *errmsg = NULL;
     return -1;
 }

--- a/libglusterfs/src/defaults-tmpl.c
+++ b/libglusterfs/src/defaults-tmpl.c
@@ -200,6 +200,7 @@ default_notify(xlator_t *this, int32_t event, void *data, ...)
                 parent = parent->next;
             }
         } break;
+        case GF_EVENT_SIGHUP:
         case GF_EVENT_CLEANUP: {
             xlator_list_t *list = this->children;
 

--- a/libglusterfs/src/glusterfs/glusterfs-fops.h
+++ b/libglusterfs/src/glusterfs/glusterfs-fops.h
@@ -101,7 +101,8 @@ enum glusterfs_event_t {
     GF_EVENT_SCRUB_ONDEMAND = 9 + 13,
     GF_EVENT_SOME_DESCENDENT_UP = 9 + 14,
     GF_EVENT_CHILD_PING = 9 + 15,
-    GF_EVENT_MAXVAL = 9 + 16,
+    GF_EVENT_SIGHUP = 9 + 16,
+    GF_EVENT_MAXVAL = 9 + 17,
 };
 typedef enum glusterfs_event_t glusterfs_event_t;
 

--- a/tests/features/volspec/brick.vol
+++ b/tests/features/volspec/brick.vol
@@ -1,0 +1,58 @@
+volume sq-posix
+    type storage/posix
+#    option volume-id UUID
+    option directory BRICK
+end-volume
+
+volume sq-access-control
+    type features/access-control
+    option super-uid 0
+    subvolumes sq-posix
+end-volume
+
+volume sq-locks
+    type features/locks
+    subvolumes sq-access-control
+end-volume
+
+volume sq-quota
+    type features/simple-quota
+    option pass-through false
+    option cmd-from-all-client true
+    subvolumes sq-locks
+end-volume
+
+volume sq-upcall
+    type features/upcall
+    option cache-invalidation off
+    option cache-invalidation-timeout 60
+    subvolumes sq-quota
+end-volume
+
+volume sq-io-threads
+    type performance/io-threads
+    subvolumes sq-upcall
+end-volume
+
+volume sq-barrier
+    type features/barrier
+    option barrier disable
+    option barrier-timeout 120
+    subvolumes sq-io-threads
+end-volume
+
+volume /d/backends/sq/brick1
+    type debug/io-stats
+    option unique-id /no/such/path
+    subvolumes sq-barrier
+end-volume
+
+volume sq-server
+    type protocol/server
+    option transport-type tcp
+    option transport.socket.read-fail-log false
+    option auth.addr./d/backends/sq/brick1.allow *
+    option transport.socket.listen-port 24011
+    #option volspec-directory BRICK/.glusterfs/vols
+    subvolumes /d/backends/sq/brick1
+end-volume

--- a/tests/features/volspec/client.vol
+++ b/tests/features/volspec/client.vol
@@ -1,0 +1,49 @@
+volume sq-client-1
+    type protocol/client
+    option remote-subvolume /d/backends/sq/brick1
+    option remote-port 24011
+    option remote-host local
+end-volume
+
+volume sq-utime
+    type features/utime
+    option noatime on
+    subvolumes sq-client-1
+end-volume
+
+volume sq-md-cache
+    type performance/md-cache
+    subvolumes sq-utime
+end-volume
+
+volume sq-write-behind
+    type performance/write-behind
+    option cache-size 1MB
+    option flush-behind on
+    option write-behind on
+    subvolumes sq-md-cache
+end-volume
+
+volume sq-open-behind
+    type performance/open-behind
+    option use-anonymous-fd no
+    option open-behind on
+    option pass-through false
+    option read-after-open yes
+    option lazy-open yes
+    subvolumes sq-write-behind
+end-volume
+
+volume sq-nl-cache
+    type performance/nl-cache
+    option pass-through false
+    option nl-cache on
+    subvolumes sq-open-behind
+end-volume
+
+volume sq
+    type debug/io-stats
+    option unique-id /no/such/path
+    subvolumes sq-nl-cache
+end-volume
+

--- a/tests/features/volspec/test.t
+++ b/tests/features/volspec/test.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup
+
+TEST mkdir -p $B0/1/.glusterfs/vols/
+TEST cp $(dirname $0)/brick.vol $B0/
+TEST sed -i -e "s#BRICK#${B0}/1#g" $B0/brick.vol
+
+TEST glusterfsd -f $B0/brick.vol -LDEBUG
+
+TEST cp $(dirname $0)/client.vol $B0/1/.glusterfs/vols/
+TEST ! glusterfs -s localhost:24011 --volfile-id client $M0
+
+mount_result=$(mount | grep fuse.glusterfs | grep -q "$M0 " && echo True || echo False)
+
+TEST [ $mount_result == "False" ]
+
+TEST sed -i -e 's/#option/option/g'  $B0/brick.vol
+
+TEST pkill -HUP glusterfsd
+
+# give 1 second for graph switch and other such things to happen
+sleep 1
+
+TEST glusterfs -s localhost:24011 --volfile-id client -l/tmp/volspec.log $M0
+
+mount_result=$(mount | grep fuse.glusterfs | grep -q "$M0 " && echo True || echo False)
+
+TEST [ $mount_result == "True" ]
+#sleep 1
+TEST pkill -HUP glusterfsd
+
+# allow time to get event
+sleep 1
+
+volfile_changed=$(grep -q "Volume file changed" /tmp/volspec.log && echo True || echo False)
+TEST [ $volfile_changed == "True" ]
+
+# Grep in logs to find 'Volfile changed' message
+
+cleanup

--- a/xlators/protocol/client/src/client-callback.c
+++ b/xlators/protocol/client/src/client-callback.c
@@ -22,7 +22,8 @@ client_cbk_null(struct rpc_clnt *rpc, void *mydata, void *data)
 static int
 client_cbk_fetchspec(struct rpc_clnt *rpc, void *mydata, void *data)
 {
-    gf_smsg(THIS->name, GF_LOG_WARNING, 0, PC_MSG_FUNCTION_CALL_ERROR, NULL);
+    /* Ignore this */
+    gf_smsg(THIS->name, GF_LOG_DEBUG, 0, PC_MSG_FUNCTION_CALL_ERROR, NULL);
     return 0;
 }
 

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -66,7 +66,8 @@ server_getspec(rpcsvc_request_t *req)
         goto out;
     }
 
-    /* By default, the behavior is not to return anything if specific option is not set */
+    /* By default, the behavior is not to return anything if specific option is
+     * not set */
     if (!conf->volfile_dir) {
         ret = -1;
         op_errno = ENOTSUP;
@@ -74,6 +75,13 @@ server_getspec(rpcsvc_request_t *req)
         goto out;
     }
     char *volid = args.key;
+    if (strstr(volid, "../")) {
+        op_errno = EINVAL;
+        rsp.spec = "having '../' in volid is not valid";
+        rsp.op_errno = gf_errno_to_error(op_errno);
+        rsp.op_ret = -1;
+        goto out;
+    }
     ret = snprintf(volpath, PATH_MAX - 1, "%s/%s.vol", conf->volfile_dir,
                    volid);
     if (ret == -1) {

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -45,20 +45,86 @@ server_getspec(rpcsvc_request_t *req)
     gf_getspec_rsp rsp = {
         0,
     };
+    struct stat stbuf = {
+        0,
+    };
+    char volpath[PATH_MAX] = {
+        0,
+    };
+    int32_t spec_fd = -1;
+    xlator_t *this = req->svc->xl;
+    server_conf_t *conf = this->private;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_getspec_req);
     if (ret < 0) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         op_errno = EINVAL;
-        goto fail;
+        rsp.spec = "<this method is not in use, use glusterd for getspec>";
+        rsp.op_errno = gf_errno_to_error(op_errno);
+        rsp.op_ret = -1;
+        goto out;
     }
 
-    op_errno = ENOSYS;
-fail:
-    rsp.spec = "<this method is not in use, use glusterd for getspec>";
-    rsp.op_errno = gf_errno_to_error(op_errno);
-    rsp.op_ret = -1;
+    /* By default, the behavior is not to return anything if specific option is not set */
+    if (!conf->volfile_dir) {
+        ret = -1;
+        op_errno = ENOTSUP;
+        rsp.spec = "<this method is not in use, use glusterd for getspec>";
+        goto out;
+    }
+    char *volid = args.key;
+    ret = snprintf(volpath, PATH_MAX - 1, "%s/%s.vol", conf->volfile_dir,
+                   volid);
+    if (ret == -1) {
+        op_errno = ENOMEM;
+        gf_msg(this->name, GF_LOG_ERROR, errno, 0, "failed to copy volfile");
+        goto out;
+    }
+
+    ret = sys_stat(volpath, &stbuf);
+    if (ret < 0) {
+        op_errno = errno;
+        goto out;
+    }
+
+    spec_fd = sys_open(volpath, O_RDONLY, 0);
+    if (spec_fd < 0) {
+        op_errno = errno;
+        gf_msg("glusterd", GF_LOG_ERROR, errno, 0, "Unable to open %s (%s)",
+               volpath, strerror(errno));
+        goto out;
+    }
+    ret = stbuf.st_size;
+
+    if (ret > 0) {
+        rsp.spec = MALLOC((ret + 1) * sizeof(char));
+        if (!rsp.spec) {
+            gf_msg(this->name, GF_LOG_ERROR, errno, 0, "no memory");
+            ret = -1;
+            goto out;
+        }
+        ret = sys_read(spec_fd, rsp.spec, ret);
+        if (ret <= 0) {
+            op_errno = errno;
+        }
+    }
+
+out:
+    if (spec_fd >= 0)
+        sys_close(spec_fd);
+
+    rsp.op_ret = ret;
+    if (rsp.op_ret < 0) {
+        gf_msg(this->name, GF_LOG_ERROR, op_errno, 0,
+               "Failed to mount the volume");
+    }
+
+    if (op_errno)
+        rsp.op_errno = gf_errno_to_error(op_errno);
+
+    if (!rsp.spec)
+        rsp.spec = strdup("");
 
     server_submit_reply(NULL, req, &rsp, NULL, 0, NULL,
                         (xdrproc_t)xdr_gf_getspec_rsp);

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -106,7 +106,7 @@ server_getspec(rpcsvc_request_t *req)
     ret = stbuf.st_size;
 
     if (ret > 0) {
-        rsp.spec = MALLOC((ret + 1) * sizeof(char));
+        rsp.spec = alloca((ret + 1) * sizeof(char));
         if (!rsp.spec) {
             gf_msg(this->name, GF_LOG_ERROR, errno, 0, "no memory");
             ret = -1;
@@ -132,7 +132,7 @@ out:
         rsp.op_errno = gf_errno_to_error(op_errno);
 
     if (!rsp.spec)
-        rsp.spec = strdup("");
+        rsp.spec = "";
 
     server_submit_reply(NULL, req, &rsp, NULL, 0, NULL,
                         (xdrproc_t)xdr_gf_getspec_rsp);

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -869,6 +869,10 @@ server_reconfigure(xlator_t *this, dict_t *options)
     if (statedump_path) {
         gf_path_strip_trailing_slashes(statedump_path);
         conf->volfile_dir = gf_strdup(statedump_path);
+        if (!conf->volfile_dir) {
+            ret = -1;
+            goto out;
+        }
     }
 do_auth:
     if (conf->auth_modules)
@@ -1177,6 +1181,12 @@ server_init(xlator_t *this)
     if (statedump_path) {
         gf_path_strip_trailing_slashes(statedump_path);
         conf->volfile_dir = gf_strdup(statedump_path);
+        if (!conf->volfile_dir) {
+            gf_smsg(this->name, GF_LOG_ERROR, 0,
+                    PS_MSG_SET_STATEDUMP_PATH_ERROR, NULL);
+            ret = -1;
+            goto err;
+        }
     }
 
     /* Authentication modules */
@@ -1944,8 +1954,8 @@ struct volume_options server_options[] = {
      .default_value = "off",
      .description = "strict-auth-accept reject connection with out"
                     "a valid username and password."},
-    /* As we append '${volid}.vol' at the end of this path, the
-       security issue is not present */
+    /* As we append '${volid}.vol' at the end of this path, no systemfiles
+       would be exposed through this option */
     {.key = {"volspec-directory", "volfile-path"},
      .type = GF_OPTION_TYPE_PATH,
      .default_value = NULL},

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -860,6 +860,16 @@ server_reconfigure(xlator_t *this, dict_t *options)
     GF_FREE(this->ctx->statedump_path);
     this->ctx->statedump_path = gf_strdup(statedump_path);
 
+    /* if the option is not set, we should fall back to NULL value */
+    GF_FREE(conf->volfile_dir);
+    conf->volfile_dir = NULL;
+    statedump_path = NULL;
+    GF_OPTION_RECONF("volspec-directory", statedump_path, options, path,
+                     do_auth);
+    if (statedump_path) {
+        gf_path_strip_trailing_slashes(statedump_path);
+        conf->volfile_dir = gf_strdup(statedump_path);
+    }
 do_auth:
     if (conf->auth_modules)
         gf_auth_fini(conf->auth_modules);
@@ -1141,6 +1151,7 @@ server_init(xlator_t *this)
     if (ret)
         goto err;
 
+    /* Volfile server */
     ret = dict_get_str_sizen(this->options, "config-directory",
                              &conf->conf_dir);
     if (ret)
@@ -1159,6 +1170,13 @@ server_init(xlator_t *this)
                 NULL);
         ret = -1;
         goto err;
+    }
+
+    statedump_path = NULL;
+    GF_OPTION_INIT("volspec-directory", statedump_path, path, err);
+    if (statedump_path) {
+        gf_path_strip_trailing_slashes(statedump_path);
+        conf->volfile_dir = gf_strdup(statedump_path);
     }
 
     /* Authentication modules */
@@ -1329,6 +1347,7 @@ server_fini(xlator_t *this)
                 if (conf->auth_modules)
                         dict_unref (conf->auth_modules);
 
+                GF_FREE (conf->volfile_dir);
                 GF_FREE (conf);
         }
 
@@ -1582,8 +1601,6 @@ server_notify(xlator_t *this, int32_t event, void *data, ...)
         }
 
         case GF_EVENT_PARENT_UP: {
-            conf = this->private;
-
             conf->parent_up = _gf_true;
 
             default_notify(this, event, data);
@@ -1621,7 +1638,6 @@ server_notify(xlator_t *this, int32_t event, void *data, ...)
         }
 
         case GF_EVENT_CLEANUP:
-            conf = this->private;
             victim_name = gf_strdup(victim->name);
             if (!victim_name) {
                 gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, PS_MSG_NO_MEMORY,
@@ -1708,6 +1724,23 @@ server_notify(xlator_t *this, int32_t event, void *data, ...)
                 }
             }
             GF_FREE(victim_name);
+            break;
+        case GF_EVENT_SIGHUP:
+            if (conf->volfile_dir) {
+                pthread_mutex_lock(&conf->mutex);
+                {
+                    list_for_each_entry(xprt, &conf->xprt_list, list)
+                    {
+                        /* TODO: optimize by sending signal to only those who
+                         * fetched data once */
+                        rpcsvc_callback_submit(conf->rpc, xprt,
+                                               &server_cbk_prog,
+                                               GF_CBK_FETCHSPEC, NULL, 0, NULL);
+                    }
+                }
+                pthread_mutex_unlock(&conf->mutex);
+            }
+            default_notify(this, event, data);
             break;
 
         default:
@@ -1911,6 +1944,11 @@ struct volume_options server_options[] = {
      .default_value = "off",
      .description = "strict-auth-accept reject connection with out"
                     "a valid username and password."},
+    /* As we append '${volid}.vol' at the end of this path, the
+       security issue is not present */
+    {.key = {"volspec-directory", "volfile-path"},
+     .type = GF_OPTION_TYPE_PATH,
+     .default_value = NULL},
     {.key = {NULL}},
 };
 

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -60,6 +60,7 @@ struct server_conf {
                              * (say *.allow | *.reject) are
                              * tweeked */
     char *conf_dir;
+    char *volfile_dir;
     struct _volfile_ctx *volfile;
     dict_t *auth_modules;
     struct list_head xprt_list;


### PR DESCRIPTION
This commit fixes an option of serving volume files through
brick processes. While this feature is not a required feature
for any deployments using `glusterd`, it would be very useful
in scenarios where glusterd is not present, eg., container usecases,
and in projects like kadalu which only deals with management layer
changes.

few changes done with this commit:

* core: Add 'EVENT_SIGHUP' event to notify framework
* make `volfile` based process also handle SIGHUP
* add port parsing along with server, so we can have process hosted in any port
* test to demonstrate all this.

Updates: #3635, #3668
Change-Id: I5c8dfdee7d06b8d5fced4cc99059dfd8bed65260
Signed-off-by: Amar Tumballi <amar@kadalu.io>

