### PR TITLE
gf_svc_releasedir() was not freeing memory

### DIFF
--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -2414,6 +2414,7 @@ gf_svc_releasedir(xlator_t *this, fd_t *fd)
         goto out;
     }
 
+    sfd = (svc_fd_t *)(long)tmp_pfd;
     GF_FREE(sfd);
 
 out:


### PR DESCRIPTION
Missing sfd = (svc_fd_t *)(long)tmp_pfd; to actually assign sfd some value
that can be freed.

Fixes: #3729
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

