### PR TITLE
dht_fd_ctx_set() - wrong check for return value (not needed once #3730 is merged!)

### DIFF
--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -85,7 +85,7 @@ dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
     LOCK(&fd->lock);
     {
         ret = __fd_ctx_get(fd, this, &value);
-        if (ret && value) {
+        if (!ret && value) {
             fd_ctx = (dht_fd_ctx_t *)(uintptr_t)value;
             if (fd_ctx->opened_on_dst == (uint64_t)(uintptr_t)dst) {
                 /* This could happen due to racing


### PR DESCRIPTION
If we wish to use the result of __fd_ctx_get() we need to check that ret is zero.

Fixes: #3742
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

