### PR TITLE
inode.c: minor code changes

### DIFF
--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -286,9 +286,6 @@ gf_boolean_t
 __is_root_gfid(uuid_t gfid);
 
 void
-__inode_table_set_lru_limit(inode_table_t *table, uint32_t lru_limit);
-
-void
 inode_table_set_lru_limit(inode_table_t *table, uint32_t lru_limit);
 
 void
@@ -297,17 +294,11 @@ inode_ctx_merge(fd_t *fd, inode_t *inode, inode_t *linked_inode);
 int
 inode_is_linked(inode_t *inode);
 
-void
-inode_set_need_lookup(inode_t *inode, xlator_t *this);
-
 gf_boolean_t
 inode_needs_lookup(inode_t *inode, xlator_t *this);
 
 int
 inode_has_dentry(inode_t *inode);
-
-size_t
-inode_ctx_size(inode_t *inode);
 
 void
 inode_find_directory_name(inode_t *inode, const char **name);

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1063,11 +1063,7 @@ __inode_link(inode_t *inode, inode_t *parent, const char *name,
             dentry->parent = __inode_ref(parent, false);
             GF_ATOMIC_INC(parent->kids);
             list_add(&dentry->inode_list, &link_inode->dentry_list);
-            if (parent->ns_inode)
-                link_inode->ns_inode = __inode_ref(parent->ns_inode, false);
-            else
-                link_inode->ns_inode = NULL;
-
+            link_inode->ns_inode = __inode_ref(parent->ns_inode, false);
             if (old_inode && __is_dentry_cyclic(dentry)) {
                 errno = ELOOP;
                 dentry_destroy(__dentry_unset(dentry));
@@ -1339,8 +1335,7 @@ inode_rename(inode_table_t *table, inode_t *srcdir, const char *srcname,
     /* free the old dentry */
     dentry_destroy(dentry);
 
-    if (table)
-        inode_table_prune(table);
+    inode_table_prune(table);
 
     return 0;
 }

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -770,7 +770,6 @@ __inode_ctx_set1
 inode_ctx_set1
 __inode_ctx_set2
 inode_ctx_set2
-inode_ctx_size
 inode_dump
 inode_dump_to_dict
 inode_find
@@ -795,15 +794,12 @@ inode_ref_reduce_by_n
 inode_rename
 inode_resolve
 inode_set_namespace_inode
-inode_set_need_lookup
-inode_table_ctx_free
 inode_table_destroy
 inode_table_destroy_all
 inode_table_dump
 inode_table_dump_to_dict
 inode_table_new
 inode_table_with_invalidator
-__inode_table_set_lru_limit
 inode_table_set_lru_limit
 inode_unlink
 inode_unref


### PR DESCRIPTION
Remove redundant null checks, dead code, CALLOC to MALLOC, etc.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

