### PR TITLE
extras: dynamic bash completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ api/src/gfapi.map
 cli/src/gluster
 contrib/fuse-util/fusermount-glusterfs
 extras/command-completion/Makefile
-extras/command-completion/README
 extras/geo-rep/gsync-sync-gfid
 extras/geo-rep/schedule_georep.py
 extras/snap_scheduler/conf.py

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ api/examples/setup.py
 api/src/gfapi.map
 cli/src/gluster
 contrib/fuse-util/fusermount-glusterfs
+extras/command-completion/Makefile
+extras/command-completion/README
 extras/geo-rep/gsync-sync-gfid
 extras/geo-rep/schedule_georep.py
 extras/snap_scheduler/conf.py

--- a/configure.ac
+++ b/configure.ac
@@ -1611,8 +1611,12 @@ if test x$BUILD_READLINE = xyes; then
     AC_DEFINE(HAVE_READLINE, 1, [Enable CLI readline support.])
 fi
 
-PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
-  bashcompdir="${sysconfdir}/bash_completion.d")
+# bash-completion script installation directory
+# PKG_CHECK_VAR should be used but is not available in some distributions
+bashcompdir="$(pkg-config --variable=completionsdir bash-completion 2>/dev/null)"
+if test "x${bashcompdir}" = "x"; then
+    bashcompdir="${sysconfdir}/bash_completion.d"
+fi
 AC_SUBST(bashcompdir)
 
 BUILD_LIBAIO=no

--- a/configure.ac
+++ b/configure.ac
@@ -204,7 +204,6 @@ AC_CONFIG_FILES([Makefile
                 extras/run-gluster.tmpfiles
                 extras/benchmarking/Makefile
                 extras/command-completion/Makefile
-                extras/command-completion/README
                 extras/hook-scripts/Makefile
                 extras/ocf/Makefile
                 extras/ocf/glusterd

--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,8 @@ AC_CONFIG_FILES([Makefile
                 extras/systemd/gluster-ta-volume.service
                 extras/run-gluster.tmpfiles
                 extras/benchmarking/Makefile
+                extras/command-completion/Makefile
+                extras/command-completion/README
                 extras/hook-scripts/Makefile
                 extras/ocf/Makefile
                 extras/ocf/glusterd
@@ -1608,6 +1610,10 @@ PKG_CHECK_MODULES([READLINE], [readline], [BUILD_READLINE="yes"],
 if test x$BUILD_READLINE = xyes; then
     AC_DEFINE(HAVE_READLINE, 1, [Enable CLI readline support.])
 fi
+
+PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
+  bashcompdir="${sysconfdir}/bash_completion.d")
+AC_SUBST(bashcompdir)
 
 BUILD_LIBAIO=no
 AC_CHECK_LIB([aio],[io_setup],[LIBAIO="-laio"])

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -12,7 +12,7 @@ EditorMode_DATA = glusterfs-mode.el glusterfs.vim
 
 SUBDIRS = init.d systemd benchmarking hook-scripts $(OCF_SUBDIR) LinuxRPM \
           $(GEOREP_EXTRAS_SUBDIR) snap_scheduler firewalld cliutils python \
-		  ganesha
+		  ganesha command-completion
 
 confdir = $(sysconfdir)/glusterfs
 if WITH_SERVER
@@ -39,7 +39,6 @@ scripts_SCRIPTS += control-mem.sh
 endif
 endif
 
-CLEANFILES = command-completion/Makefile command-completion/README
 EXTRA_DIST = glusterfs-logrotate gluster-rsyslog-7.2.conf gluster-rsyslog-5.8.conf \
 	logger.conf.example glusterfs-georep-logrotate group-virt.example \
 	group-metadata-cache group-gluster-block group-nl-cache \
@@ -48,8 +47,6 @@ EXTRA_DIST = glusterfs-logrotate gluster-rsyslog-7.2.conf gluster-rsyslog-5.8.co
 	backend-cleanup.sh disk_usage_sync.sh clear_xattrs.sh \
 	glusterd-sysconfig glusterd.vol post-upgrade-script-for-quota.sh \
 	pre-upgrade-script-for-quota.sh \
-	command-completion/gluster.bash command-completion/README.in \
-	command-completion/Makefile.am command-completion/Makefile.in \
 	stop-all-gluster-processes.sh clang-checker.sh mount-shared-storage.sh \
 	control-cpu-load.sh control-mem.sh group-distributed-virt \
 	thin-arbiter/thin-arbiter.vol thin-arbiter/setup-thin-arbiter.sh

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -39,6 +39,7 @@ scripts_SCRIPTS += control-mem.sh
 endif
 endif
 
+CLEANFILES = command-completion/Makefile command-completion/README
 EXTRA_DIST = glusterfs-logrotate gluster-rsyslog-7.2.conf gluster-rsyslog-5.8.conf \
 	logger.conf.example glusterfs-georep-logrotate group-virt.example \
 	group-metadata-cache group-gluster-block group-nl-cache \
@@ -46,8 +47,9 @@ EXTRA_DIST = glusterfs-logrotate gluster-rsyslog-7.2.conf gluster-rsyslog-5.8.co
 	migrate-unify-to-distribute.sh backend-xattr-sanitize.sh \
 	backend-cleanup.sh disk_usage_sync.sh clear_xattrs.sh \
 	glusterd-sysconfig glusterd.vol post-upgrade-script-for-quota.sh \
-	pre-upgrade-script-for-quota.sh command-completion/gluster.bash \
-	command-completion/Makefile command-completion/README \
+	pre-upgrade-script-for-quota.sh \
+	command-completion/gluster.bash command-completion/README.in \
+	command-completion/Makefile.am command-completion/Makefile.in \
 	stop-all-gluster-processes.sh clang-checker.sh mount-shared-storage.sh \
 	control-cpu-load.sh control-mem.sh group-distributed-virt \
 	thin-arbiter/thin-arbiter.vol thin-arbiter/setup-thin-arbiter.sh

--- a/extras/command-completion/Makefile
+++ b/extras/command-completion/Makefile
@@ -1,6 +1,0 @@
-install:
-	mkdir -p /usr/share/bash-completion/completions
-	cp gluster.bash /usr/share/bash-completion/completions/gluster
-
-uninstall:
-	rm -f /usr/share/bash-completion/completions/gluster

--- a/extras/command-completion/Makefile
+++ b/extras/command-completion/Makefile
@@ -1,6 +1,6 @@
 install:
-	mkdir -p /etc/bash_completion.d
-	cp gluster.bash /etc/bash_completion.d/gluster
+	mkdir -p /usr/share/bash-completion/completions
+	cp gluster.bash /usr/share/bash-completion/completions/gluster
 
 uninstall:
-	rm -f /etc/bash_completion.d/gluster
+	rm -f /usr/share/bash-completion/completions/gluster

--- a/extras/command-completion/Makefile.am
+++ b/extras/command-completion/Makefile.am
@@ -1,0 +1,2 @@
+bashcompdir = @bashcompdir@
+dist_bashcomp_DATA = gluster.bash

--- a/extras/command-completion/README
+++ b/extras/command-completion/README
@@ -1,5 +1,7 @@
-This file is not moved to /etc/bash_completion.d/ with the source installation.
+This file is not moved to /usr/share/bash-completion/completions/
+with the source installation.
 Please execute make install explicity from here to move this file to
-/etc/bash_completion.d
+/usr/share/bash-completion/completions/
 
-Similarly, use make uninstall to remove it from /etc/bash_completion.d
+Similarly, use make uninstall to remove it from
+/usr/share/bash-completion/completions/

--- a/extras/command-completion/README.in
+++ b/extras/command-completion/README.in
@@ -1,7 +1,7 @@
-This file is not moved to /usr/share/bash-completion/completions/
+This file is not moved to @bashcompdir@
 with the source installation.
 Please execute make install explicity from here to move this file to
-/usr/share/bash-completion/completions/
+@bashcompdir@
 
 Similarly, use make uninstall to remove it from
-/usr/share/bash-completion/completions/
+@bashcompdir@

--- a/extras/command-completion/README.in
+++ b/extras/command-completion/README.in
@@ -1,7 +1,0 @@
-This file is not moved to @bashcompdir@
-with the source installation.
-Please execute make install explicity from here to move this file to
-@bashcompdir@
-
-Similarly, use make uninstall to remove it from
-@bashcompdir@

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -984,7 +984,7 @@ touch %{buildroot}%{_sharedstatedir}/glusterd/nfs/run/nfs.pid
 find ./tests ./run-tests.sh -type f | cpio -pd %{buildroot}%{_prefix}/share/glusterfs
 
 ## Install bash completion for cli
-install -p -m 0744 -D extras/command-completion/gluster.bash \
+install -p -m 0644 -D extras/command-completion/gluster.bash \
     %{buildroot}%{bashcompdir}/gluster.bash
 
 %clean

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -338,6 +338,7 @@ and client framework.
 
 %package cli
 Summary:          GlusterFS CLI
+BuildRequires:    pkgconfig(bash-completion)
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 
 %description cli

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -984,10 +984,6 @@ touch %{buildroot}%{_sharedstatedir}/glusterd/nfs/run/nfs.pid
 
 find ./tests ./run-tests.sh -type f | cpio -pd %{buildroot}%{_prefix}/share/glusterfs
 
-## Install bash completion for cli
-install -p -m 0644 -D extras/command-completion/gluster.bash \
-    %{buildroot}%{bashcompdir}/gluster.bash
-
 %clean
 rm -rf %{buildroot}
 

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -981,7 +981,7 @@ find ./tests ./run-tests.sh -type f | cpio -pd %{buildroot}%{_prefix}/share/glus
 
 ## Install bash completion for cli
 install -p -m 0744 -D extras/command-completion/gluster.bash \
-    %{buildroot}%{_sysconfdir}/bash_completion.d/gluster
+    %{buildroot}%{_datadir}/bash-completion/completions/gluster
 
 %clean
 rm -rf %{buildroot}
@@ -1291,7 +1291,7 @@ exit 0
 %files cli
 %{_sbindir}/gluster
 %{_mandir}/man8/gluster.8*
-%{_sysconfdir}/bash_completion.d/gluster
+%{_datadir}/bash-completion/completions/gluster
 
 %files cloudsync-plugins
 %dir %{_libdir}/glusterfs/%{version}%{?prereltag}/cloudsync-plugins

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -224,6 +224,10 @@
 %global __provides_exclude_from ^%{_libdir}/glusterfs/%{version}/.*$
 %endif
 
+%global bashcompdir %(pkg-config --variable=completionsdir bash-completion 2>/dev/null)
+%if "%{bashcompdir}" == ""
+%global bashcompdir ${sysconfdir}/bash_completion.d
+%endif
 
 ##-----------------------------------------------------------------------------
 ## All package definitions should be placed here in alphabetical order
@@ -981,7 +985,7 @@ find ./tests ./run-tests.sh -type f | cpio -pd %{buildroot}%{_prefix}/share/glus
 
 ## Install bash completion for cli
 install -p -m 0744 -D extras/command-completion/gluster.bash \
-    %{buildroot}%{_datadir}/bash-completion/completions/gluster
+    %{buildroot}%{bashcompdir}/gluster.bash
 
 %clean
 rm -rf %{buildroot}
@@ -1291,7 +1295,7 @@ exit 0
 %files cli
 %{_sbindir}/gluster
 %{_mandir}/man8/gluster.8*
-%{_datadir}/bash-completion/completions/gluster
+%{bashcompdir}/gluster.bash
 
 %files cloudsync-plugins
 %dir %{_libdir}/glusterfs/%{version}%{?prereltag}/cloudsync-plugins

--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -338,7 +338,13 @@ and client framework.
 
 %package cli
 Summary:          GlusterFS CLI
+%if ( ! (0%{?rhel} && 0%{?rhel} < 7) )
 BuildRequires:    pkgconfig(bash-completion)
+# bash-completion >= 1.90 satisfies this requirement.
+# If it is not available, the condition can be adapted
+# and the completion script will be installed in the backwards compatible
+# %{sysconfdir}/bash_completion.d
+%endif
 Requires:         libglusterfs0%{?_isa} = %{version}-%{release}
 
 %description cli


### PR DESCRIPTION
Move bash-completion script for the `gluster` command
in `/usr/share/bash-completion/completions`
instead of `/etc/bash_completion.d`.

Allow bash-completion to dynamically load the script
only when a user tries to tab complete on the `gluster` command.

Fixes: #3750
Change-Id: Ifca300bdf5b14a68726a6fdfdcc19052cf624f85
Signed-off-by: Frédéric Moulins <frederic@moulins.org>

