### PR TITLE
rpc: use generic reference counting

### DIFF
--- a/rpc/rpc-lib/src/libgfrpc.sym
+++ b/rpc/rpc-lib/src/libgfrpc.sym
@@ -60,6 +60,7 @@ rpc_transport_notify
 rpc_transport_pollin_alloc
 rpc_transport_pollin_destroy
 rpc_transport_ref
+rpc_transport_release
 rpc_transport_unix_options_build
 rpc_transport_unref
 rpc_clnt_mgmt_pmap_signout

--- a/rpc/rpc-lib/src/rpc-drc.h
+++ b/rpc/rpc-lib/src/rpc-drc.h
@@ -12,18 +12,23 @@
 #define RPC_DRC_H
 
 #include "rpcsvc.h"
+#include <glusterfs/refcount.h>
 #include <glusterfs/locking.h>
 #include <glusterfs/dict.h>
 #include "rb.h"
 
+struct drc_globals;
+
 /* per-client cache structure */
 struct drc_client {
+    GF_REF_DECL;
     union gf_sock_union sock_union;
     /* pointers to the cache */
     struct rb_table *rbtree;
+    /* backpointer to drc data */
+    struct drc_globals *drc;
     /* no. of ops currently cached */
     uint32_t op_count;
-    gf_atomic_uint32_t ref;
     struct list_head client_list;
 };
 

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -2924,6 +2924,8 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
             goto out;
         }
 
+        GF_REF_INIT(new_trans, rpc_transport_release);
+
         ret = pthread_mutex_init(&new_trans->lock, NULL);
         if (ret != 0) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -3027,12 +3029,6 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
         new_priv->ssl_enabled = priv->ssl_enabled;
         new_priv->connected = 1;
         new_priv->is_server = _gf_true;
-
-        /*
-         * This is the first ref on the newly accepted
-         * transport.
-         */
-        rpc_transport_ref(new_trans);
 
         {
             /* Take a ref on the new_trans to avoid


### PR DESCRIPTION
Use generic reference counting to manage the lifetime of
RPC client, RPC transport and DRC service objects, adjust
related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000