### PR TITLE
locks: cleanup data structures

### DIFF
--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -923,7 +923,6 @@ new_inode_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,
     lock->volume = volume;
     lk_owner_copy(&lock->owner, &frame->root->lk_owner);
     lock->frame = frame;
-    lock->this = this;
 
     if (conn_id) {
         lock->connection_id = gf_strdup(conn_id);

--- a/xlators/features/locks/src/locks.h
+++ b/xlators/features/locks/src/locks.h
@@ -33,7 +33,6 @@ struct __posix_lock {
     short fl_type;
     short blocked;              /* waiting to acquire */
     struct gf_flock user_flock; /* the flock supplied by the user */
-    xlator_t *this;             /* required for blocked locks */
     unsigned long fd_num;
 
     fd_t *fd;
@@ -75,7 +74,6 @@ struct __pl_inode_lock {
     const char *volume;
 
     struct gf_flock user_flock; /* the flock supplied by the user */
-    xlator_t *this;             /* required for blocked locks */
     struct __pl_inode *pl_inode;
 
     call_frame_t *frame;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2683,7 +2683,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             /* fall through */
         case F_RESLK_LCK:
             reqlock->frame = frame;
-            reqlock->this = this;
 
             ret = pl_reserve_setlk(this, pl_inode, reqlock, can_block);
             if (ret < 0) {
@@ -2703,7 +2702,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
         case F_RESLK_UNLCK:
             reqlock->frame = frame;
-            reqlock->this = this;
             ret = pl_reserve_unlock(this, pl_inode, reqlock);
             if (ret < 0) {
                 op_ret = -1;
@@ -2716,7 +2714,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
         case F_GETLK_FD:
             reqlock->frame = frame;
-            reqlock->this = this;
             ret = pl_verify_reservelk(this, pl_inode, reqlock, can_block);
             GF_ASSERT(ret >= 0);
 
@@ -2752,7 +2749,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
         case F_SETLKW:
             can_block = 1;
             reqlock->frame = frame;
-            reqlock->this = this;
             reqlock->blocking = can_block;
             /* fall through */
 
@@ -2761,7 +2757,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 #endif
         case F_SETLK:
             reqlock->frame = frame;
-            reqlock->this = this;
             lock_type = flock->l_type;
 
             pthread_mutex_lock(&pl_inode->mutex);


### PR DESCRIPTION
Drop unused (assigned-only) `xlator_t` pointer from
`struct __posix_lock` and `struct __pl_inode_lock`,
adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>
Updates: #1000