### PR TITLE
Allow opening directories using `glfs_open()` / `glfs_h_open()` from libgfapi (#3307, #3650)

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -454,15 +454,23 @@ retry:
         goto out;
 
     if (IA_ISDIR(iatt.ia_type)) {
-        ret = -1;
-        errno = EISDIR;
-        goto out;
-    }
-
-    if (!IA_ISREG(iatt.ia_type)) {
-        ret = -1;
-        errno = EINVAL;
-        goto out;
+        if ((flags & (O_RDWR | O_WRONLY)) ||
+            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
+            ret = -1;
+            errno = EISDIR;
+            goto out;
+        }
+    } else {
+        if (flags & O_DIRECTORY) {
+            ret = -1;
+            errno = ENOTDIR;
+            goto out;
+        }
+        if (!IA_ISREG(iatt.ia_type)) {
+            ret = -1;
+            errno = EINVAL;
+            goto out;
+        }
     }
 
     if (glfd->fd) {

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -453,25 +453,9 @@ retry:
     if (ret)
         goto out;
 
-    if (IA_ISDIR(iatt.ia_type)) {
-        if ((flags & (O_RDWR | O_WRONLY)) ||
-            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
-            ret = -1;
-            errno = EISDIR;
-            goto out;
-        }
-    } else {
-        if (flags & O_DIRECTORY) {
-            ret = -1;
-            errno = ENOTDIR;
-            goto out;
-        }
-        if (!IA_ISREG(iatt.ia_type)) {
-            ret = -1;
-            errno = EINVAL;
-            goto out;
-        }
-    }
+    ret = validate_open_flags(flags, iatt.ia_type);
+    if (ret)
+        goto out;
 
     if (glfd->fd) {
         /* Retry. Safe to touch glfd->fd as we

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -655,18 +655,9 @@ pub_glfs_h_open(struct glfs *fs, struct glfs_object *object, int flags)
         goto out;
     }
 
-    /* check types to open */
-    if (IA_ISDIR(inode->ia_type)) {
-        ret = -1;
-        errno = EISDIR;
+    ret = validate_open_flags(flags, inode->ia_type);
+    if (ret)
         goto out;
-    }
-
-    if (!IA_ISREG(inode->ia_type)) {
-        ret = -1;
-        errno = EINVAL;
-        goto out;
-    }
 
     glfd = glfs_fd_new(fs);
     if (!glfd) {

--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -716,6 +716,9 @@ get_fop_attr_thrd_key(dict_t **fop_attr);
 void
 unset_fop_attr(dict_t **fop_attr);
 
+int
+validate_open_flags(int flags, ia_type_t ia_type);
+
 /*
   SYNOPSIS
   glfs_statx: Fetch extended file attributes for the given path.

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -651,6 +651,30 @@ unset_fop_attr(dict_t **fop_attr)
     }
 }
 
+int
+validate_open_flags(int flags, ia_type_t ia_type)
+{
+    int ret = 0;
+
+    if (IA_ISDIR(ia_type)) {
+        if ((flags & (O_RDWR | O_WRONLY)) ||
+            ((flags & O_CREAT) && !(flags & O_DIRECTORY))) {
+            ret = -1;
+            errno = EISDIR;
+        }
+    } else {
+        if (flags & O_DIRECTORY) {
+            ret = -1;
+            errno = ENOTDIR;
+        } else if (!IA_ISREG(ia_type)) {
+            ret = -1;
+            errno = EINVAL;
+        }
+    }
+
+    return ret;
+}
+
 GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_from_glfd, 3.4.0)
 struct glfs *
 pub_glfs_from_glfd(struct glfs_fd *glfd)


### PR DESCRIPTION
As a consumer of libgfapi, Samba used to differentiate[[source](https://git.samba.org/?p=samba.git;a=blob;f=source3/modules/vfs_glusterfs.c;h=bce73094c54a577d5ee39d26dbc43de8b5690d6a;hb=HEAD#l783)] between file and directory OPENs based on stat information(and thereby setting `O_DIRECTORY` flag) acquired prior to actual OPEN. Recent improvements in Samba took out the need for `O_DIRECTORY` in OPEN flags causing failure(with **EISDIR**) to connect to GlusterFS backed shares via libgfapi. Explanation from one such [change](https://git.samba.org/?p=samba.git;a=commit;h=2bbdaca8da8a0f4d4ff6bb5d4a98470db223b265) in Samba made me realize that _glfs_open()_ wasn't returning error codes in a proper fashion and according to [standards](https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html).

Changes from the current PR aims to implement proper handling of `O_DIRECTORY` flag inside _glfs_open()_ and _glfs_h_open()_. The presence of `O_DIRECTORY` flag is to ensure the file being opened is a directory.

Find more details from commit messages.