### PR TITLE
test: ./tests/bugs/posix/bug-1651445.t is failing while running test …

### DIFF
--- a/tests/bugs/posix/bug-1651445.t
+++ b/tests/bugs/posix/bug-1651445.t
@@ -20,11 +20,20 @@ TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0
 #Setting the size in bytes
 TEST $CLI volume set $V0 storage.reserve 40MB
 
-#wait 5s to reset disk_space_full flag
-sleep 5
+disk_size=$(df -k $L1 | tail -1 | awk -F " " '{print $2}')
+TEST dd if=/dev/zero of=$M0/a bs=90M count=1
+# LVM has reseved different space on the partition in case of centos-7/8 so in
+# case of centos-8 the 2nd dd is failed because no sufficient
+# space is available. To avoid the test failure change the block size
+# if disk_size is not matching ~150M
+if [[ $disk_size -eq "152576" ]]
+then
+   bsize="10M"
+else
+   bsize="4M"
+fi
 
-TEST dd if=/dev/zero of=$M0/a bs=100M count=1
-TEST dd if=/dev/zero of=$M0/b bs=10M count=1
+TEST dd if=/dev/zero of=$M0/b bs=${bsize} count=1
 
 # Wait 5s to update disk_space_full flag because thread check disk space
 # after every 5s
@@ -40,10 +49,11 @@ rm -rf $M0/*
 #Setting the size in percent and repeating the above steps
 TEST $CLI volume set $V0 storage.reserve 40
 
+# Wait 5s to update disk_space_full flag because thread check disk space
+# after every 5s
 sleep 5
-
-TEST dd if=/dev/zero of=$M0/a bs=80M count=1
-TEST dd if=/dev/zero of=$M0/b bs=10M count=1
+TEST dd if=/dev/zero of=$M0/a bs=70M count=1
+TEST dd if=/dev/zero of=$M0/b bs=${bsize} count=1
 
 sleep 5
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1


### PR DESCRIPTION
…suite (#3696)

The ./tests/bugs/posix/bug-1651445.t is getting failed continuously
while running test suite. The test case is failing after reaching a
situation while brick is throwing an ENOSPC error and after cleanup, as the
test case is trying to create a file it is failing. The file creation is
failing because the flag (disk_space_full) is reset after every 5s by
a thread posix_ctx_disk_thread_proc.

The test case is failing also in centos-8 because LVM reserved more
space in centos-8 as compare to centos-7

Solution: 1) After cleanup data wait for 5s to reset the flag. Earlier
             the test case did the same but it was changed by the patch(#3637).
          2) Change the overwrite condition in posix_writev.
          3) In case of centos-8 call 2nd dd command with low block size.

>Fixes: #3695
>Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: Ifa0310ba9266651557e29480f5ea476016726e41
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

