### PR TITLE
lock/clear: Perform stack unwind outside of the inode lock

### DIFF
--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -36,14 +36,20 @@
         frame->local = NULL;                                                   \
         STACK_UNWIND_STRICT(fop, frame, op_ret, params);                       \
         if (__local) {                                                         \
-            if (__local->inodelk_dom_count_req)                                \
+            if (__local->inodelk_dom_count_req) {                              \
                 data_unref(__local->inodelk_dom_count_req);                    \
+                __local->inodelk_dom_count_req = NULL;                         \
+            }                                                                  \
             loc_wipe(&__local->loc[0]);                                        \
             loc_wipe(&__local->loc[1]);                                        \
-            if (__local->fd)                                                   \
+            if (__local->fd) {                                                 \
                 fd_unref(__local->fd);                                         \
-            if (__local->inode)                                                \
+                __local->fd = NULL;                                            \
+            }                                                                  \
+            if (__local->inode) {                                              \
                 inode_unref(__local->inode);                                   \
+                __local->inode = NULL;                                         \
+            }                                                                  \
             if (__local->xdata) {                                              \
                 dict_unref(__local->xdata);                                    \
                 __local->xdata = NULL;                                         \
@@ -52,11 +58,7 @@
         }                                                                      \
     } while (0)
 
-enum {
-    PL_LOCK_GRANTED = 0,
-    PL_LOCK_WOULD_BLOCK,
-    PL_LOCK_QUEUED
-};
+enum { PL_LOCK_GRANTED = 0, PL_LOCK_WOULD_BLOCK, PL_LOCK_QUEUED };
 
 posix_lock_t *
 new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,


### PR DESCRIPTION
While we handle lock interrupt xatrrs, the blocked locks
are unwind with EINTR inside pl_inode lock. This is not
a good idea, since the stack unwind may choose to wind
a fop, and there can be a deadlock if the wind fop is requested
for the pl_inode lock. One such example would be a EINTR
call on a blocked lock with an fd having only one ref.
This will result in calling pl_release while holding
a lock on pl_inode. Since there is an pl_inode lock
request inside a pl_release too, it will end up in a
dead lock.

This patch will send the stack unwind call for an interrupt
from outside of pl_lock.

Change-Id: I3178843d184a3cf5151b9adb76cee91906c87fc4
Fixes: #3774
Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

