### PR TITLE
tests:  Increase timeout for spare_file_rebalance.t test case

### DIFF
--- a/tests/basic/distribute/sparse_file_rebalance.t
+++ b/tests/basic/distribute/sparse_file_rebalance.t
@@ -4,6 +4,8 @@
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../dht.rc
 
+SCRIPT_TIMEOUT=300
+
 # Initialize
 #------------------------------------------------------------
 cleanup;
@@ -33,8 +35,8 @@ TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 --entry-timeout=0 $M0;
 
 # Create some sparse files and get their size
 TEST cd $M0;
-dd if=/dev/urandom of=sparse_file bs=10k count=1 seek=2M
-cp --sparse=always sparse_file sparse_file_3;
+TEST dd if=/dev/urandom of=sparse_file bs=10k count=1 seek=2M
+TEST cp --sparse=always sparse_file sparse_file_3;
 
 # Add a 3rd brick
 TEST $CLI volume add-brick $V0 $H0:$B0/${V0}3;


### PR DESCRIPTION
The test (./tests/basic/distribute/spare_file_rebalance.t ) is
not finished within default time(200s), It is taking
time while a test is calling seek at 2M offset and trying to copy
sparse file.

Change-Id: Id174f4a9d66d1caaf69f495c3cf62a2e09e87b80
Fixes: #3778
Solution: To pass regression jobs increase the timeout to 300s
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

