### PR TITLE
dht-hashfn.c: remove strcpy() from DHT calculation

### DIFF
--- a/xlators/cluster/dht/src/dht-hashfn.c
+++ b/xlators/cluster/dht/src/dht-hashfn.c
@@ -51,7 +51,7 @@ dht_munge_name(const char *original, char *modified, size_t len, regex_t *re)
 
     ret = regexec(re, original, 2, matches, 0);
 
-    if (caa_unlikely(ret == REG_NOERROR)) {
+    if (caa_unlikely(ret == 0)) {
         if (matches[1].rm_so != -1) {
             new_len = matches[1].rm_eo - matches[1].rm_so;
             if (new_len <= len) {

--- a/xlators/cluster/dht/src/dht-hashfn.c
+++ b/xlators/cluster/dht/src/dht-hashfn.c
@@ -51,20 +51,16 @@ dht_munge_name(const char *original, char *modified, size_t len, regex_t *re)
 
     ret = regexec(re, original, 2, matches, 0);
 
-    if (ret != REG_NOMATCH) {
+    if (caa_unlikely(ret == REG_NOERROR)) {
         if (matches[1].rm_so != -1) {
             new_len = matches[1].rm_eo - matches[1].rm_so;
-            /* Equal would fail due to the NUL at the end. */
-            if (new_len < len) {
+            if (new_len <= len) {
                 memcpy(modified, original + matches[1].rm_so, new_len);
-                modified[new_len] = '\0';
-                return new_len + 1; /* +1 for the terminating NULL */
+                return new_len;
             }
         }
     }
 
-    /* This is guaranteed safe because of how the dest was allocated. */
-    strcpy(modified, original);
     return 0;
 }
 
@@ -75,36 +71,39 @@ dht_hash_compute(xlator_t *this, int type, const char *name, uint32_t *hash_p)
     dht_conf_t *priv = NULL;
     size_t len = 0;
     int munged = 0;
+    gf_boolean_t trying_regexp_log = _gf_false;
+
+    if (caa_unlikely(name == NULL))
+        return -1;
+
+    len = strlen(name);
+    rsync_friendly_name = alloca(len);
 
     priv = this->private;
 
-    if (name == NULL)
-        return -1;
-
-    len = strlen(name) + 1;
-    rsync_friendly_name = alloca(len);
-
     LOCK(&priv->lock);
     {
-        if (priv->extra_regex_valid) {
+        if (caa_unlikely(priv->extra_regex_valid)) {
             munged = dht_munge_name(name, rsync_friendly_name, len,
                                     &priv->extra_regex);
         }
 
         if (!munged && priv->rsync_regex_valid) {
-            gf_msg_trace(this->name, 0, "trying regex for %s", name);
+            trying_regexp_log = _gf_true;
             munged = dht_munge_name(name, rsync_friendly_name, len,
                                     &priv->rsync_regex);
         }
     }
     UNLOCK(&priv->lock);
-    if (munged) {
+    if (trying_regexp_log)
+        gf_msg_trace(this->name, 0, "trying regex for %s", name);
+
+    if (caa_unlikely(munged)) {
         gf_msg_debug(this->name, 0, "munged down to %s", rsync_friendly_name);
         len = munged;
     } else {
         rsync_friendly_name = (char *)name;
     }
 
-    return dht_hash_compute_internal(type, rsync_friendly_name, len - 1,
-                                     hash_p);
+    return dht_hash_compute_internal(type, rsync_friendly_name, len, hash_p);
 }

--- a/xlators/cluster/dht/src/dht-hashfn.c
+++ b/xlators/cluster/dht/src/dht-hashfn.c
@@ -96,7 +96,7 @@ dht_hash_compute(xlator_t *this, int type, const char *name, uint32_t *hash_p)
     }
     UNLOCK(&priv->lock);
 
-    if (caa_unlikely(munged)) {
+    if (munged) {
         gf_msg_debug(this->name, 0, "munged down to %s", rsync_friendly_name);
         len = munged;
     } else {


### PR DESCRIPTION
It did not seem there was a need to strcpy() the modified string, as it was not used eventually.

Also, minor code changes - removed the (unused) NULL at the end of the string, caa_unlikely() decorations, removed
call to gf_trace() under LOCK, etc.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

