### PR TITLE
tests: Fix bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t

### DIFF
--- a/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
+++ b/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
@@ -9,10 +9,9 @@ function create_files {
         local i=1
         while (true)
         do
-                dd if=/dev/zero of=$M0/file$i bs=1M count=10
-                blksize1=`stat -c %b $B0/${V0}0/file$i`
-                blksize2=`stat -c %b $B0/${V0}1/file$i`
-                if [[ $blkize1 -eq 20480 ]] || [[ $blksize2 -eq 20480 ]]; then
+                touch $M0/file$i
+                if [ -e $B0/${V0}0/file$i ] || [ -e $B0/${V0}1/file$i ]; then
+                        dd if=/dev/zero of=$M0/file$i bs=1M count=10 2>/dev/null
                         ((i++))
                 else
                         break
@@ -48,8 +47,6 @@ TEST $CLI volume start $V0
 TEST $CLI volume set $V0 performance.write-behind off
 TEST $CLI volume set $V0 self-heal-daemon off
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
-
-gluster v set $V0 diagnostics.client-log-level DEBUG
 
 # Create some data on backend to test dirty xattr in case
 # while entry is created successfully on 1 node


### PR DESCRIPTION
Issue:
The test case tries to simulate a scenario where the entry creation succeeds on a single brick by filling the other two bricks. The condition which was checking the file creation failure on the other 2 brick has been changed recently to check for the number of blocks allocated for the file. In some cases when the brick gets filled, it might still be able to create few empty files but not accommodate data.

Fix:
Change the condition to check whether the file creation itself will fail on the 2 brick before exiting the loop, so that the next file creation operation will fail on both the bricks, simulating the expected scenario.

Change-Id: Ifd2ee5b7cbe6bc713c3e19eae79c31a91238579f
Signed-off-by: karthik-us <ksubrahm@redhat.com>
Fixes: #3793

