### PR TITLE
Small improvements to content population (for quick read)

### DIFF
--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -450,7 +450,11 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
         /* file content request */
         req_size = data_to_uint64(data);
         if (req_size >= filler->stbuf->ia_size && filler->stbuf->ia_size > 0) {
+#ifdef GF_LINUX_HOST_OS
             _fd = open(filler->real_path, O_RDONLY | O_NOATIME);
+#else /* O_NOATIME does not exist on BSD */
+            _fd = open(filler->real_path, O_RDONLY);
+#endif
             if (_fd == -1) {
                 gf_msg(filler->this->name, GF_LOG_ERROR, errno,
                        P_MSG_XDATA_GETXATTR, "Opening file %s failed",

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -446,8 +446,6 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
         (len == SLEN(GF_CONTENT_KEY) && !strcmp(key, GF_CONTENT_KEY))) {
         if (!filler->real_path)
             goto out;
-        else if (filler->stbuf->ia_size == 0)
-            goto set_content_key_in_dict;
 
         /* file content request */
         req_size = data_to_uint64(data);
@@ -485,7 +483,7 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
                        filler->real_path);
                 goto err;
             }
-        set_content_key_in_dict:
+
             ret = dict_set_bin(filler->xattr, GF_CONTENT_KEY, databuf,
                                read_len);
             if (ret < 0) {

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -449,7 +449,7 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
 
         /* file content request */
         req_size = data_to_uint64(data);
-        if (req_size >= filler->stbuf->ia_size && filler->stbuf->ia_size > 0) {
+        if (req_size >= filler->stbuf->ia_size) {
 #ifdef GF_LINUX_HOST_OS
             _fd = open(filler->real_path, O_RDONLY | O_NOATIME);
 #else /* O_NOATIME does not exist on BSD */

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -484,8 +484,7 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
                 goto err;
             }
 
-            ret = dict_set_bin(filler->xattr, key, databuf,
-                               read_len);
+            ret = dict_set_bin(filler->xattr, key, databuf, read_len);
             if (ret < 0) {
                 gf_msg(filler->this->name, GF_LOG_ERROR, 0,
                        P_MSG_XDATA_GETXATTR,

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -468,7 +468,7 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
             }
 
             read_len = sys_read(_fd, databuf, filler->stbuf->ia_size);
-            if (read_len <= 0) {
+            if (read_len < 0) {
                 gf_msg(filler->this->name, GF_LOG_ERROR, errno,
                        P_MSG_XDATA_GETXATTR, "Read on file %s failed",
                        filler->real_path);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -424,7 +424,7 @@ _posix_xattr_get_set(dict_t *xattr_req, char *key, data_t *data,
     posix_xattr_filler_t *filler = xattrargs;
     int ret = -1;
     int len = 0;
-    char *databuf = NULL;
+    char *databuf = "";
     int _fd = -1;
     ssize_t req_size = 0;
     int32_t list_offset = 0;


### PR DESCRIPTION
- No need to CALLOC the whole array, MALLOC is OK, as we are going to read into it.
- Skip zero length files.
- Open the file with O_NOATIME - I don't think there's a need to update access time over this read.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

