### PR TITLE
macfuse/mount_darwin: remove a ';'

### DIFF
--- a/contrib/macfuse/mount_darwin.c
+++ b/contrib/macfuse/mount_darwin.c
@@ -60,7 +60,7 @@ gf_fuse_mount (const char *mountpoint, char *fsname, char *mnt_param,
         size_t version_len                 = MAXHOSTNAMELEN;
         size_t version_len_desired         = 0;
         int r                              = 0;
-        char devpath[MAXPATHLEN]           = { 0 };;
+        char devpath[MAXPATHLEN]           = { 0 };
 
         if (!mountpoint) {
                 gf_log ("glustefs-fuse", GF_LOG_ERROR,


### PR DESCRIPTION
Signed-off-by: Li zeming <zeming@nfschina.com>

Remove a symbol and the statement looks more perfect.