### PR TITLE
glusterd: don't force send-gids when manage-gids is off

### DIFF
--- a/tests/bugs/glusterd/issue-3781.t
+++ b/tests/bugs/glusterd/issue-3781.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup
+
+TEST glusterd
+TEST pidof glusterd
+
+TEST ${CLI} volume create ${V0} ${H0}:${B0}/brick
+
+BRICK="${B0//\//-}-brick"
+BRICK="${BRICK:1}"
+
+VOLFILE_CLNT="$(gluster system:: getwd)/vols/${V0}/${V0}.tcp-fuse.vol"
+VOLFILE_SRVR="$(gluster system:: getwd)/vols/${V0}/${V0}.${H0}.${BRICK}.vol"
+
+EXPECT "^$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} send-gids false
+EXPECT "^$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^false$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} send-gids true
+EXPECT "^$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^true$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume reset ${V0} send-gids
+EXPECT "^$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} manage-gids true
+EXPECT "^true$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^false$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} manage-gids false
+EXPECT "^false$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} send-gids false
+EXPECT "^false$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^false$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+TEST gluster volume set ${V0} send-gids true
+EXPECT "^false$" volgen_volume_option ${VOLFILE_SRVR} ${V0}-server protocol server manage-gids
+EXPECT "^true$" volgen_volume_option ${VOLFILE_CLNT} ${V0}-client-0 protocol client send-gids
+
+cleanup

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -4451,9 +4451,17 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     ret = dict_get_str_boolean(set_dict, "server.manage-gids", _gf_false);
-    if (ret != -1) {
-        ret = dict_set_str_sizen(set_dict, "client.send-gids",
-                                 ret ? "false" : "true");
+    if (ret > 0) {
+        /* If manage-gids is enabled, it means that servers will take care of
+         * the user groups themselves. In this case it's useless to send the
+         * list from the client side because it will be ignored, so we disable
+         * send-gids option always.
+         *
+         * In case manage-gids is disabled, we cannot assume that the client
+         * needs to send the gids. It's possible to completely handle ACL
+         * checks in client side, so we don't touch the value of send-gids in
+         * this case. The user is free to enable or disable it. */
+        ret = dict_set_str_sizen(set_dict, "client.send-gids", "false");
         if (ret)
             gf_msg(THIS->name, GF_LOG_WARNING, -ret, GD_MSG_DICT_SET_FAILED,
                    "changing client"

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -249,10 +249,10 @@ client_submit_request(xlator_t *this, void *req, call_frame_t *frame,
 
     /* do not send all groups if they are resolved server-side */
     if (!conf->send_gids) {
-        if (frame->root->ngrps <= SMALL_GROUP_COUNT) {
-            frame->root->groups_small[0] = frame->root->gid;
-            frame->root->groups = frame->root->groups_small;
-        }
+        /* We don't need to send the gids of the user. Just reset the list to
+         * a single item with the primary gid. */
+        frame->root->groups_small[0] = frame->root->gid;
+        frame->root->groups = frame->root->groups_small;
         frame->root->ngrps = 1;
     }
 


### PR DESCRIPTION
Currently glusterd always sets send-gids to the negated value of manage-gids. This is not correct when we just want to check user permissions in the client side. In this case we don't need to enable manage-gids, but we also don't need to enable send-gids.

Updates: #3781
Change-Id: Ia42825e7f6993896b1000a07d420b84d1d0422b6
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

