### PR TITLE
cdc xlator improvements

### DIFF
--- a/tests/basic/cdc.t
+++ b/tests/basic/cdc.t
@@ -43,6 +43,9 @@ TEST ! $CLI volume set $V0 network.compression.mode client
 TEST $CLI volume set $V0 network.compression.debug on
 EXPECT 'on' volinfo_field $V0 'network.compression.debug'
 
+## don't use min-size, so any size will be compressed.
+TEST $CLI volume set $V0 network.compression.min-size 0
+
 ## Start the volume
 TEST $CLI volume start $V0;
 EXPECT 'Started' volinfo_field $V0 'Status';

--- a/xlators/features/compress/src/cdc.c
+++ b/xlators/features/compress/src/cdc.c
@@ -22,7 +22,7 @@ cdc_cleanup_iobref(cdc_info_t *ci)
     iobref_clear(ci->iobref);
 }
 
-int32_t
+static int32_t
 cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
               int32_t op_errno, struct iovec *vector, int32_t count,
               struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
@@ -36,10 +36,10 @@ cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     GF_VALIDATE_OR_GOTO("cdc", this, default_out);
     GF_VALIDATE_OR_GOTO(this->name, frame, default_out);
 
-    priv = this->private;
-
     if (op_ret <= 0)
         goto default_out;
+
+    priv = this->private;
 
     if ((priv->min_file_size != 0) && (op_ret < priv->min_file_size))
         goto default_out;
@@ -87,7 +87,7 @@ cdc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 }
 
-int32_t
+static int32_t
 cdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
@@ -112,12 +112,12 @@ cdc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     GF_VALIDATE_OR_GOTO("cdc", this, err);
     GF_VALIDATE_OR_GOTO(this->name, frame, err);
 
-    priv = this->private;
-
     isize = iov_length(vector, count);
 
     if (isize <= 0)
         goto default_out;
+
+    priv = this->private;
 
     if ((priv->min_file_size != 0) && (isize < priv->min_file_size))
         goto default_out;
@@ -304,13 +304,13 @@ struct volume_options options[] = {
                     "compression ratio; memLevel=9 uses maximum memory "
                     "for optimal speed. The default value is 8."},
     {.key = {"compression-level"},
-     .default_value = "-1",
+     .default_value = "1",
      .type = GF_OPTION_TYPE_INT,
      .description = "Compression levels \n"
                     "0 : no compression, 1 : best speed, \n"
                     "9 : best compression, -1 : default compression "},
     {.key = {"min-size"},
-     .default_value = "0",
+     .default_value = "1024",
      .type = GF_OPTION_TYPE_INT,
      .description = "Data is compressed only when its size exceeds this."},
     {.key = {"mode"},

--- a/xlators/features/compress/src/cdc.h
+++ b/xlators/features/compress/src/cdc.h
@@ -21,7 +21,6 @@ typedef struct cdc_priv {
     int min_file_size;
     int op_mode;
     gf_boolean_t debug;
-    gf_lock_t lock;
 } cdc_priv_t;
 
 typedef struct cdc_info {
@@ -44,7 +43,6 @@ typedef struct cdc_info {
     unsigned long crc;
 } cdc_info_t;
 
-#define NVEC(ci) (ci->ncount - 1)
 #define CURR_VEC(ci) ci->vec[ci->ncount - 1]
 #define THIS_VEC(ci, i) ci->vector[i]
 
@@ -53,7 +51,7 @@ typedef struct cdc_info {
 #define GF_CDC_MAX_WINDOWSIZE -8  /* max value     */
 
 #define GF_CDC_DEF_MEMLEVEL 8
-#define GF_CDC_DEF_BUFFERSIZE 262144  // 256K - default compression buffer size
+#define GF_CDC_DEF_BUFFERSIZE 1024*128  // 128K - default compression buffer size
 
 /* Operation mode
  * If xlator is loaded on client, readv decompresses and writev compresses

--- a/xlators/features/compress/src/cdc.h
+++ b/xlators/features/compress/src/cdc.h
@@ -51,7 +51,8 @@ typedef struct cdc_info {
 #define GF_CDC_MAX_WINDOWSIZE -8  /* max value     */
 
 #define GF_CDC_DEF_MEMLEVEL 8
-#define GF_CDC_DEF_BUFFERSIZE 1024*128  // 128K - default compression buffer size
+#define GF_CDC_DEF_BUFFERSIZE                                                  \
+    1024 * 128  // 128K - default compression buffer size
 
 /* Operation mode
  * If xlator is loaded on client, readv decompresses and writev compresses


### PR DESCRIPTION
- Minor code movements, removal of unused variables.
- The default for min_file_size should not be 0 - we really should not bother with compressing files < 1K files or so.
- The default compression level is too high - zlib isn't that great anyway (performance-wise), so we should use the fastest possible
- deflateInit2() is called repeatedly (within do_cdc_compress() function) instead of once (in cdc_compress() function)
- The fixed size (GF_CDC_DEF_BUFFERSIZE) is too large - if FUSE can only do up to 128K, unsure what's the point in allocating up to 256K iobufs

Updates: #3797
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

