### PR TITLE
posix: posix xlator does not respects storage.reserve value (#3637)

### DIFF
--- a/tests/bugs/posix/bug-1651445.t
+++ b/tests/bugs/posix/bug-1651445.t
@@ -20,16 +20,9 @@ TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0
 #Setting the size in bytes
 TEST $CLI volume set $V0 storage.reserve 40MB
 
-#wait 5s to reset disk_space_full flag
-sleep 5
-
-TEST dd if=/dev/zero of=$M0/a bs=100M count=1
+TEST dd if=/dev/zero of=$M0/a bs=90M count=1
 TEST dd if=/dev/zero of=$M0/b bs=10M count=1
 
-# Wait 5s to update disk_space_full flag because thread check disk space
-# after every 5s
-
-sleep 5
 # setup_lvm create lvm partition of 150M and 40M are reserve so after
 # consuming more than 110M next dd should fail
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1
@@ -40,12 +33,9 @@ rm -rf $M0/*
 #Setting the size in percent and repeating the above steps
 TEST $CLI volume set $V0 storage.reserve 40
 
-sleep 5
-
-TEST dd if=/dev/zero of=$M0/a bs=80M count=1
+TEST dd if=/dev/zero of=$M0/a bs=70M count=1
 TEST dd if=/dev/zero of=$M0/b bs=10M count=1
 
-sleep 5
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1
 
 TEST $CLI volume stop $V0

--- a/tests/bugs/shard/issue-2038.t
+++ b/tests/bugs/shard/issue-2038.t
@@ -35,7 +35,7 @@ sleep 5
 TEST touch $M0/test
 TEST unlink $M0/test
 
-TEST dd if=/dev/zero of=$M0/a bs=80M count=1
+TEST dd if=/dev/zero of=$M0/a bs=70M count=1
 TEST dd if=/dev/zero of=$M0/b bs=10M count=1
 
 gfid_new=$(get_gfid_string $M0/a)

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -3935,6 +3935,15 @@ server4_0_writev(rpcsvc_request_t *req)
         goto out;
     }
 
+    if (state->xdata) {
+        ret = dict_set_int32_sizen(state->xdata, "buffer-size", len);
+        if (ret) {
+            gf_msg(THIS->name, GF_LOG_INFO, ENOMEM, 0,
+                   "%zu: dict set (buffer-size) failed, continuing", len);
+            goto out;
+        }
+    }
+
 #ifdef GF_TESTING_IO_XDATA
     dict_dump_to_log(state->xdata);
 #endif

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -328,6 +328,56 @@ set_xattr_user_namespace_mode(struct posix_private *priv, const char *str)
 }
 #endif
 
+static int32_t
+posix_statfs_path(xlator_t *this, char *real_path)
+{
+    int32_t op_ret = -1;
+    struct statvfs buf = {
+        0,
+    };
+
+    struct posix_private *priv = NULL;
+    double percent = 0;
+    uint64_t reserved_blocks = 0;
+
+    priv = this->private;
+
+    op_ret = sys_statvfs(real_path, &buf);
+
+    if (op_ret == -1) {
+        gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_STATVFS_FAILED,
+               "statvfs failed on (path: %s)", real_path);
+        return op_ret;
+    }
+
+    if (priv->disk_unit_percent) {
+        percent = priv->disk_reserve;
+        reserved_blocks = (((buf.f_blocks * percent) / 100) + 0.5);
+    } else {
+        if (buf.f_bsize) {
+            reserved_blocks = ((uint64_t)(priv->disk_reserve) + buf.f_bsize -
+                               1) /
+                              buf.f_bsize;
+        }
+    }
+
+    if (buf.f_bfree > reserved_blocks) {
+        buf.f_bfree = (buf.f_bfree - reserved_blocks);
+        if (buf.f_bavail > buf.f_bfree) {
+            buf.f_bavail = buf.f_bfree;
+        }
+    } else {
+        buf.f_bfree = 0;
+        buf.f_bavail = 0;
+    }
+    reserved_blocks = (buf.f_bfree * buf.f_bsize);
+
+    priv->disk_size_after_reserve = reserved_blocks;
+    gf_log(this->name, GF_LOG_INFO, "Set disk_size_after reserve is %" PRIu64,
+           reserved_blocks);
+    return 0;
+}
+
 int
 posix_reconfigure(xlator_t *this, dict_t *options)
 {
@@ -488,6 +538,14 @@ posix_reconfigure(xlator_t *this, dict_t *options)
                      bool, out);
 
     GF_OPTION_RECONF("ctime", priv->ctime, options, bool, out);
+
+    if ((old_disk_reserve != priv->disk_reserve)) {
+        if (posix_statfs_path(this, priv->base_path)) {
+            gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_DISK_SPACE_CHECK_FAILED,
+                   "Getting disk space check failed ");
+            goto out;
+        }
+    }
 
     ret = 0;
 out:
@@ -1222,6 +1280,11 @@ posix_init(xlator_t *this)
                    out);
 
     GF_OPTION_INIT("ctime", _private->ctime, bool, out);
+    ret = posix_statfs_path(this, _private->base_path);
+    if (ret) {
+        gf_msg(this->name, GF_LOG_INFO, 0, P_MSG_DISK_SPACE_CHECK_FAILED,
+               "Getting disk space check failed ");
+    }
 
 out:
     if (ret) {

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -1510,6 +1510,10 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
     unwind_dict = posix_dict_set_nlink(xdata, unwind_dict, stbuf.ia_nlink);
+    if (IA_ISREG(loc->inode->ia_type) && (stbuf.ia_nlink <= 2)) {
+        GF_ATOMIC_SUB(priv->write_value, ((stbuf.ia_blocks) * 512));
+    }
+
     op_ret = 0;
 out:
     SET_TO_OLD_FS_ID();

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1543,6 +1543,10 @@ posix_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
     posix_set_ctime(frame, this, real_path, -1, loc->inode, &postbuf);
 
+    if (postbuf.ia_blocks < prebuf.ia_blocks)
+        GF_ATOMIC_SUB(priv->write_value,
+                      ((prebuf.ia_blocks - postbuf.ia_blocks) * 512));
+
     op_ret = 0;
 out:
     SET_TO_OLD_FS_ID();
@@ -1983,7 +1987,7 @@ posix_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     priv = this->private;
 
     VALIDATE_OR_GOTO(priv, unwind);
-    DISK_SPACE_CHECK_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out);
+    DISK_SPACE_CHECK_WRITEV_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out);
 
 overwrite:
 
@@ -2120,7 +2124,9 @@ overwrite:
         }
     }
 
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
+    if (preop.ia_blocks < postop.ia_blocks)
+        GF_ATOMIC_ADD(priv->write_value,
+                      ((postop.ia_blocks - preop.ia_blocks) * 512));
 
 out:
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -77,6 +77,41 @@
         }                                                                      \
     } while (0)
 
+#define DISK_SPACE_CHECK_WRITEV_AND_GOTO(frame, priv, xdata, op_ret, op_errno, \
+                                         out)                                  \
+    do {                                                                       \
+        gf_boolean_t flag = _gf_false;                                         \
+        int32_t buffer_size = 0;                                               \
+        int64_t write_val = 0;                                                 \
+        int64_t disk_free = 0;                                                 \
+        if (frame->root->pid >= 0 &&                                           \
+            !dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY)) {              \
+            if (priv->disk_space_full) {                                       \
+                flag = _gf_true;                                               \
+            } else {                                                           \
+                if (dict_get_int32(xdata, "buffer-size", &buffer_size)) {      \
+                    gf_log(frame->this->name, GF_LOG_TRACE,                    \
+                           "failed to get "                                    \
+                           " buffer-size");                                    \
+                }                                                              \
+                write_val = GF_ATOMIC_GET(priv->write_value);                  \
+                disk_free = priv->disk_size_after_reserve;                     \
+                if ((buffer_size + write_val) > disk_free) {                   \
+                    flag = _gf_true;                                           \
+                }                                                              \
+            }                                                                  \
+            if (flag) {                                                        \
+                op_ret = -1;                                                   \
+                op_errno = ENOSPC;                                             \
+                gf_msg_debug("posix", ENOSPC,                                  \
+                             "disk space utilization reached limits"           \
+                             " for path %s ",                                  \
+                             priv->base_path);                                 \
+                goto out;                                                      \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
 /* Setting microseconds or nanoseconds depending on what's supported:
    The passed in `tv` can be
        struct timespec
@@ -155,6 +190,7 @@ struct posix_private {
 
     gf_atomic_t read_value;  /* Total read, from init */
     gf_atomic_t write_value; /* Total write, from init */
+    uint64_t disk_size_after_reserve;
 
     /* janitor task which cleans up /.trash (created by replicate) */
     struct gf_tw_timer_list *janitor;


### PR DESCRIPTION
* posix: posix xlator does not respects storage.reserve value

In a small storage environment (brick_root is < 100G) the POSIX xlator does not respects storage.reserve value.The flag value is set after every 5s basis and so in that window if the client has generated the data the posix xlator does not validate storage.reserve spacee check and allow client to consume the brick space unless the flag has not been set by a posixctxres thread.

Solution: Before doing any writev for an external client check
          the current free storage space with writev buffer and if
          it has surpassed the limit return ENOSPC. The priv->write_value
          parameter has been updated during call unlink
          and truncate fop also to use the correct value.

>Fixes: #3636
>Change-Id: I7e174553c22893dd44438f48406e895e13b5db5e
>Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

* posix: Resolve reviewer comments

>Fixes: #3636
>Change-Id: I569b8e5d96f138204d25e9753a92cb19135bd584
>Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

* posix: Calculate file written size based on (pre|post)op block size difference to avoid overwrite cases.

>Fixes: #3636
>Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: I87efee72e9cdbd1a20df30b07a6e2587ce0675a6
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

