### PR TITLE
lock/clear: Perform stack unwind outside of the inode lock (#3775)

### DIFF
--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -157,6 +157,7 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
     struct gf_flock ulock = {
         0,
     };
+    struct list_head blocked_list;
     int ret = -1;
     int bcount = 0;
     int gcount = 0;
@@ -167,6 +168,7 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
         goto out;
     }
 
+    INIT_LIST_HEAD(&blocked_list);
     pthread_mutex_lock(&pl_inode->mutex);
     {
         list_for_each_entry_safe(plock, tmp, &pl_inode->ext_list, list)
@@ -189,21 +191,30 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
 
             list_del_init(&plock->list);
             if (plock->blocked) {
+                list_add_tail(&plock->list, &blocked_list);
                 bcount++;
-                pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
-                             &plock->user_flock, -1, EINTR, NULL);
-
-                local = plock->frame->local;
-                PL_STACK_UNWIND_AND_FREE(local, lk, plock->frame, -1, EINTR,
-                                         &plock->user_flock, NULL);
-
             } else {
                 gcount++;
+                __destroy_lock(plock);
             }
-            __destroy_lock(plock);
         }
     }
     pthread_mutex_unlock(&pl_inode->mutex);
+
+    plock = NULL;
+    tmp = NULL;
+    /* Perform stack unwind outside of pl_inode lock */
+    list_for_each_entry_safe(plock, tmp, &blocked_list, list)
+    {
+        list_del_init(&plock->list);
+        pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
+                     &plock->user_flock, -1, EINTR, NULL);
+
+        local = plock->frame->local;
+        PL_STACK_UNWIND_AND_FREE(local, lk, plock->frame, -1, EINTR,
+                                 &plock->user_flock, NULL);
+        __destroy_lock(plock);
+    }
     grant_blocked_locks(this, pl_inode);
     ret = 0;
 out:

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -36,14 +36,20 @@
         frame->local = NULL;                                                   \
         STACK_UNWIND_STRICT(fop, frame, op_ret, params);                       \
         if (__local) {                                                         \
-            if (__local->inodelk_dom_count_req)                                \
+            if (__local->inodelk_dom_count_req) {                              \
                 data_unref(__local->inodelk_dom_count_req);                    \
+                __local->inodelk_dom_count_req = NULL;                         \
+            }                                                                  \
             loc_wipe(&__local->loc[0]);                                        \
             loc_wipe(&__local->loc[1]);                                        \
-            if (__local->fd)                                                   \
+            if (__local->fd) {                                                 \
                 fd_unref(__local->fd);                                         \
-            if (__local->inode)                                                \
+                __local->fd = NULL;                                            \
+            }                                                                  \
+            if (__local->inode) {                                              \
                 inode_unref(__local->inode);                                   \
+                __local->inode = NULL;                                         \
+            }                                                                  \
             if (__local->xdata) {                                              \
                 dict_unref(__local->xdata);                                    \
                 __local->xdata = NULL;                                         \
@@ -52,11 +58,7 @@
         }                                                                      \
     } while (0)
 
-enum {
-    PL_LOCK_GRANTED = 0,
-    PL_LOCK_WOULD_BLOCK,
-    PL_LOCK_QUEUED
-};
+enum { PL_LOCK_GRANTED = 0, PL_LOCK_WOULD_BLOCK, PL_LOCK_QUEUED };
 
 posix_lock_t *
 new_posix_lock(struct gf_flock *flock, client_t *client, pid_t client_pid,


### PR DESCRIPTION
While we handle lock interrupt xatrrs, the blocked locks are unwind with EINTR inside pl_inode lock. This is not a good idea, since the stack unwind may choose to wind a fop, and there can be deadlock if the wind fop requested for the pl_inode lock. One such example would be a EINTR call on a blocked lock with an fd having only one ref. This will result in calling pl_release while holding a lock on pl_inode. Since there is an pl_inode lock request inside a pl_release too, it will end up in a dead lock.

This patch will send the stack unwind call for an interrupt from outside of pl_lock.

>Change-Id: I3178843d184a3cf5151b9adb76cee91906c87fc4
>Fixes: #3774
>Signed-off-by: Mohammed Rafi KC <rafi.kavungal@iternity.com>

Change-Id: I3178843d184a3cf5151b9adb76cee91906c87fc4
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

