### PR TITLE
posix_disk_space_check, dht_disk_usage: save multiplcation if using p…

### DIFF
--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -589,7 +589,7 @@ struct dht_conf {
 
     char vol_uuid[UUID_SIZE + 1];
 
-    char disk_unit;
+    gf_boolean_t disk_unit_percent;
 
     gf_boolean_t lock_migration_enabled;
 

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -222,7 +222,7 @@ dht_is_subvol_filled(xlator_t *this, xlator_t *subvol)
     {
         for (i = 0; i < conf->subvolume_cnt; i++) {
             if (subvol == conf->subvolumes[i]) {
-                if (conf->disk_unit == 'p') {
+                if (conf->disk_unit_percent) {
                     if (conf->du_stats[i].avail_percent < conf->min_free_disk) {
                         subvol_filled_space = _gf_true;
                         break;
@@ -403,7 +403,7 @@ dht_subvol_with_free_space_inodes(xlator_t *this, xlator_t *subvol,
         if (ignore_subvol)
             continue;
 
-        if ((conf->disk_unit == 'p') &&
+        if ((conf->disk_unit_percent) &&
             (conf->du_stats[i].avail_percent > conf->min_free_disk) &&
             (conf->du_stats[i].avail_inodes > conf->min_free_inodes)) {
             if ((conf->du_stats[i].avail_inodes > max_inodes) ||
@@ -417,7 +417,7 @@ dht_subvol_with_free_space_inodes(xlator_t *this, xlator_t *subvol,
             }
         }
 
-        if ((conf->disk_unit != 'p') &&
+        if ((!conf->disk_unit_percent) &&
             (conf->du_stats[i].avail_space > conf->min_free_disk) &&
             (conf->du_stats[i].avail_inodes > conf->min_free_inodes)) {
             if ((conf->du_stats[i].avail_inodes > max_inodes) ||
@@ -430,13 +430,18 @@ dht_subvol_with_free_space_inodes(xlator_t *this, xlator_t *subvol,
     }
 
     if (avail_subvol) {
-        if (conf->disk_unit == 'p') {
-            post_availspace = (avail_blocks * frsize) - filesize;
-            post_percent = (post_availspace * 100) / (total_blocks * frsize);
+        if (conf->disk_unit_percent) {
+            if (filesize) {
+                post_availspace = (avail_blocks * frsize) - filesize;
+                post_percent = (post_availspace * 100) /
+                               (total_blocks * frsize);
+            } else {
+                post_availspace = avail_blocks;
+                post_percent = (post_availspace * 100) / (total_blocks);
+            }
             if (post_percent < conf->min_free_disk)
                 avail_subvol = NULL;
-        }
-        if (conf->disk_unit != 'p') {
+        } else {
             if ((max - filesize) < conf->min_free_disk)
                 avail_subvol = NULL;
         }
@@ -468,7 +473,7 @@ dht_subvol_maxspace_nonzeroinode(xlator_t *this, xlator_t *subvol,
         if (ignore_subvol)
             continue;
 
-        if (conf->disk_unit == 'p') {
+        if (conf->disk_unit_percent) {
             if ((conf->du_stats[i].avail_percent > max) &&
                 (conf->du_stats[i].avail_inodes > 0)) {
                 max = conf->du_stats[i].avail_percent;

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -912,7 +912,7 @@ __dht_check_free_space(xlator_t *this, xlator_t *to, xlator_t *from, loc_t *loc,
     }
 
 check_avail_space:
-    if (conf->disk_unit == 'p' && dst_statfs.f_blocks) {
+    if (conf->disk_unit_percent && dst_statfs.f_blocks) {
         dst_post_availspacepercent = (dst_statfs_blocks * 100) /
                                      dst_total_blocks;
 
@@ -936,7 +936,7 @@ check_avail_space:
         }
     }
 
-    if (conf->disk_unit != 'p') {
+    if (!conf->disk_unit_percent) {
         if ((dst_statfs_blocks * GF_DISK_SECTOR_SIZE) < conf->min_free_disk) {
             gf_msg_debug(this->name, 0,
                          "file : %s,  destination frsize: %lu "

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -113,7 +113,7 @@ dht_priv_dump(xlator_t *this)
     gf_proc_dump_write("gen", "%d", conf->gen);
     gf_proc_dump_write("min_free_disk", "%lf", conf->min_free_disk);
     gf_proc_dump_write("min_free_inodes", "%lf", conf->min_free_inodes);
-    gf_proc_dump_write("disk_unit", "%c", conf->disk_unit);
+    gf_proc_dump_write("disk_unit percentage", "%d", conf->disk_unit_percent);
     gf_proc_dump_write("refresh_interval", "%d", conf->refresh_interval);
     gf_proc_dump_write("unhashed_sticky_bit", "%d", conf->unhashed_sticky_bit);
     gf_proc_dump_write("use-readdirp", "%d", conf->use_readdirp);
@@ -457,9 +457,9 @@ dht_reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("min-free-disk", conf->min_free_disk, options,
                      percent_or_size, out);
     /* option can be any one of percent or bytes */
-    conf->disk_unit = 0;
+    conf->disk_unit_percent = _gf_false;
     if (conf->min_free_disk < 100.0)
-        conf->disk_unit = 'p';
+        conf->disk_unit_percent = _gf_true;
 
     GF_OPTION_RECONF("min-free-inodes", conf->min_free_inodes, options, percent,
                      out);
@@ -771,9 +771,9 @@ dht_init(xlator_t *this)
     }
 
     /* option can be any one of percent or bytes */
-    conf->disk_unit = 0;
+    conf->disk_unit_percent = _gf_false;
     if (conf->min_free_disk < 100)
-        conf->disk_unit = 'p';
+        conf->disk_unit_percent = _gf_true;
 
     ret = dht_init_subvolumes(this, conf);
     if (ret == -1) {

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -419,9 +419,9 @@ posix_reconfigure(xlator_t *this, dict_t *options)
     GF_OPTION_RECONF("reserve", priv->disk_reserve, options, percent_or_size,
                      out);
     /* option can be any one of percent or bytes */
-    priv->disk_unit = 0;
+    priv->disk_unit_percent = _gf_false;
     if (priv->disk_reserve < 100.0)
-        priv->disk_unit = 'p';
+        priv->disk_unit_percent = _gf_true;
 
     /* Delete a pxl object from a list of disk_reserve while something
        is changed for reserve option during graph reconfigure
@@ -1113,10 +1113,10 @@ posix_init(xlator_t *this)
     GF_OPTION_INIT("reserve", _private->disk_reserve, percent_or_size, out);
 
     /* option can be any one of percent or bytes */
-    _private->disk_unit = 0;
+    _private->disk_unit_percent = _gf_false;
     pthread_cond_init(&_private->fd_cond, NULL);
     if (_private->disk_reserve < 100.0)
-        _private->disk_unit = 'p';
+        _private->disk_unit_percent = _gf_true;
 
     if (_private->disk_reserve) {
         ret = posix_spawn_disk_space_check_thread(this);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2264,9 +2264,7 @@ posix_disk_space_check(struct posix_private *priv)
     char *subvol_path = NULL;
     int op_ret = 0;
     double size = 0;
-    double percent = 0;
     struct statvfs buf = {0};
-    double totsz = 0;
     double freesz = 0;
 
     GF_VALIDATE_OR_GOTO("posix-helpers", priv, out);
@@ -2275,21 +2273,20 @@ posix_disk_space_check(struct posix_private *priv)
 
     op_ret = sys_statvfs(subvol_path, &buf);
 
-    if (op_ret == -1) {
+    if (op_ret != 0) {
         gf_msg("posix-disk", GF_LOG_ERROR, errno, P_MSG_STATVFS_FAILED,
                "statvfs failed on %s", subvol_path);
         goto out;
     }
 
-    if (priv->disk_unit == 'p') {
-        percent = priv->disk_reserve;
-        totsz = (buf.f_blocks * buf.f_bsize);
-        size = ((totsz * percent) / 100);
+    if (priv->disk_unit_percent) {
+        size = ((buf.f_blocks * priv->disk_reserve) / 100);
+        freesz = buf.f_bfree;
     } else {
         size = priv->disk_reserve;
+        freesz = (buf.f_bfree * buf.f_bsize);
     }
 
-    freesz = (buf.f_bfree * buf.f_bsize);
     if (freesz <= size) {
         priv->disk_space_full = 1;
     } else {

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2469,7 +2469,7 @@ posix_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         goto out;
     }
 
-    if (priv->disk_unit == 'p') {
+    if (priv->disk_unit_percent) {
         percent = priv->disk_reserve;
         reserved_blocks = (((buf.f_blocks * percent) / 100) + 0.5);
     } else {

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -235,7 +235,7 @@ struct posix_private {
     gf_boolean_t ctime;
     gf_boolean_t janitor_task_stop;
 
-    char disk_unit;
+    gf_boolean_t disk_unit_percent;
     gf_boolean_t health_check_active;
     gf_boolean_t update_pgfid_nlinks;
     gf_boolean_t gfid2path;


### PR DESCRIPTION
…ercentage (#3040)

If we are using percentage of free space, there's no need to multiply both the free space and the and the total size by buf.f_bsize, as we compare one to each other.

Similar work in DHT's code.

Also, switched from using a char ('p') to signify we are using percentage for disk usage to a simple boolean. True means we are using percentage.

>Updates: #1000
>Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

Updates: #1000
Signed-off-by: Shwetha K Acharya

