### PR TITLE
Fix compilation warning with gNFS enabled

### DIFF
--- a/rpc/xdr/src/xdr-generic.c
+++ b/rpc/xdr/src/xdr-generic.c
@@ -59,7 +59,7 @@ ssize_t
 xdr_to_generic_payload(struct iovec inmsg, void *args, xdrproc_t proc,
                        struct iovec *pendingpayload)
 {
-    ssize_t ret;
+    ssize_t ret = 0;
 #ifdef BUILD_GNFS
     XDR xdr;
 


### PR DESCRIPTION
Regression from a1d1f864292afb2dbd13797fc5ac65e8de684768

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

