### PR TITLE
[events-api] Create cfg file in parallel without data truncation

### DIFF
--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -80,7 +80,6 @@ def create_custom_config_file_if_not_exists(args):
     if not os.path.exists(CUSTOM_CONFIG_FILE):
         with NamedTempOpen(CUSTOM_CONFIG_FILE, "w") as f:
             f.write(json.dumps({}))
-            f.persist()
 
 
 def create_webhooks_file_if_not_exists(args):
@@ -94,7 +93,6 @@ def create_webhooks_file_if_not_exists(args):
     if not os.path.exists(WEBHOOKS_FILE):
         with NamedTempOpen(WEBHOOKS_FILE, "w") as f:
            f.write(json.dumps({}))
-           f.persist()
 
 
 def boolify(value):

--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -80,6 +80,7 @@ def create_custom_config_file_if_not_exists(args):
     if not os.path.exists(CUSTOM_CONFIG_FILE):
         with NamedTempOpen(CUSTOM_CONFIG_FILE, "w") as f:
             f.write(json.dumps({}))
+            f.persist()
 
 
 def create_webhooks_file_if_not_exists(args):
@@ -93,6 +94,7 @@ def create_webhooks_file_if_not_exists(args):
     if not os.path.exists(WEBHOOKS_FILE):
         with NamedTempOpen(WEBHOOKS_FILE, "w") as f:
            f.write(json.dumps({}))
+           f.persist()
 
 
 def boolify(value):

--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -78,8 +78,8 @@ def create_custom_config_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(CUSTOM_CONFIG_FILE):
-        with open(CUSTOM_CONFIG_FILE, "w") as f:
-            f.write("{}")
+        with LockedOpen(CUSTOM_CONFIG_FILE, "w") as f:
+            f.write(json.dumps({}))
 
 
 def create_webhooks_file_if_not_exists(args):
@@ -91,8 +91,8 @@ def create_webhooks_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(WEBHOOKS_FILE):
-        with open(WEBHOOKS_FILE, "w") as f:
-            f.write("{}")
+        with LockedOpen(WEBHOOKS_FILE, "w") as f:
+           f.write(json.dumps({}))
 
 
 def boolify(value):

--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -27,7 +27,7 @@ from gluster.cliutils import (Cmd, node_output_ok, node_output_notok,
                               sync_file_to_peers, GlusterCmdException,
                               output_error, execute_in_peers, runcli,
                               set_common_args_func)
-from gfevents.utils import LockedOpen, get_jwt_token, save_https_cert
+from gfevents.utils import LockedOpen, get_jwt_token, save_https_cert, NamedTempOpen
 
 from gfevents.eventsapiconf import (WEBHOOKS_FILE_TO_SYNC,
                                     WEBHOOKS_FILE,
@@ -78,7 +78,7 @@ def create_custom_config_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(CUSTOM_CONFIG_FILE):
-        with LockedOpen(CUSTOM_CONFIG_FILE, "w") as f:
+        with NamedTempOpen(CUSTOM_CONFIG_FILE, "w") as f:
             f.write(json.dumps({}))
 
 
@@ -91,7 +91,7 @@ def create_webhooks_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(WEBHOOKS_FILE):
-        with LockedOpen(WEBHOOKS_FILE, "w") as f:
+        with NamedTempOpen(WEBHOOKS_FILE, "w") as f:
            f.write(json.dumps({}))
 
 

--- a/events/src/utils.py
+++ b/events/src/utils.py
@@ -321,7 +321,7 @@ class NamedTempOpen(object):
         This class is used to avoid the data loss or truncation in case of multiple processes
         writing to the same file without the use of fcntl locks.
 
-        The temporary file is created in the cwd of the process.
+        The temporary file is created in the dest dir of the file.
     """
 
     def __init__(self, filename, open_mode, *args, **kwagrs) -> None:
@@ -329,17 +329,22 @@ class NamedTempOpen(object):
         self.open_mode = open_mode
         self.open_args = args
         self.open_kwargs = kwagrs
+        self.working_dir = "."
         self.fileobj = None
+
+        if os.path.dirname(self.filename) != "":
+            self.working_dir = os.path.dirname(self.filename)
 
     def __enter__(self):
         tfile = NamedTemporaryFile(mode=self.open_mode,
                                    delete=False,
-                                   dir=".",
+                                   prefix='.',
+                                   dir=self.working_dir,
                                    *self.open_args,
                                    **self.open_kwargs)
 
         if tfile is None:
-            raise
+            raise Exception("failed to create the temp file for %s" % self.filename)
 
         self.fileobj = tfile
         return self.fileobj

--- a/events/src/utils.py
+++ b/events/src/utils.py
@@ -345,8 +345,8 @@ class NamedTempOpen(object):
         return self.fileobj
 
     def __exit__(self, ex_type, ex_val, ex_tb):
-        os.rename(self.fileobj.name, self.filename)
         self.fileobj.close()
+        os.rename(self.fileobj.name, self.filename)
 
 class LockedOpen(object):
 


### PR DESCRIPTION
to prevent race cases that might occur when several nodes are trying to create the config file at the same time if it is non existent (first run).

Fixes: #3714
Updates: #3715

Signed-off-by: black-dragon74 <niryadav@redhat.com>

