### PR TITLE
test: tests/bugs/distribute/bug-882278.t is failing due to dns issue

### DIFF
--- a/tests/bugs/distribute/bug-882278.t
+++ b/tests/bugs/distribute/bug-882278.t
@@ -4,10 +4,6 @@
 . $(dirname $0)/../../volume.rc
 cleanup
 
-# Is there a good reason to require --fqdn elsewhere?  It's worse than useless
-# here.
-H0=$(hostname -s)
-
 function recreate {
 	# The rm is necessary so we don't get fooled by leftovers from old runs.
 	rm -rf $1 && mkdir -p $1


### PR DESCRIPTION
The test is trying to pass hostname during volume creation and sometime if dns resolution is failing on the environment test case is failed.

Solution: Use standard H0 environment variable to create volume
          that uses ip address to create a volume
Fixes: #3833
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: Idefa62cb00fe6e534532dee2fafdd32c3330098f

