### PR TITLE
cdc-helper: move the CRC and len (gzip trailer to the 1st iovec - and…

### DIFF
--- a/tests/basic/cdc.t
+++ b/tests/basic/cdc.t
@@ -58,15 +58,15 @@ TEST $GFS -s $H0 --volfile-id $V0 $M0;
 ## Testing writev ##
 ####################
 
-## Create a 1K file locally and find the md5sum
+## Create a 1K file locally and find the sha256sum
 TEST dd if=/dev/zero of=/tmp/cdc-orig count=1 bs=1k 2>/dev/null
-checksum[original-file]=`md5sum /tmp/cdc-orig | cut -d' ' -f1`
+checksum[original-file]=`sha256sum /tmp/cdc-orig | cut -d' ' -f1`
 
-## Copy the file to mountpoint and find its md5sum on brick
-TEST dd if=/tmp/cdc-orig of=$M0/cdc-server count=1 bs=1k 2>/dev/null
-checksum[brick-file]=`md5sum $B0/${V0}1/cdc-server | cut -d' ' -f1`
+## Copy the file to mountpoint and find its sha256sum on brick
+TEST cp /tmp/cdc-orig $M0/cdc-server
+checksum[brick-file]=`sha256sum $B0/${V0}1/cdc-server | cut -d' ' -f1`
 
-## Uncompress the gzip dump file and find its md5sum
+## Uncompress the gzip dump file and find its sha256sum
 # mime outputs for gzip are different for file version > 5.14
 TEST touch /tmp/gzipfile
 TEST gzip /tmp/gzipfile
@@ -77,7 +77,7 @@ TEST rm -f /tmp/gzipfile.gz
 EXPECT "$GZIP_MIME_TYPE" echo $(file_mime_type /tmp/cdcdump.gz)
 
 TEST gunzip -f /tmp/cdcdump.gz
-checksum[dump-file-writev]=`md5sum /tmp/cdcdump | cut -d' ' -f1`
+checksum[dump-file-writev]=`sha256sum /tmp/cdcdump | cut -d' ' -f1`
 
 ## Check if all 3 checksums are same
 TEST test ${checksum[original-file]} = ${checksum[brick-file]}
@@ -91,15 +91,15 @@ TEST rm -f /tmp/cdcdump.gz
 ###################
 
 ## Copy file from mount point to client and find checksum
-TEST dd if=$M0/cdc-server of=/tmp/cdc-client count=1 bs=1k 2>/dev/null
-checksum[client-file]=`md5sum /tmp/cdc-client | cut -d' ' -f1`
+TEST cp $M0/cdc-server /tmp/cdc-client
+checksum[client-file]=`sha256sum /tmp/cdc-client | cut -d' ' -f1`
 
-## Uncompress the gzip dump file and find its md5sum
+## Uncompress the gzip dump file and find its sha256sum
 # mime outputs for gzip are different for file version > 5.14
 EXPECT "$GZIP_MIME_TYPE" echo $(file_mime_type /tmp/cdcdump.gz)
 
 TEST gunzip -f /tmp/cdcdump.gz
-checksum[dump-file-readv]=`md5sum /tmp/cdcdump | cut -d' ' -f1`
+checksum[dump-file-readv]=`sha256sum /tmp/cdcdump | cut -d' ' -f1`
 
 ## Check if all 3 checksums are same
 TEST test ${checksum[brick-file]} = ${checksum[client-file]}

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -134,6 +134,7 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
 {
     int i = 0;
     int fd = 0;
+    ssize_t written = 0;
     size_t total_written = 0;
 
     fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0777);
@@ -142,18 +143,37 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
         return;
     }
 
-    total_written += sys_write(fd, (char *)gzip_header, 10);
+    written = sys_write(fd, (char *)gzip_header, 10);
+    if (caa_unlikely(written != 10)) {
+        gf_log(this->name, GF_LOG_ERROR, "Failed to write gzip_header: %ld",
+               written);
+        goto out;
+    }
+    total_written += written;
+
     for (i = 1; i < ci->ncount; i++) {
-        total_written += sys_write(fd, (char *)ci->vec[i].iov_base,
-                                   ci->vec[i].iov_len);
+        written = sys_write(fd, (char *)ci->vec[i].iov_base,
+                            ci->vec[i].iov_len);
+        if (caa_unlikely(written != ci->vec[i].iov_len)) {
+            gf_log(this->name, GF_LOG_ERROR,
+                   "Failed to write data to gzip file: %ld", written);
+            goto out;
+        }
+        total_written += written;
     }
     /* gzip trailer, in the 1st iovec */
-    total_written += sys_write(fd, (char *)ci->vec[0].iov_base,
-                               ci->vec[0].iov_len);
+    written = sys_write(fd, (char *)ci->vec[0].iov_base, ci->vec[0].iov_len);
+    if (caa_unlikely(written != ci->vec[0].iov_len)) {
+        gf_log(this->name, GF_LOG_ERROR, "Failed to write gzip_trailer: %ld",
+               written);
+        goto out;
+    }
+    total_written += written;
 
     gf_log(this->name, GF_LOG_DEBUG, "dump'd %zu bytes to %s", total_written,
            GF_CDC_DEBUG_DUMP_FILE);
 
+out:
     sys_close(fd);
 }
 

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -145,8 +145,8 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
 
     written = sys_write(fd, (char *)gzip_header, 10);
     if (caa_unlikely(written != 10)) {
-        gf_log(this->name, GF_LOG_ERROR, "Failed to write gzip_header: %ld",
-               written);
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to write gzip_header: %zd bytes written", written);
         goto out;
     }
     total_written += written;
@@ -156,7 +156,8 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
                             ci->vec[i].iov_len);
         if (caa_unlikely(written != ci->vec[i].iov_len)) {
             gf_log(this->name, GF_LOG_ERROR,
-                   "Failed to write data to gzip file: %ld", written);
+                   "Failed to write data to gzip file: %zd bytes written",
+                   written);
             goto out;
         }
         total_written += written;
@@ -164,8 +165,8 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
     /* gzip trailer, in the 1st iovec */
     written = sys_write(fd, (char *)ci->vec[0].iov_base, ci->vec[0].iov_len);
     if (caa_unlikely(written != ci->vec[0].iov_len)) {
-        gf_log(this->name, GF_LOG_ERROR, "Failed to write gzip_trailer: %ld",
-               written);
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to write gzip_trailer: %zd bytes written", written);
         goto out;
     }
     total_written += written;


### PR DESCRIPTION
… use the correct size)

I suspect it always allocated (and leaked?) a 128KB IOVEC for the gzip trailer. In fact, it only needed 8 bytes. It was cleaner to use the 1st iovec for it.

Adjusted code accordingly across compression, decompression and gzip dump functions.

Updates: #3797
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

