### PR TITLE
tests: daemon-log-level-option.t regression failures

### DIFF
--- a/tests/bugs/glusterd/daemon-log-level-option.t
+++ b/tests/bugs/glusterd/daemon-log-level-option.t
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 . $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
 
 function Info_messages_count() {
         local shd_log=$1
@@ -61,6 +62,8 @@ rm -f /var/log/glusterfs/glustershd.log
 TEST $CLI volume set all cluster.daemon-log-level WARNING
 TEST $CLI volume start $V0
 
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "6" online_brick_count
+
 # log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
 EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"
 
@@ -77,6 +80,8 @@ rm -f /var/log/glusterfs/glustershd.log
 # set cluster.daemon-log-level option to ERROR and start the volume
 TEST $CLI volume set all cluster.daemon-log-level ERROR
 TEST $CLI volume start $V0
+
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "6" online_brick_count
 
 # log does have 1 info message specific to configure ios_sample_buf_size in io-stats xlator
 EXPECT 1 Info_messages_count "/var/log/glusterfs/glustershd.log"


### PR DESCRIPTION
It takes a while for /var/log/glusterfs/glustershd.log to get created and get populated
after the volume start command execution

Adding sleep 2 to make sure the log file is created before grepping for the values in it.

Fixes: #3836
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

