### PR TITLE
api: Fix `glfs_openat()` by linking the inode

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -665,10 +665,13 @@ pub_glfs_openat(struct glfs_fd *pglfd, const char *path, int flags, mode_t mode)
     if (!is_create)
         ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
     else
-        ret = syncop_create(subvol, &loc, flags, mode, glfd->fd, NULL, fop_attr,
-                            NULL);
+        ret = syncop_create(subvol, &loc, flags, mode, glfd->fd, &iatt,
+                            fop_attr, NULL);
 
     DECODE_SYNCOP_ERR(ret);
+
+    if (is_create && ret == 0)
+        ret = glfs_loc_link(&loc, &iatt);
 
     /* Because it is openat(), no ESTALE expected */
 out:


### PR DESCRIPTION
Newly added _glfs_openat()_ failed to link inode causing the next immediate open without a lookup to fail with `ENOENT`. Therefore add the missing inode link using _glfs_loc_link()_. This also reverts a hunk from https://github.com/gluster/glusterfs/commit/8cec2188565f35178fafbb159e0f6dd1d21cd4c6 as iatt struct is required for _glfs_loc_link()_.

fixes #3838 
