### PR TITLE
index.c: skip some strcmp() in case entry length is short enough.

### DIFF
--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -524,8 +524,16 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
         }
 
         entry_dname_len = strlen(entry->d_name);
-        if (entry_dname_len >= 42) {
-            /* 42 = strlen('dirty-') + UUID_CANONICAL_FORM_LEN (36) */
+
+        /* Skip entry name comparison unless the length is equal to either:
+         * SLEN('dirty-') + '-' + UUID_CANONICAL_FORM_LEN (36)
+         * or
+         * SLEN('xattrop') + '-' + UUID_CANONICAL_FORM_LEN (36)
+         */
+        if (entry_dname_len ==
+                (SLEN(XATTROP_SUBDIR) + 1 + UUID_CANONICAL_FORM_LEN) ||
+            entry_dname_len ==
+                (SLEN(DIRTY_SUBDIR) + 1 + UUID_CANONICAL_FORM_LEN)) {
             if (!strncmp(entry->d_name, XATTROP_SUBDIR "-",
                          strlen(XATTROP_SUBDIR "-"))) {
                 check_delete_stale_index_file(this, entry->d_name,

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -523,17 +523,22 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
             break;
         }
 
-        if (!strncmp(entry->d_name, XATTROP_SUBDIR "-",
-                     strlen(XATTROP_SUBDIR "-"))) {
-            check_delete_stale_index_file(this, entry->d_name, XATTROP_SUBDIR);
-            continue;
-        } else if (!strncmp(entry->d_name, DIRTY_SUBDIR "-",
-                            strlen(DIRTY_SUBDIR "-"))) {
-            check_delete_stale_index_file(this, entry->d_name, DIRTY_SUBDIR);
-            continue;
+        entry_dname_len = strlen(entry->d_name);
+        if (entry_dname_len >= 42) {
+            /* 42 = strlen('dirty-') + UUID_CANONICAL_FORM_LEN (36) */
+            if (!strncmp(entry->d_name, XATTROP_SUBDIR "-",
+                         strlen(XATTROP_SUBDIR "-"))) {
+                check_delete_stale_index_file(this, entry->d_name,
+                                              XATTROP_SUBDIR);
+                continue;
+            } else if (!strncmp(entry->d_name, DIRTY_SUBDIR "-",
+                                strlen(DIRTY_SUBDIR "-"))) {
+                check_delete_stale_index_file(this, entry->d_name,
+                                              DIRTY_SUBDIR);
+                continue;
+            }
         }
 
-        entry_dname_len = strlen(entry->d_name);
         this_size = max(sizeof(gf_dirent_t), sizeof(gfx_dirplist)) +
                     entry_dname_len + 1;
 


### PR DESCRIPTION
In most cases we'll calculate - strlen() the length of the entry. Use that length - only if it's longer than 42, which is 'dirty-<uuid in ascii...>', then there's a point in checking if it matches 'dirty-...' or 'xattrop-...' string.

(Note: unsure, but I suspect we could have and should have skipped . and .. in as well)

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

