### PR TITLE
posix-inode-fd-ops.c: perform __is_root_gfid() check once

### DIFF
--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -5667,6 +5667,7 @@ posix_fill_readdir(fd_t *fd, struct posix_fd *pfd, off_t off, size_t size,
         },
     };
     size_t entry_dname_len;
+    gf_boolean_t is_root_gfid = __is_root_gfid(fd->inode->gfid);
 
     if (!off) {
         rewinddir(pfd->dir);
@@ -5724,7 +5725,7 @@ posix_fill_readdir(fd_t *fd, struct posix_fd *pfd, off_t off, size_t size,
             continue;
 #endif /* __NetBSD__ */
 
-        if (__is_root_gfid(fd->inode->gfid) &&
+        if (is_root_gfid &&
             (!strcmp(GF_HIDDEN_PATH, entry->d_name))) {
             continue;
         }


### PR DESCRIPTION
Exactly the same as in https://github.com/gluster/glusterfs/pull/3150 - we can run __is_root_gfid() check once, no need to run it within the readdir loop.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

