### PR TITLE
fuse_readdirp_cbk() - minor modifications

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3734,8 +3734,8 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         send_fuse_data(this, finh, 0, 0);
         goto out;
     }
-
-    buf = GF_MALLOC(max_size, gf_fuse_mt_char);
+m
+    buf = GF_CALLOC(1, max_size, gf_fuse_mt_char);
     if (!buf) {
         gf_log("glusterfs-fuse", GF_LOG_DEBUG,
                "%" PRIu64 ": READDIRP => -1 (%s)", frame->root->unique,

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -3734,7 +3734,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         send_fuse_data(this, finh, 0, 0);
         goto out;
     }
-m
+
     buf = GF_CALLOC(1, max_size, gf_fuse_mt_char);
     if (!buf) {
         gf_log("glusterfs-fuse", GF_LOG_DEBUG,

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -578,8 +578,8 @@ gf_fuse_fill_dirent(gf_dirent_t *entry, struct fuse_dirent *fde,
         fde->ino = entry->d_ino;
 
     fde->off = entry->d_off;
-    fde->type = entry->d_type;
     fde->namelen = entry->d_len;
+    fde->type = entry->d_type;
     (void)memcpy(fde->name, entry->d_name, fde->namelen);
 }
 


### PR DESCRIPTION
1. Reuse gf_fuse_fill_dirent() code
2. Pre-cal the attributes and timeouts - calc_timeout_sec() and calc_timeout_nsec() once.

Updates: #3845
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

