### PR TITLE
Multiple minor changes to index xlator

### DIFF
--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -38,7 +38,7 @@ static char *index_subdirs[XATTROP_TYPE_END] = {
     [DIRTY] = DIRTY_SUBDIR,
     [ENTRY_CHANGES] = ENTRY_CHANGES_SUBDIR};
 
-int
+static int
 index_get_type_from_vgfid(index_priv_t *priv, uuid_t vgfid)
 {
     int i = 0;
@@ -50,7 +50,7 @@ index_get_type_from_vgfid(index_priv_t *priv, uuid_t vgfid)
     return -1;
 }
 
-gf_boolean_t
+static gf_boolean_t
 index_is_virtual_gfid(index_priv_t *priv, uuid_t vgfid)
 {
     if (index_get_type_from_vgfid(priv, vgfid) < 0)
@@ -126,7 +126,7 @@ index_get_type_from_vgfid_xattr(const char *name)
     return -1;
 }
 
-gf_boolean_t
+static gf_boolean_t
 index_is_fop_on_internal_inode(xlator_t *this, inode_t *inode, uuid_t gfid)
 {
     index_priv_t *priv = this->private;
@@ -155,7 +155,7 @@ index_is_vgfid_xattr(const char *name)
     return _gf_true;
 }
 
-call_stub_t *
+static call_stub_t *
 __index_dequeue(struct list_head *callstubs)
 {
     call_stub_t *stub = NULL;
@@ -189,7 +189,7 @@ worker_enqueue(xlator_t *this, call_stub_t *stub)
     pthread_mutex_unlock(&priv->mutex);
 }
 
-void *
+static void *
 index_worker(void *data)
 {
     index_priv_t *priv = NULL;
@@ -243,7 +243,7 @@ make_index_dir_path(char *base, const char *subdir, char *index_dir, size_t len)
     return snprintf(index_dir, len, "%s/%s", base, subdir);
 }
 
-int
+static int
 index_dir_create(xlator_t *this, const char *subdir)
 {
     int ret = 0;
@@ -298,7 +298,7 @@ out:
     return ret;
 }
 
-void
+static void
 index_get_index(index_priv_t *priv, uuid_t index)
 {
     LOCK(&priv->lock);
@@ -308,7 +308,7 @@ index_get_index(index_priv_t *priv, uuid_t index)
     UNLOCK(&priv->lock);
 }
 
-void
+static void
 index_generate_index(index_priv_t *priv, uuid_t index)
 {
     LOCK(&priv->lock);
@@ -446,7 +446,7 @@ index_update_link_count_cache(index_priv_t *priv, index_xattrop_type_t type,
     }
 }
 
-char *
+static char *
 index_get_subdir_from_type(index_xattrop_type_t type)
 {
     if (type < XATTROP || type >= XATTROP_TYPE_END)
@@ -454,7 +454,7 @@ index_get_subdir_from_type(index_xattrop_type_t type)
     return index_subdirs[type];
 }
 
-char *
+static char *
 index_get_subdir_from_vgfid(index_priv_t *priv, uuid_t vgfid)
 {
     return index_get_subdir_from_type(index_get_type_from_vgfid(priv, vgfid));
@@ -589,7 +589,7 @@ out:
     return count;
 }
 
-int
+static int
 index_link_to_base(xlator_t *this, char *fpath, const char *subdir)
 {
     int ret = 0;
@@ -650,7 +650,7 @@ out:
     return -op_errno;
 }
 
-int
+static int
 index_add(xlator_t *this, uuid_t gfid, const char *subdir,
           index_xattrop_type_t type)
 {
@@ -680,7 +680,7 @@ out:
     return ret;
 }
 
-int
+static int
 index_del(xlator_t *this, uuid_t gfid, const char *subdir, int type)
 {
     int32_t op_errno __attribute__((unused)) = 0;
@@ -780,7 +780,7 @@ index_find_xattr_type(dict_t *d, char *k, data_t *v)
     return idx;
 }
 
-int
+static int
 index_fill_zero_array(dict_t *d, char *k, data_t *v, void *adata)
 {
     int idx = -1;
@@ -831,7 +831,7 @@ _check_key_is_zero_filled(dict_t *d, char *k, data_t *v, void *tmp)
     return 0;
 }
 
-int
+static int
 index_entry_create(xlator_t *this, inode_t *inode, char *filename)
 {
     int ret = -1;
@@ -893,7 +893,7 @@ out:
     return ret;
 }
 
-int
+static int
 index_entry_delete(xlator_t *this, uuid_t pgfid, char *filename)
 {
     int op_errno = 0;
@@ -932,7 +932,7 @@ out:
     return -op_errno;
 }
 
-int
+static int
 index_entry_action(xlator_t *this, inode_t *inode, dict_t *xdata, char *key)
 {
     int ret = 0;
@@ -953,7 +953,7 @@ out:
     return ret;
 }
 
-void
+static void
 _index_action(xlator_t *this, inode_t *inode, int *zfilled)
 {
     int ret = 0;
@@ -1012,7 +1012,7 @@ index_init_state(xlator_t *this, inode_t *inode, index_inode_ctx_t *ctx,
     return;
 }
 
-void
+static void
 xattrop_index_action(xlator_t *this, index_local_t *local, dict_t *xattr,
                      dict_match_t match, void *match_data)
 {
@@ -1086,7 +1086,7 @@ index_xattrop_track(xlator_t *this, gf_xattrop_flags_t flags, dict_t *dict)
     return _gf_false;
 }
 
-int
+static int
 index_inode_path(xlator_t *this, inode_t *inode, char *dirpath, size_t len)
 {
     char *subdir = NULL;
@@ -1130,7 +1130,7 @@ out:
     return ret;
 }
 
-int
+static int
 __index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
 {
     int ret = 0;
@@ -1175,7 +1175,7 @@ out:
     return ret;
 }
 
-int
+static int
 index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
 {
     int ret = 0;
@@ -1189,7 +1189,7 @@ index_fd_ctx_get(fd_t *fd, xlator_t *this, index_fd_ctx_t **ctx)
 
 // new - Not NULL means start a fop
 // new - NULL means done processing the fop
-void
+static void
 index_queue_process(xlator_t *this, inode_t *inode, call_stub_t *new)
 {
     call_stub_t *stub = NULL;
@@ -1257,7 +1257,7 @@ out:
     return 0;
 }
 
-int32_t
+static int32_t
 index_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, dict_t *xattr,
                   dict_t *xdata)
@@ -1269,7 +1269,7 @@ index_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 }
 
-int32_t
+static int32_t
 index_xattrop64_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, dict_t *xattr,
                     dict_t *xdata)
@@ -1280,7 +1280,7 @@ index_xattrop64_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        is_xattr_in_watchlist, priv->pending_watchlist);
 }
 
-void
+static void
 index_xattrop_do(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
                  gf_xattrop_flags_t optype, dict_t *xattr, dict_t *xdata)
 {
@@ -1334,7 +1334,7 @@ index_xattrop_do(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
                    FIRST_CHILD(this)->fops->fxattrop, fd, optype, xattr, xdata);
 }
 
-int
+static int
 index_xattrop_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
                       gf_xattrop_flags_t optype, dict_t *xattr, dict_t *xdata)
 {
@@ -1342,7 +1342,7 @@ index_xattrop_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 }
 
-int
+static int
 index_fxattrop_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
                        gf_xattrop_flags_t optype, dict_t *xattr, dict_t *xdata)
 {
@@ -1420,8 +1420,8 @@ out:
     return 0;
 }
 
-uint64_t
-index_entry_count(xlator_t *this, char *subdir)
+static uint64_t
+index_entry_count(xlator_t *this, const char *subdir, const int subdir_len)
 {
     uint64_t count = 0;
     index_priv_t *priv = NULL;
@@ -1435,12 +1435,11 @@ index_entry_count(xlator_t *this, char *subdir)
     char index_dir[PATH_MAX] = {
         0,
     };
-    int subdir_len = 0;
 
     priv = this->private;
 
-    subdir_len = make_index_dir_path(priv->index_basepath, subdir, index_dir,
-                                     sizeof(index_dir));
+    (void)make_index_dir_path(priv->index_basepath, subdir, index_dir,
+                              sizeof(index_dir));
 
     dirp = sys_opendir(index_dir);
     if (!dirp)
@@ -1466,7 +1465,7 @@ index_entry_count(xlator_t *this, char *subdir)
     return count;
 }
 
-int32_t
+static int32_t
 index_getxattr_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
                        const char *name, dict_t *xdata)
 {
@@ -1501,7 +1500,7 @@ index_getxattr_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     /* TODO: Need to check what kind of link-counts are needed for
      * ENTRY-CHANGES before refactor of this block with array*/
     if (strcmp(name, GF_XATTROP_INDEX_COUNT) == 0) {
-        count = index_entry_count(this, XATTROP_SUBDIR);
+        count = index_entry_count(this, XATTROP_SUBDIR, SLEN(XATTROP_SUBDIR));
 
         ret = dict_set_uint64(xattr, (char *)name, count);
         if (ret) {
@@ -1512,7 +1511,7 @@ index_getxattr_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
             goto done;
         }
     } else if (strcmp(name, GF_XATTROP_DIRTY_COUNT) == 0) {
-        count = index_entry_count(this, DIRTY_SUBDIR);
+        count = index_entry_count(this, DIRTY_SUBDIR, SLEN(DIRTY_SUBDIR));
 
         ret = dict_set_uint64(xattr, (char *)name, count);
         if (ret) {
@@ -1567,7 +1566,7 @@ index_save_pargfid_for_entry_changes(xlator_t *this, loc_t *loc, char *path)
     return 0;
 }
 
-int32_t
+static int32_t
 index_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
                      dict_t *xattr_req)
 {
@@ -1684,7 +1683,7 @@ done:
     return 0;
 }
 
-int
+static int
 index_get_gfid_type(void *opaque)
 {
     gf_dirent_t *entry = NULL;
@@ -1726,7 +1725,7 @@ index_get_gfid_type(void *opaque)
     return 0;
 }
 
-int32_t
+static int32_t
 index_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
                       size_t size, off_t off, dict_t *xdata)
 {
@@ -1777,7 +1776,7 @@ done:
     return 0;
 }
 
-int
+static int
 deletion_handler(const char *fpath, const struct stat *sb, int typeflag,
                  struct FTW *ftwbuf)
 {
@@ -1833,7 +1832,7 @@ index_get_parent_iatt(struct iatt *parent, char *path, loc_t *loc,
     return;
 }
 
-int
+static int
 index_rmdir_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
                     dict_t *xdata)
 {
@@ -1890,7 +1889,7 @@ done:
     return 0;
 }
 
-int
+static int
 index_unlink_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
                      dict_t *xdata)
 {
@@ -2046,7 +2045,7 @@ out:
     return count;
 }
 
-dict_t *
+static dict_t *
 index_fill_link_count(xlator_t *this, dict_t *xdata)
 {
     int ret = -1;
@@ -2080,7 +2079,7 @@ out:
     return xdata;
 }
 
-int32_t
+static int32_t
 index_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  int32_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, dict_t *xdata, struct iatt *postparent)
@@ -2136,7 +2135,7 @@ normal:
     return 0;
 }
 
-int32_t
+static int32_t
 index_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
@@ -2249,7 +2248,7 @@ out:
     return 0;
 }
 
-int
+static int
 index_make_xattrop_watchlist(xlator_t *this, index_priv_t *priv,
                              char *watchlist, index_xattrop_type_t type)
 {

--- a/xlators/features/index/src/index.h
+++ b/xlators/features/index/src/index.h
@@ -27,11 +27,11 @@ typedef enum {
 } index_xattrop_type_t;
 
 typedef struct index_inode_ctx {
-    gf_boolean_t processing;
     struct list_head callstubs;
-    int state[XATTROP_TYPE_END];
     uuid_t virtual_pargfid; /* virtual gfid of dir under
                               .glusterfs/indices/entry-changes. */
+    int state[XATTROP_TYPE_END];
+    gf_boolean_t processing;
 } index_inode_ctx_t;
 
 typedef struct index_fd_ctx {


### PR DESCRIPTION
- index.c: use the return value of snprintf() to save few strlen() calls. Instead of a strlen(), use the return value of a snprintf() call.
- index xlator: return a pointer instead of passing a variable to store the ctx