### PR TITLE
gftest: fix commit checkout

### DIFF
--- a/tools/tests/gftest
+++ b/tools/tests/gftest
@@ -556,7 +556,8 @@ def build(commit, name):
     try:
         container = vm.cfg.get('containers/images/testing')
         with HTTPServer({'config': vm.cfg.base, 'glusterfs': root}) as httpd:
-            vm.run(f'git clone -b {commit} http://{vm.host}:{httpd.port}/glusterfs /root/glusterfs')
+            vm.run(f'git clone http://{vm.host}:{httpd.port}/glusterfs /root/glusterfs')
+            vm.run(f'git -C /root/glusterfs checkout {commit}')
             vm.run(f'podman build --squash -t glusterfs/testing -f http://{vm.host}:{httpd.port}/config/{container} /root/glusterfs')
     except:
         vm.run('rm -rf /root/glusterfs')


### PR DESCRIPTION
The specified commit in 'gftest build' command was interpreted as a branch name instead of a commit hash, which was incorrect and caused failures when trying to use a it.

Fixes: #3847
Change-Id: I3ae3f255996cced722573fdc9ae189acfb22eb85
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>

