### PR TITLE
memory accounting - reduce code in non DEBUG build

### DIFF
--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -47,10 +47,10 @@ struct mem_acct_rec {
     const char *typestr;
     gf_atomic_t num_allocs;
 #ifdef DEBUG
+    gf_lock_t lock;
     uint64_t size;
     uint64_t max_size;
     uint32_t max_num_allocs;
-    gf_lock_t lock;
     struct list_head obj_list;
 #endif
 };

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -44,15 +44,15 @@ typedef uint32_t gf_mem_magic_t;
 #define NPOOLS (POOL_LARGEST - POOL_SMALLEST + 1)
 
 struct mem_acct_rec {
-    const char *typestr;
     gf_atomic_t num_allocs;
+    const char *typestr;
 #ifdef DEBUG
     gf_lock_t lock;
     uint64_t size;
     uint64_t max_size;
     uint32_t max_num_allocs;
     struct list_head obj_list;
-#endif
+#endif /* DEBUG */
 };
 
 struct mem_acct {

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -994,7 +994,7 @@ loc_is_nameless(loc_t *loc);
 int
 xlator_mem_acct_init(xlator_t *xl, int num_types);
 void
-xlator_mem_acct_unref(struct mem_acct *mem_acct);
+xlator_mem_acct_destroy(struct mem_acct *mem_acct);
 int
 is_gf_log_command(xlator_t *trans, const char *name, char *value, size_t size);
 int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1082,7 +1082,7 @@ xlator_foreach
 xlator_foreach_depth_first
 xlator_init
 xlator_mem_acct_init
-xlator_mem_acct_unref
+xlator_mem_acct_destroy
 xlator_notify
 xlator_option_info_list
 xlator_option_init_bool

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -306,8 +306,8 @@ __gf_mem_invalidate(void *ptr)
 
     /* zero out remaining (old) mem_header bytes) */
     /* and the first byte of data */
-    memset(old_ptr + sizeof(inval), 0x00, (sizeof(struct mem_header) - sizeof(inval)) + 1);
-
+    memset(old_ptr + sizeof(inval), 0x00,
+           (sizeof(struct mem_header) - sizeof(inval)) + 1);
 }
 #endif /* DEBUG */
 
@@ -369,8 +369,8 @@ __gf_free(void *free_ptr)
     }
     UNLOCK(&mem_acct->rec[header->type].lock);
 #endif
-    if (!num_allocs) {
-        xlator_mem_acct_unref(mem_acct);
+    if (!num_allocs && (GF_ATOMIC_DEC(mem_acct->refcnt) == 0)) {
+        xlator_mem_acct_destroy(mem_acct);
     }
 
 free:

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -121,6 +121,7 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
     return gf_mem_header_prepare(header, size);
 }
 
+#ifdef DEBUG
 static void *
 gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
                         size_t size)
@@ -129,7 +130,6 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 
     if (mem_acct != NULL) {
         rec = &mem_acct->rec[header->type];
-#ifdef DEBUG
         LOCK(&rec->lock);
         {
             rec->size += size - header->size;
@@ -143,11 +143,11 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
             list_move(&header->acct_list, &rec->obj_list);
         }
         UNLOCK(&rec->lock);
-#endif
     }
 
     return gf_mem_header_prepare(header, size);
 }
+#endif /* DEBUG */
 
 static bool
 gf_mem_acct_enabled(xlator_t *xl)
@@ -227,7 +227,11 @@ __gf_realloc(void *ptr, size_t size)
         return NULL;
     }
 
+#ifdef DEBUG
     return gf_mem_update_acct_info(header->mem_acct, header, size);
+#else
+    return gf_mem_header_prepare(header, size);
+#endif
 }
 
 int

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -758,10 +758,10 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
 void
 xlator_mem_acct_unref(struct mem_acct *mem_acct)
 {
-    uint32_t i;
 
     if (GF_ATOMIC_DEC(mem_acct->refcnt) == 0) {
 #ifdef DEBUG
+        uint32_t i;
         for (i = 0; i < mem_acct->num_types; i++) {
             LOCK_DESTROY(&(mem_acct->rec[i].lock));
         }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -721,9 +721,6 @@ xlator_notify(xlator_t *xl, int event, void *data, ...)
 int
 xlator_mem_acct_init(xlator_t *xl, int num_types)
 {
-    int i = 0;
-    int ret = 0;
-
     if (!xl)
         return -1;
 
@@ -733,8 +730,8 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
     if (!xl->ctx->mem_acct_enable)
         return 0;
 
-    xl->mem_acct = MALLOC(sizeof(struct mem_acct) +
-                          sizeof(struct mem_acct_rec) * num_types);
+    xl->mem_acct = CALLOC(
+        1, sizeof(struct mem_acct) + sizeof(struct mem_acct_rec) * num_types);
 
     if (!xl->mem_acct) {
         return -1;
@@ -743,16 +740,17 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
     xl->mem_acct->num_types = num_types;
     GF_ATOMIC_INIT(xl->mem_acct->refcnt, 1);
 
-    for (i = 0; i < num_types; i++) {
-        memset(&xl->mem_acct->rec[i], 0, sizeof(struct mem_acct_rec));
 #ifdef DEBUG
-        INIT_LIST_HEAD(&(xl->mem_acct->rec[i].obj_list));
-        ret = LOCK_INIT(&(xl->mem_acct->rec[i].lock));
-        if (ret) {
+    struct mem_acct_rec *rec = NULL;
+    int i;
+    for (i = 0; i < num_types; i++) {
+        rec = &xl->mem_acct->rec[i];
+        if (LOCK_INIT(&rec->lock) != 0) {
             fprintf(stderr, "Unable to lock..errno : %d", errno);
         }
-#endif
+        INIT_LIST_HEAD(&rec->obj_list);
     }
+#endif /* DEBUG */
 
     return 0;
 }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -756,17 +756,15 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
 }
 
 void
-xlator_mem_acct_unref(struct mem_acct *mem_acct)
+xlator_mem_acct_destroy(struct mem_acct *mem_acct)
 {
-    if (GF_ATOMIC_DEC(mem_acct->refcnt) == 0) {
 #ifdef DEBUG
-        uint32_t i;
-        for (i = 0; i < mem_acct->num_types; i++) {
-            LOCK_DESTROY(&(mem_acct->rec[i].lock));
-        }
-#endif
-        FREE(mem_acct);
+    uint32_t i;
+    for (i = 0; i < mem_acct->num_types; i++) {
+        LOCK_DESTROY(&(mem_acct->rec[i].lock));
     }
+#endif
+    FREE(mem_acct);
 }
 
 void
@@ -807,8 +805,8 @@ xlator_memrec_free(xlator_t *xl)
     }
     mem_acct = xl->mem_acct;
 
-    if (mem_acct) {
-        xlator_mem_acct_unref(mem_acct);
+    if (mem_acct && (GF_ATOMIC_DEC(mem_acct->refcnt) == 0)) {
+        xlator_mem_acct_destroy(mem_acct);
         xl->mem_acct = NULL;
     }
 

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -758,7 +758,6 @@ xlator_mem_acct_init(xlator_t *xl, int num_types)
 void
 xlator_mem_acct_unref(struct mem_acct *mem_acct)
 {
-
     if (GF_ATOMIC_DEC(mem_acct->refcnt) == 0) {
 #ifdef DEBUG
         uint32_t i;

--- a/tests/basic/fop-sampling.t
+++ b/tests/basic/fop-sampling.t
@@ -39,7 +39,7 @@ cleanup;
 TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
-TEST $CLI volume set $V0 nfs.disable off
+$CLI volume set $V0 nfs.disable off
 TEST $CLI volume set $V0 diagnostics.latency-measurement on
 TEST $CLI volume set $V0 diagnostics.count-fop-hits on
 TEST $CLI volume set $V0 diagnostics.stats-dump-interval 2


### PR DESCRIPTION
Subset of https://github.com/gluster/glusterfs/pull/3852 - just the changes for the memory accounting parts:
- reorder some variables, according to access pattern
- ifdef code that's only relevant under DEBUG mode.