### PR TITLE
iobuf: allocate iobuf arrays along with the arena itself

### DIFF
--- a/libglusterfs/src/glusterfs/iobuf.h
+++ b/libglusterfs/src/glusterfs/iobuf.h
@@ -74,14 +74,10 @@ struct iobuf_arena {
     struct list_head list;
     size_t page_size; /* size of all iobufs in this arena */
     size_t arena_size;
-    /* this is equal to rounded_size * num_iobufs.
-       (rounded_size comes with gf_iobuf_get_pagesize().) */
-    size_t page_count;
 
     struct iobuf_pool *iobuf_pool;
 
     void *mem_base;
-    struct iobuf *iobufs; /* allocated iobufs list */
 
     struct list_head passive_list;
     struct list_head active_list;
@@ -89,6 +85,8 @@ struct iobuf_arena {
     int active_cnt;
     int passive_cnt;
     int max_active; /* max active buffers at a given time */
+    uint32_t page_count;
+    struct iobuf iobufs[]; /* allocated iobufs list */
 };
 
 struct iobuf_pool {

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -103,8 +103,7 @@ __iobuf_arena_destroy_iobufs(struct iobuf_arena *iobuf_arena)
 static void
 __iobuf_arena_destroy(struct iobuf_arena *iobuf_arena)
 {
-    if (iobuf_arena->mem_base && iobuf_arena->mem_base != MAP_FAILED)
-        munmap(iobuf_arena->mem_base, iobuf_arena->arena_size);
+    munmap(iobuf_arena->mem_base, iobuf_arena->arena_size);
 
     __iobuf_arena_destroy_iobufs(iobuf_arena);
 


### PR DESCRIPTION
For locality, reduce the no. of calls to CALLOC and the number of NULL checks, it's easier to just allocate them together (since the no. of iobufs in an arena is known and fixed at the time of arena allocation)

This allows removal of some checks. I've also made the no. of iobufs a 32bit unsigned and ensured the struct is correctly aligned and without padding.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

