### PR TITLE
tests: use larger block size in 'dd' command where applicable.

### DIFF
--- a/tests/000-flaky/basic_afr_split-brain-favorite-child-policy.t
+++ b/tests/000-flaky/basic_afr_split-brain-favorite-child-policy.t
@@ -23,12 +23,12 @@ TEST touch $M0/file
 
 ############ Healing using favorite-child-policy = ctime #################
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
@@ -71,12 +71,12 @@ EXPECT "0" echo $?
 TEST $CLI volume set $V0 cluster.favorite-child-policy none
 TEST $CLI volume set $V0 cluster.self-heal-daemon off
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
@@ -109,12 +109,12 @@ TEST [ "$LATEST_CTIME_MD5" == "$HEALED_MD5" ]
 TEST $CLI volume set $V0 cluster.favorite-child-policy none
 TEST $CLI volume set $V0 cluster.self-heal-daemon off
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=10240
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
@@ -160,13 +160,13 @@ TEST $CLI volume set $V0 cluster.quorum-type none
 TEST $CLI volume set $V0 cluster.favorite-child-policy none
 TEST $CLI volume set $V0 cluster.self-heal-daemon off
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
 TEST kill_brick $V0 $H0 $B0/${V0}2
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=10240
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=80
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1

--- a/tests/000-flaky/basic_afr_split-brain-favorite-child-policy.t
+++ b/tests/000-flaky/basic_afr_split-brain-favorite-child-policy.t
@@ -114,7 +114,7 @@ TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=80
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0

--- a/tests/basic/afr/arbiter-add-brick.t
+++ b/tests/basic/afr/arbiter-add-brick.t
@@ -20,7 +20,7 @@ TEST dd if=/dev/urandom of=$M0/file1 bs=1024 count=1
 #Kill second brick and perform I/O to have pending heals.
 TEST kill_brick $V0 $H0 $B0/${V0}1
 TEST mkdir $M0/dir2
-TEST dd if=/dev/urandom of=$M0/file1 bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file1 bs=128k count=8
 
 
 #convert replica 2 to arbiter volume
@@ -62,7 +62,7 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2
 TEST mkdir $M0/dir3
-TEST dd if=/dev/urandom of=$M0/file2 bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file2 bs=128k count=8
 
 # File hierarchy must be same in all 3 bricks.
 TEST diff <(ls $B0/${V0}0 | sort) <(ls $B0/${V0}2 | sort)

--- a/tests/basic/afr/arbiter-remove-brick.t
+++ b/tests/basic/afr/arbiter-remove-brick.t
@@ -22,7 +22,7 @@ TEST $CLI volume remove-brick $V0 replica 2  $H0:$B0/${V0}2 force
 EXPECT "1 x 2 = 2" volinfo_field $V0 "Number of Bricks"
 
 TEST mkdir $M0/dir
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST diff <(ls $B0/${V0}0 | sort) <(ls $B0/${V0}1 | sort)
 
 #Mount serves the correct file size

--- a/tests/basic/afr/sparse-file-self-heal.t
+++ b/tests/basic/afr/sparse-file-self-heal.t
@@ -46,7 +46,7 @@ TEST dd if=/dev/urandom of=$M0/FILE count=1 bs=131072
 TEST truncate -s 1G $M0/FILE
 
 #Create a non-sparse file containing zeroes.
-TEST dd if=/dev/zero of=$M0/zeroedfile bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/zeroedfile bs=128k count=8
 
 $CLI volume start $V0 force
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 0
@@ -132,7 +132,7 @@ TEST dd if=/dev/urandom of=$M0/FILE count=1 bs=131072
 TEST truncate -s 1G $M0/FILE
 
 #Create a non-sparse file containing zeroes.
-TEST dd if=/dev/zero of=$M0/zeroedfile bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/zeroedfile bs=128k count=8
 
 $CLI volume start $V0 force
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 0

--- a/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
+++ b/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
@@ -37,12 +37,12 @@ TEST touch $M0/data/file
 
 ############ Client side healing using favorite-child-policy = mtime #################
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/data/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/data/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/data/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/data/file bs=128k count=8
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1

--- a/tests/basic/ec/ec-common
+++ b/tests/basic/ec/ec-common
@@ -30,7 +30,7 @@ TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "$DISPERSE" ec_child_up_count $V0 0
 
 TEST dd if=/dev/urandom of=$tmp/small bs=1024 count=1
-TEST dd if=/dev/urandom of=$tmp/big bs=1024 count=4096
+TEST dd if=/dev/urandom of=$tmp/big bs=128k count=32
 
 cs_small=$(sha1sum $tmp/small | awk '{ print $1 }')
 cs_big=$(sha1sum $tmp/big | awk '{ print $1 }')

--- a/tests/basic/ec/ec-discard.t
+++ b/tests/basic/ec/ec-discard.t
@@ -53,7 +53,7 @@ TEST unlink $M0/file
 ###Punch hole test cases without fallocate
 ##With write
 #Touching starting boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 0 -l 500 $B0/test_file
 TEST fallocate -p -o 0 -l 500 $M0/test_file
@@ -62,7 +62,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Touching boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 500 -l 1548 $B0/test_file
 TEST fallocate -p -o 500 -l 1548 $M0/test_file
@@ -71,7 +71,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Not touching boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 500 -l 1000 $B0/test_file
 TEST fallocate -p -o 500 -l 1000 $M0/test_file
@@ -80,7 +80,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Over boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 1500 -l 1000 $B0/test_file
 TEST fallocate -p -o 1500 -l 1000 $M0/test_file
@@ -92,7 +92,7 @@ TEST rm -f $B0/test_file $M0/test_file
 ##Without write
 
 #Zero size
-TEST dd if=/dev/urandom of=$M0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$M0/test_file bs=8192 count=1
 TEST ! fallocate -p -o 1500 -l 0 $M0/test_file
 
 #Negative size
@@ -100,7 +100,7 @@ TEST ! fallocate -p -o 1500 -l -100 $M0/test_file
 TEST rm -f $M0/test_file
 
 #Touching boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 2048 -l 2048 $B0/test_file
 TEST fallocate -p -o 2048 -l 2048 $M0/test_file
@@ -109,7 +109,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Touching boundary,multiple stripe
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 2048 -l 4096 $B0/test_file
 TEST fallocate -p -o 2048 -l 4096 $M0/test_file
@@ -120,7 +120,7 @@ TEST rm -f $B0/test_file $M0/test_file
 ##With write
 
 #Size ends in boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 600 -l 3496 $B0/test_file
 TEST fallocate -p -o 600 -l 3496 $M0/test_file
@@ -129,7 +129,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Offset at boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 2048 -l 3072 $B0/test_file
 TEST fallocate -p -o 2048 -l 3072 $M0/test_file
@@ -138,7 +138,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Offset and Size not at boundary covering a stripe
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 1500 -l 3000 $B0/test_file
 TEST fallocate -p -o 1500 -l 3000 $M0/test_file
@@ -147,7 +147,7 @@ EXPECT $md5_sum get_md5_sum $M0/test_file
 TEST rm -f $B0/test_file $M0/test_file
 
 #Offset and Size not at boundary
-TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=8
+TEST dd if=/dev/urandom of=$B0/test_file bs=8192 count=1
 TEST cp $B0/test_file $M0/test_file
 TEST fallocate -p -o 1000 -l 3072 $B0/test_file
 TEST fallocate -p -o 1000 -l 3072 $M0/test_file

--- a/tests/basic/ec/ec-stripe.t
+++ b/tests/basic/ec/ec-stripe.t
@@ -42,9 +42,9 @@ function mount_get_test_files {
         local stripe_count=$1
         TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0;
         EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0
-        TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=20
+        TEST dd if=/dev/urandom of=$B0/test_file bs=4096 count=5
         TEST cp $B0/test_file $M0/test_file
-        TEST dd if=/dev/urandom of=$B0/misc_file bs=1024 count=20
+        TEST dd if=/dev/urandom of=$B0/misc_file bs=4096 count=5
         EXPECT_WITHIN $UMOUNT_TIMEOUT "$stripe_count" get_stripes_in_cache $B0/test_file $stripe_count
         EXPECT_WITHIN $UMOUNT_TIMEOUT "$stripe_count" get_stripes_in_cache $M0/test_file $stripe_count
 }

--- a/tests/basic/ec/ec-stripe.t
+++ b/tests/basic/ec/ec-stripe.t
@@ -42,9 +42,9 @@ function mount_get_test_files {
         local stripe_count=$1
         TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0;
         EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count $V0 0
-        TEST dd if=/dev/urandom of=$B0/test_file bs=4096 count=5
+        TEST dd if=/dev/urandom of=$B0/test_file bs=1024 count=20
         TEST cp $B0/test_file $M0/test_file
-        TEST dd if=/dev/urandom of=$B0/misc_file bs=4096 count=5
+        TEST dd if=/dev/urandom of=$B0/misc_file bs=1024 count=20
         EXPECT_WITHIN $UMOUNT_TIMEOUT "$stripe_count" get_stripes_in_cache $B0/test_file $stripe_count
         EXPECT_WITHIN $UMOUNT_TIMEOUT "$stripe_count" get_stripes_in_cache $M0/test_file $stripe_count
 }

--- a/tests/basic/ec/self-heal.t
+++ b/tests/basic/ec/self-heal.t
@@ -141,7 +141,7 @@ TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 --direct-io-mode=yes $M0;
 # Wait until all 6 childs have been recognized by the ec xlator
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
 
-TEST dd if=/dev/urandom of=$tmp/test bs=1024 count=1024
+TEST dd if=/dev/urandom of=$tmp/test bs=128k count=8
 
 cs=$(sha1sum $tmp/test | awk '{ print $1 }')
 

--- a/tests/bugs/fuse/bug-858488-min-free-disk.t
+++ b/tests/bugs/fuse/bug-858488-min-free-disk.t
@@ -69,6 +69,7 @@ done
 
 ## Bring free space on one of the bricks to less than minfree value by
 ## creating one big file.
+#TODO: use fallocate instead of 'dd' - much faster.
 dd if=/dev/zero of=$M0/fillonebrick.data bs=128k count=200 1>/dev/null 2>&1
 
 #Lets find out where it was created

--- a/tests/bugs/fuse/bug-858488-min-free-disk.t
+++ b/tests/bugs/fuse/bug-858488-min-free-disk.t
@@ -48,7 +48,7 @@ BRICK1FILE=0
 BRICK2FILE=0
 while [[ $CONTINUE -ne 0 ]]
 do
-        dd if=/dev/zero of=$M0/file$i.data bs=1024 count=1024 1>/dev/null 2>&1
+        dd if=/dev/zero of=$M0/file$i.data bs=128k count=8 1>/dev/null 2>&1
 
         if  [[ -e  $B0/${V0}1/file$i.data &&  $BRICK1FILE = "0" ]]
         then
@@ -69,7 +69,7 @@ done
 
 ## Bring free space on one of the bricks to less than minfree value by
 ## creating one big file.
-dd if=/dev/zero of=$M0/fillonebrick.data bs=1024 count=25600 1>/dev/null 2>&1
+dd if=/dev/zero of=$M0/fillonebrick.data bs=128k count=200 1>/dev/null 2>&1
 
 #Lets find out where it was created
 if [ -f $B0/${V0}1/fillonebrick.data ]
@@ -92,7 +92,7 @@ do
         touch $M0/dummyfile$k
 done
 
-dd if=/dev/zero of=$M0/$FILETOCREATE bs=1024 count=2048 1>/dev/null 2>&1
+dd if=/dev/zero of=$M0/$FILETOCREATE bs=128k count=16 1>/dev/null 2>&1
 TEST [ -e $OTHERBRICK/$FILETOCREATE ]
 ## Done testing, lets clean up
 TEST rm -rf $M0/*

--- a/tests/bugs/glusterd/removing-multiple-bricks-in-single-remove-brick-command.t
+++ b/tests/bugs/glusterd/removing-multiple-bricks-in-single-remove-brick-command.t
@@ -55,7 +55,7 @@ EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "9" brick_count ${V1}
 TEST glusterfs -s $H0 --volfile-id $V1 $M0
 TEST touch $M0/zerobytefile.txt
 TEST mkdir $M0/test_dir
-TEST dd if=/dev/zero of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/file bs=128k count=8
 
 function remove_brick_start {
         $CLI volume remove-brick $V1 replica 2 $H0:$B0/${V1}{1,4,7} start 2>&1|grep -oE 'success|failed'

--- a/tests/bugs/read-only/bug-1134822-read-only-default-in-graph.t
+++ b/tests/bugs/read-only/bug-1134822-read-only-default-in-graph.t
@@ -21,7 +21,7 @@ TEST $CLI volume start $V0
 TEST glusterfs -s $H0 --volfile-id $V0 $M0
 TEST touch $M0/zerobytefile1.txt
 TEST mkdir $M0/test_dir1
-TEST dd if=/dev/zero of=$M0/file1 bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/file1 bs=128k count=8
 
 # turn on read-only option through volume set
 TEST gluster volume set $V0 read-only on
@@ -48,7 +48,7 @@ TEST cat $M0/file1
 # All write operations should fail now
 TEST ! touch $M0/zerobytefile2.txt
 TEST ! mkdir $M0/test_dir2
-TEST ! dd if=/dev/zero of=$M0/file2 bs=1024 count=1024
+TEST ! dd if=/dev/zero of=$M0/file2 bs=128k count=8
 
 # turn off read-only option through volume set
 TEST gluster volume set $V0 read-only off
@@ -56,7 +56,7 @@ TEST gluster volume set $V0 read-only off
 # All write operations should succeed now
 TEST touch $M0/zerobytefile2.txt
 TEST mkdir $M0/test_dir2
-TEST dd if=/dev/zero of=$M0/file2 bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/file2 bs=128k count=8
 
 # Turn on worm
 TEST gluster volume set $V0 worm on

--- a/tests/bugs/replicate/bug-1305031-block-reads-on-metadata-sbrain.t
+++ b/tests/bugs/replicate/bug-1305031-block-reads-on-metadata-sbrain.t
@@ -21,7 +21,7 @@ TEST $CLI volume set $V0 performance.open-behind off
 TEST $CLI volume start $V0
 
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 
 TEST kill_brick $V0 $H0 $B0/${V0}0
 TEST chmod 700 $M0/file

--- a/tests/bugs/replicate/bug-1386188-sbrain-fav-child.t
+++ b/tests/bugs/replicate/bug-1386188-sbrain-fav-child.t
@@ -18,13 +18,13 @@ TEST touch $M0/mdata.txt
 
 #Create data and metadata split-brain
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/data.txt bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/data.txt bs=128k count=8
 TEST setfattr -n user.value -v value1 $M0/mdata.txt
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/data.txt bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/data.txt bs=128k count=8
 TEST setfattr -n user.value -v value2 $M0/mdata.txt
 
 TEST $CLI volume start $V0 force

--- a/tests/bugs/replicate/bug-1417522-block-split-brain-resolution.t
+++ b/tests/bugs/replicate/bug-1417522-block-split-brain-resolution.t
@@ -21,7 +21,7 @@ TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST kill_brick $V0 $H0 $B0/${V0}2
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=20
+TEST dd if=/dev/urandom of=$M0/file bs=4096 count=5
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}2
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2

--- a/tests/bugs/replicate/bug-1637249-gfid-heal.t
+++ b/tests/bugs/replicate/bug-1637249-gfid-heal.t
@@ -25,7 +25,7 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 # xattrs are in split-brain or have dirty xattrs.
 
 TEST mkdir $M0/dir_pending
-TEST dd if=/dev/urandom of=$M0/dir_pending/file1 bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/dir_pending/file1 bs=128k count=8
 TEST mkdir $M0/dir_pending/dir11
 TEST mkdir $M0/dir_dirty
 TEST touch $M0/dir_dirty/file2
@@ -97,7 +97,7 @@ EXPECT "$gfid_f4" gf_get_gfid_xattr $B0/${V0}1/dir_pending/file4
 # does not have any pending or dirty xattrs.
 
 TEST mkdir $M0/dir_clean
-TEST dd if=/dev/urandom of=$M0/dir_clean/file1 bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/dir_clean/file1 bs=128k count=8
 TEST mkdir $M0/dir_clean/dir11
 
 gfid_f1=$(gf_get_gfid_xattr $B0/${V0}0/dir_clean/file1)

--- a/tests/bugs/replicate/bug-1655052-sbrain-policy-same-size.t
+++ b/tests/bugs/replicate/bug-1655052-sbrain-policy-same-size.t
@@ -22,12 +22,12 @@ TEST touch $M0/file
 
 ############ Healing using favorite-child-policy = size and size of bricks is same #################
 TEST kill_brick $V0 $H0 $B0/${V0}1
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
 TEST kill_brick $V0 $H0 $B0/${V0}0
-TEST dd if=/dev/urandom of=$M0/file bs=1024 count=1024
+TEST dd if=/dev/urandom of=$M0/file bs=128k count=8
 
 TEST $CLI volume start $V0 force
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0

--- a/tests/bugs/replicate/bug-1756938-replica-3-sbrain-cli.t
+++ b/tests/bugs/replicate/bug-1756938-replica-3-sbrain-cli.t
@@ -26,7 +26,7 @@ EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status $V0 2
 #file2 will have one shard which will be in data split-brain.
 #file3 will have one shard which will be in gfid split-brain.
 #file4 will have one shard which will be in data & metadata split-brain.
-TEST dd if=/dev/zero of=$M0/file1 bs=1024 count=1024 oflag=direct
+TEST dd if=/dev/zero of=$M0/file1 bs=4096 count=256 oflag=direct
 TEST dd if=/dev/zero of=$M0/file2 bs=1M count=6 oflag=direct
 TEST dd if=/dev/zero of=$M0/file3 bs=1M count=6 oflag=direct
 TEST dd if=/dev/zero of=$M0/file4 bs=1M count=6 oflag=direct

--- a/tests/bugs/replicate/issue-3238-mdata-unnecessary-heal.t
+++ b/tests/bugs/replicate/issue-3238-mdata-unnecessary-heal.t
@@ -16,7 +16,7 @@ TEST $CLI volume profile $V0 start
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M1;
-dd if=/dev/zero of=$M0/datafile bs=1024 count=1024
+dd if=/dev/zero of=$M0/datafile bs=128k count=8
 EXPECT "^0$" echo $?
 
 #Perform a lookup from second client to validate the metadata

--- a/tests/bugs/shard/bug-1258334.t
+++ b/tests/bugs/shard/bug-1258334.t
@@ -32,7 +32,7 @@ TEST unlink $M0/dir/foo
 # Now rename "new" to "bar". If the bug exists, it should fail with EINVAL.
 TEST mv -f $M0/dir/new $M0/dir/bar
 
-TEST dd if=/dev/zero of=$M0/dir/new bs=1024 count=5120
+TEST dd if=/dev/zero of=$M0/dir/new bs=128k count=40
 
 # Now test that this fix does not break unlink of files without holes
 TEST unlink $M0/dir/new

--- a/tests/bugs/shard/bug-1568521-EEXIST.t
+++ b/tests/bugs/shard/bug-1568521-EEXIST.t
@@ -27,7 +27,7 @@ TEST unlink $M0/tmp
 TEST stat $B0/${V0}0/.shard/.remove_me
 TEST stat $B0/${V0}1/.shard/.remove_me
 
-TEST dd if=/dev/zero of=$M0/dir/file bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/file bs=4096 count=2304
 gfid_file=$(get_gfid_string $M0/dir/file)
 
 # Create marker file from the backend to simulate ENODATA.
@@ -60,7 +60,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/$gfid_file
 ##############################
 
 TEST touch $M0/src
-TEST dd if=/dev/zero of=$M0/dir/dst bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/dst bs=4096 count=2304
 gfid_dst=$(get_gfid_string $M0/dir/dst)
 
 # Create marker file from the backend to simulate ENODATA.

--- a/tests/bugs/shard/unlinks-and-renames.t
+++ b/tests/bugs/shard/unlinks-and-renames.t
@@ -56,7 +56,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 ######################################################
 
 # Create a 9M sharded file
-TEST dd if=/dev/zero of=$M0/dir/new bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/new bs=4096 count=2304
 gfid_new=$(get_gfid_string $M0/dir/new)
 # Ensure its shards are created.
 TEST stat $B0/${V0}0/.shard/$gfid_new.1
@@ -95,7 +95,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 
 TEST touch $M0/dir/foo
 gfid_foo=$(get_gfid_string $M0/dir/foo)
-TEST dd if=/dev/zero of=$M0/dir/foo bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/dir/foo bs=128k count=8
 # Test to ensure that unlink of a file with only base shard works fine.
 TEST unlink $M0/dir/foo
 TEST ! stat $B0/${V0}0/dir/foo
@@ -109,7 +109,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 ########################################################
 
 # Create a 9M sharded file
-TEST dd if=/dev/zero of=$M0/dir/original bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/original bs=4096 count=2304
 gfid_original=$(get_gfid_string $M0/dir/original)
 # Ensure its shards are created.
 TEST stat $B0/${V0}0/.shard/$gfid_original.1
@@ -190,7 +190,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 TEST unlink $M0/dir/dst
 TEST touch $M0/dir/src
 # Create a 9M sharded file
-TEST dd if=/dev/zero of=$M0/dir/dst bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/dst bs=4096 count=2304
 gfid_dst=$(get_gfid_string $M0/dir/dst)
 # Ensure its shards are created.
 TEST stat $B0/${V0}0/.shard/$gfid_dst.1
@@ -234,7 +234,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 
 TEST unlink $M0/dir/dst
 TEST touch $M0/dir/src
-TEST dd if=/dev/zero of=$M0/dir/dst bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/dir/dst bs=128k count=8
 gfid_dst=$(get_gfid_string $M0/dir/dst)
 # Test to ensure that rename into a file with only base shard works fine.
 TEST mv -f $M0/dir/src $M0/dir/dst
@@ -254,7 +254,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 TEST unlink $M0/dir/dst
 TEST touch $M0/dir/src
 # Create a 9M sharded file
-TEST dd if=/dev/zero of=$M0/dir/dst bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/dst bs=4096 count=2304
 gfid_dst=$(get_gfid_string $M0/dir/dst)
 # Ensure its shards are created.
 TEST stat $B0/${V0}0/.shard/$gfid_dst.1
@@ -296,7 +296,7 @@ EXPECT_WITHIN $FILE_COUNT_TIME 0 get_file_count $B0/${V0}1/.shard/.remove_me/$gf
 ##############################################################l
 
 TEST touch $M0/dir/src
-TEST dd if=/dev/zero of=$M0/dir/src bs=1024 count=9216
+TEST dd if=/dev/zero of=$M0/dir/src bs=4096 count=2304
 gfid_src=$(get_gfid_string $M0/dir/src)
 # Ensure its shards are created.
 TEST stat $B0/${V0}0/.shard/$gfid_src.1
@@ -322,7 +322,7 @@ TEST   stat $B0/${V0}1/dir/dst2
 #############################################################################
 
 TEST touch $M0/dir/src
-TEST dd if=/dev/zero of=$M0/dir/src bs=1024 count=1024
+TEST dd if=/dev/zero of=$M0/dir/src bs=128k count=8
 gfid_src=$(get_gfid_string $M0/dir/src)
 TEST ! stat $B0/${V0}0/.shard/$gfid_src.1
 TEST ! stat $B0/${V0}1/.shard/$gfid_src.1


### PR DESCRIPTION
In many tests, we just want to create some file. Use 128K or whatever makes sense (over 1K) block size.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

