### PR TITLE
syncop: use flexible array for synctask's stack (allocate along the t…

### DIFF
--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -99,7 +99,6 @@ enum gf_common_mem_types_ {
     gf_common_mt_int,
     gf_common_mt_pointer,
     gf_common_mt_synctask,  /* used only in one location */
-    gf_common_mt_syncstack, /* used only in one location */
     gf_common_mt_syncenv,   /* used only in one location */
     gf_common_mt_scan_data, /* used only in one location */
     gf_common_list_node,

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -67,7 +67,6 @@ struct synctask {
     gf_timer_t *timer;
     struct synccond *synccond;
     void *opaque;
-    void *stack;
     synctask_state_t state;
     int woken;
     int slept;
@@ -99,6 +98,7 @@ struct synctask {
 
     struct list_head waitq; /* can wait only "once" at a time */
     int done;
+    char stack[];
 };
 
 struct syncproc {
@@ -353,9 +353,6 @@ synctask_new1(struct syncenv *, size_t stacksize, synctask_fn_t, synctask_cbk_t,
 int
 synctask_new(struct syncenv *, synctask_fn_t, synctask_cbk_t,
              call_frame_t *frame, void *);
-struct synctask *
-synctask_create(struct syncenv *, size_t stacksize, synctask_fn_t,
-                synctask_cbk_t, call_frame_t *, void *);
 int
 synctask_join(struct synctask *task);
 void

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -472,15 +472,20 @@ synctask_create(struct syncenv *env, size_t stacksize, synctask_fn_t fn,
     if (stacksize <= 0) {
         newtask = GF_MALLOC(sizeof(struct synctask) + env->stacksize,
                             gf_common_mt_synctask);
+        if (caa_unlikely(!newtask))
+            return NULL;
+
+        memset(newtask, 0, sizeof(struct synctask));
         newtask->ctx.uc_stack.ss_size = env->stacksize;
     } else {
         newtask = GF_MALLOC(sizeof(struct synctask) + stacksize,
                             gf_common_mt_synctask);
+        if (caa_unlikely(!newtask))
+            return NULL;
+
+        memset(newtask, 0, sizeof(struct synctask));
         newtask->ctx.uc_stack.ss_size = stacksize;
     }
-
-    if (!newtask)
-        return NULL;
 
     INIT_LIST_HEAD(&newtask->all_tasks);
     newtask->env = env;


### PR DESCRIPTION
…ask)

Use a single allocation for both the task and its stack, for locality.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

