### PR TITLE
epoll - allocate table 0 as part of the event pool allocation

### DIFF
--- a/libglusterfs/src/event-epoll.c
+++ b/libglusterfs/src/event-epoll.c
@@ -20,27 +20,6 @@
 #ifdef HAVE_SYS_EPOLL_H
 #include <sys/epoll.h>
 
-struct event_slot_epoll {
-    int fd;
-    int events;
-    int gen;
-    int idx;
-    gf_atomic_t ref;
-    int do_close;
-    int in_handler;
-    int handled_error;
-    void *data;
-    event_handler_t handler;
-    struct list_head poller_death;
-    gf_lock_t lock;
-};
-
-struct event_slot_epoll_table {
-    int slots_used;
-    int _pad;
-    struct event_slot_epoll slots[EVENT_EPOLL_SLOTS];
-};
-
 struct event_thread_data {
     struct event_pool *event_pool;
     int event_index;
@@ -280,6 +259,7 @@ event_pool_new_epoll(int count, int eventthreadcount)
 {
     struct event_pool *event_pool = NULL;
     int epfd;
+    int i;
 
     event_pool = GF_CALLOC(1, sizeof(*event_pool), gf_common_mt_event_pool);
 
@@ -292,9 +272,16 @@ event_pool_new_epoll(int count, int eventthreadcount)
         goto err;
     }
 
-    if (__event_newtable(event_pool, 0) == NULL) {
-        goto err;
+    event_pool->table0.slots_used = 0;
+    for (i = 0; i < EVENT_EPOLL_SLOTS; i++) {
+        event_pool->table0.slots[i].fd = -1;
     }
+
+    event_pool->ereg[0] = &event_pool->table0;
+
+    /*if (__event_newtable(event_pool, 0) == NULL) {
+        goto err;
+    }*/
 
     event_pool->fd = epfd;
 
@@ -940,7 +927,8 @@ event_pool_destroy_epoll(struct event_pool *event_pool)
                 if (table->slots[j].fd != -1)
                     LOCK_DESTROY(&table->slots[j].lock);
             }
-            GF_FREE(table);
+            if (i)  // skip table 0
+                GF_FREE(table);
         }
     }
 

--- a/libglusterfs/src/glusterfs/gf-event.h
+++ b/libglusterfs/src/glusterfs/gf-event.h
@@ -51,8 +51,7 @@ struct event_slot_epoll {
 };
 
 struct event_slot_epoll_table {
-    int slots_used;
-    int _pad;
+    uint64_t slots_avail;
     struct event_slot_epoll slots[EVENT_EPOLL_SLOTS];
 };
 

--- a/libglusterfs/src/glusterfs/gf-event.h
+++ b/libglusterfs/src/glusterfs/gf-event.h
@@ -35,6 +35,27 @@ typedef void (*event_handler_t)(int fd, int idx, int gen, void *data,
 /* See rpcsvc.h to check why. */
 GF_STATIC_ASSERT(EVENT_MAX_THREADS % __BITS_PER_LONG == 0);
 
+struct event_slot_epoll {
+    int fd;
+    int events;
+    int gen;
+    int idx;
+    gf_atomic_t ref;
+    int do_close;
+    int in_handler;
+    int handled_error;
+    void *data;
+    event_handler_t handler;
+    struct list_head poller_death;
+    gf_lock_t lock;
+};
+
+struct event_slot_epoll_table {
+    int slots_used;
+    int _pad;
+    struct event_slot_epoll slots[EVENT_EPOLL_SLOTS];
+};
+
 struct event_pool {
     struct event_ops *ops;
 
@@ -82,6 +103,7 @@ struct event_pool {
     struct event_slot_epoll_table *ereg[EVENT_EPOLL_TABLES];
     pthread_t pollers[EVENT_MAX_THREADS]; /* poller thread_id store, and live
                                              status */
+    struct event_slot_epoll_table table0;
 };
 
 struct event_destroy_data {


### PR DESCRIPTION
It's allocated as part of it anyway, so making it part of the event pool struct.
Remembered not to GF_FREE() it in deallocation.

