### PR TITLE
Make client_uid variable a flexible array member of client structure - and allocate / deallocate together

### DIFF
--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -170,7 +170,6 @@ gf_client_get(xlator_t *this, client_auth_data_t *cred, char *client_uid,
             errno = ENOMEM;
             goto unlock;
         }
-        client->scratch_ctx_count = GF_CLIENTCTX_INITIAL_SIZE;
         client->scratch_ctx = GF_CALLOC(GF_CLIENTCTX_INITIAL_SIZE,
                                         sizeof(struct client_ctx),
                                         gf_common_mt_client_ctx);
@@ -404,12 +403,12 @@ __client_ctx_get_int(client_t *client, void *key, void **value)
     int index = 0;
     int ret = 0;
 
-    for (index = 0; index < client->scratch_ctx_count; index++) {
+    for (index = 0; index < GF_CLIENTCTX_INITIAL_SIZE; index++) {
         if (client->scratch_ctx[index].ctx_key == key)
             break;
     }
 
-    if (index == client->scratch_ctx_count) {
+    if (index == GF_CLIENTCTX_INITIAL_SIZE) {
         ret = -1;
         goto out;
     }
@@ -428,7 +427,7 @@ __client_ctx_set_int(client_t *client, void *key, void *value)
     int ret = 0;
     int set_idx = -1;
 
-    for (index = 0; index < client->scratch_ctx_count; index++) {
+    for (index = 0; index < GF_CLIENTCTX_INITIAL_SIZE; index++) {
         if (!client->scratch_ctx[index].ctx_key) {
             if (set_idx == -1)
                 set_idx = index;
@@ -503,12 +502,12 @@ __client_ctx_del_int(client_t *client, void *key, void **value)
     int index = 0;
     int ret = 0;
 
-    for (index = 0; index < client->scratch_ctx_count; index++) {
+    for (index = 0; index < GF_CLIENTCTX_INITIAL_SIZE; index++) {
         if (client->scratch_ctx[index].ctx_key == key)
             break;
     }
 
-    if (index == client->scratch_ctx_count) {
+    if (index == GF_CLIENTCTX_INITIAL_SIZE) {
         ret = -1;
         goto out;
     }

--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -316,7 +316,6 @@ client_destroy(client_t *client)
     GF_FREE(client->auth.data);
     GF_FREE(client->auth.username);
     GF_FREE(client->auth.passwd);
-    GF_FREE(client->client_uid);
     GF_FREE(client->subdir_mount);
     GF_FREE(client->client_name);
     GF_FREE(client);

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -31,12 +31,6 @@ struct client_ctx {
 };
 
 typedef struct _client {
-    struct {
-        /* e.g. protocol/server stashes its ctx here */
-        gf_lock_t lock;
-        unsigned short count;
-        struct client_ctx *ctx;
-    } scratch_ctx;
     gf_atomic_t bind;
     gf_atomic_t count;
     xlator_t *bound_xl;
@@ -59,6 +53,9 @@ typedef struct _client {
     uuid_t subdir_gfid;
     /* Variable to save fd_count for detach brick */
     gf_atomic_t fd_cnt;
+    gf_lock_t scratch_ctx_lock;
+    unsigned int scratch_ctx_count;
+    struct client_ctx *scratch_ctx;
 } client_t;
 
 #define GF_CLIENTCTX_INITIAL_SIZE 8

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -54,7 +54,6 @@ typedef struct _client {
     /* Variable to save fd_count for detach brick */
     gf_atomic_t fd_cnt;
     gf_lock_t scratch_ctx_lock;
-    unsigned int scratch_ctx_count;
     struct client_ctx *scratch_ctx;
 } client_t;
 

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -54,7 +54,7 @@ typedef struct _client {
     /* Variable to save fd_count for detach brick */
     gf_atomic_t fd_cnt;
     gf_lock_t scratch_ctx_lock;
-    struct client_ctx *scratch_ctx;
+    struct client_ctx scratch_ctx[];
 } client_t;
 
 #define GF_CLIENTCTX_INITIAL_SIZE 8

--- a/libglusterfs/src/glusterfs/client_t.h
+++ b/libglusterfs/src/glusterfs/client_t.h
@@ -30,6 +30,8 @@ struct client_ctx {
     void *ctx_value;
 };
 
+#define GF_CLIENTCTX_INITIAL_SIZE 8
+
 typedef struct _client {
     gf_atomic_t bind;
     gf_atomic_t count;
@@ -37,7 +39,6 @@ typedef struct _client {
     xlator_t *this;
     int tbl_index;
     int32_t opversion;
-    char *client_uid;
     char *client_name;
     struct {
         int flavour;
@@ -54,10 +55,9 @@ typedef struct _client {
     /* Variable to save fd_count for detach brick */
     gf_atomic_t fd_cnt;
     gf_lock_t scratch_ctx_lock;
-    struct client_ctx scratch_ctx[];
+    struct client_ctx scratch_ctx[GF_CLIENTCTX_INITIAL_SIZE];
+    char client_uid[];
 } client_t;
-
-#define GF_CLIENTCTX_INITIAL_SIZE 8
 
 struct client_table_entry {
     client_t *client;

--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -75,7 +75,6 @@ enum gf_common_mem_types_ {
     gf_common_mt_cliententry_t, /* used only in one location */
     gf_common_mt_clienttable_t, /* used only in one location */
     gf_common_mt_client_t,      /* used only in one location */
-    //gf_common_mt_client_ctx,    /* unused - could either be removed or code needs to be undef */
     gf_common_mt_auxgids,       /* used only in one location */
     gf_common_mt_syncopctx,     /* used only in one location */
     gf_common_mt_iobrefs,       /* used only in one location */

--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -75,7 +75,7 @@ enum gf_common_mem_types_ {
     gf_common_mt_cliententry_t, /* used only in one location */
     gf_common_mt_clienttable_t, /* used only in one location */
     gf_common_mt_client_t,      /* used only in one location */
-    gf_common_mt_client_ctx,    /* used only in one location */
+    //gf_common_mt_client_ctx,    /* unused - could either be removed or code needs to be undef */
     gf_common_mt_auxgids,       /* used only in one location */
     gf_common_mt_syncopctx,     /* used only in one location */
     gf_common_mt_iobrefs,       /* used only in one location */


### PR DESCRIPTION
1. Similar to multiple previous PRs, it makes it part of the client structure. It also removes the unneeded counter - it is a fixed size.
2. Made scratch ctx a fixed array (as it actually was), allocated and deallocated as part of the client struct.

(note - client_uid could also be a flexible array member in other structs, such as lock_migration_info_t)