### PR TITLE
Use a flexible array member for data pair key

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -119,11 +119,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
     if (!ctx->dict_pool)
         goto err;
 
-    ctx->dict_pair_pool = mem_pool_new(data_pair_t,
-                                       GF_MEMPOOL_COUNT_OF_DATA_PAIR_T);
-    if (!ctx->dict_pair_pool)
-        goto err;
-
     ctx->dict_data_pool = mem_pool_new(data_t, GF_MEMPOOL_COUNT_OF_DATA_T);
     if (!ctx->dict_data_pool)
         goto err;
@@ -154,8 +149,6 @@ err:
             mem_pool_destroy(ctx->dict_pool);
         if (ctx->dict_data_pool)
             mem_pool_destroy(ctx->dict_data_pool);
-        if (ctx->dict_pair_pool)
-            mem_pool_destroy(ctx->dict_pair_pool);
         if (ctx->logbuf_pool)
             mem_pool_destroy(ctx->logbuf_pool);
     }
@@ -1198,8 +1191,6 @@ glusterfs_ctx_destroy(glusterfs_ctx_t *ctx)
         mem_pool_destroy(ctx->dict_pool);
     if (ctx->dict_data_pool)
         mem_pool_destroy(ctx->dict_data_pool);
-    if (ctx->dict_pair_pool)
-        mem_pool_destroy(ctx->dict_pair_pool);
     if (ctx->logbuf_pool)
         mem_pool_destroy(ctx->logbuf_pool);
 

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -129,12 +129,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
         goto out;
     }
 
-    ctx->dict_pair_pool = mem_pool_new(data_pair_t, 512);
-    if (!ctx->dict_pair_pool) {
-        gf_log("cli", GF_LOG_ERROR, "Failed to create dict pair pool.");
-        goto out;
-    }
-
     ctx->dict_data_pool = mem_pool_new(data_t, 512);
     if (!ctx->dict_data_pool) {
         gf_log("cli", GF_LOG_ERROR, "Failed to create dict data pool.");
@@ -171,7 +165,6 @@ out:
         pool = NULL;
         GF_FREE(ctx->process_uuid);
         mem_pool_destroy(ctx->dict_pool);
-        mem_pool_destroy(ctx->dict_pair_pool);
         mem_pool_destroy(ctx->dict_data_pool);
         mem_pool_destroy(ctx->logbuf_pool);
     }

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1626,11 +1626,6 @@ glusterfs_ctx_defaults_init(glusterfs_ctx_t *ctx)
     if (!ctx->dict_pool)
         goto out;
 
-    ctx->dict_pair_pool = mem_pool_new(data_pair_t,
-                                       GF_MEMPOOL_COUNT_OF_DATA_PAIR_T);
-    if (!ctx->dict_pair_pool)
-        goto out;
-
     ctx->dict_data_pool = mem_pool_new(data_t, GF_MEMPOOL_COUNT_OF_DATA_T);
     if (!ctx->dict_data_pool)
         goto out;
@@ -1700,7 +1695,6 @@ out:
         GF_FREE(ctx->pool);
         mem_pool_destroy(ctx->dict_pool);
         mem_pool_destroy(ctx->dict_data_pool);
-        mem_pool_destroy(ctx->dict_pair_pool);
         mem_pool_destroy(ctx->logbuf_pool);
     }
 

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -73,7 +73,6 @@ get_new_dict_full()
         return NULL;
     }
 
-    dict->free_pair.key = NULL;
     dict->totkvlen = 0;
     LOCK_INIT(&dict->lock);
 
@@ -325,7 +324,7 @@ dict_lookup_common(const dict_t *this, const char *key)
     data_pair_t *pair;
 
     for (pair = this->members_list; pair != NULL; pair = pair->next) {
-        if (pair->key && !strcmp(pair->key, key))
+        if (!strcmp(pair->key, key))
             return pair;
     }
 
@@ -376,24 +375,12 @@ dict_set_lk(dict_t *this, char *key, const int key_len, data_t *value,
         }
     }
 
-    if (this->free_pair.key) { /* the free_pair is used */
-        pair = mem_get(THIS->ctx->dict_pair_pool);
-        if (!pair) {
-            return -1;
-        }
-    } else { /* assign the pair to the free pair */
-        pair = &this->free_pair;
-    }
-
-    pair->key = (char *)GF_MALLOC(key_len + 1, gf_common_mt_char);
-    if (!pair->key) {
-        if (pair != &this->free_pair) {
-            mem_put(pair);
-        }
+    pair = GF_MALLOC(sizeof(data_pair_t) + key_len + 1, gf_common_mt_char);
+    if (caa_unlikely(!pair))
         return -1;
-    }
-    strcpy(pair->key, key);
+
     pair->value = data_ref(value);
+    strcpy(pair->key, key);
     this->totkvlen += (key_len + 1 + value->len);
 
     pair->next = this->members_list;
@@ -517,12 +504,7 @@ dict_deln(dict_t *this, char *key, const int keylen)
                 this->members_list = pair->next;
 
             this->totkvlen -= (keylen + 1);
-            GF_FREE(pair->key);
-            if (pair == &this->free_pair) {
-                this->free_pair.key = NULL;
-            } else {
-                mem_put(pair);
-            }
+            GF_FREE(pair);
             this->count--;
             rc = _gf_true;
             break;
@@ -548,12 +530,7 @@ dict_clear_data(dict_t *this)
     while (curr != NULL) {
         next = curr->next;
         data_unref(curr->value);
-        GF_FREE(curr->key);
-        if (curr == &this->free_pair) {
-            this->free_pair.key = NULL;
-        } else {
-            mem_put(curr);
-        }
+        GF_FREE(curr);
         curr = next;
     }
     this->count = this->totkvlen = 0;
@@ -1999,27 +1976,17 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
             else
                 BIT_CLEAR((unsigned char *)(data->data), flag);
 
-            if (this->free_pair.key) { /* the free pair is in use */
-                pair = mem_get0(THIS->ctx->dict_pair_pool);
-                if (!pair) {
-                    gf_smsg("dict", GF_LOG_ERROR, ENOMEM, LG_MSG_NO_MEMORY,
-                            "dict pair", NULL);
-                    ret = -ENOMEM;
-                    goto err;
-                }
-            } else { /* use the free pair */
-                pair = &this->free_pair;
-            }
-
-            pair->key = (char *)GF_MALLOC(strlen(key) + 1, gf_common_mt_char);
-            if (!pair->key) {
+            pair = GF_MALLOC(sizeof(data_pair_t) + strlen(key) + 1,
+                             gf_common_mt_char);
+            if (caa_unlikely(!pair)) {
                 gf_smsg("dict", GF_LOG_ERROR, ENOMEM, LG_MSG_NO_MEMORY,
                         "dict pair", NULL);
                 ret = -ENOMEM;
                 goto err;
             }
-            strcpy(pair->key, key);
+
             pair->value = data_ref(data);
+            strcpy(pair->key, key);
             this->totkvlen += (strlen(key) + 1 + data->len);
 
             pair->next = this->members_list;
@@ -2038,15 +2005,8 @@ err:
     if (key && this)
         UNLOCK(&this->lock);
 
-    if (pair) {
-        if (pair->key) {
-            GF_FREE(pair->key);
-            pair->key = NULL;
-        }
-        if (pair != &this->free_pair) {
-            mem_put(pair);
-        }
-    }
+    if (pair)
+        GF_FREE(pair);
 
     if (data)
         data_destroy(data);
@@ -2779,11 +2739,6 @@ dict_serialize_lk(dict_t *this, char *buf)
         if (!pair) {
             gf_smsg("dict", GF_LOG_ERROR, 0, LG_MSG_PAIRS_LESS_THAN_COUNT,
                     NULL);
-            goto out;
-        }
-
-        if (!pair->key) {
-            gf_smsg("dict", GF_LOG_ERROR, 0, LG_MSG_NULL_PTR, NULL);
             goto out;
         }
 

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -1989,7 +1989,7 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
             }
 
             pair->value = data_ref(data);
-            strcpy(pair->key, key);
+            memcpy(pair->key, key, keylen);
             this->totkvlen += (keylen + data->len);
 
             pair->next = this->members_list;

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -375,7 +375,8 @@ dict_set_lk(dict_t *this, char *key, const int key_len, data_t *value,
         }
     }
 
-    pair = GF_MALLOC(sizeof(data_pair_t) + key_len + 1, gf_common_mt_char);
+    pair = GF_MALLOC(sizeof(data_pair_t) + key_len + 1,
+                     gf_common_mt_data_pair_t);
     if (caa_unlikely(!pair))
         return -1;
 
@@ -1978,7 +1979,8 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
                 BIT_CLEAR((unsigned char *)(data->data), flag);
 
             keylen = strlen(key) + 1;  // including terminating NULL char
-            pair = GF_MALLOC(sizeof(data_pair_t) + keylen, gf_common_mt_char);
+            pair = GF_MALLOC(sizeof(data_pair_t) + keylen,
+                             gf_common_mt_data_pair_t);
             if (caa_unlikely(!pair)) {
                 gf_smsg("dict", GF_LOG_ERROR, ENOMEM, LG_MSG_NO_MEMORY,
                         "dict pair", NULL);

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -380,7 +380,7 @@ dict_set_lk(dict_t *this, char *key, const int key_len, data_t *value,
         return -1;
 
     pair->value = data_ref(value);
-    strcpy(pair->key, key);
+    memcpy(pair->key, key, key_len + 1);
     this->totkvlen += (key_len + 1 + value->len);
 
     pair->next = this->members_list;
@@ -1928,6 +1928,7 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
     int ret = 0;
     data_pair_t *pair = NULL;
     char *ptr = NULL;
+    size_t keylen;
 
     if (!this || !key) {
         gf_msg_callingfn("dict", GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,
@@ -1976,8 +1977,8 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
             else
                 BIT_CLEAR((unsigned char *)(data->data), flag);
 
-            pair = GF_MALLOC(sizeof(data_pair_t) + strlen(key) + 1,
-                             gf_common_mt_char);
+            keylen = strlen(key) + 1;  // including terminating NULL char
+            pair = GF_MALLOC(sizeof(data_pair_t) + keylen, gf_common_mt_char);
             if (caa_unlikely(!pair)) {
                 gf_smsg("dict", GF_LOG_ERROR, ENOMEM, LG_MSG_NO_MEMORY,
                         "dict pair", NULL);
@@ -1987,7 +1988,7 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
 
             pair->value = data_ref(data);
             strcpy(pair->key, key);
-            this->totkvlen += (strlen(key) + 1 + data->len);
+            this->totkvlen += (keylen + data->len);
 
             pair->next = this->members_list;
             this->members_list = pair;

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -97,7 +97,7 @@ struct _data {
 struct _data_pair {
     struct _data_pair *next;
     data_t *value;
-    char *key;
+    char key[];
 };
 
 struct _dict {
@@ -108,7 +108,6 @@ struct _dict {
     gf_atomic_t refcount;
     gf_lock_t lock;
     data_pair_t *members_list;
-    data_pair_t free_pair;
     char *extra_stdfree;
 };
 

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -689,7 +689,6 @@ struct _glusterfs_ctx {
     char *statedump_path;
 
     struct mem_pool *dict_pool;
-    struct mem_pool *dict_pair_pool;
     struct mem_pool *dict_data_pool;
 
     glusterfsd_mgmt_event_notify_fn_t notify; /* Used for xlators to make

--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -116,7 +116,8 @@ enum gf_common_mem_types_ {
     gf_common_ping_local_t,      /* used only in one location */
     gf_common_volfile_t,
     gf_common_mt_server_cmdline_t, /* used only in one location */
-    gf_common_mt_latency_t,
+    gf_common_mt_latency_t,        /* used only in one location */
+    gf_common_mt_data_pair_t,      /* used only in one location */
     gf_common_mt_end,
 };
 #endif

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -124,10 +124,6 @@ gf_changelog_ctx_defaults_init(glusterfs_ctx_t *ctx)
     if (!ctx->dict_pool)
         goto free_pool;
 
-    ctx->dict_pair_pool = mem_pool_new(data_pair_t, 512);
-    if (!ctx->dict_pair_pool)
-        goto free_pool;
-
     ctx->dict_data_pool = mem_pool_new(data_t, 512);
     if (!ctx->dict_data_pool)
         goto free_pool;
@@ -162,8 +158,6 @@ free_pool:
     }
 
     GF_FREE(ctx->dict_pool);
-
-    GF_FREE(ctx->dict_pair_pool);
 
     GF_FREE(ctx->dict_data_pool);
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3254,13 +3254,6 @@ glusterd_dict_searialize(dict_t *dict_arr[], unsigned int count,
                     goto out;
                 }
 
-                if (!pair->key) {
-                    gf_msg("glusterd", GF_LOG_ERROR, 0, LG_MSG_NULL_PTR,
-                           "pair->key is null!");
-                    ret = -1;
-                    goto out;
-                }
-
                 keylen = strlen(pair->key);
                 netword = htobe32(keylen);
                 memcpy(buf, &netword, sizeof(netword));

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -580,8 +580,6 @@ glusterfs_ctx_pool_destroy(glusterfs_ctx_t *ctx)
         mem_pool_destroy(ctx->dict_pool);
     if (ctx->dict_data_pool)
         mem_pool_destroy(ctx->dict_data_pool);
-    if (ctx->dict_pair_pool)
-        mem_pool_destroy(ctx->dict_pair_pool);
     if (ctx->logbuf_pool)
         mem_pool_destroy(ctx->logbuf_pool);
 


### PR DESCRIPTION
1.    
    We always ended up calling allocation - even though we tried to avoid it using the free pair which was supposed to handle
    the common case of a single data pair in a dictionary, we still called GF_MALLOC for the key.
    Instead, allocate the key together with the data pair, unconditionally, in a single call.
    This also simplifies the code a bit by getting rid of the logic around the free pair and removes multiple checks for NULL of pair->key.

2. Following that, remove the now unused dict_pair_pool memory pool.