### PR TITLE
glfs-fops: turn gio->iov to a flexible array member (for read and wri…

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1592,7 +1592,7 @@ glfs_preadv_async_common(struct glfs_fd *glfd, const struct iovec *iovec,
     gio->oldcb = oldcb;
     gio->fn = fn;
     gio->data = data;
-    memcpy(gio->iov, iovec, count);
+    memcpy(gio->iov, iovec, sizeof(struct iovec) * count);
 
     frame->local = gio;
 


### PR DESCRIPTION
…te FOPS)

Allocate the IOV vector as part of the gio struct allocation (and same for deallocation). Also change from GF_CALLOC() to GF_MALLOC() as we initialize all variables.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

