### PR TITLE
inode.c: dentry->name is now a flexible array member instead of a poi…

### DIFF
--- a/doc/developer-guide/datastructure-inode.md
+++ b/doc/developer-guide/datastructure-inode.md
@@ -34,7 +34,6 @@ struct _inode_table {
         struct list_head   purge;       /* list of inodes to be purged soon */
         uint32_t           purge_size;  /* count of inodes in purge list */
 
-        struct mem_pool   *dentry_pool; /* memory pool for dentrys */
         struct mem_pool   *fd_mem_pool; /* memory pool for fd_t */
         int                ctxcount;    /* number of slots in inode->ctx */
 };

--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -50,7 +50,6 @@ struct _inode_table {
     uint32_t purge_size;     /* count of inodes in purge list */
     struct list_head purge;  /* list of inodes to be purged soon */
 
-    struct mem_pool *dentry_pool; /* memory pool for dentrys */
     struct mem_pool *fd_mem_pool; /* memory pool for fd_t */
     int ctxcount;                 /* number of slots in inode->ctx */
 
@@ -73,8 +72,8 @@ struct _dentry {
     struct list_head inode_list; /* list of dentries of inode */
     struct list_head hash;       /* hash table pointers */
     inode_t *inode;              /* inode of this directory entry */
-    char *name;                  /* name of the directory entry */
     inode_t *parent;             /* directory of the entry */
+    char name[];                  /* name of the directory entry */
 };
 
 struct _inode_ctx {

--- a/libglusterfs/src/glusterfs/mem-types.h
+++ b/libglusterfs/src/glusterfs/mem-types.h
@@ -20,7 +20,8 @@ enum gf_common_mem_types_ {
     gf_common_mt_fdtable_t, /* used only in one location */
     gf_common_mt_fd_ctx,    /* used only in one location */
     gf_common_mt_gf_dirent_t,
-    gf_common_mt_inode_ctx, /* used only in one location */
+    gf_common_mt_inode_ctx,  /* used only in one location */
+    gf_common_mt_dentry_ctx, /* used only in one location */
     gf_common_mt_list_head,
     gf_common_mt_inode_table_t, /* used only in one location */
     gf_common_mt_xlator_t,


### PR DESCRIPTION
…nter

It was later allocated anyway, via strdup(), so now it's allocated and deallocated along with the dentry structure. Switched to using malloc() instead of calloc() as we were initializing all members. Lastly, removed the (now unused) pool for dentries.

Updates: #1000
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

