### PR TITLE
api: Use opendir for directories in glfs_open and glfs_openat

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -475,7 +475,11 @@ retry:
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+    if (IA_ISDIR(iatt.ia_type))
+        ret = syncop_opendir(subvol, &loc, glfd->fd, NULL, NULL);
+    else
+        ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+
     DECODE_SYNCOP_ERR(ret);
 
     ESTALE_RETRY(ret, errno, reval, &loc, retry);
@@ -662,9 +666,12 @@ pub_glfs_openat(struct glfs_fd *pglfd, const char *path, int flags, mode_t mode)
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    if (!is_create)
-        ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
-    else
+    if (!is_create) {
+        if (IA_ISDIR(iatt.ia_type))
+            ret = syncop_opendir(subvol, &loc, glfd->fd, NULL, NULL);
+        else
+            ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+    } else
         ret = syncop_create(subvol, &loc, flags, mode, glfd->fd, &iatt,
                             fop_attr, NULL);
 


### PR DESCRIPTION
In addition to files _glfs_open()_ and _glfs_openat()_ are capable of handling directory opens. But there are various other components like DHT and probably other client xlators which are tightly coupled to work with directory opens using just OPENDIR. One such example is the case where _fsetxattr()_ is called with a file descriptor opened for the directory using _glfs_open()_ or _glfs_openat()_ resulting in `EBADFD`.

Therefore we make a differentiation within these APIs to correctly call _syncop_open()_ or _syncop_opendir()_ for file and directory entries respectively to avoid any possible file descriptor errors.

Credits: Xavi Hernandez

fixes #3876 