### PR TITLE
api: Use opendir for directories in `glfs_h_open`

### DIFF
--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -684,7 +684,11 @@ pub_glfs_h_open(struct glfs *fs, struct glfs_object *object, int flags)
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+    if (IA_ISDIR(inode->ia_type))
+        ret = syncop_opendir(subvol, &loc, glfd->fd, NULL, NULL);
+    else
+        ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+
     DECODE_SYNCOP_ERR(ret);
 
     glfd->fd->flags = flags;


### PR DESCRIPTION
In addition to files _glfs_h_open()_ is capable of handling directory opens. But there are various other components like DHT and probably other client xlators which are tightly coupled to work with directory opens using just OPENDIR. One such example is the case where _fsetxattr()_ is called with a file descriptor opened for the directory using _glfs_h_open()_ resulting in `EBADFD`.

Therefore we make a differentiation in _glfs_h_open()_ to correctly call _syncop_open()_ or _syncop_opendir()_ for file and directory entries respectively to avoid any possible file descriptor errors.

Credits: Xavi Hernandez
