### PR TITLE
glusterfs: Build with Modern C, change set 1

### DIFF
--- a/contrib/timer-wheel/timer-wheel.c
+++ b/contrib/timer-wheel/timer-wheel.c
@@ -330,7 +330,7 @@ int gf_tw_cleanup_timers (struct tvec_base *base)
  * Initialize various timer wheel lists and spawn a thread that
  * invokes run_timers()
  */
-struct tvec_base *gf_tw_init_timers ()
+struct tvec_base *gf_tw_init_timers (void)
 {
         int               j    = 0;
         int               ret  = 0;

--- a/contrib/timer-wheel/timer-wheel.h
+++ b/contrib/timer-wheel/timer-wheel.h
@@ -61,7 +61,7 @@ struct gf_tw_timer_list {
 };
 
 /** The API! */
-struct tvec_base *gf_tw_init_timers ();
+struct tvec_base *gf_tw_init_timers (void);
 int gf_tw_cleanup_timers (struct tvec_base *);
 void gf_tw_add_timer (struct tvec_base *, struct gf_tw_timer_list *);
 int gf_tw_del_timer (struct tvec_base *, struct gf_tw_timer_list *);

--- a/libglusterfs/src/changelog.h
+++ b/libglusterfs/src/changelog.h
@@ -93,10 +93,10 @@ int
 gf_changelog_register(char *brick_path, char *scratch_dir, char *log_file,
                       int log_levl, int max_reconnects);
 ssize_t
-gf_changelog_scan();
+gf_changelog_scan(void);
 
 int
-gf_changelog_start_fresh();
+gf_changelog_start_fresh(void);
 
 ssize_t
 gf_changelog_next_change(char *bufptr, size_t maxlen);

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -544,7 +544,7 @@ gf_log_dump_graph(FILE *specfp, glusterfs_graph_t *graph)
 }
 
 static void
-gf_dump_config_flags()
+gf_dump_config_flags(void)
 {
     gf_msg_plain_nomem(GF_LOG_ALERT, "configuration details:");
 
@@ -2294,13 +2294,13 @@ out:
 }
 
 char *
-gf_leaseid_get()
+gf_leaseid_get(void)
 {
     return glusterfs_leaseid_buf_get();
 }
 
 char *
-gf_existing_leaseid()
+gf_existing_leaseid(void)
 {
     return glusterfs_leaseid_exist();
 }
@@ -2388,7 +2388,7 @@ gf_path_strip_trailing_slashes(char *path)
 }
 
 uint64_t
-get_mem_size()
+get_mem_size(void)
 {
     uint64_t memsize = -1;
 
@@ -2484,7 +2484,7 @@ generate_glusterfs_ctx_id(void)
 }
 
 static char *
-gf_get_reserved_ports()
+gf_get_reserved_ports(void)
 {
     char *ports_info = NULL;
 #if defined GF_LINUX_HOST_OS
@@ -4297,7 +4297,7 @@ out:
 }
 
 char **
-get_xattrs_to_heal()
+get_xattrs_to_heal(void)
 {
     return xattrs_to_heal;
 }

--- a/libglusterfs/src/compat-errno.c
+++ b/libglusterfs/src/compat-errno.c
@@ -19,7 +19,7 @@ static int32_t gf_compat_errno_init_done;
 
 #ifdef GF_SOLARIS_HOST_OS
 static void
-init_compat_errno_arrays()
+init_compat_errno_arrays(void)
 {
     /*      ENOMSG  35      / * No message of desired type          */
     gf_error_to_errno_array[GF_ERROR_CODE_NOMSG] = ENOMSG;
@@ -330,7 +330,7 @@ init_compat_errno_arrays()
 
 #ifdef GF_DARWIN_HOST_OS
 static void
-init_compat_errno_arrays()
+init_compat_errno_arrays(void)
 {
     /*    EDEADLK         11              / * Resource deadlock would occur */
     gf_error_to_errno_array[GF_ERROR_CODE_DEADLK] = EDEADLK;
@@ -637,7 +637,7 @@ init_compat_errno_arrays()
 
 #ifdef GF_BSD_HOST_OS
 static void
-init_compat_errno_arrays()
+init_compat_errno_arrays(void)
 {
     /* Quite a bit of things changed in FreeBSD - current */
 
@@ -903,7 +903,7 @@ init_compat_errno_arrays()
 
 #ifdef GF_LINUX_HOST_OS
 static void
-init_compat_errno_arrays()
+init_compat_errno_arrays(void)
 {
     /* Things are fine. Everything should work seemlessly on GNU/Linux machines
      */
@@ -912,7 +912,7 @@ init_compat_errno_arrays()
 #endif /* GF_LINUX_HOST_OS */
 
 static void
-init_errno_arrays()
+init_errno_arrays(void)
 {
     int i;
     for (i = 0; i < GF_ERROR_CODE_UNKNOWN; i++) {

--- a/libglusterfs/src/ctx.c
+++ b/libglusterfs/src/ctx.c
@@ -15,7 +15,7 @@
 
 glusterfs_ctx_t *global_ctx = NULL;
 glusterfs_ctx_t *
-glusterfs_ctx_new()
+glusterfs_ctx_new(void)
 {
     long namelen = 0;
     glusterfs_ctx_t *ctx = NULL;

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -45,7 +45,7 @@ struct dict_cmp {
     } while (0)
 
 static data_t *
-get_new_data()
+get_new_data(void)
 {
     data_t *data = NULL;
 

--- a/libglusterfs/src/fd-lk.c
+++ b/libglusterfs/src/fd-lk.c
@@ -97,7 +97,7 @@ fd_lk_ctx_ref(fd_lk_ctx_t *lk_ctx)
 }
 
 fd_lk_ctx_t *
-fd_lk_ctx_create()
+fd_lk_ctx_create(void)
 {
     fd_lk_ctx_t *fd_lk_ctx = NULL;
 

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -204,7 +204,7 @@ struct volume_options global_xl_options[] = {
 static volume_opt_list_t global_xl_opt_list;
 
 void
-glusterfs_this_init()
+glusterfs_this_init(void)
 {
     global_xlator.name = "glusterfs";
     global_xlator.type = GF_GLOBAL_XLATOR_NAME;
@@ -222,7 +222,7 @@ glusterfs_this_init()
 }
 
 xlator_t **
-__glusterfs_this_location()
+__glusterfs_this_location(void)
 {
     xlator_t **this_location;
 
@@ -236,7 +236,7 @@ __glusterfs_this_location()
 /* SYNCOPCTX */
 
 void *
-syncopctx_getctx()
+syncopctx_getctx(void)
 {
     return &thread_syncopctx;
 }
@@ -244,7 +244,7 @@ syncopctx_getctx()
 /* SYNCTASK */
 
 void *
-synctask_get()
+synctask_get(void)
 {
     return thread_synctask;
 }
@@ -258,7 +258,7 @@ synctask_set(void *synctask)
 // UUID_BUFFER
 
 char *
-glusterfs_uuid_buf_get()
+glusterfs_uuid_buf_get(void)
 {
     return thread_uuid_buf;
 }
@@ -266,7 +266,7 @@ glusterfs_uuid_buf_get()
 /* LKOWNER_BUFFER */
 
 char *
-glusterfs_lkowner_buf_get()
+glusterfs_lkowner_buf_get(void)
 {
     return thread_lkowner_buf;
 }
@@ -274,7 +274,7 @@ glusterfs_lkowner_buf_get()
 /* Leaseid buffer */
 
 char *
-glusterfs_leaseid_buf_get()
+glusterfs_leaseid_buf_get(void)
 {
     char *buf = NULL;
 
@@ -288,7 +288,7 @@ glusterfs_leaseid_buf_get()
 }
 
 char *
-glusterfs_leaseid_exist()
+glusterfs_leaseid_exist(void)
 {
     return thread_leaseid;
 }
@@ -315,7 +315,7 @@ gf_thread_needs_cleanup(void)
 }
 
 static void
-gf_globals_init_once()
+gf_globals_init_once(void)
 {
     int ret = 0;
 

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -200,7 +200,7 @@ typedef enum _gf_xlator_ipc_targets _gf_xlator_ipc_targets_t;
 extern char *xattrs_to_heal[];
 
 char **
-get_xattrs_to_heal();
+get_xattrs_to_heal(void);
 
 char *
 gf_gethostname(void);

--- a/libglusterfs/src/glusterfs/statedump.h
+++ b/libglusterfs/src/glusterfs/statedump.h
@@ -59,7 +59,7 @@ _gf_proc_dump_build_key(char *key, const char *prefix, const char *fmt, ...)
     }
 
 void
-gf_proc_dump_init();
+gf_proc_dump_init(void);
 
 void
 gf_proc_dump_fini(void);

--- a/libglusterfs/src/glusterfs/strfd.h
+++ b/libglusterfs/src/glusterfs/strfd.h
@@ -19,7 +19,7 @@ typedef struct {
 } strfd_t;
 
 strfd_t *
-strfd_open();
+strfd_open(void);
 
 int
 strprintf(strfd_t *strfd, const char *fmt, ...)

--- a/libglusterfs/src/glusterfs/trie.h
+++ b/libglusterfs/src/glusterfs/trie.h
@@ -23,7 +23,7 @@ struct trienodevec {
 };
 
 trie_t *
-trie_new();
+trie_new(void);
 
 int
 trie_add(trie_t *trie, const char *word);

--- a/libglusterfs/src/graph.y
+++ b/libglusterfs/src/graph.y
@@ -41,7 +41,7 @@ static void option_error (void);
 #define GF_CMD_BUFFER_LEN (8 * GF_UNIT_KB)
 
 int graphyyerror (const char *);
-int graphyylex ();
+int graphyylex (void);
 %}
 
 
@@ -330,7 +330,7 @@ volume_end (void)
 
 
 int
-graphyywrap ()
+graphyywrap (void)
 {
         return 1;
 }
@@ -532,7 +532,7 @@ out:
 extern FILE *graphyyin;
 
 glusterfs_graph_t *
-glusterfs_graph_new ()
+glusterfs_graph_new (void)
 {
         glusterfs_graph_t *graph = NULL;
 

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -650,7 +650,7 @@ out:
 }
 
 struct iobref *
-iobref_new()
+iobref_new(void)
 {
     struct iobref *iobref = NULL;
 

--- a/libglusterfs/src/rot-buffs.c
+++ b/libglusterfs/src/rot-buffs.c
@@ -63,7 +63,7 @@ __rlist_has_waiter(rbuf_list_t *rlist)
 }
 
 static void *
-rbuf_alloc_rvec()
+rbuf_alloc_rvec(void)
 {
     return GF_CALLOC(1, RLIST_IOV_MELDED_ALLOC_SIZE, gf_common_mt_rvec_t);
 }

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -344,7 +344,7 @@ gf_mallinfo(gf_mallinfo_t *info)
 #endif /* HAVE_MALLINFO2 */
 
 void
-gf_proc_dump_mem_info()
+gf_proc_dump_mem_info(void)
 {
 #if defined(HAVE_MALLINFO2) || defined(HAVE_MALLINFO)
     gf_mallinfo_t info;
@@ -636,7 +636,7 @@ gf_proc_dump_oldgraph_xlator_info(xlator_t *top)
 }
 
 static int
-gf_proc_dump_enable_all_options()
+gf_proc_dump_enable_all_options(void)
 {
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_mem, _gf_true);
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_iobuf, _gf_true);
@@ -652,7 +652,7 @@ gf_proc_dump_enable_all_options()
 }
 
 gf_boolean_t
-is_gf_proc_dump_all_disabled()
+is_gf_proc_dump_all_disabled(void)
 {
     gf_boolean_t all_disabled = _gf_true;
 
@@ -680,7 +680,7 @@ out:
    file exists and it is emtpty
 */
 static int
-gf_proc_dump_enable_default_options()
+gf_proc_dump_enable_default_options(void)
 {
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_mem, _gf_true);
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_callpool, _gf_true);
@@ -689,7 +689,7 @@ gf_proc_dump_enable_default_options()
 }
 
 static int
-gf_proc_dump_disable_all_options()
+gf_proc_dump_disable_all_options(void)
 {
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_mem, _gf_false);
     GF_PROC_DUMP_SET_OPTION(dump_options.dump_iobuf, _gf_false);
@@ -761,7 +761,7 @@ out:
 }
 
 static int
-gf_proc_dump_options_init()
+gf_proc_dump_options_init(void)
 {
     int ret = -1;
     FILE *fp = NULL;
@@ -985,7 +985,7 @@ gf_proc_dump_fini(void)
 }
 
 void
-gf_proc_dump_init()
+gf_proc_dump_init(void)
 {
     pthread_mutex_init(&gf_proc_dump_mutex, NULL);
 

--- a/libglusterfs/src/strfd.c
+++ b/libglusterfs/src/strfd.c
@@ -16,7 +16,7 @@
 #include "glusterfs/common-utils.h"
 
 strfd_t *
-strfd_open()
+strfd_open(void)
 {
     strfd_t *strfd = NULL;
 

--- a/libglusterfs/src/trie.c
+++ b/libglusterfs/src/trie.c
@@ -35,7 +35,7 @@ struct trie {
 };
 
 trie_t *
-trie_new()
+trie_new(void)
 {
     trie_t *trie = NULL;
 


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: Ibb393780e8e6cce70f0f7f9910a91f4b588f70c3
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

