### PR TITLE
glusterfs: Build with Modern C, change set 2

### DIFF
--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -786,7 +786,7 @@ extern glusterfs_ctx_t *global_ctx;
 extern pthread_mutex_t global_ctx_mutex;
 
 static int
-glfs_init_global_ctx()
+glfs_init_global_ctx(void)
 {
     int ret = 0;
     glusterfs_ctx_t *ctx = NULL;


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: I8271269e4f6d504a7b812f89c7d6b4e60edf661f
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

