### PR TITLE
glusterfs: Build with Modern C, change set 3

### DIFF
--- a/xlators/features/changelog/lib/src/gf-changelog-api.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-api.c
@@ -74,7 +74,7 @@ out:
  *  for a set of changelogs, start from the beginning
  */
 int
-gf_changelog_start_fresh()
+gf_changelog_start_fresh(void)
 {
     xlator_t *this = NULL;
     gf_changelog_journal_t *jnl = NULL;
@@ -151,7 +151,7 @@ out:
  * This call also acts as a cancellation point for the consumer.
  */
 ssize_t
-gf_changelog_scan()
+gf_changelog_scan(void)
 {
     int tracker_fd = 0;
     size_t off = 0;

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -43,7 +43,7 @@
 xlator_t *primary = NULL;
 
 static inline gf_private_t *
-gf_changelog_alloc_priv()
+gf_changelog_alloc_priv(void)
 {
     int ret = 0;
     gf_private_t *priv = NULL;
@@ -190,7 +190,7 @@ gf_changelog_cleanup_this(xlator_t *this)
 }
 
 static int
-gf_changelog_init_context()
+gf_changelog_init_context(void)
 {
     glusterfs_ctx_t *ctx = NULL;
 
@@ -218,7 +218,7 @@ error_return:
 }
 
 static int
-gf_changelog_init_primary()
+gf_changelog_init_primary(void)
 {
     int ret = 0;
 

--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -103,7 +103,7 @@ out:
  *    -1: On error.
  */
 int
-gf_history_changelog_start_fresh()
+gf_history_changelog_start_fresh(void)
 {
     xlator_t *this = NULL;
     gf_changelog_journal_t *jnl = NULL;
@@ -214,7 +214,7 @@ out:
  *
  */
 ssize_t
-gf_history_changelog_scan()
+gf_history_changelog_scan(void)
 {
     int tracker_fd = 0;
     size_t off = 0;

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -973,7 +973,7 @@ changelog_start_next_change(xlator_t *this, changelog_priv_t *priv, time_t ts,
  * return the length of entry
  */
 size_t
-changelog_entry_length()
+changelog_entry_length(void)
 {
     return sizeof(changelog_log_data_t);
 }

--- a/xlators/features/changelog/src/changelog-helpers.h
+++ b/xlators/features/changelog/src/changelog-helpers.h
@@ -427,7 +427,7 @@ int
 changelog_inject_single_event(xlator_t *this, changelog_priv_t *priv,
                               changelog_log_data_t *cld);
 size_t
-changelog_entry_length();
+changelog_entry_length(void);
 int
 changelog_write(int fd, char *buffer, size_t len);
 int

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -1139,7 +1139,7 @@ pl_getlk(pl_inode_t *pl_inode, posix_lock_t *lock)
 }
 
 gf_boolean_t
-pl_does_monkey_want_stuck_lock()
+pl_does_monkey_want_stuck_lock(void)
 {
     long int monkey_unlock_rand = 0;
     long int monkey_unlock_rand_rem = 0;

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -232,7 +232,7 @@ entrylk_contention_notify_check(xlator_t *xl, pl_entry_lock_t *lock,
                                 struct list_head *contend);
 
 gf_boolean_t
-pl_does_monkey_want_stuck_lock();
+pl_does_monkey_want_stuck_lock(void);
 
 gf_boolean_t
 pl_is_mandatory_locking_enabled(pl_inode_t *pl_inode);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -587,7 +587,7 @@ pl_is_fop_allowed(pl_inode_t *pl_inode, posix_lock_t *region, fd_t *fd,
 }
 
 static pl_fdctx_t *
-pl_new_fdctx()
+pl_new_fdctx(void)
 {
     pl_fdctx_t *fdctx = GF_MALLOC(sizeof(*fdctx), gf_locks_mt_pl_fdctx_t);
     GF_VALIDATE_OR_GOTO("posix-locks", fdctx, out);

--- a/xlators/features/marker/src/marker-common.c
+++ b/xlators/features/marker/src/marker-common.c
@@ -11,7 +11,7 @@
 #include "marker-common.h"
 
 marker_inode_ctx_t *
-marker_inode_ctx_new()
+marker_inode_ctx_new(void)
 {
     marker_inode_ctx_t *ctx = NULL;
 

--- a/xlators/features/marker/src/marker-quota-helper.c
+++ b/xlators/features/marker/src/marker-quota-helper.c
@@ -128,7 +128,7 @@ err:
 }
 
 quota_inode_ctx_t *
-mq_alloc_inode_ctx()
+mq_alloc_inode_ctx(void)
 {
     int32_t ret = -1;
     quota_inode_ctx_t *ctx = NULL;

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -185,7 +185,7 @@ out:
 }
 
 static quota_local_t *
-quota_local_new()
+quota_local_new(void)
 {
     quota_local_t *local = NULL;
     local = mem_get0(THIS->local_pool);

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -39,7 +39,7 @@ mem_acct_init(xlator_t *this)
 }
 
 static uid_t
-r00t()
+r00t(void)
 {
     struct posix_acl_conf *conf = NULL;
 


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: I4c1726915883e4a9912f41d92644c1e8916a979d
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

