### PR TITLE
glusterfs: Build with Modern C, change set 4

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.c
@@ -30,7 +30,7 @@ glusterd_bitdsvc_init(glusterd_svc_t *svc)
 }
 
 static int
-glusterd_bitdsvc_create_volfile()
+glusterd_bitdsvc_create_volfile(void)
 {
     char filepath[PATH_MAX] = {
         0,
@@ -112,7 +112,7 @@ glusterd_bitdsvc_stop(glusterd_svc_t *svc, int sig)
 }
 
 int
-glusterd_bitdsvc_reconfigure()
+glusterd_bitdsvc_reconfigure(void)
 {
     int ret = -1;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-bitd-svc.h
@@ -28,6 +28,6 @@ int
 glusterd_bitdsvc_stop(glusterd_svc_t *svc, int sig);
 
 int
-glusterd_bitdsvc_reconfigure();
+glusterd_bitdsvc_reconfigure(void);
 
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -496,7 +496,7 @@ out:
 }
 
 gf_boolean_t
-glusterd_should_i_stop_bitd()
+glusterd_should_i_stop_bitd(void)
 {
     xlator_t *this = THIS;
     glusterd_conf_t *conf = this->private;

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -156,7 +156,7 @@ manage_service(char *action)
  * Check if the cluster is a ganesha cluster or not *
  */
 gf_boolean_t
-glusterd_is_ganesha_cluster()
+glusterd_is_ganesha_cluster(void)
 {
     int ret = -1;
     glusterd_conf_t *priv = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -353,7 +353,7 @@ out:
 }
 
 int
-glusterd_gfproxydsvc_restart()
+glusterd_gfproxydsvc_restart(void)
 {
     glusterd_volinfo_t *volinfo = NULL;
     glusterd_volinfo_t *tmp = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.h
@@ -39,5 +39,5 @@ int
 glusterd_gfproxydsvc_reconfigure(glusterd_volinfo_t *volinfo);
 
 int
-glusterd_gfproxydsvc_restart();
+glusterd_gfproxydsvc_restart(void);
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-locks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.c
@@ -51,7 +51,7 @@ glusterd_mgmt_v3_is_type_valid(char *type)
 /* Initialize the global mgmt_v3 lock list(dict) when
  * glusterd is spawned */
 int32_t
-glusterd_mgmt_v3_lock_init()
+glusterd_mgmt_v3_lock_init(void)
 {
     int32_t ret = -1;
     glusterd_conf_t *priv = NULL;
@@ -71,7 +71,7 @@ out:
 /* Destroy the global mgmt_v3 lock list(dict) when
  * glusterd cleanup is performed */
 void
-glusterd_mgmt_v3_lock_fini()
+glusterd_mgmt_v3_lock_fini(void)
 {
     glusterd_conf_t *priv = NULL;
 
@@ -85,7 +85,7 @@ glusterd_mgmt_v3_lock_fini()
 /* Initialize the global mgmt_v3_timer lock list(dict) when
  * glusterd is spawned */
 int32_t
-glusterd_mgmt_v3_lock_timer_init()
+glusterd_mgmt_v3_lock_timer_init(void)
 {
     int32_t ret = -1;
     xlator_t *this = THIS;
@@ -106,7 +106,7 @@ out:
 /* Destroy the global mgmt_v3_timer lock list(dict) when
  * glusterd cleanup is performed */
 void
-glusterd_mgmt_v3_lock_timer_fini()
+glusterd_mgmt_v3_lock_timer_fini(void)
 {
     xlator_t *this = THIS;
     glusterd_conf_t *priv = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-locks.h
+++ b/xlators/mgmt/glusterd/src/glusterd-locks.h
@@ -23,16 +23,16 @@ typedef struct glusterd_mgmt_v3_lock_valid_entities {
 } glusterd_valid_entities;
 
 int32_t
-glusterd_mgmt_v3_lock_init();
+glusterd_mgmt_v3_lock_init(void);
 
 void
-glusterd_mgmt_v3_lock_fini();
+glusterd_mgmt_v3_lock_fini(void);
 
 int32_t
-glusterd_mgmt_v3_lock_timer_init();
+glusterd_mgmt_v3_lock_timer_init(void);
 
 void
-glusterd_mgmt_v3_lock_timer_fini();
+glusterd_mgmt_v3_lock_timer_fini(void);
 
 int32_t
 glusterd_mgmt_v3_lock(const char *key, uuid_t uuid, uint32_t *op_errno,

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -87,7 +87,7 @@ glusterd_op_info_t opinfo = {
 };
 
 int32_t
-glusterd_txn_opinfo_dict_init()
+glusterd_txn_opinfo_dict_init(void)
 {
     int32_t ret = -1;
     xlator_t *this = THIS;
@@ -111,7 +111,7 @@ out:
 }
 
 void
-glusterd_txn_opinfo_dict_fini()
+glusterd_txn_opinfo_dict_fini(void)
 {
     glusterd_conf_t *priv = NULL;
 
@@ -5715,7 +5715,7 @@ out:
 }
 
 int32_t
-glusterd_op_clear_errstr()
+glusterd_op_clear_errstr(void)
 {
     opinfo.op_errstr = NULL;
     return 0;
@@ -5730,7 +5730,7 @@ glusterd_op_set_ctx(void *ctx)
 }
 
 int32_t
-glusterd_op_reset_ctx()
+glusterd_op_reset_ctx(void)
 {
     glusterd_op_set_ctx(NULL);
 
@@ -5764,9 +5764,6 @@ glusterd_op_txn_complete(uuid_t *txn_id)
 
     opinfo.op_ret = 0;
     opinfo.op_errno = 0;
-    glusterd_op_clear_op();
-    glusterd_op_reset_ctx();
-    glusterd_op_clear_errstr();
 
     /* Based on the op-version, we release the cluster or mgmt_v3 lock */
     if (priv->op_version < GD_OP_VERSION_3_6_0) {
@@ -8185,7 +8182,7 @@ glusterd_destroy_op_event_ctx(glusterd_op_sm_event_t *event)
 }
 
 int
-glusterd_op_sm()
+glusterd_op_sm(void)
 {
     glusterd_op_sm_event_t *event = NULL;
     glusterd_op_sm_event_t *tmp = NULL;
@@ -8315,7 +8312,7 @@ glusterd_op_set_op(glusterd_op_t op)
 }
 
 int32_t
-glusterd_op_get_op()
+glusterd_op_get_op(void)
 {
     return opinfo.op;
 }
@@ -8381,7 +8378,7 @@ glusterd_op_get_ctx(void)
 }
 
 int
-glusterd_op_sm_init()
+glusterd_op_sm_init(void)
 {
     CDS_INIT_LIST_HEAD(&gd_op_sm_queue);
     synclock_init(&gd_op_sm_lock, SYNC_LOCK_DEFAULT);

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.h
@@ -172,10 +172,10 @@ glusterd_op_sm_inject_event(glusterd_op_sm_event_type_t event_type,
                             uuid_t *txn_id, void *ctx);
 
 int
-glusterd_op_sm_init();
+glusterd_op_sm_init(void);
 
 int
-glusterd_op_sm();
+glusterd_op_sm(void);
 
 int32_t
 glusterd_op_set_ctx(void *ctx);
@@ -212,7 +212,7 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
                               int32_t op_errno, rpcsvc_request_t *req,
                               void *ctx, char *op_errstr);
 int32_t
-glusterd_op_get_op();
+glusterd_op_get_op(void);
 
 int32_t
 glusterd_op_clear_op(void);
@@ -255,7 +255,7 @@ int
 glusterd_start_bricks(glusterd_volinfo_t *volinfo);
 
 gf_boolean_t
-glusterd_are_all_volumes_stopped();
+glusterd_are_all_volumes_stopped(void);
 int
 glusterd_stop_bricks(glusterd_volinfo_t *volinfo);
 int

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -507,7 +507,7 @@ gd_peer_uuid_str(glusterd_peerinfo_t *peerinfo)
 }
 
 gf_boolean_t
-glusterd_are_all_peers_up()
+glusterd_are_all_peers_up(void)
 {
     glusterd_peerinfo_t *peerinfo = NULL;
     xlator_t *this = THIS;
@@ -1034,7 +1034,7 @@ glusterd_peerinfo_find_by_generation(uint32_t generation)
 }
 
 int
-glusterd_get_peers_count()
+glusterd_get_peers_count(void)
 {
     int count = 0;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.h
@@ -42,7 +42,7 @@ char *
 gd_peer_uuid_str(glusterd_peerinfo_t *peerinfo);
 
 gf_boolean_t
-glusterd_are_all_peers_up();
+glusterd_are_all_peers_up(void);
 
 gf_boolean_t
 glusterd_are_vol_all_peers_up(glusterd_volinfo_t *volinfo,
@@ -79,5 +79,5 @@ glusterd_peerinfo_t *
 glusterd_peerinfo_find_by_generation(uint32_t generation);
 
 int
-glusterd_get_peers_count();
+glusterd_get_peers_count(void);
 #endif /* _GLUSTERD_PEER_UTILS_H */

--- a/xlators/mgmt/glusterd/src/glusterd-quotad-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quotad-svc.c
@@ -40,7 +40,7 @@ out:
 }
 
 static int
-glusterd_quotadsvc_create_volfile()
+glusterd_quotadsvc_create_volfile(void)
 {
     char filepath[PATH_MAX] = {
         0,
@@ -150,7 +150,7 @@ out:
 }
 
 int
-glusterd_quotadsvc_reconfigure()
+glusterd_quotadsvc_reconfigure(void)
 {
     int ret = -1;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-quotad-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-quotad-svc.h
@@ -26,6 +26,6 @@ int
 glusterd_quotadsvc_manager(glusterd_svc_t *svc, void *data, int flags);
 
 int
-glusterd_quotadsvc_reconfigure();
+glusterd_quotadsvc_reconfigure(void);
 
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.c
@@ -32,7 +32,7 @@ glusterd_scrubsvc_init(glusterd_svc_t *svc)
 }
 
 static int
-glusterd_scrubsvc_create_volfile()
+glusterd_scrubsvc_create_volfile(void)
 {
     char filepath[PATH_MAX] = {
         0,
@@ -116,7 +116,7 @@ glusterd_scrubsvc_stop(glusterd_svc_t *svc, int sig)
 }
 
 int
-glusterd_scrubsvc_reconfigure()
+glusterd_scrubsvc_reconfigure(void)
 {
     int ret = -1;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-scrub-svc.h
@@ -33,6 +33,6 @@ int
 glusterd_scrubsvc_stop(glusterd_svc_t *svc, int sig);
 
 int
-glusterd_scrubsvc_reconfigure();
+glusterd_scrubsvc_reconfigure(void);
 
 #endif

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -421,7 +421,7 @@ out:
 }
 
 int
-glusterd_do_quorum_action()
+glusterd_do_quorum_action(void)
 {
     xlator_t *this = THIS;
     glusterd_conf_t *conf = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.h
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.h
@@ -20,7 +20,7 @@ gf_boolean_t
 glusterd_is_quorum_changed(dict_t *options, char *option, char *value);
 
 int
-glusterd_do_quorum_action();
+glusterd_do_quorum_action(void);
 
 int
 glusterd_get_quorum_cluster_counts(xlator_t *this, int *active_count,

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -653,7 +653,7 @@ out:
 }
 
 int
-glusterd_shdsvc_restart()
+glusterd_shdsvc_restart(void)
 {
     glusterd_volinfo_t *volinfo = NULL;
     glusterd_volinfo_t *tmp = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.h
@@ -40,7 +40,7 @@ int
 glusterd_shdsvc_reconfigure(glusterd_volinfo_t *volinfo);
 
 int
-glusterd_shdsvc_restart();
+glusterd_shdsvc_restart(void);
 
 int
 glusterd_shdsvc_stop(glusterd_svc_t *svc, int sig);

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -1429,7 +1429,7 @@ out:
 }
 
 int
-glusterd_friend_sm()
+glusterd_friend_sm(void)
 {
     glusterd_friend_sm_event_t *event = NULL;
     glusterd_friend_sm_event_t *tmp = NULL;
@@ -1595,7 +1595,7 @@ out:
 }
 
 int
-glusterd_friend_sm_init()
+glusterd_friend_sm_init(void)
 {
     CDS_INIT_LIST_HEAD(&gd_friend_sm_queue);
     return 0;

--- a/xlators/mgmt/glusterd/src/glusterd-sm.h
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.h
@@ -180,10 +180,10 @@ int
 glusterd_friend_sm_inject_event(glusterd_friend_sm_event_t *event);
 
 int
-glusterd_friend_sm_init();
+glusterd_friend_sm_init(void);
 
 int
-glusterd_friend_sm();
+glusterd_friend_sm(void);
 
 void
 glusterd_destroy_probe_ctx(glusterd_probe_ctx_t *ctx);

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -367,7 +367,7 @@ out:
 }
 
 int
-glusterd_snapdsvc_restart()
+glusterd_snapdsvc_restart(void)
 {
     glusterd_volinfo_t *volinfo = NULL;
     glusterd_volinfo_t *tmp = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.h
@@ -34,7 +34,7 @@ int
 glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags);
 
 int
-glusterd_snapdsvc_restart();
+glusterd_snapdsvc_restart(void);
 
 int
 glusterd_snapdsvc_rpc_notify(glusterd_conn_t *conn, rpc_clnt_event_t event);

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -1283,7 +1283,7 @@ out:
 
 /* Perform missed deletes and restores on this node */
 int32_t
-glusterd_perform_missed_snap_ops()
+glusterd_perform_missed_snap_ops(void)
 {
     int32_t ret = -1;
     int32_t op_status = -1;

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -2322,7 +2322,7 @@ out:
 }
 
 glusterd_snap_t *
-glusterd_new_snap_object()
+glusterd_new_snap_object(void)
 {
     glusterd_snap_t *snap = NULL;
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -1270,7 +1270,7 @@ glusterd_store_create_quota_conf_sh_on_absence(glusterd_volinfo_t *volinfo)
 }
 
 static int32_t
-glusterd_store_create_missed_snaps_list_shandle_on_absence()
+glusterd_store_create_missed_snaps_list_shandle_on_absence(void)
 {
     char missed_snaps_list[PATH_MAX] = "";
     int32_t ret = -1;
@@ -2233,7 +2233,7 @@ out:
 }
 
 int32_t
-glusterd_retrieve_uuid()
+glusterd_retrieve_uuid(void)
 {
     char *uuid_str = NULL;
     int32_t ret = -1;
@@ -4214,7 +4214,7 @@ out:
 /* Adds the missed snap entries to the in-memory conf->missed_snap_list *
  * and writes them to disk */
 int32_t
-glusterd_store_update_missed_snaps()
+glusterd_store_update_missed_snaps(void)
 {
     int32_t fd = -1;
     int32_t ret = -1;
@@ -4350,7 +4350,7 @@ glusterd_store_peerinfo_dirpath_set(char *path, size_t len)
 }
 
 int32_t
-glusterd_store_create_peer_dir()
+glusterd_store_create_peer_dir(void)
 {
     int32_t ret = 0;
     char path[PATH_MAX];
@@ -4898,7 +4898,7 @@ out:
 }
 
 int32_t
-glusterd_restore()
+glusterd_restore(void)
 {
     int32_t ret = -1;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-store.h
+++ b/xlators/mgmt/glusterd/src/glusterd-store.h
@@ -145,7 +145,7 @@ int32_t
 glusterd_store_delete_snap(glusterd_snap_t *snap);
 
 int32_t
-glusterd_retrieve_uuid();
+glusterd_retrieve_uuid(void);
 
 int32_t
 glusterd_store_peerinfo(glusterd_peerinfo_t *peerinfo);
@@ -157,7 +157,7 @@ int32_t
 glusterd_store_delete_brick(glusterd_brickinfo_t *brickinfo, char *delete_path);
 
 int32_t
-glusterd_restore();
+glusterd_restore(void);
 
 void
 glusterd_perform_volinfo_version_action(glusterd_volinfo_t *volinfo,
@@ -205,7 +205,7 @@ int32_t
 glusterd_store_snap(glusterd_snap_t *snap);
 
 int32_t
-glusterd_store_update_missed_snaps();
+glusterd_store_update_missed_snaps(void);
 
 glusterd_volinfo_t *
 glusterd_store_retrieve_volume(char *volname, glusterd_snap_t *snap);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -452,7 +452,7 @@ out:
 }
 
 glusterd_svc_proc_t *
-glusterd_svcprocess_new()
+glusterd_svcprocess_new(void)
 {
     glusterd_svc_proc_t *new_svcprocess = NULL;
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.h
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.h
@@ -49,7 +49,7 @@ void *
 __gf_find_compatible_svc(gd_node_type daemon);
 
 glusterd_svc_proc_t *
-glusterd_svcprocess_new();
+glusterd_svcprocess_new(void);
 
 int
 glusterd_shd_svc_mux_init(glusterd_volinfo_t *volinfo, glusterd_svc_t *svc);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -318,7 +318,7 @@ glusterd_svc_build_rundir(char *server, char *workdir, char *path, size_t len)
 }
 
 int
-glusterd_svc_reconfigure(int (*create_volfile)())
+glusterd_svc_reconfigure(int (*create_volfile)(void))
 {
     int ret = -1;
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.h
@@ -96,7 +96,7 @@ void
 glusterd_svc_build_rundir(char *server, char *workdir, char *path, size_t len);
 
 int
-glusterd_svc_reconfigure(int (*create_volfile)());
+glusterd_svc_reconfigure(int (*create_volfile)(void));
 
 int
 glusterd_svc_common_rpc_notify(glusterd_conn_t *conn, rpc_clnt_event_t event);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -384,7 +384,7 @@ glusterd_unset_lock_owner(uuid_t owner)
 }
 
 gf_boolean_t
-glusterd_is_fuse_available()
+glusterd_is_fuse_available(void)
 {
     int fd = 0;
 
@@ -5333,7 +5333,7 @@ glusterd_pending_node_put_rpc(glusterd_pending_node_t *pending_node)
 
 #ifdef BUILD_GNFS
 void
-glusterd_nfs_pmap_deregister()
+glusterd_nfs_pmap_deregister(void)
 {
     if (pmap_unset(MOUNT_PROGRAM, MOUNTV3_VERSION))
         gf_msg("glusterd", GF_LOG_INFO, 0, GD_MSG_DEREGISTER_SUCCESS,
@@ -5418,7 +5418,7 @@ out:
 }
 
 gf_boolean_t
-glusterd_are_all_volumes_stopped()
+glusterd_are_all_volumes_stopped(void)
 {
     glusterd_conf_t *priv = NULL;
     glusterd_volinfo_t *voliter = NULL;
@@ -5436,7 +5436,7 @@ glusterd_are_all_volumes_stopped()
 }
 
 gf_boolean_t
-glusterd_all_volumes_with_quota_stopped()
+glusterd_all_volumes_with_quota_stopped(void)
 {
     glusterd_conf_t *priv = NULL;
     glusterd_volinfo_t *voliter = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -347,7 +347,7 @@ glusterd_add_brick_to_dict(glusterd_volinfo_t *volinfo,
                            int32_t count);
 
 gf_boolean_t
-glusterd_is_fuse_available();
+glusterd_is_fuse_available(void);
 
 int
 glusterd_brick_statedump(glusterd_volinfo_t *volinfo,
@@ -499,7 +499,7 @@ int
 glusterd_is_bitrot_enabled(glusterd_volinfo_t *volinfo);
 
 gf_boolean_t
-glusterd_all_volumes_with_quota_stopped();
+glusterd_all_volumes_with_quota_stopped(void);
 
 void
 glusterd_clean_up_quota_store(glusterd_volinfo_t *volinfo);
@@ -593,11 +593,11 @@ gf_boolean_t
 glusterd_is_shd_compatible_volume(glusterd_volinfo_t *volinfo);
 
 gf_boolean_t
-glusterd_are_all_volumes_stopped();
+glusterd_are_all_volumes_stopped(void);
 
 #ifdef BUILD_GNFS
 void
-glusterd_nfs_pmap_deregister();
+glusterd_nfs_pmap_deregister(void);
 #endif
 
 gf_boolean_t

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -134,7 +134,7 @@ const char *gd_op_list[GD_OP_MAX + 1] = {
 #define GLUSTERD_RUN_DIR "/run"
 
 static int
-glusterd_opinfo_init()
+glusterd_opinfo_init(void)
 {
     int32_t ret = -1;
 
@@ -144,7 +144,7 @@ glusterd_opinfo_init()
 }
 
 int
-glusterd_uuid_init()
+glusterd_uuid_init(void)
 {
     int ret = -1;
     xlator_t *this = THIS;
@@ -172,7 +172,7 @@ glusterd_uuid_init()
 }
 
 int
-glusterd_uuid_generate_save()
+glusterd_uuid_generate_save(void)
 {
     int ret = -1;
     glusterd_conf_t *priv = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -634,15 +634,15 @@ enum glusterd_op_ret {
     pthread_mutex_unlock(&(THIS->ctx)->cleanup_lock);
 
 int
-glusterd_uuid_init();
+glusterd_uuid_init(void);
 
 int
-glusterd_uuid_generate_save();
+glusterd_uuid_generate_save(void);
 
 #define MY_UUID (__glusterd_uuid())
 
 static inline unsigned char *
-__glusterd_uuid()
+__glusterd_uuid(void)
 {
     glusterd_conf_t *priv = THIS->private;
 
@@ -893,7 +893,7 @@ ganesha_manage_export(dict_t *dict, char *value,
 int
 gd_ganesha_send_dbus(char *volname, char *value);
 gf_boolean_t
-glusterd_is_ganesha_cluster();
+glusterd_is_ganesha_cluster(void);
 gf_boolean_t
 glusterd_check_ganesha_export(glusterd_volinfo_t *volinfo);
 int
@@ -972,7 +972,7 @@ glusterd_defrag_event_notify_handle(dict_t *dict);
 
 /* snapshot */
 glusterd_snap_t *
-glusterd_new_snap_object();
+glusterd_new_snap_object(void);
 
 int32_t
 glusterd_list_add_snapvol(glusterd_volinfo_t *origin_vol,
@@ -1011,7 +1011,7 @@ int
 glusterd_snapshot_revert_restore_from_snap(glusterd_snap_t *snap);
 
 gf_boolean_t
-glusterd_should_i_stop_bitd();
+glusterd_should_i_stop_bitd(void);
 
 int
 glusterd_remove_brick_migrate_cbk(glusterd_volinfo_t *volinfo,


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: I9c4b4a0b002835d6555d8fef9456fea16c31b28a
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

