### PR TITLE
glusterfs: Build with Modern C, change set 5

### DIFF
--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -2036,7 +2036,7 @@ out:
 
 #if (SYNCDAEMON_COMPILE)
 static int
-cli_check_gsync_present()
+cli_check_gsync_present(void)
 {
     char buff[PATH_MAX] = {
         0,

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -230,14 +230,14 @@ out:
 }
 
 int
-cli_cmd_lock()
+cli_cmd_lock(void)
 {
     pthread_mutex_lock(&cond_mutex);
     return 0;
 }
 
 int
-cli_cmd_unlock()
+cli_cmd_unlock(void)
 {
     pthread_mutex_unlock(&cond_mutex);
     return 0;

--- a/cli/src/cli-cmd.h
+++ b/cli/src/cli-cmd.h
@@ -100,10 +100,10 @@ int
 cli_cmd_broadcast_response(int32_t status);
 
 int
-cli_cmd_lock();
+cli_cmd_lock(void);
 
 int
-cli_cmd_unlock();
+cli_cmd_unlock(void);
 
 int
 cli_cmd_submit(struct rpc_clnt *rpc, void *req, call_frame_t *frame,

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -716,7 +716,7 @@ out:
 }
 
 cli_local_t *
-cli_local_get()
+cli_local_get(void)
 {
     cli_local_t *local = NULL;
 

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -335,13 +335,13 @@ cli_cmd_volume_clrlks_opts_parse(const char **words, int wordcount,
                                  dict_t **options);
 
 cli_local_t *
-cli_local_get();
+cli_local_get(void);
 
 void
 cli_local_wipe(cli_local_t *local);
 
 gf_boolean_t
-cli_cmd_connected();
+cli_cmd_connected(void);
 
 int32_t
 cli_cmd_await_connected(unsigned timeout);

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -80,7 +80,7 @@ typedef enum {
 } glfsh_fail_mode_t;
 
 int
-glfsh_init()
+glfsh_init(void)
 {
     return 0;
 }
@@ -146,7 +146,7 @@ glfsh_print_hr_heal_status(char *path, uuid_t gfid, char *status)
 #if (HAVE_LIB_XML)
 
 int
-glfsh_xml_init()
+glfsh_xml_init(void)
 {
     int ret = -1;
     glfsh_writer = xmlNewTextWriterDoc(&glfsh_doc, 0);

--- a/tools/gfind_missing_files/gcrawler.c
+++ b/tools/gfind_missing_files/gcrawler.c
@@ -79,7 +79,7 @@ int stats = 0;
     } while (0)
 
 void
-stats_dump()
+stats_dump(void)
 {
     if (!stats)
         return;


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: I2025e39566aeb1f68836226d6d18c43418ca7f95
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

