### PR TITLE
glusterfs: Build with Modern C, change set 6

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -65,7 +65,7 @@ get_new_data()
 }
 
 static dict_t *
-get_new_dict_full()
+get_new_dict_full(void)
 {
     dict_t *dict = mem_get0(THIS->ctx->dict_pool);
 

--- a/libglusterfs/src/glusterfs/glfs-message-id.h
+++ b/libglusterfs/src/glusterfs/glfs-message-id.h
@@ -153,6 +153,38 @@
 #define GLFS_APPLY(_macro, _in, _num, _fields...)                              \
     GLFS_APPLY_##_num(_macro, _in, ##_fields)
 
+#define GLFS_APPLY_ARGS_0(_macro, _in) void
+
+#define GLFS_APPLY_ARGS_1(_macro, _in, _f) _macro _f
+
+#define GLFS_APPLY_ARGS_2(_macro, _in, _f, _more)                              \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_1(_macro, _in, _more)
+
+#define GLFS_APPLY_ARGS_3(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_2(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_4(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_3(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_5(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_4(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_6(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_5(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_7(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_6(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_8(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_7(_macro, _in, ##_more)
+
+#define GLFS_APPLY_ARGS_9(_macro, _in, _f, _more...)                           \
+    _macro _f GLFS_EXPAND _in GLFS_APPLY_ARGS_8(_macro, _in, ##_more)
+
+/* Apply a macro to a variable number of fields. */
+#define GLFS_APPLY_ARGS(_macro, _in, _num, _fields...)                         \
+    GLFS_APPLY_ARGS_##_num(_macro, _in, ##_fields)
+
 /* Translate a name into an internal name to avoid variable name collisions. */
 #define GLFS_GET(_name) _glfs_var_##_name
 
@@ -190,11 +222,10 @@
 #define GLFS_NAMES(_num, _fields...) GLFS_APPLY(GLFS_NAME, (), _num, ##_fields)
 
 /* Generate a format string for all fields. */
-#define GLFS_FMTS(_num, _fields...)                                            \
-    GLFS_APPLY(GLFS_FMT, (", "), _num, ##_fields)
+#define GLFS_FMTS(_num, _fields...) GLFS_APPLY(GLFS_FMT, (", "), _num, ##_fields)
 
 /* Generate the function call argument declaration for all fields. */
-#define GLFS_ARGS(_num, _fields...) GLFS_APPLY(GLFS_ARG, (, ), _num, ##_fields)
+#define GLFS_ARGS(_num, _fields...) GLFS_APPLY_ARGS(GLFS_ARG, (, ), _num, ##_fields)
 
 /* Generate the list of variables for all fields from a structure. */
 #define GLFS_VARS(_num, _fields...) GLFS_APPLY(GLFS_VAR, (), _num, ##_fields)

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -1030,7 +1030,7 @@ err:
  *          FAILURE: NULL
  */
 static struct dnscache_entry *
-gf_dnscache_entry_init()
+gf_dnscache_entry_init(void)
 {
     struct dnscache_entry *entry = GF_CALLOC(1, sizeof(*entry),
                                              gf_common_mt_dnscache_entry);

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1234,7 +1234,7 @@ out:
 }
 
 static gf_boolean_t
-glusterd_have_volumes()
+glusterd_have_volumes(void)
 {
     xlator_t *this = THIS;
     glusterd_conf_t *priv = NULL;
@@ -1249,7 +1249,7 @@ out:
 }
 
 static gf_boolean_t
-glusterd_have_peers()
+glusterd_have_peers(void)
 {
     glusterd_conf_t *conf = NULL;
 

--- a/xlators/mgmt/glusterd/src/glusterd-nfs-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-nfs-svc.c
@@ -21,7 +21,7 @@
 #include "glusterd-svc-helper.h"
 
 static gf_boolean_t
-glusterd_nfssvc_need_start()
+glusterd_nfssvc_need_start(void)
 {
     glusterd_conf_t *priv = NULL;
     gf_boolean_t start = _gf_false;
@@ -44,7 +44,7 @@ glusterd_nfssvc_need_start()
 }
 
 static int
-glusterd_nfssvc_create_volfile()
+glusterd_nfssvc_create_volfile(void)
 {
     char filepath[PATH_MAX] = {
         0,
@@ -142,7 +142,7 @@ glusterd_nfssvc_build(glusterd_svc_t *svc)
 }
 
 int
-glusterd_nfssvc_reconfigure()
+glusterd_nfssvc_reconfigure(void)
 {
     int ret = -1;
     xlator_t *this = THIS;

--- a/xlators/mgmt/glusterd/src/glusterd-nfs-svc.h
+++ b/xlators/mgmt/glusterd/src/glusterd-nfs-svc.h
@@ -18,7 +18,7 @@ void
 glusterd_nfssvc_build(glusterd_svc_t *svc);
 
 int
-glusterd_nfssvc_reconfigure();
+glusterd_nfssvc_reconfigure(void);
 
 #endif /* BUILD_GNFS */
 #endif


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

This change fixes a subset of the errors found when compiling with this set of options.

Change-Id: Ia436ef321ad7963331d5cc813c98880525d0525e
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

