### PR TITLE
api: Use opendir for directories in `glfs_open` and `glfs_h_open` (#3877, #3879)

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -477,7 +477,11 @@ retry:
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+    if (IA_ISDIR(iatt.ia_type))
+        ret = syncop_opendir(subvol, &loc, glfd->fd, NULL, NULL);
+    else
+        ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+
     DECODE_SYNCOP_ERR(ret);
 
     ESTALE_RETRY(ret, errno, reval, &loc, retry);

--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -682,7 +682,11 @@ pub_glfs_h_open(struct glfs *fs, struct glfs_object *object, int flags)
     if (ret)
         gf_msg_debug("gfapi", 0, "Getting leaseid from thread failed");
 
-    ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+    if (IA_ISDIR(inode->ia_type))
+        ret = syncop_opendir(subvol, &loc, glfd->fd, NULL, NULL);
+    else
+        ret = syncop_open(subvol, &loc, flags, glfd->fd, fop_attr, NULL);
+
     DECODE_SYNCOP_ERR(ret);
 
     glfd->fd->flags = flags;


### PR DESCRIPTION
In addition to files _glfs_open()_ and _glfs_h_open()_ are capable of handling directory opens. But there are various other components like DHT and probably other client xlators which are tightly coupled to work with directory opens using just OPENDIR. One such example is the case where _fsetxattr()_ is called with a file descriptor opened for the directory using _glfs_open()_ or _glfs_h_open()_ resulting in `EBADFD`.

Therefore we make a differentiation within these APIs to correctly call _syncop_open()_ or _syncop_opendir()_ for file and directory entries respectively to avoid any possible file descriptor errors.

Credits: Xavi Hernandez