### PR TITLE
io-stat: xlator Segmentation fault

### DIFF
--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -3536,32 +3536,42 @@ ios_destroy_top_stats(struct ios_conf *conf)
         list_head = &conf->list[i];
         if (!list_head)
             continue;
-        list_for_each_entry_safe(entry, tmp, &list_head->iosstats->list, list)
+        LOCK(&list_head->lock);
         {
-            list = entry;
-            stat = list->iosstat;
-            ios_stat_unref(stat);
-            list_del(&list->list);
-            GF_FREE(list);
-            list_head->members--;
+            list_for_each_entry_safe(entry, tmp, &list_head->iosstats->list,
+                                     list)
+            {
+                list = entry;
+                stat = list->iosstat;
+                ios_stat_unref(stat);
+                list_del(&list->list);
+                GF_FREE(list);
+                list_head->members--;
+            }
+            GF_FREE(list_head->iosstats);
         }
-        GF_FREE(list_head->iosstats);
+        UNLOCK(&list_head->lock);
     }
 
     for (i = 0; i < IOS_STATS_THRU_MAX; i++) {
         list_head = &conf->thru_list[i];
         if (!list_head)
             continue;
-        list_for_each_entry_safe(entry, tmp, &list_head->iosstats->list, list)
+        LOCK(&list_head->lock);
         {
-            list = entry;
-            stat = list->iosstat;
-            ios_stat_unref(stat);
-            list_del(&list->list);
-            GF_FREE(list);
-            list_head->members--;
+            list_for_each_entry_safe(entry, tmp, &list_head->iosstats->list,
+                                     list)
+            {
+                list = entry;
+                stat = list->iosstat;
+                ios_stat_unref(stat);
+                list_del(&list->list);
+                GF_FREE(list);
+                list_head->members--;
+            }
+            GF_FREE(list_head->iosstats);
         }
-        GF_FREE(list_head->iosstats);
+        UNLOCK(&list_head->lock);
     }
 
     UNLOCK(&conf->lock);


### PR DESCRIPTION
The process is getting crashed during call ios_bump_stats in cbk code path. After checked the code it seems the process is getting crashed because the ios_stat_head list is destroyed by the function ios_destroy_top_stats without taking a list mutex while receive a clear profile event from the client. If at the same time a process is trying to access the list it can be crash.

Solution: Destroy the ios_stat under the list mutex.
> Change-Id: I1b4d56517fa405eb84da7fffca61e15530652204
> Fixes: #3901
> Signed-off-by: Mohit Agrawal moagrawa@redhat.com
> (Cherry picked from commit 3e874d0b50f474f90861b58d391b17a0a7c6e343)
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/3902)

Change-Id: I1b4d56517fa405eb84da7fffca61e15530652204
Fixes: #3901
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

