### PR TITLE
libglusterfs/common_utils: Fix handling of IPV6 IP addrs without port number

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3063,6 +3063,12 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
     }
 
     char *lastptr = rindex(duphost, ':');
+
+    /* Handle IPV6 IP addr without port number */
+    if (lastptr && *(lastptr-1) == ':') {
+        lastptr = NULL;
+    }
+
     if (lastptr) {
         *lastptr = '\0';
         long port_argument = strtol(lastptr + 1, NULL, 0);

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3065,7 +3065,7 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
     char *lastptr = rindex(duphost, ':');
 
     /* Handle IPV6 IP addr without port number */
-    if (lastptr && *(lastptr-1) == ':') {
+    if (lastptr && strlen(lastptr) > 1 && *(lastptr - 1) == ':') {
         lastptr = NULL;
     }
 


### PR DESCRIPTION
This PR fixes the issue of improper parsing of IPV6 IP address hostname given without port number.

Fixes: #3918
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>

