### PR TITLE
mem-pool: fix memory corruption in debug builds

### DIFF
--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -335,7 +335,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define VALIDATE_OR_GOTO(arg, label)                                           \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = EINVAL;                                                    \
             gf_msg_callingfn((this ? (this->name) : "(Govinda! Govinda!)"),    \
                              GF_LOG_WARNING, EINVAL, LG_MSG_INVALID_ARG,       \
@@ -346,7 +346,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_VALIDATE_OR_GOTO(name, arg, label)                                  \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = EINVAL;                                                    \
             gf_msg_callingfn(name, GF_LOG_ERROR, errno, LG_MSG_INVALID_ARG,    \
                              "invalid argument: " #arg);                       \
@@ -356,7 +356,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_VALIDATE_OR_GOTO_WITH_ERROR(name, arg, label, errno, error)         \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             errno = error;                                                     \
             gf_msg_callingfn(name, GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG,   \
                              "invalid argument: " #arg);                       \
@@ -366,7 +366,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_CHECK_ALLOC(arg, retval, label)                                     \
     do {                                                                       \
-        if (!(arg)) {                                                          \
+        if (caa_unlikely(!(arg))) {                                            \
             retval = -ENOMEM;                                                  \
             goto label;                                                        \
         }                                                                      \
@@ -383,7 +383,7 @@ BIT_VALUE(unsigned char *array, unsigned int index)
 
 #define GF_ASSERT_AND_GOTO_WITH_ERROR(name, arg, label, errno, error)          \
     do {                                                                       \
-        if (!arg) {                                                            \
+        if (caa_unlikely(!arg)) {                                              \
             GF_ASSERT(0);                                                      \
             errno = error;                                                     \
             goto label;                                                        \
@@ -1104,7 +1104,7 @@ __gf_thread_set_name(pthread_t thread, const char *name)
 #elif defined(HAVE_PTHREAD_SET_NAME_NP)
     pthread_set_name_np(thread, name);
     return 0;
-#else /* none found */
+#else  /* none found */
     return -ENOSYS;
 #endif /* set name */
 }

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -16,6 +16,7 @@
 #include "glusterfs/logging.h"
 #include "glusterfs/mem-types.h"
 #include "glusterfs/glusterfs.h" /* for glusterfs_ctx_t */
+#include <urcu/compiler.h>       /* for caa_likely/unlikely() */
 #include <stdlib.h>
 #include <inttypes.h>
 #include <string.h>
@@ -109,7 +110,7 @@ __gf_default_malloc(size_t size)
     void *ptr = NULL;
 
     ptr = malloc(size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, size);
 
     return ptr;
@@ -121,7 +122,7 @@ __gf_default_calloc(int cnt, size_t size)
     void *ptr = NULL;
 
     ptr = calloc(cnt, size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, (cnt * size));
 
     return ptr;
@@ -133,7 +134,7 @@ __gf_default_realloc(void *oldptr, size_t size)
     void *ptr = NULL;
 
     ptr = realloc(oldptr, size);
-    if (!ptr)
+    if (caa_unlikely(!ptr))
         gf_msg_nomem("", GF_LOG_ALERT, size);
 
     return ptr;
@@ -181,17 +182,15 @@ gf_strndup(const char *src, size_t len)
 {
     char *dup_str = NULL;
 
-    if (!src) {
+    if (caa_unlikely(!src)) {
         goto out;
     }
 
     dup_str = GF_MALLOC(len + 1, gf_common_mt_strdup);
-    if (!dup_str) {
-        goto out;
+    if (caa_likely(dup_str)) {
+        memcpy(dup_str, src, len);
+        dup_str[len] = '\0';
     }
-
-    memcpy(dup_str, src, len);
-    dup_str[len] = '\0';
 out:
     return dup_str;
 }
@@ -199,7 +198,7 @@ out:
 static inline char *
 gf_strdup(const char *src)
 {
-    if (!src)
+    if (caa_unlikely(!src))
         return NULL;
 
     return gf_strndup(src, strlen(src));
@@ -211,12 +210,9 @@ gf_memdup(const void *src, size_t size)
     void *dup_mem = NULL;
 
     dup_mem = GF_MALLOC(size, gf_common_mt_memdup);
-    if (!dup_mem)
-        goto out;
+    if (caa_likely(dup_mem))
+        memcpy(dup_mem, src, size);
 
-    memcpy(dup_mem, src, size);
-
-out:
     return dup_mem;
 }
 

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -43,15 +43,15 @@ typedef uint32_t gf_mem_magic_t;
 #define NPOOLS (POOL_LARGEST - POOL_SMALLEST + 1)
 
 struct mem_acct_rec {
-    const char *typestr;
     gf_atomic_t num_allocs;
+    const char *typestr;
 #ifdef DEBUG
+    gf_lock_t lock;
     uint64_t size;
     uint64_t max_size;
     uint32_t max_num_allocs;
-    gf_lock_t lock;
     struct list_head obj_list;
-#endif
+#endif /* DEBUG */
 };
 
 struct mem_acct {

--- a/libglusterfs/src/glusterfs/mem-pool.h
+++ b/libglusterfs/src/glusterfs/mem-pool.h
@@ -77,8 +77,8 @@ struct mem_header {
 #ifdef DEBUG
 struct mem_invalid {
     gf_mem_magic_t magic;
-    void *mem_acct;
     uint32_t type;
+    void *mem_acct;
     size_t size;
     void *baseaddr;
 };

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -1033,7 +1033,7 @@ loc_is_nameless(loc_t *loc);
 int
 xlator_mem_acct_init(xlator_t *xl, int num_types);
 void
-xlator_mem_acct_unref(struct mem_acct *mem_acct);
+xlator_mem_acct_destroy(struct mem_acct *mem_acct);
 int
 is_gf_log_command(xlator_t *trans, const char *name, char *value, size_t size);
 int

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1115,7 +1115,7 @@ xlator_foreach
 xlator_foreach_depth_first
 xlator_init
 xlator_mem_acct_init
-xlator_mem_acct_unref
+xlator_mem_acct_destroy
 xlator_notify
 xlator_option_info_list
 xlator_option_init_bool

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -176,7 +176,7 @@ __gf_calloc(size_t nmemb, size_t size, uint32_t type, const char *typestr)
 
     ptr = calloc(1, tot_size);
 
-    if (!ptr) {
+    if (caa_unlikely(!ptr)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -199,7 +199,7 @@ __gf_malloc(size_t size, uint32_t type, const char *typestr)
     tot_size = __gf_total_alloc_size(size);
 
     ptr = malloc(tot_size);
-    if (!ptr) {
+    if (caa_unlikely(!ptr)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -223,7 +223,7 @@ __gf_realloc(void *ptr, size_t size)
 
     tot_size = __gf_total_alloc_size(size);
     header = realloc(header, tot_size);
-    if (!header) {
+    if (caa_unlikely(!header)) {
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
@@ -335,7 +335,7 @@ __gf_free(void *free_ptr)
     struct mem_header *header = NULL;
     uint64_t num_allocs = 0;
 
-    if (!free_ptr)
+    if (caa_unlikely(!free_ptr))
         return;
 
     if (!gf_mem_acct_enabled()) {

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -273,16 +273,16 @@ gf_asprintf(char **string_ptr, const char *format, ...)
 }
 
 #ifdef DEBUG
-void
+static void
 __gf_mem_invalidate(void *ptr)
 {
     struct mem_header *header = ptr;
-    void *end = NULL;
+    void *end, *old_ptr = NULL;
 
     struct mem_invalid inval = {
         .magic = GF_MEM_INVALID_MAGIC,
-        .mem_acct = header->mem_acct,
         .type = header->type,
+        .mem_acct = header->mem_acct,
         .size = header->size,
         .baseaddr = ptr + GF_MEM_HEADER_SIZE,
     };
@@ -290,19 +290,9 @@ __gf_mem_invalidate(void *ptr)
     /* calculate the last byte of the allocated area */
     end = ptr + __gf_total_alloc_size(inval.size);
 
-    /* overwrite the old mem_header */
-    memcpy(ptr, &inval, sizeof(inval));
-    ptr += sizeof(inval);
+    old_ptr = ptr;
 
-    /* zero out remaining (old) mem_header bytes) */
-    memset(ptr, 0x00, sizeof(*header) - sizeof(inval));
-    ptr += sizeof(*header) - sizeof(inval);
-
-    /* zero out the first byte of data */
-    *(uint32_t *)(ptr) = 0x00;
-    ptr += 1;
-
-    /* repeated writes of invalid structurein data area */
+    /* repeated writes of invalid structure in data area */
     while ((ptr + (sizeof(inval))) < (end - 1)) {
         memcpy(ptr, &inval, sizeof(inval));
         ptr += sizeof(inval);
@@ -310,6 +300,11 @@ __gf_mem_invalidate(void *ptr)
 
     /* fill out remaining data area with 0xff */
     memset(ptr, 0xff, end - ptr);
+
+    /* zero out remaining (old) mem_header bytes) */
+    /* and the first byte of data */
+    memset(old_ptr + sizeof(inval), 0x00, (sizeof(struct mem_header) - sizeof(inval)) + 1);
+
 }
 #endif /* DEBUG */
 
@@ -348,10 +343,10 @@ __gf_free(void *free_ptr)
     ptr = free_ptr - GF_MEM_HEADER_SIZE;
     header = (struct mem_header *)ptr;
 
+    mem_acct = header->mem_acct;
     // Possible corruption, assert here
     GF_ASSERT(GF_MEM_HEADER_MAGIC == header->magic);
 
-    mem_acct = header->mem_acct;
     if (!mem_acct) {
         goto free;
     }

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -121,6 +121,7 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
     return gf_mem_header_prepare(header, size);
 }
 
+#ifdef DEBUG
 static void *
 gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
                         size_t size)
@@ -129,7 +130,6 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 
     if (mem_acct != NULL) {
         rec = &mem_acct->rec[header->type];
-#ifdef DEBUG
         LOCK(&rec->lock);
         {
             rec->size += size - header->size;
@@ -143,11 +143,11 @@ gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
             list_move(&header->acct_list, &rec->obj_list);
         }
         UNLOCK(&rec->lock);
-#endif
     }
 
     return gf_mem_header_prepare(header, size);
 }
+#endif /* DEBUG */
 
 static bool
 gf_mem_acct_enabled(void)
@@ -228,7 +228,11 @@ __gf_realloc(void *ptr, size_t size)
         return NULL;
     }
 
+#ifdef DEBUG
     return gf_mem_update_acct_info(header->mem_acct, header, size);
+#else
+    return gf_mem_header_prepare(header, size);
+#endif
 }
 
 int
@@ -303,8 +307,8 @@ __gf_mem_invalidate(void *ptr)
 
     /* zero out remaining (old) mem_header bytes) */
     /* and the first byte of data */
-    memset(old_ptr + sizeof(inval), 0x00, (sizeof(struct mem_header) - sizeof(inval)) + 1);
-
+    memset(old_ptr + sizeof(inval), 0x00,
+           (sizeof(struct mem_header) - sizeof(inval)) + 1);
 }
 #endif /* DEBUG */
 
@@ -366,8 +370,8 @@ __gf_free(void *free_ptr)
     }
     UNLOCK(&mem_acct->rec[header->type].lock);
 #endif
-    if (!num_allocs) {
-        xlator_mem_acct_unref(mem_acct);
+    if (!num_allocs && (GF_ATOMIC_DEC(mem_acct->refcnt) == 0)) {
+        xlator_mem_acct_destroy(mem_acct);
     }
 
 free:

--- a/libglusterfs/src/mem-pool.c
+++ b/libglusterfs/src/mem-pool.c
@@ -122,30 +122,40 @@ gf_mem_set_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
 }
 
 #ifdef DEBUG
-static void *
-gf_mem_update_acct_info(struct mem_acct *mem_acct, struct mem_header *header,
+static struct mem_acct_rec *
+gf_mem_remove_acct_info(struct mem_acct *mem_acct, struct mem_header *header)
+{
+    struct mem_acct_rec *rec;
+
+    if (mem_acct == NULL) {
+        return NULL;
+    }
+
+    GF_ASSERT(header->type <= mem_acct->num_types);
+
+    rec = &mem_acct->rec[header->type];
+    LOCK(&rec->lock);
+    {
+        list_del_init(&header->acct_list);
+    }
+    UNLOCK(&rec->lock);
+
+    return rec;
+}
+
+static void
+gf_mem_update_acct_info(struct mem_acct_rec *rec, struct mem_header *header,
                         size_t size)
 {
-    struct mem_acct_rec *rec = NULL;
-
-    if (mem_acct != NULL) {
-        rec = &mem_acct->rec[header->type];
+    if (rec != NULL) {
         LOCK(&rec->lock);
         {
             rec->size += size - header->size;
             rec->max_size = max(rec->max_size, rec->size);
-            /* The old 'header' already was present in 'obj_list', but
-             * realloc() could have changed its address. We need to remove
-             * the old item from the list and add the new one. This can be
-             * done this way because list_move() doesn't use the pointers
-             * to the old location (which are not valid anymore) already
-             * present in the list, it simply overwrites them. */
-            list_move(&header->acct_list, &rec->obj_list);
+            list_add(&header->acct_list, &rec->obj_list);
         }
         UNLOCK(&rec->lock);
     }
-
-    return gf_mem_header_prepare(header, size);
 }
 #endif /* DEBUG */
 
@@ -211,7 +221,7 @@ void *
 __gf_realloc(void *ptr, size_t size)
 {
     size_t tot_size = 0;
-    struct mem_header *header = NULL;
+    struct mem_header *tmp, *header = NULL;
 
     if (!gf_mem_acct_enabled())
         return REALLOC(ptr, size);
@@ -222,17 +232,25 @@ __gf_realloc(void *ptr, size_t size)
     GF_ASSERT(header->magic == GF_MEM_HEADER_MAGIC);
 
     tot_size = __gf_total_alloc_size(size);
-    header = realloc(header, tot_size);
-    if (caa_unlikely(!header)) {
+#ifdef DEBUG
+    struct mem_acct_rec *rec;
+
+    rec = gf_mem_remove_acct_info(header->mem_acct, header);
+#endif
+    tmp = realloc(header, tot_size);
+    if (caa_unlikely(!tmp)) {
+#ifdef DEBUG
+        gf_mem_update_acct_info(rec, header, header->size);
+#endif
         gf_msg_nomem("", GF_LOG_ALERT, tot_size);
         return NULL;
     }
 
 #ifdef DEBUG
-    return gf_mem_update_acct_info(header->mem_acct, header, size);
-#else
-    return gf_mem_header_prepare(header, size);
+    gf_mem_update_acct_info(rec, tmp, size);
 #endif
+
+    return gf_mem_header_prepare(tmp, size);
 }
 
 int

--- a/tests/basic/fop-sampling.t
+++ b/tests/basic/fop-sampling.t
@@ -39,7 +39,7 @@ cleanup;
 TEST glusterd
 TEST pidof glusterd
 TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2}
-TEST $CLI volume set $V0 nfs.disable off
+$CLI volume set $V0 nfs.disable off
 TEST $CLI volume set $V0 diagnostics.latency-measurement on
 TEST $CLI volume set $V0 diagnostics.count-fop-hits on
 TEST $CLI volume set $V0 diagnostics.stats-dump-interval 2


### PR DESCRIPTION
This is a backport of #3917, including 3 other small patches to avoid merge conflicts.