### PR TITLE
md-cache: Improve readdir(p) performance for fuse

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1498,7 +1498,13 @@ fuse_getattr(xlator_t *this, fuse_in_header_t *finh, void *msg,
             return;
         }
 
-        fuse_gfid_set(state);
+        /* Call fuse_gfid_set for / while it has received an error
+           from POSIX layer, In case of a big directory while an
+           application is calling readdirp call this generates an
+           unnecessary lookup fop traffic for root and the performance
+           is reduced significantly.
+        */
+        /* fuse_gfid_set(state); */
 
         FUSE_FOP(state, fuse_root_lookup_cbk, GF_FOP_LOOKUP, lookup,
                  &state->loc, state->xdata);


### PR DESCRIPTION
The fuse has passed readdir(p) buffer size 4K while fetching entries from a server. In the case of a big directory (having more than 1M entries), it takes time to fetch all the entries. In case if 4k buffer we can fetch maximum 18 to 20 entries even gluster RPC supports to fetch 128K buffer from the server. The gluster already provides a readdir-ahead xlator that fetches the entries in the background and keep the entries in the local cache and server them as fuse wind a readdirp call. The issue with readdir-ahead is it does not handle cache invalidation so data may be inconsistent. The other issue readdir-ahead only uses readdirp call so in case if a user has disabled readdirp it won't work and the user would not be able to use it.

Solution: 
1) To avoid it implement an entry cache logic at md-cache
     xlator. The md-cache has already provided cache invalidation logic
     so there is no consistency issue. The entries are fetched during
     readdir(p) call the only difference is the md-cache has changed
     the buffer size to 128k and saved the entries in the local buffer.
     After receiving the next wind operation the md-cache returns the
     entries to the fuse. The local buffer is valid only between opendir
     and close dir. As the application call closedir the buffer is cleaned up.
2) Avoid fuse_gfid_set for / in fuse_getattr, the fuse will set the
     gfid only in case of error. This key is to use by POSIX to validate
     gfid link and in case if a link does not exists it has created a link.
     The link validation is not required if inode->gfid is not NULL and
     for (/) It would be present so it has generated unnecessary
     lookup traffic while running " ls -l " on big directories because
     md-cache is not able to serve this key(gfid-req).

Fixes: #3927
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Note: To test the patch I have setup 1 brick on a physical server and
      has created 1.2M files(10kb) in a single directory.
      Below are the results

   1) With patch Default (while readdirp is enabled)
         time ls -l /mnt/test/ | wc -l
         1228254
           real	3m21.151s
           user	0m9.207s
           sys	0m25.539s
   2) Disable readdirp
         time ls /mnt/test/ | wc -l
         1228253
           real	0m13.337s
           user	0m3.239s
          sys	0m1.071s
  3) Without patch Default(when readdirp is enabled)
         time ls -l /mnt/test/ | wc -l
         1228251
           real	5m49.055s
           user	0m9.756s
           sys	0m28.599s
  4) Disable readdirp
         time ls /mnt/test/ | wc -l
         1228253
           real	1m49.754s
           user	0m3.904s
           sys	0m3.462s

Change-Id: I4f6efb63b4ef2bdb1ea2e86f1d597b28dd236907

