### PR TITLE
api: set volume id from graph if available

### DIFF
--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -66,6 +66,9 @@ glfs_process_volfp(struct glfs *fs, FILE *fp)
         goto out;
     }
 
+    /* set vol_uuid here */
+    gf_uuid_parse(graph->volume_id, fs->vol_uuid);
+
     gf_log_dump_graph(fp, graph);
 
     ret = 0;


### PR DESCRIPTION
`graph->vol-id` would contain volume-id if it is passed as an option in io-stats xlator. This method can allow one to avoid checking for volume-id on client side by querying the server with a glusterd. (note: glfsapi has hardcoded glusterd query for getting vol-id)

This one line removes that hard need of having glusterd for working of fetching vol-id.

Updates: #1000
Signed-off-by: Amar Tumballi <amar@dhiway.com>

