### PR TITLE
cli: Optimize the bug that quota list command output was blank.

### DIFF
--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -147,6 +147,10 @@ struct cli_local {
 
     dict_t *dict;
     const char **words;
+
+    /* Indicates the count of gfids */
+    /* with wrong path during quota limit list acquisition*/
+    int32_t err_count;
     /* Marker for volume status all */
     gf_boolean_t all;
 #if (HAVE_LIB_XML)


### PR DESCRIPTION
Problem: 
When the last quota-limited path is deleted directly
before the quota limit is cleared,
the output of the quota list command appears blank.

Solution:
 When executing the quota list command,
the client receives the wrong rpc status when the last path path does not exist,
and skips the last path at this time,
so that other path quota restriction information can not be printed.

Fixes: bz#2157037

