### PR TITLE
cli:optimize quota list command display as blank

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -3402,6 +3402,7 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
     cli_local_t *local = NULL;
     int32_t list_count = 0;
+    int32_t err_count = 0;
     pthread_t th_id = {
         0,
     };
@@ -3432,11 +3433,35 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
+    ret = dict_get_int32(local->dict, "max_count", &max_count);
+    if (ret < 0) {
+        gf_log("cli", GF_LOG_ERROR, "failed to get max_count");
+        goto out;
+    }
+
     if (-1 == req->rpc_status) {
         if (list_count == 0)
             cli_err(
                 "Connection failed. Please check if quota "
                 "daemon is operational.");
+
+        LOCK(&local->lock);
+            {
+                err_count = local->err_count;
+                err_count++;
+                local->err_count = err_count;
+            }
+        UNLOCK(&local->lock);
+
+	    if (list_count == max_count){
+             gf_log("cli", GF_LOG_WARNING,
+                "Warning :%d gfids failed to get quota limits or "
+                "they path may have been deleted,"
+                "So their quota limit information are not available!",err_count);
+             ret = -1;
+             goto last_quota_list;
+	        }
+
         ret = -1;
         goto out;
     }
@@ -3476,12 +3501,29 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
 
+<<<<<<< HEAD
     ret = dict_get_int32_sizen(local->dict, "max_count", &max_count);
     if (ret < 0) {
         gf_log("cli", GF_LOG_ERROR, "failed to get max_count");
         goto out;
+=======
+    if (local->err_count != 0){
+        err_count =  local->err_count;
+    }else{
+        err_count =  0;
+>>>>>>> c12fcab959 (cli:optimize quota list command display as blank)
     }
+    if (err_count != 0 && list_count == max_count)
+	    gf_log("cli", GF_LOG_WARNING,
+            "Warning :%d gfids Failed to get quota limits or "
+            "they path may have been deleted,"
+            "So their quota limit information are not available!",err_count);
 
+last_quota_list:
+    /* When the last quota-limited path is not found due to deletion,
+     * this path is skipped directly,
+     * thus not affecting the output of all path quota-limited lists already found.
+     */
     if (list_count == max_count) {
         list_for_each_entry_safe(node, tmpnode, &local->dict_list, list)
         {

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -160,6 +160,10 @@ struct cli_local {
 
     dict_t *dict;
     const char **words;
+
+    /* Indicates the count of gfids */
+    /* with wrong path during quota limit list acquisition*/
+    int32_t err_count;
     /* Marker for volume status all */
     gf_boolean_t all;
 #if (HAVE_LIB_XML)

--- a/doc/release-notes/6.0.md
+++ b/doc/release-notes/6.0.md
@@ -118,6 +118,19 @@ process
 This enables better performance as the data is served from the kernel page cache
 where possible.
 
+#### 6. Changes to gluster based SMB share management
+
+Previously all GlusterFS volumes were being exported by default via smb.conf in
+a Samba-CTDB setup. This includes creating a share section for CTDB lock volume
+too which is not recommended. Along with few syntactical errors these scripts
+failed to execute in a non-Samba setup in the absence of necessary configuration
+and binary files.
+
+Hereafter newly created GlusterFS volumes are not exported as SMB share via
+Samba unless either of 'user.cifs' or 'user.smb' volume set options are enabled
+on the volume. The existing GlusterFS volume share sections in smb.conf will
+remain unchanged.
+
 ### Developer
 
 #### 1. Gluster code can be compiled and executed using [TSAN](https://clang.llvm.org/docs/ThreadSanitizer.html)

--- a/doc/release-notes/6.0.md
+++ b/doc/release-notes/6.0.md
@@ -202,4 +202,232 @@ older API SDK will continue to work as before.
 ## Bugs addressed
 
 Bugs addressed since release-5 are listed below.
-<TODO>
+- [#1138841](https://bugzilla.redhat.com/1138841): allow the use of the CIDR format with auth.allow
+- [#1236272](https://bugzilla.redhat.com/1236272): socket: Use newer system calls that provide better interface/performance on Linux/*BSD when available
+- [#1243991](https://bugzilla.redhat.com/1243991): "gluster volume set <VOLNAME> group <GROUP>" is not in the help text
+- [#1285126](https://bugzilla.redhat.com/1285126): RFE: GlusterFS NFS does not implement an all_squash volume setting
+- [#1343926](https://bugzilla.redhat.com/1343926): port-map: let brick choose its own port
+- [#1364707](https://bugzilla.redhat.com/1364707): Remove deprecated stripe xlator
+- [#1427397](https://bugzilla.redhat.com/1427397): script to strace processes consuming high CPU
+- [#1467614](https://bugzilla.redhat.com/1467614): Gluster read/write performance improvements on NVMe backend
+- [#1486532](https://bugzilla.redhat.com/1486532): need a script to resolve backtraces
+- [#1511339](https://bugzilla.redhat.com/1511339): In Replica volume 2*2 when quorum is set, after glusterd restart nfs server is coming up instead of self-heal daemon
+- [#1535495](https://bugzilla.redhat.com/1535495): Add option -h and --help to gluster cli
+- [#1535528](https://bugzilla.redhat.com/1535528): Gluster cli show no help message in prompt
+- [#1560561](https://bugzilla.redhat.com/1560561): systemd service file enhancements
+- [#1560969](https://bugzilla.redhat.com/1560969): Garbage collect inactive inodes in fuse-bridge
+- [#1564149](https://bugzilla.redhat.com/1564149): Agree upon a coding standard, and automate check for this in smoke
+- [#1564890](https://bugzilla.redhat.com/1564890): mount.glusterfs: can't shift that many
+- [#1575836](https://bugzilla.redhat.com/1575836): logic in S30samba-start.sh hook script needs tweaking
+- [#1579788](https://bugzilla.redhat.com/1579788): Thin-arbiter: Have the state of volume in memory
+- [#1582516](https://bugzilla.redhat.com/1582516): libgfapi: glfs init fails on afr volume with ctime feature enabled
+- [#1590385](https://bugzilla.redhat.com/1590385): Refactor dht lookup code
+- [#1593538](https://bugzilla.redhat.com/1593538): ctime: Access time is different with in same replica/EC volume
+- [#1596787](https://bugzilla.redhat.com/1596787): glusterfs rpc-clnt.c: error returned while attempting to connect to host: (null), port 0
+- [#1598345](https://bugzilla.redhat.com/1598345): gluster get-state command is crashing glusterd process when geo-replication is configured
+- [#1600145](https://bugzilla.redhat.com/1600145): [geo-rep]: Worker still ACTIVE after killing bricks
+- [#1605056](https://bugzilla.redhat.com/1605056): [RHHi] Mount hung and not accessible
+- [#1605077](https://bugzilla.redhat.com/1605077): If a node disconnects during volume delete, it assumes deleted volume as a freshly created volume when it is back online
+- [#1608512](https://bugzilla.redhat.com/1608512): cluster.server-quorum-type help text is missing possible settings
+- [#1624006](https://bugzilla.redhat.com/1624006): /var/run/gluster/metrics/ wasn't created automatically
+- [#1624332](https://bugzilla.redhat.com/1624332): [Thin-arbiter]: Add tests for thin arbiter feature
+- [#1624724](https://bugzilla.redhat.com/1624724): ctime: Enable ctime feature by default and also improve usability by providing single option to enable
+- [#1624796](https://bugzilla.redhat.com/1624796): mkdir -p fails with "No data available" when root-squash is enabled
+- [#1625850](https://bugzilla.redhat.com/1625850): tests: fixes to bug-1015990-rep.t
+- [#1625961](https://bugzilla.redhat.com/1625961): Writes taking very long time leading to system hogging
+- [#1626313](https://bugzilla.redhat.com/1626313): fix glfs_fini related problems
+- [#1626610](https://bugzilla.redhat.com/1626610): [USS]: Change gf_log to gf_msg
+- [#1626994](https://bugzilla.redhat.com/1626994): split-brain observed on parent dir
+- [#1627610](https://bugzilla.redhat.com/1627610): glusterd crash in regression build
+- [#1627620](https://bugzilla.redhat.com/1627620): SAS job aborts complaining about file doesn't exist
+- [#1628194](https://bugzilla.redhat.com/1628194): tests/dht: Additional tests for dht operations
+- [#1628605](https://bugzilla.redhat.com/1628605): One client hangs when another client loses communication with bricks during intensive write I/O
+- [#1628664](https://bugzilla.redhat.com/1628664): Update op-version from 4.2 to 5.0
+- [#1629561](https://bugzilla.redhat.com/1629561): geo-rep: geo-rep config set fails to set rsync-options
+- [#1630368](https://bugzilla.redhat.com/1630368): Low Random write IOPS in VM workloads
+- [#1630798](https://bugzilla.redhat.com/1630798): Add performance options to  virt profile
+- [#1630804](https://bugzilla.redhat.com/1630804): libgfapi-python: test_listdir_with_stat and test_scandir failure on release 5 branch
+- [#1630922](https://bugzilla.redhat.com/1630922): glusterd crashed and core generated at gd_mgmt_v3_unlock_timer_cbk after huge number of volumes were created
+- [#1631128](https://bugzilla.redhat.com/1631128): rpc marks brick disconnected from glusterd & volume stop transaction gets timed out
+- [#1631357](https://bugzilla.redhat.com/1631357): glusterfsd keeping fd open in index xlator after stop the volume
+- [#1631886](https://bugzilla.redhat.com/1631886): Update database profile settings for gluster
+- [#1632161](https://bugzilla.redhat.com/1632161): [Disperse] : Set others.eager-lock on for ec-1468261.t test to pass
+- [#1632236](https://bugzilla.redhat.com/1632236): Provide indication at the console or in the logs about the progress being made with changelog processing.
+- [#1632503](https://bugzilla.redhat.com/1632503): FUSE client segfaults when performance.md-cache-statfs is enabled for a volume
+- [#1632717](https://bugzilla.redhat.com/1632717): EC crashes when running on non 64-bit architectures
+- [#1632889](https://bugzilla.redhat.com/1632889): 'df' shows half as much space on volume after upgrade to RHGS 3.4
+- [#1633926](https://bugzilla.redhat.com/1633926): Script to collect system-stats
+- [#1634102](https://bugzilla.redhat.com/1634102): MAINTAINERS: Add sunny kumar as a peer for snapshot component
+- [#1634220](https://bugzilla.redhat.com/1634220): md-cache: some problems of cache virtual glusterfs ACLs for ganesha
+- [#1635050](https://bugzilla.redhat.com/1635050): [SNAPSHOT]: with brick multiplexing, snapshot restore will make glusterd send wrong volfile
+- [#1635145](https://bugzilla.redhat.com/1635145): I/O errors observed on the application side after the creation of a 'linkto' file
+- [#1635480](https://bugzilla.redhat.com/1635480): Correction for glusterd memory leak because use "gluster volume status volume_name --detail" continuesly (cli)
+- [#1635593](https://bugzilla.redhat.com/1635593): glusterd crashed in cleanup_and_exit when glusterd comes up with upgrade mode.
+- [#1635688](https://bugzilla.redhat.com/1635688): Keep only the valid (maintained/supported) components in the build
+- [#1635820](https://bugzilla.redhat.com/1635820): Seeing defunt translator and discrepancy  in volume info when issued from node which doesn't host bricks in that volume
+- [#1635863](https://bugzilla.redhat.com/1635863): Gluster peer probe doesn't work for IPv6
+- [#1636570](https://bugzilla.redhat.com/1636570): Cores due to SIGILL during multiplex regression tests
+- [#1636631](https://bugzilla.redhat.com/1636631): Issuing a "heal ... full" on a disperse volume causes permanent high CPU utilization.
+- [#1637196](https://bugzilla.redhat.com/1637196): Disperse volume 'df' usage is extremely incorrect after replace-brick.
+- [#1637249](https://bugzilla.redhat.com/1637249): gfid heal does not happen when there is no source brick
+- [#1637802](https://bugzilla.redhat.com/1637802): data-self-heal in arbiter volume results in stale locks.
+- [#1637934](https://bugzilla.redhat.com/1637934): glusterfsd is keeping fd open in index xlator
+- [#1638453](https://bugzilla.redhat.com/1638453): Gfid mismatch seen on shards when lookup and mknod are in progress at the same time
+- [#1639599](https://bugzilla.redhat.com/1639599): Improve support-ability of glusterfs
+- [#1640026](https://bugzilla.redhat.com/1640026): improper checking to avoid identical mounts
+- [#1640066](https://bugzilla.redhat.com/1640066): [Stress] : Mismatching iatt in glustershd logs during MTSH and continous IO from Ganesha mounts
+- [#1640165](https://bugzilla.redhat.com/1640165): io-stats: garbage characters in the filenames generated
+- [#1640489](https://bugzilla.redhat.com/1640489): Invalid memory read after freed in dht_rmdir_readdirp_cbk
+- [#1640495](https://bugzilla.redhat.com/1640495): [GSS] Fix log level issue with brick mux
+- [#1640581](https://bugzilla.redhat.com/1640581): [AFR] : Start crawling indices and healing only if both data bricks are UP in replica 2 (thin-arbiter)
+- [#1641344](https://bugzilla.redhat.com/1641344): Spurious failures in bug-1637802-arbiter-stale-data-heal-lock.t
+- [#1642448](https://bugzilla.redhat.com/1642448): EC volume getting created without any redundant brick
+- [#1642597](https://bugzilla.redhat.com/1642597): tests/bugs/glusterd/optimized-basic-testcases-in-cluster.t failing
+- [#1642800](https://bugzilla.redhat.com/1642800): socket: log voluntary socket close/shutdown and EOF on socket at INFO log-level
+- [#1642807](https://bugzilla.redhat.com/1642807): remove 'tier' translator from build and code
+- [#1642810](https://bugzilla.redhat.com/1642810): remove glupy from code and build
+- [#1642850](https://bugzilla.redhat.com/1642850): glusterd: raise default transport.listen-backlog to 1024
+- [#1642865](https://bugzilla.redhat.com/1642865): geo-rep: geo-replication gets stuck after file rename and gfid conflict
+- [#1643349](https://bugzilla.redhat.com/1643349): [OpenSSL] : auth.ssl-allow has no option description.
+- [#1643402](https://bugzilla.redhat.com/1643402): [Geo-Replication] Geo-rep faulty sesion  because of the directories are not synced to slave.
+- [#1643519](https://bugzilla.redhat.com/1643519): Provide an option to silence glfsheal logs
+- [#1643929](https://bugzilla.redhat.com/1643929): geo-rep: gluster-mountbroker status crashes
+- [#1643932](https://bugzilla.redhat.com/1643932): geo-rep: On gluster command failure on slave, worker crashes with python3
+- [#1643935](https://bugzilla.redhat.com/1643935): cliutils: geo-rep cliutils' usage of Popen is not python3 compatible
+- [#1644129](https://bugzilla.redhat.com/1644129): Excessive logging in posix_update_utime_in_mdata
+- [#1644164](https://bugzilla.redhat.com/1644164): Use GF_ATOMIC ops to update inode->nlookup
+- [#1644629](https://bugzilla.redhat.com/1644629): [rpcsvc] Single request Queue for all event threads is a performance bottleneck
+- [#1644755](https://bugzilla.redhat.com/1644755): CVE-2018-14651 glusterfs: glusterfs server exploitable via symlinks to relative paths [fedora-all]
+- [#1644756](https://bugzilla.redhat.com/1644756): CVE-2018-14653 glusterfs: Heap-based buffer overflow via "gf_getspec_req" RPC message [fedora-all]
+- [#1644757](https://bugzilla.redhat.com/1644757): CVE-2018-14659 glusterfs: Unlimited file creation via "GF_XATTR_IOSTATS_DUMP_KEY" xattr allows for denial of service [fedora-all]
+- [#1644758](https://bugzilla.redhat.com/1644758): CVE-2018-14660 glusterfs: Repeat use of "GF_META_LOCK_KEY" xattr allows for memory exhaustion [fedora-all]
+- [#1644760](https://bugzilla.redhat.com/1644760): CVE-2018-14654 glusterfs: "features/index" translator can create arbitrary, empty files [fedora-all]
+- [#1644763](https://bugzilla.redhat.com/1644763): CVE-2018-14661 glusterfs: features/locks translator passes an user-controlled string to snprintf without a proper format string resulting in a denial of service [fedora-all]
+- [#1645986](https://bugzilla.redhat.com/1645986): tests/bugs/glusterd/optimized-basic-testcases-in-cluster.t failing in distributed regression
+- [#1646104](https://bugzilla.redhat.com/1646104): [Geo-rep]: Faulty geo-rep sessions due to link ownership on slave volume
+- [#1646728](https://bugzilla.redhat.com/1646728): [snapview-server]:forget  glfs handles during inode forget
+- [#1646869](https://bugzilla.redhat.com/1646869): gNFS crashed when processing "gluster v status [vol] nfs clients"
+- [#1646892](https://bugzilla.redhat.com/1646892): Portmap entries showing stale brick entries when bricks are down
+- [#1647029](https://bugzilla.redhat.com/1647029): can't enable shared-storage
+- [#1647074](https://bugzilla.redhat.com/1647074): when peer detach is issued, throw a warning to remount volumes using other cluster IPs before proceeding
+- [#1647651](https://bugzilla.redhat.com/1647651): gfapi: fix bad dict setting of lease-id
+- [#1648237](https://bugzilla.redhat.com/1648237): Bumping up of op-version times out on a scaled system with ~1200 volumes
+- [#1648298](https://bugzilla.redhat.com/1648298): dht_revalidate may not heal attrs on the brick root
+- [#1648687](https://bugzilla.redhat.com/1648687): Incorrect usage of local->fd in  afr_open_ftruncate_cbk
+- [#1648768](https://bugzilla.redhat.com/1648768): Tracker bug for all leases related issues
+- [#1649709](https://bugzilla.redhat.com/1649709): profile info doesn't work when decompounder xlator is not in graph
+- [#1650115](https://bugzilla.redhat.com/1650115): glusterd requests are timing out in a brick multiplex setup
+- [#1650389](https://bugzilla.redhat.com/1650389): rpc: log flooding with ENODATA errors
+- [#1650403](https://bugzilla.redhat.com/1650403): Memory leaks observed in brick-multiplex scenario on volume start/stop loop
+- [#1650893](https://bugzilla.redhat.com/1650893): fails to sync non-ascii (utf8) file and directory names, causes permanently faulty geo-replication state
+- [#1651059](https://bugzilla.redhat.com/1651059): [OpenSSL] :  Retrieving the value of "client.ssl" option,before SSL is set up, fails .
+- [#1651165](https://bugzilla.redhat.com/1651165): Race in per-thread mem-pool when a thread is terminated
+- [#1651431](https://bugzilla.redhat.com/1651431): Resolve memory leak at the time of graph init
+- [#1651439](https://bugzilla.redhat.com/1651439): gluster-NFS crash while expanding volume
+- [#1651463](https://bugzilla.redhat.com/1651463): glusterd can't regenerate volfiles in container storage upgrade workflow
+- [#1651498](https://bugzilla.redhat.com/1651498): [geo-rep]: Failover / Failback shows fault status in a non-root setup
+- [#1651584](https://bugzilla.redhat.com/1651584): [geo-rep]: validate the config checkpoint date and fail if it is not is exact format hh:mm:ss
+- [#1652118](https://bugzilla.redhat.com/1652118): default cluster.max-bricks-per-process to 250
+- [#1652430](https://bugzilla.redhat.com/1652430): glusterd fails to start, when glusterd is restarted in a loop for every 45 seconds while volume creation is in-progress
+- [#1652852](https://bugzilla.redhat.com/1652852): "gluster volume get" doesn't show real default value for server.tcp-user-timeout
+- [#1652887](https://bugzilla.redhat.com/1652887): Geo-rep help looks to have a typo.
+- [#1652911](https://bugzilla.redhat.com/1652911): Add no-verify and ssh-port n options for create command in man page
+- [#1653277](https://bugzilla.redhat.com/1653277): bump up default value of server.event-threads
+- [#1653359](https://bugzilla.redhat.com/1653359): Self-heal:Improve heal performance
+- [#1653565](https://bugzilla.redhat.com/1653565): tests/geo-rep: Add arbiter volume test case
+- [#1654138](https://bugzilla.redhat.com/1654138): Optimize for virt store fails with distribute volume type
+- [#1654181](https://bugzilla.redhat.com/1654181): glusterd segmentation fault: glusterd_op_ac_brick_op_failed (event=0x7f44e0e63f40, ctx=0x0) at glusterd-op-sm.c:5606
+- [#1654187](https://bugzilla.redhat.com/1654187): [geo-rep]: RFE - Make slave volume read-only while setting up geo-rep (by default)
+- [#1654270](https://bugzilla.redhat.com/1654270): glusterd crashed with seg fault possibly during node reboot while volume creates and deletes were happening
+- [#1654521](https://bugzilla.redhat.com/1654521): io-stats outputs json numbers as strings
+- [#1654805](https://bugzilla.redhat.com/1654805): Bitrot: Scrub status say file is corrupted even it was just created AND 'path' in the output is broken
+- [#1654917](https://bugzilla.redhat.com/1654917): cleanup resources in server_init in case of failure
+- [#1655050](https://bugzilla.redhat.com/1655050): automatic split resolution  with size as policy should not work on a directory which is in metadata splitbrain
+- [#1655052](https://bugzilla.redhat.com/1655052): Automatic Splitbrain with size as policy must not resolve splitbrains when both the copies are of same size
+- [#1655827](https://bugzilla.redhat.com/1655827): [Glusterd]: Glusterd crash while expanding volumes using heketi
+- [#1655854](https://bugzilla.redhat.com/1655854): Converting distribute to replica-3/arbiter volume fails
+- [#1656100](https://bugzilla.redhat.com/1656100): configure.ac does not enforce automake --foreign
+- [#1656264](https://bugzilla.redhat.com/1656264): Fix tests/bugs/shard/zero-flag.t
+- [#1656348](https://bugzilla.redhat.com/1656348): Commit c9bde3021202f1d5c5a2d19ac05a510fc1f788ac causes ls slowdown
+- [#1656517](https://bugzilla.redhat.com/1656517): [GSS] Gluster client logs filling with 0-glusterfs-socket: invalid port messages
+- [#1656682](https://bugzilla.redhat.com/1656682): brick memory consumed by volume is not getting released even after delete
+- [#1656771](https://bugzilla.redhat.com/1656771): [Samba-Enhancement] Need for a single group command for setting up volume options for samba
+- [#1656951](https://bugzilla.redhat.com/1656951): cluster.max-bricks-per-process 250 not working as expected
+- [#1657607](https://bugzilla.redhat.com/1657607): Convert nr_files to gf_atomic in posix_private structure
+- [#1657744](https://bugzilla.redhat.com/1657744): quorum count not updated in nfs-server vol file
+- [#1657783](https://bugzilla.redhat.com/1657783): Rename of a file leading to stale reads
+- [#1658045](https://bugzilla.redhat.com/1658045): Resolve memory leak in mgmt_pmap_signout_cbk
+- [#1658116](https://bugzilla.redhat.com/1658116): python2 to python3 compatibilty issues
+- [#1659327](https://bugzilla.redhat.com/1659327): 43% regression in small-file sequential read performance
+- [#1659432](https://bugzilla.redhat.com/1659432): Memory leak: dict_t leak in rda_opendir
+- [#1659708](https://bugzilla.redhat.com/1659708): Optimize by not stopping (restart) selfheal deamon (shd)  when a volume is stopped unless it is the last volume
+- [#1659857](https://bugzilla.redhat.com/1659857): change max-port value in glusterd vol file to 60999
+- [#1659868](https://bugzilla.redhat.com/1659868): glusterd : features.selinux was missing in glusterd-volume-set file
+- [#1659869](https://bugzilla.redhat.com/1659869): improvements to io-cache
+- [#1659971](https://bugzilla.redhat.com/1659971): Setting slave volume read-only option by default results in failure
+- [#1660577](https://bugzilla.redhat.com/1660577): [Ganesha] Ganesha failed on one node while exporting volumes in loop
+- [#1660701](https://bugzilla.redhat.com/1660701): Use adaptive mutex in rpcsvc_program_register to improve performance
+- [#1661214](https://bugzilla.redhat.com/1661214): Brick is getting OOM for tests/bugs/core/bug-1432542-mpx-restart-crash.t
+- [#1662089](https://bugzilla.redhat.com/1662089): NL cache: fix typos
+- [#1662264](https://bugzilla.redhat.com/1662264): thin-arbiter: Check with  thin-arbiter file before marking new entry change log
+- [#1662368](https://bugzilla.redhat.com/1662368): [ovirt-gluster] Fuse mount crashed while deleting a 1 TB image file from ovirt
+- [#1662679](https://bugzilla.redhat.com/1662679): Log connection_id in statedump for posix-locks as well for better debugging experience
+- [#1662906](https://bugzilla.redhat.com/1662906): Longevity: glusterfsd(brick process) crashed when we do volume creates and deletes
+- [#1663077](https://bugzilla.redhat.com/1663077): memory leak in mgmt handshake
+- [#1663102](https://bugzilla.redhat.com/1663102): Change default value for client side heal to off for replicate volumes
+- [#1663223](https://bugzilla.redhat.com/1663223): profile info command is not displaying information of bricks which are hosted on peers
+- [#1663243](https://bugzilla.redhat.com/1663243): rebalance status does not display localhost statistics when op-version is not bumped up
+- [#1664122](https://bugzilla.redhat.com/1664122): do not send bit-rot virtual xattrs in lookup response
+- [#1664124](https://bugzilla.redhat.com/1664124): Improve information dumped from io-threads in statedump
+- [#1664551](https://bugzilla.redhat.com/1664551): Wrong description of localtime-logging in manpages
+- [#1664647](https://bugzilla.redhat.com/1664647): dht: Add NULL check for stbuf in dht_rmdir_lookup_cbk
+- [#1664934](https://bugzilla.redhat.com/1664934): glusterfs-fuse client not benefiting from page cache on read after write
+- [#1665038](https://bugzilla.redhat.com/1665038): glusterd crashed while running "gluster get-state glusterd odir /get-state"
+- [#1665332](https://bugzilla.redhat.com/1665332): Wrong offset is used in offset for zerofill fop
+- [#1665358](https://bugzilla.redhat.com/1665358): allow regression to not run tests with nfs, if nfs is disabled.
+- [#1665363](https://bugzilla.redhat.com/1665363): Fix incorrect definition in index-mem-types.h
+- [#1665656](https://bugzilla.redhat.com/1665656): testcaes glusterd/add-brick-and-validate-replicated-volume-options.t is crash while brick_mux is enable
+- [#1665826](https://bugzilla.redhat.com/1665826): [geo-rep]: Directory renames not synced to slave in Hybrid Crawl
+- [#1666143](https://bugzilla.redhat.com/1666143): Several fixes on socket pollin and pollout return value
+- [#1666833](https://bugzilla.redhat.com/1666833): move few recurring logs to DEBUG level.
+- [#1667779](https://bugzilla.redhat.com/1667779): glusterd leaks about 1GB memory per day on single machine of storage pool
+- [#1667804](https://bugzilla.redhat.com/1667804): Unable to delete directories that contain linkto files that point to itself.
+- [#1667905](https://bugzilla.redhat.com/1667905): dict_leak in __glusterd_handle_cli_uuid_get function
+- [#1668190](https://bugzilla.redhat.com/1668190): Block hosting volume deletion via heketi-cli failed with error "target is busy" but deleted from gluster backend
+- [#1668268](https://bugzilla.redhat.com/1668268): Unable to mount gluster volume
+- [#1669077](https://bugzilla.redhat.com/1669077): [ovirt-gluster] Fuse mount crashed while creating the preallocated image
+- [#1669937](https://bugzilla.redhat.com/1669937): Rebalance : While rebalance is in progress , SGID and sticky bit which is set on the files while file migration is in progress is seen on the mount point
+- [#1670031](https://bugzilla.redhat.com/1670031): performance regression seen with smallfile workload tests
+- [#1670253](https://bugzilla.redhat.com/1670253): Writes on Gluster 5 volumes fail with EIO when "cluster.consistent-metadata" is set
+- [#1670259](https://bugzilla.redhat.com/1670259): New GFID file recreated in a replica set after a GFID mismatch resolution
+- [#1671213](https://bugzilla.redhat.com/1671213): core: move "dict is NULL" logs to DEBUG log level
+- [#1671637](https://bugzilla.redhat.com/1671637): geo-rep: Issue with configparser import
+- [#1672205](https://bugzilla.redhat.com/1672205): 'gluster get-state' command fails if volume brick doesn't exist.
+- [#1672818](https://bugzilla.redhat.com/1672818): GlusterFS 6.0 tracker
+- [#1673267](https://bugzilla.redhat.com/1673267): Fix timeouts so the tests pass on AWS
+- [#1673972](https://bugzilla.redhat.com/1673972): insufficient logging in glusterd_resolve_all_bricks
+- [#1674364](https://bugzilla.redhat.com/1674364): glusterfs-fuse client not benefiting from page cache on read after write
+- [#1676429](https://bugzilla.redhat.com/1676429): distribute: Perf regression in mkdir path
+- [#1677260](https://bugzilla.redhat.com/1677260): rm -rf fails with  "Directory not empty"
+- [#1678570](https://bugzilla.redhat.com/1678570): glusterfs FUSE client crashing every few days with 'Failed to dispatch handler'
+- [#1679004](https://bugzilla.redhat.com/1679004): With parallel-readdir enabled, deleting a directory containing stale linkto files fails with "Directory not empty"
+- [#1679275](https://bugzilla.redhat.com/1679275): dht: fix double extra unref of inode at heal path
+- [#1679965](https://bugzilla.redhat.com/1679965): Upgrade from glusterfs 3.12 to gluster 4/5 broken
+- [#1679998](https://bugzilla.redhat.com/1679998): GlusterFS can be improved
+- [#1680020](https://bugzilla.redhat.com/1680020): Integer Overflow possible in md-cache.c due to data type inconsistency
+- [#1680585](https://bugzilla.redhat.com/1680585): remove glupy from code and build
+- [#1680586](https://bugzilla.redhat.com/1680586): Building RPM packages with _for_fedora_koji_builds enabled fails on el6
+- [#1683008](https://bugzilla.redhat.com/1683008): glustereventsd does not start on Ubuntu 16.04 LTS
+- [#1683506](https://bugzilla.redhat.com/1683506): remove experimental xlators informations from glusterd-volume-set.c
+- [#1683716](https://bugzilla.redhat.com/1683716): glusterfind: revert shebangs to #!/usr/bin/python3
+- [#1683880](https://bugzilla.redhat.com/1683880): Multiple shd processes are running on brick_mux environmet
+- [#1683900](https://bugzilla.redhat.com/1683900): Failed to dispatch handler
+- [#1684029](https://bugzilla.redhat.com/1684029): upgrade from 3.12, 4.1 and 5 to 6 broken
+- [#1684777](https://bugzilla.redhat.com/1684777): gNFS crashed when processing "gluster v profile [vol] info nfs"
+- [#1685771](https://bugzilla.redhat.com/1685771): glusterd memory usage grows at 98 MB/h while being monitored by RHGSWA
+- [#1686364](https://bugzilla.redhat.com/1686364): [ovirt-gluster] Rolling gluster upgrade from 3.12.5 to 5.3 led to shard on-disk xattrs disappearing
+- [#1686399](https://bugzilla.redhat.com/1686399): listing a file while writing to it causes deadlock
+- [#1686875](https://bugzilla.redhat.com/1686875): packaging: rdma on s390x, unnecessary ldconfig scriptlets
+- [#1687248](https://bugzilla.redhat.com/1687248): Error handling in /usr/sbin/gluster-eventsapi produces IndexError: tuple index out of range
+- [#1687672](https://bugzilla.redhat.com/1687672): [geo-rep]: Checksum mismatch when 2x2 vols are converted to arbiter
+- [#1688218](https://bugzilla.redhat.com/1688218): Brick process has coredumped, when starting glusterd

--- a/doc/release-notes/6.0.md
+++ b/doc/release-notes/6.0.md
@@ -156,6 +156,31 @@ Samba unless either of 'user.cifs' or 'user.smb' volume set options are enabled
 on the volume. The existing GlusterFS volume share sections in smb.conf will
 remain unchanged.
 
+#### 7. ctime feature is enabled by default
+
+The ctime feature which maintains (c/m) time consistency across replica and
+disperse subvolumes is enabled by default.
+
+Also, with this release, a single option is provided to enable/disable ctime
+feature,
+
+```
+#gluster vol set <volname> ctime <on/off>
+```
+
+**NOTE:** The time information used is from clients, hence it's required that
+clients are synced with respect to their times, using NTP or other such means.
+
+**Limitations:**
+- Mounting gluster volume with time attribute options (noatime, realatime...)
+  is not supported with this feature
+- This feature does not guarantee consistent time for directories if the hashed
+  sub-volume for the directory is down
+- Directory listing is not supported with this feature, and may report
+  inconsistent time information
+- Older files created before upgrade, would witness update of ctime upon
+  accessing after upgrade [BUG:1593542](https://bugzilla.redhat.com/show_bug.cgi?id=1593542)
+
 ### Developer
 
 #### 1. Gluster code can be compiled and executed using [TSAN](https://clang.llvm.org/docs/ThreadSanitizer.html)

--- a/doc/release-notes/6.0.md
+++ b/doc/release-notes/6.0.md
@@ -1,0 +1,142 @@
+# Release notes for Gluster 6.0
+
+This is a major release that includes a range of code improvements and stability
+fixes among a few features as noted below.
+
+A selection of the key features and changes are documented on this page.
+A full list of bugs that have been addressed is included further below.
+
+- [Announcements](#announcements)
+- [Major changes and features](#major-changes-and-features)
+- [Major issues](#major-issues)
+- [Bugs addressed in the release](#bugs-addressed)
+
+## Announcements
+
+1. Releases that receive maintenance updates post release 6 are, 4.1 and 5
+([reference](https://www.gluster.org/release-schedule/))
+
+2. Release 6 will receive maintenance updates around the 30th of every month
+for the first 3 months post release (i.e Mar'19, Apr'19, May'19). Post the
+initial 3 months, it will receive maintenance updates every 2 months till EOL.
+([reference](https://lists.gluster.org/pipermail/announce/2018-July/000103.html))
+
+3. A series of features/xlators have been deprecated in release 6 as follows,
+for upgrade procedures from volumes that use these features to release 6 refer
+to the release 6 [upgrade guide](https://docs.gluster.org/en/latest/Upgrade-Guide/upgrade_to_6/).
+
+This deprecation was announced at the gluster-users list [here](https://lists.gluster.org/pipermail/gluster-users/2018-July/034400.html).
+
+Features deprecated:
+- Block device (bd) xlator
+- Decompounder feature
+- Crypt xlator
+- Symlink-cache xlator
+- Stripe feature
+- Tiering support (tier xlator and changetimerecorder)
+
+## Major changes and features
+
+Features are categorized into the following sections,
+
+- [Management](#management)
+- [Standalone](#standalone)
+- [Developer](#developer)
+
+### Management
+
+#### GlusterD2
+
+TODO: Fill in GD2 status, as pertaining to GCS (container storage) release.
+
+### Standalone
+
+#### 1. Glusterfind tool enhanced with a filter option
+
+glusterfind tool has an added option "--type", to be used with the "--full"
+option. The option supports finding and listing files or directories only, and
+defaults to both if not specified.
+
+Example usage with the pre and query commands are given below,
+1. Pre command ([reference](https://docs.gluster.org/en/latest/GlusterFS%20Tools/glusterfind/#pre-command)):
+- Lists both files and directories in OUTFILE:
+    `glusterfind pre SESSION_NAME VOLUME_NAME OUTFILE`
+
+- Lists only files in OUTFILE:
+    `glusterfind pre SESSION_NAME VOLUME_NAME OUTFILE --type f`
+
+- Lists only directories in OUTFILE:
+    `glusterfind pre SESSION_NAME VOLUME_NAME OUTFILE --type d`
+
+2. Query command:
+- Lists both files and directories in OUTFILE:
+    `glusterfind query VOLUME_NAME --full OUTFILE`
+
+- Lists only files in OUTFILE:
+    `glusterfind query VOLUME_NAME --full --type f OUTFILE`
+
+- Lists only directories in OUTFILE:
+    `glusterfind query VOLUME_NAME --full --type d OUTFILE`
+
+#### 2. FUSE mounts are enhanced to handle interrupts to blocked lock requests
+
+FUSE mounts are enhanced to handle interrupts to blocked locks.
+
+For example scripts using flock (`man 1 flock`) utility without the -n(nonblock)
+option against files on a FUSE based gluster mount, can now be interrupted when
+the lock is not granted in time or using the -w option from the same utility.
+
+#### 3. client-side inode garbage collection via LRU list
+
+A FUSE mounts inode cache can now be limited to a maximum number, thus reducing
+the memory footprint of FUSE mount processes.
+
+See lru-limit option in `man 8 mount.glusterfs` for usage details.
+
+NOTE: Setting this to low numbers (say less than 4000), will evict inodes from
+FUSE and Gluster caches at a much faster rate, and can cause performance
+degrades. The setting has to be balanced across available client memory and
+performance.
+
+#### 4. Optimized/pass-through distribute functionality for 1-way distributed volumes
+
+**NOTE:** There are no user controllable changes with this feature
+
+Distribute xlator is optimized, to mostly pass-through operations, when the
+distribute count is one for a volume, resulting in improved performance.
+
+#### 5. Options introduced to disable invalidations of kernel page cache
+
+For workloads, where multiple FUSE client mounts do not concurrently operate on
+any files in the volume, it is now possible to maintain a longer duration kernel
+page cache using the following options in conjunction,
+
+- Setting `--auto-invalidation` option to "no" on the glusterfs FUSE mount
+process
+- Disabling the volume option `performance.global-cache-invalidation`
+
+This enables better performance as the data is served from the kernel page cache
+where possible.
+
+### Developer
+
+#### 1. Gluster code can be compiled and executed using [TSAN](https://clang.llvm.org/docs/ThreadSanitizer.html)
+
+While configuring the sources for a build use the extra option `--enable-tsan`
+to enable thread sanitizer based builds.
+
+#### 2. gfapi: A class of APIs have been enhances to return pre/post gluster_stat information
+
+A set of [apis](https://github.com/gluster/glusterfs/blob/release-6/api/src/gfapi.map#L245) have been enhanced to return pre/post gluster_stat information.
+Applications using gfapi would need to adapt to the newer interfaces to compile
+against release-6 apis. Pre-compiled applications, or applications using the
+older API SDK will continue to work as before.
+
+## Major issues
+
+<TODO>
+
+## Bugs addressed
+
+Bugs addressed since release-5 are listed below.
+<TODO>

--- a/doc/release-notes/6.0.md
+++ b/doc/release-notes/6.0.md
@@ -1,9 +1,9 @@
 # Release notes for Gluster 6.0
 
 This is a major release that includes a range of code improvements and stability
-fixes among a few features as noted below.
+fixes along with a few features as noted below.
 
-A selection of the key features and changes are documented on this page.
+A selection of the key features and changes are documented in this page.
 A full list of bugs that have been addressed is included further below.
 
 - [Announcements](#announcements)
@@ -16,8 +16,8 @@ A full list of bugs that have been addressed is included further below.
 1. Releases that receive maintenance updates post release 6 are, 4.1 and 5
 ([reference](https://www.gluster.org/release-schedule/))
 
-2. Release 6 will receive maintenance updates around the 30th of every month
-for the first 3 months post release (i.e Mar'19, Apr'19, May'19). Post the
+2. Release 6 will receive maintenance updates around the 10th of every month
+for the first 3 months post release (i.e Apr'19, May'19, Jun'19). Post the
 initial 3 months, it will receive maintenance updates every 2 months till EOL.
 ([reference](https://lists.gluster.org/pipermail/announce/2018-July/000103.html))
 
@@ -28,6 +28,7 @@ to the release 6 [upgrade guide](https://docs.gluster.org/en/latest/Upgrade-Guid
 This deprecation was announced at the gluster-users list [here](https://lists.gluster.org/pipermail/gluster-users/2018-July/034400.html).
 
 Features deprecated:
+
 - Block device (bd) xlator
 - Decompounder feature
 - Crypt xlator
@@ -37,6 +38,19 @@ Features deprecated:
 
 ## Major changes and features
 
+### Highlights
+
+- Several stability fixes addressing,
+  - coverity, clang-scan, address sanitizer and valgrind reported issues
+  - removal of unused and hence, deprecated code and features
+- Client side inode garbage collection
+  - This release addresses one of the major concerns regarding FUSE mount
+  process memory footprint, by introducing client side inode garbage collection
+  - See [standalone](#standalone) section for more details
+- Performance Improvements
+  - `--auto-invalidation` on FUSE mounts to leverage kernel page cache more
+  effectively
+
 Features are categorized into the following sections,
 
 - [Management](#management)
@@ -45,19 +59,41 @@ Features are categorized into the following sections,
 
 ### Management
 
+**NOTE:** There have been several stability improvements around the brick
+multiplexing feature
+
 #### GlusterD2
 
-TODO: Fill in GD2 status, as pertaining to GCS (container storage) release.
+GlusterD2 (or GD2, in short) was planned as the next generation management
+service for Gluster project.
+
+Currently, GD2s main focus is not replacing `glusterd`, but to serve as a thin
+management layer when using gluster with container orchestration systems.
+
+There is no specific update around GD2 provided as a part of this release.
 
 ### Standalone
 
-#### 1. Glusterfind tool enhanced with a filter option
+#### 1. client-side inode garbage collection via LRU list
+
+A FUSE mount's inode cache can now be limited to a maximum number, thus reducing
+the memory footprint of FUSE mount processes.
+
+See the lru-limit option in `man 8 mount.glusterfs` for details.
+
+NOTE: Setting this to a low value (say less than 4000), will evict inodes from
+FUSE and Gluster caches at a much faster rate, and can cause performance
+degrades. The setting has to be determined based on the available client memory
+and required performance.
+
+#### 2. Glusterfind tool enhanced with a filter option
 
 glusterfind tool has an added option "--type", to be used with the "--full"
 option. The option supports finding and listing files or directories only, and
 defaults to both if not specified.
 
 Example usage with the pre and query commands are given below,
+
 1. Pre command ([reference](https://docs.gluster.org/en/latest/GlusterFS%20Tools/glusterfind/#pre-command)):
 - Lists both files and directories in OUTFILE:
     `glusterfind pre SESSION_NAME VOLUME_NAME OUTFILE`
@@ -78,31 +114,20 @@ Example usage with the pre and query commands are given below,
 - Lists only directories in OUTFILE:
     `glusterfind query VOLUME_NAME --full --type d OUTFILE`
 
-#### 2. FUSE mounts are enhanced to handle interrupts to blocked lock requests
+#### 3. FUSE mounts are enhanced to handle interrupts to blocked lock requests
 
 FUSE mounts are enhanced to handle interrupts to blocked locks.
 
-For example scripts using flock (`man 1 flock`) utility without the -n(nonblock)
-option against files on a FUSE based gluster mount, can now be interrupted when
-the lock is not granted in time or using the -w option from the same utility.
-
-#### 3. client-side inode garbage collection via LRU list
-
-A FUSE mounts inode cache can now be limited to a maximum number, thus reducing
-the memory footprint of FUSE mount processes.
-
-See lru-limit option in `man 8 mount.glusterfs` for usage details.
-
-NOTE: Setting this to low numbers (say less than 4000), will evict inodes from
-FUSE and Gluster caches at a much faster rate, and can cause performance
-degrades. The setting has to be balanced across available client memory and
-performance.
+For example, scripts using the flock (`man 1 flock`) utility without the
+-n(nonblock) option against files on a FUSE based gluster mount, can now be
+interrupted when the lock is not granted in time or using the -w option with
+the same utility.
 
 #### 4. Optimized/pass-through distribute functionality for 1-way distributed volumes
 
 **NOTE:** There are no user controllable changes with this feature
 
-Distribute xlator is optimized, to mostly pass-through operations, when the
+The distribute xlator now skips unnecessary checks and operations when the
 distribute count is one for a volume, resulting in improved performance.
 
 #### 5. Options introduced to disable invalidations of kernel page cache
@@ -138,7 +163,7 @@ remain unchanged.
 While configuring the sources for a build use the extra option `--enable-tsan`
 to enable thread sanitizer based builds.
 
-#### 2. gfapi: A class of APIs have been enhances to return pre/post gluster_stat information
+#### 2. gfapi: A class of APIs have been enhanced to return pre/post gluster_stat information
 
 A set of [apis](https://github.com/gluster/glusterfs/blob/release-6/api/src/gfapi.map#L245) have been enhanced to return pre/post gluster_stat information.
 Applications using gfapi would need to adapt to the newer interfaces to compile
@@ -147,7 +172,7 @@ older API SDK will continue to work as before.
 
 ## Major issues
 
-<TODO>
+**None**
 
 ## Bugs addressed
 

--- a/doc/release-notes/6.1.md
+++ b/doc/release-notes/6.1.md
@@ -1,0 +1,41 @@
+# Release notes for Gluster 6.1
+
+This is a bugfix release. The release notes for [6.0](6.0.md) contains a listing of
+all the new features that were added and bugs fixed in the GlusterFS 6 stable
+release.
+
+**NOTE:** Next minor release tentative date: Week of 10th May, 2019
+
+## Major changes, features and limitations addressed in this release
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.0 are listed below.
+
+- [#1679904](https://bugzilla.redhat.com/1679904): client log flooding with intentional socket shutdown message when a brick is down
+- [#1690950](https://bugzilla.redhat.com/1690950): lots of "Matching lock not found for unlock xxx" when using disperse (ec) xlator
+- [#1691187](https://bugzilla.redhat.com/1691187): fix Coverity CID 1399758
+- [#1692101](https://bugzilla.redhat.com/1692101): Network throughput usage increased x5
+- [#1692957](https://bugzilla.redhat.com/1692957): rpclib: slow floating point math and libm
+- [#1693155](https://bugzilla.redhat.com/1693155): Excessive AFR messages from gluster showing in RHGSWA.
+- [#1693223](https://bugzilla.redhat.com/1693223): [Disperse] : Client side heal is not removing dirty flag for some of the files.
+- [#1693992](https://bugzilla.redhat.com/1693992): Thin-arbiter minor fixes
+- [#1694002](https://bugzilla.redhat.com/1694002): Geo-re: Geo replication failing in "cannot allocate memory"
+- [#1694561](https://bugzilla.redhat.com/1694561): gfapi: do not block epoll thread for upcall notifications
+- [#1694610](https://bugzilla.redhat.com/1694610): glusterd leaking memory when issued gluster vol status all tasks continuosly
+- [#1695436](https://bugzilla.redhat.com/1695436): geo-rep session creation fails with IPV6
+- [#1695445](https://bugzilla.redhat.com/1695445): ssh-port config set is failing
+- [#1697764](https://bugzilla.redhat.com/1697764): [cluster/ec] : Fix handling of heal info cases without locks
+- [#1698471](https://bugzilla.redhat.com/1698471): ctime feature breaks old client to connect to new server
+- [#1699198](https://bugzilla.redhat.com/1699198): Glusterfs create a flock lock by anonymous fd, but can't release it forever.
+- [#1699319](https://bugzilla.redhat.com/1699319): Thin-Arbiter SHD minor fixes
+- [#1699499](https://bugzilla.redhat.com/1699499): fix truncate lock to cover the write in tuncate clean
+- [#1699703](https://bugzilla.redhat.com/1699703): ctime: Creation of tar file on gluster mount throws warning "file changed as we read it"
+- [#1699713](https://bugzilla.redhat.com/1699713): glusterfs build is failing on rhel-6
+- [#1699714](https://bugzilla.redhat.com/1699714): Brick is not able to detach successfully in brick_mux environment
+- [#1699715](https://bugzilla.redhat.com/1699715): Log level changes do not take effect until the process is restarted
+- [#1699731](https://bugzilla.redhat.com/1699731): Fops hang when inodelk fails on the first fop

--- a/doc/release-notes/6.10.md
+++ b/doc/release-notes/6.10.md
@@ -1,0 +1,26 @@
+# Release notes for Gluster 6.10
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md), [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md), [6.5](6.5.md), [6.6](6.6.md),
+[6.7](6.7.md), [6.8](6.8.md) and [6.9](6.9.md)
+contain a listing of all the new features that were added and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** This is last minor release of 6. Users are highly encouraged to upgrade to newer releases of GlusterFS.
+
+
+## Bugs addressed
+
+Bugs addressed since release-6.9 are listed below.
+
+- [#1740494](https://bugzilla.redhat.com/1740494): Fencing: Added the tcmu-runner ALUA feature support but after one of node is rebooted the glfs_file_lock() get stucked
+- [#1000](https://github.com/gluster/glusterfs/issues/1000) [bug:1193929] GlusterFS can be improved
+- [#1016](https://github.com/gluster/glusterfs/issues/1016) [bug:1795609] glusterfsd memory leak observed after enable tls
+- [#1060](https://github.com/gluster/glusterfs/issues/1060) [bug:789278] Issues reported by Coverity static analysis tool
+- [#1127](https://github.com/gluster/glusterfs/issues/1127) Mount crash during background shard cleanup
+- [#1179](https://github.com/gluster/glusterfs/issues/1179) gnfs split brain when 1 server in 3x1 down (high load)
+- [#1220](https://github.com/gluster/glusterfs/issues/1220) cluster/ec: return correct error code and log the message in ...
+- [#1223](https://github.com/gluster/glusterfs/issues/1223) Failure of tests/basic/gfapi/gfapi-copy-file-range.t
+- [#1254](https://github.com/gluster/glusterfs/issues/1254) Prioritize ENOSPC over other lesser priority errors
+- [#1303](https://github.com/gluster/glusterfs/issues/1303) Failures in rebalance due to [Input/output error]
+- [#1307](https://github.com/gluster/glusterfs/issues/1307) Spurious failure of tests/bug-844688.t: test bug-844688.t on ...
+- [#1349](https://github.com/gluster/glusterfs/issues/1349) Issue for backporting https://review.gluster.org//c/glusterf...
+- [#1362](https://github.com/gluster/glusterfs/issues/1362) [bug: 1687326]: Revoke access from nodes using Certificate Re...

--- a/doc/release-notes/6.2.md
+++ b/doc/release-notes/6.2.md
@@ -1,0 +1,35 @@
+# Release notes for Gluster 6.2
+
+This is a bugfix release. The release notes for [6.0](6.0.md) and [6.1](6.1.md)
+contains a listing of all the new features that were added and bugs fixed
+in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 10th June, 2019
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.1 are listed below.
+
+- [#1699917](https://bugzilla.redhat.com/1699917): I/O error on writes to a disperse volume when replace-brick is executed
+- [#1701818](https://bugzilla.redhat.com/1701818): Syntactical errors in hook scripts for managing SELinux context on bricks #2 (S10selinux-label-brick.sh + S10selinux-del-fcontext.sh)
+- [#1702271](https://bugzilla.redhat.com/1702271): Memory accounting information is not always accurate
+- [#1702734](https://bugzilla.redhat.com/1702734): ctime: Logs are flooded with "posix set mdata failed, No ctime" error during open
+- [#1703759](https://bugzilla.redhat.com/1703759): statedump is not capturing info related to glusterd
+- [#1707393](https://bugzilla.redhat.com/1707393): Refactor dht lookup code
+- [#1709130](https://bugzilla.redhat.com/1709130): thin-arbiter lock release fixes
+- [#1709143](https://bugzilla.redhat.com/1709143): [Thin-arbiter] : send correct error code in case of failure
+- [#1709660](https://bugzilla.redhat.com/1709660): Glusterfsd crashing in ec-inode-write.c, in GF_ASSERT
+- [#1709685](https://bugzilla.redhat.com/1709685): Geo-rep: Value of pending entry operations in detail status output is going up after each synchronization.
+- [#1709734](https://bugzilla.redhat.com/1709734): Geo-rep: Data inconsistency while syncing heavy renames with constant destination name
+- [#1709737](https://bugzilla.redhat.com/1709737): geo-rep: Always uses rsync even with use_tarssh set to true
+- [#1709738](https://bugzilla.redhat.com/1709738): geo-rep: Sync hangs with tarssh as sync-engine
+- [#1712220](https://bugzilla.redhat.com/1712220): tests/geo-rep: arequal checksum comparison always succeeds
+- [#1712223](https://bugzilla.redhat.com/1712223): geo-rep: With heavy rename workload geo-rep log if flooded

--- a/doc/release-notes/6.3.md
+++ b/doc/release-notes/6.3.md
@@ -1,0 +1,23 @@
+# Release notes for Gluster 6.3
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md)
+and [6.2](6.2.md) contain a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 10th July, 2019
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.2 are listed below.
+
+- [#1714172](https://bugzilla.redhat.com/1714172): ec ignores lock contention notifications for partially acquired locks
+- [#1715012](https://bugzilla.redhat.com/1715012): Failure when glusterd is configured to bind specific IPv6 address. If bind-address is IPv6, *addr_len will be non-zero and it goes to ret = -1 branch, which will cause listen failure eventually
+

--- a/doc/release-notes/6.4.md
+++ b/doc/release-notes/6.4.md
@@ -1,0 +1,40 @@
+# Release notes for Gluster 6.4
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md) and [6.3](6.3.md) contains a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 10th August, 2019
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.3 are listed below.
+
+- [#1679998](https://bugzilla.redhat.com/1679998): GlusterFS can be improved
+- [#1683815](https://bugzilla.redhat.com/1683815): Memory leak when peer detach fails
+- [#1716812](https://bugzilla.redhat.com/1716812): Failed to create volume which transport_type is "tcp,rdma"
+- [#1716871](https://bugzilla.redhat.com/1716871): Image size as reported from the fuse mount is incorrect
+- [#1718227](https://bugzilla.redhat.com/1718227): SELinux context labels are missing for newly added bricks using add-brick command
+- [#1720633](https://bugzilla.redhat.com/1720633): Upcall: Avoid sending upcalls for invalid Inode
+- [#1720635](https://bugzilla.redhat.com/1720635): Ganesha-gfapi logs are flooded with error messages related to "gf_uuid_is_null(gfid)) [Invalid argument]" when lookups are running from multiple clients
+- [#1720993](https://bugzilla.redhat.com/1720993): tests/features/subdir-mount.t is failing for brick_mux regrssion
+- [#1721105](https://bugzilla.redhat.com/1721105): Failed to create volume which transport_type is "tcp,rdma"
+- [#1721783](https://bugzilla.redhat.com/1721783): ctime changes:  tar still complains file changed as we read it if uss is enabled
+- [#1722805](https://bugzilla.redhat.com/1722805): Healing not proceeding during in-service upgrade on a disperse volume
+- [#1723658](https://bugzilla.redhat.com/1723658): [In-service] Post upgrade glusterd is crashing with a backtrace on the upgraded node while issuing gluster volume status from non-upgraded nodes
+- [#1723659](https://bugzilla.redhat.com/1723659): ESTALE change in fuse breaks get_real_filename implementation
+- [#1724210](https://bugzilla.redhat.com/1724210): Incorrect power of two calculation in mem_pool_get_fn
+- [#1724558](https://bugzilla.redhat.com/1724558): [Ganesha]: truncate operation not updating the ctime
+- [#1726294](https://bugzilla.redhat.com/1726294): DHT: severe memory leak in dht rename
+- [#1726327](https://bugzilla.redhat.com/1726327): tests/features/subdir-mount.t is failing for brick_mux regrssion
+- [#1727984](https://bugzilla.redhat.com/1727984): User serviceable snapshots (USS) are not accessible after changing transport.socket.bind-address of glusterd
+- [#1728126](https://bugzilla.redhat.com/1728126): [In-service] Post upgrade glusterd is crashing with a backtrace on the upgraded node while issuing gluster volume status from non-upgraded nodes
+- [#1729952](https://bugzilla.redhat.com/1729952): Deadlock when generating statedumps

--- a/doc/release-notes/6.5.md
+++ b/doc/release-notes/6.5.md
@@ -1,0 +1,28 @@
+# Release notes for Gluster 6.5
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md), [6.3](6.3.md) and [6.4](6.4.md) contains a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 10th September, 2019
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.4 are listed below.
+
+- [#1716848](https://bugzilla.redhat.com/1716848): DHT: directory permissions are wiped out
+- [#1730545](https://bugzilla.redhat.com/1730545): gluster v geo-rep status command timing out
+- [#1731509](https://bugzilla.redhat.com/1731509): snapd crashes sometimes
+- [#1736341](https://bugzilla.redhat.com/1736341): potential deadlock while processing callbacks in gfapi- [#1733880](https://bugzilla.redhat.com/1733880): [geo-rep]: gluster command not found while setting up a non-root session
+- [#1733885](https://bugzilla.redhat.com/1733885): ctime: Upgrade/Enabling ctime feature wrongly updates older files with latest {a|m|c}time
+- [#1737712](https://bugzilla.redhat.com/1737712): Unable to create geo-rep session on a non-root setup.
+- [#1737745](https://bugzilla.redhat.com/1737745): ctime: When healing ctime xattr for legacy files, if multiple clients access and modify the same file, the ctime might be updated incorrectly.
+- [#1737746](https://bugzilla.redhat.com/1737746): ctime: nfs client gets bad ctime for copied file which is on glusterfs disperse volume with ctime on

--- a/doc/release-notes/6.6.md
+++ b/doc/release-notes/6.6.md
@@ -1,0 +1,56 @@
+# Release notes for Gluster 6.5
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md) and [6.5](6.5.md)
+contains a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 30th December, 2019
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.5 are listed below.
+
+- [#1726175](https://bugzilla.redhat.com/1726175): CentOs 6 GlusterFS client creates files with time 01/01/1970
+- [#1737141](https://bugzilla.redhat.com/1737141): read() returns more than file size when using direct I/O
+- [#1739320](https://bugzilla.redhat.com/1739320): The result (hostname) of getnameinfo for all bricks (ipv6 addresses)  are the same, while they are not.
+- [#1739335](https://bugzilla.redhat.com/1739335): Multiple disconnect events being propagated for the same child
+- [#1739451](https://bugzilla.redhat.com/1739451): An Input/Output error happens on a disperse volume when doing unaligned writes to a sparse file
+- [#1740525](https://bugzilla.redhat.com/1740525): event: rename event_XXX with gf_ prefixed to avoid crash when apps linked libevent at the same time
+- [#1741044](https://bugzilla.redhat.com/1741044): atime/mtime is not restored after healing for entry self heals
+- [#1741402](https://bugzilla.redhat.com/1741402): READDIRP incorrectly updates posix-acl inode ctx
+- [#1743219](https://bugzilla.redhat.com/1743219): glusterd start is failed and throwing an error Address already in use
+- [#1743782](https://bugzilla.redhat.com/1743782): Windows client fails to copy large file to GlusterFS volume share with fruit and streams_xattr VFS modules via Samba
+- [#1743988](https://bugzilla.redhat.com/1743988): Setting cluster.heal-timeout requires volume restart
+- [#1745421](https://bugzilla.redhat.com/1745421): ./tests/bugs/glusterd/bug-1595320.t is failing
+- [#1746118](https://bugzilla.redhat.com/1746118): capture stat failure error while setting the gfid
+- [#1746138](https://bugzilla.redhat.com/1746138): ctime: If atime is updated via utimensat syscall ctime is not getting updated
+- [#1749157](https://bugzilla.redhat.com/1749157): bug-1402841.t-mt-dir-scan-race.t fails spuriously
+- [#1749307](https://bugzilla.redhat.com/1749307): Failures in remove-brick due to  [Input/output error] errors
+- [#1750228](https://bugzilla.redhat.com/1750228): [geo-rep]: Non-root - Unable to set up mountbroker root directory and group
+- [#1751557](https://bugzilla.redhat.com/1751557): syncop: Bail out if frame creation fails
+- [#1752413](https://bugzilla.redhat.com/1752413): ctime: Cannot see the "trusted.glusterfs.mdata" xattr for directory on a new brick after rebalance
+- [#1753561](https://bugzilla.redhat.com/1753561): Custom xattrs are not healed on newly added brick
+- [#1753571](https://bugzilla.redhat.com/1753571): interrupts leak memory
+- [#1755679](https://bugzilla.redhat.com/1755679): Segmentation fault occurs while truncate file
+- [#1755785](https://bugzilla.redhat.com/1755785): git clone fails on gluster volumes exported via nfs-ganesha
+- [#1760361](https://bugzilla.redhat.com/1760361): packaging: remove leftover bd cruft in rpm .spec.in
+- [#1760706](https://bugzilla.redhat.com/1760706): glustershd can not decide heald_sinks, and skip repair, so some entries lingering in volume heal info
+- [#1760792](https://bugzilla.redhat.com/1760792): afr: support split-brain CLI for replica 3
+- [#1761907](https://bugzilla.redhat.com/1761907): Rebalance causing  IO Error - File descriptor in bad state
+- [#1763028](https://bugzilla.redhat.com/1763028): [geo-rep] sync_method showing rsync instead of tarssh post in-service upgrade
+- [#1764171](https://bugzilla.redhat.com/1764171): [Upgrade] Config files are not upgraded to new version
+- [#1764172](https://bugzilla.redhat.com/1764172): geo-replication sessions going faulty
+- [#1764174](https://bugzilla.redhat.com/1764174): geo-rep syncing significantly behind and also only one of the directories are synced with tracebacks seen
+- [#1764176](https://bugzilla.redhat.com/1764176): geo-rep: Changelog archive file format is incorrect
+- [#1764178](https://bugzilla.redhat.com/1764178): tests/geo-rep: Add test case to validate non-root geo-replication setup
+- [#1764183](https://bugzilla.redhat.com/1764183): [GSS] geo-rep entering into faulty state with OSError: [Errno 13] Permission denied
+- [#1765433](https://bugzilla.redhat.com/1765433): test: fix non-root geo-rep test case

--- a/doc/release-notes/6.6.md
+++ b/doc/release-notes/6.6.md
@@ -1,4 +1,4 @@
-# Release notes for Gluster 6.5
+# Release notes for Gluster 6.6
 
 This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
  [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md) and [6.5](6.5.md)

--- a/doc/release-notes/6.7.md
+++ b/doc/release-notes/6.7.md
@@ -1,0 +1,32 @@
+# Release notes for Gluster 6.7
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md), [6.5](6.5.md) and [6.6](6.6.md)
+contains a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Next minor release tentative date: Week of 30th February, 2020
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.6 are listed below.
+
+- [#1739446](https://bugzilla.redhat.com/1739446): [Disperse] : Client side heal is not removing dirty flag for some of the files.
+- [#1739449](https://bugzilla.redhat.com/1739449): Disperse volume : data corruption with ftruncate data in 4+2 config
+- [#1739450](https://bugzilla.redhat.com/1739450): Open fd heal should filter O_APPEND/O_EXCL
+- [#1749625](https://bugzilla.redhat.com/1749625): [GlusterFS 6.1] GlusterFS brick process crash
+- [#1766425](https://bugzilla.redhat.com/1766425): cgroup control-cpu-load.sh script not working
+- [#1768726](https://bugzilla.redhat.com/1768726): Memory leak in glusterfsd process
+- [#1770100](https://bugzilla.redhat.com/1770100): [geo-rep]: Geo-rep goes FAULTY with OSError
+- [#1771842](https://bugzilla.redhat.com/1771842): [CENTOS 6] Geo-replication session not starting after creation
+- [#1778182](https://bugzilla.redhat.com/1778182): glusterfsd crashed with "'MemoryError' Cannot access memory at address"
+- [#1782495](https://bugzilla.redhat.com/1782495): GlusterFS brick process crash
+- [#1784796](https://bugzilla.redhat.com/1784796): tests/00-geo-rep/00-georep-verify-non-root-setup.t fail on freshly installed builder

--- a/doc/release-notes/6.8.md
+++ b/doc/release-notes/6.8.md
@@ -1,0 +1,39 @@
+# Release notes for Gluster 6.8
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md), [6.5](6.5.md) [6.7](6.7.md) and [6.8](6.8.md)
+contain a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Tentative date for next minor release: Week of 30th April, 2020
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.7 are listed below.
+
+- [#1786754](https://bugzilla.redhat.com/1786754): Functionality to enable log rotation for user serviceable snapshot's logs.
+- [#1786983](https://bugzilla.redhat.com/1786983): Rebalance is causing glusterfs crash on client node
+- [#1789337](https://bugzilla.redhat.com/1789337): glusterfs process memory leak in ior test
+- [#1790445](https://bugzilla.redhat.com/1790445): glusterfind pre output file is empty
+- [#1790449](https://bugzilla.redhat.com/1790449): S57glusterfind-delete-post.py not python3 ready (does not decode bytestring)
+- [#1790850](https://bugzilla.redhat.com/1790850): Remove extra argument
+- [#1792857](https://bugzilla.redhat.com/1792857): Memory corruption when sending events to an IPv6 host
+- [#1793096](https://bugzilla.redhat.com/1793096): gf_event doesn't work for glfsheal process
+- [#1794020](https://bugzilla.redhat.com/1794020): Mounts fails after reboot of 1/3 gluster nodes
+- [#1797985](https://bugzilla.redhat.com/1797985): Brick logs  inundated with [2019-04-27 22:14:53.378047] I [dict.c:541:dict_get] (-->/usr/lib64/glusterfs/6.0/xlator/features/worm.so(+0x7241) [0x7fe857bb3241] -->/usr/lib64/glusterfs/6.0/xlator/features/locks.so(+0x1c219) [0x7fe857dda219] [Invalid argumen
+- [#1804546](https://bugzilla.redhat.com/1804546): [Thin-arbiter] : Wait for connection with TA node before sending lookup/create of ta-replica id file
+- [#1804594](https://bugzilla.redhat.com/1804594): Heal pending on volume, even after all the bricks are up
+- [#1805097](https://bugzilla.redhat.com/1805097): Changes to self-heal logic w.r.t. detecting metadata split-brains
+- [#1805671](https://bugzilla.redhat.com/1805671): Memory corruption when glfs_init() is called after glfs_fini()
+- [#1806836](https://bugzilla.redhat.com/1806836): [EC] shd crashed while heal failed due to out of memory error.
+- [#1806838](https://bugzilla.redhat.com/1806838): Disperse volume : Ganesha crash with IO in 4+2 config when one glusterfsd restart every 600s
+- [#1807786](https://bugzilla.redhat.com/1807786): seeing error message in glustershd.log on volume start(or may be as part of shd graph regeneration) inet_pton failed with return code 0 [Invalid argument]
+- [#1807793](https://bugzilla.redhat.com/1807793): glusterfs-libs: usage of inet_addr() may impact IPv6

--- a/doc/release-notes/6.9.md
+++ b/doc/release-notes/6.9.md
@@ -1,0 +1,32 @@
+# Release notes for Gluster 6.9
+
+This is a bugfix release. The release notes for [6.0](6.0.md), [6.1](6.1.md),
+ [6.2](6.2.md), [6.3](6.3.md), [6.4](6.4.md), [6.5](6.5.md), [6.7](6.7.md),
+[6.8](6.8.md) and [6.9](6.9.md)
+contain a listing of all the new features that were added
+and bugs fixed in the GlusterFS 6 stable release.
+
+**NOTE:** Tentative date for next minor release: Week of 30th June, 2020
+
+## Major changes, features and limitations addressed in this release
+
+**None**
+
+## Major issues
+
+**None**
+
+## Bugs addressed
+
+Bugs addressed since release-6.8 are listed below.
+
+- [#832](https://github.com/gluster/glusterfs/issues/832): Permission Denied in logs.
+- [#1152](https://github.com/gluster/glusterfs/issues/1152): Spurious failure of tests/bugs/protocol/bug-1433815-auth-allow.t
+- [#1140](https://github.com/gluster/glusterfs/issues/1140): getfattr returns ENOATTR for system.posix_acl_access on disperse type volumes
+- [#884](https://github.com/gluster/glusterfs/issues/884): [bug:1808688] Data corruption with asynchronous writes (please try to reproduce!)
+- [#1134](https://github.com/gluster/glusterfs/issues/1134): snap_scheduler.py init failing with "TypeError: Can't mix strings and bytes in path components"
+- [#1067](https://github.com/gluster/glusterfs/issues/1067): [bug:1661889] Metadata heal picks different brick each time as source if there are no pending xattrs.
+- [#1028](https://github.com/gluster/glusterfs/issues/1028): [bug:1810934] Segfault in FUSE process, potential use after free
+- [#1146](https://github.com/gluster/glusterfs/issues/1146): gfapi/Upcall: Potential deadlock in synctask threads processing upcall notifications
+- [#1808966](https://bugzilla.redhat.com/1808966): Set volume option when one of the node is powered off, After powering the node brick processes are offline
+- [#1809439](https://bugzilla.redhat.com/1809439): [brickmux]: glustershd crashed when rebooting 1/3 nodes at regular intervals


### PR DESCRIPTION
Problem:
When the last quota-limited path is deleted directly
before the quota limit is cleared,
the output of the quota list command appears blank.

Solution:
When executing the quota list command,
the client receives the wrong rpc status when the last path path does not exist,
and skips the last path at this time,
so that other path quota restriction information can not be printed.

Fixes: bz#2157037

Change-Id: Ia2fdd7606eab11b449364544c2603156fb93215a
Signed-off-by: huping <huping@cmss.chinamobile.com>