### PR TITLE
dict.c: remove unneeded NULL check - dict->key is never NULL

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -2992,7 +2992,7 @@ dict_serialize_value_with_delim_lk(dict_t *this, char *buf, int32_t *serz_len,
             goto out;
         }
 
-        if (!pair->key || !pair->value) {
+        if (!pair->value) {
             gf_smsg("dict", GF_LOG_ERROR, 0, LG_MSG_KEY_OR_VALUE_NULL, NULL);
             goto out;
         }


### PR DESCRIPTION
As part of https://github.com/gluster/glusterfs/commit/0b1dcc1b2f392a6d47a5d11484cd2d0b4fa85668 , the key is now allocated along, not separately, and thus cannot be NULL.

Removed the check that's now not needed.

Fixes: #3948
Signed-off-by: Yaniv Kaul <mykaul@gmail.com>

