### PR TITLE
geo-replication: fix for secondary node fail-over

### DIFF
--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -1396,10 +1396,15 @@ class SSH(object):
         if gconf.get("use-rsync-xattrs"):
             extra_opts.append('--use-rsync-xattrs')
 
+        if '@' in rconf.args.resource_remote or '@' not in self.remote_addr:
+            remote_host = rconf.args.resource_remote
+        else:
+            user = self.remote_addr.split("@")[0]
+            remote_host = user + '@' + rconf.args.resource_remote
         args_to_secondary = [gconf.get("ssh-command")] + \
             gconf.get("ssh-options").split() + \
             ["-p", str(gconf.get("ssh-port"))] + \
-            rconf.ssh_ctl_args + [self.remote_addr] + \
+            rconf.ssh_ctl_args + [remote_host] + \
             [remote_gsyncd, "secondary"] + \
             extra_opts + \
             [rconf.args.primary, rconf.args.secondary] + \

--- a/geo-replication/syncdaemon/resource.py
+++ b/geo-replication/syncdaemon/resource.py
@@ -1396,10 +1396,15 @@ class SSH(object):
         if gconf.get("use-rsync-xattrs"):
             extra_opts.append('--use-rsync-xattrs')
 
+        if '@' in rconf.args.resource_remote:
+            remote_host = rconf.args.resource_remote
+        else:
+            user = self.remote_addr.split("@")[0]
+            remote_host = user + '@' + rconf.args.resource_remote
         args_to_secondary = [gconf.get("ssh-command")] + \
             gconf.get("ssh-options").split() + \
             ["-p", str(gconf.get("ssh-port"))] + \
-            rconf.ssh_ctl_args + [self.remote_addr] + \
+            rconf.ssh_ctl_args + [remote_host] + \
             [remote_gsyncd, "secondary"] + \
             extra_opts + \
             [rconf.args.primary, rconf.args.secondary] + \


### PR DESCRIPTION
Problem: When geo-replication session is setup, all the gsyncd slave
processes are coming up on the host which is used in creating the
geo-rep session. When this primary slave node goes down, all the
bricks are going into faulty state.

Cause: When monitor process tries to connect to the remote secondary
node, we are always using the remote_addr as a hostname. This variable
holds the hostname of the node which is used in creating the geo-rep
session. Thus, the gsyncd slave processes are always coming up on the
primary slave node. When this node goes down, monitor process is not able
to bring up gsyncd slave process and bricks are going into faulty state.

Fix: Instead of remote_addr, we should use resource_remote which holds
the hostname of randomly picked remote node. This way, when geo-rep
session is created and started, we will have the gsyncd slave processes
distributed across the secondary cluster. If the node which is used in
creating the session goes down, monitor process will bring the gsyncd
slave process on a randomly picked remote node (from the nodes which are
up at the moment). Bricks will not go into faulty state.

fixes:#3956

Signed-off-by: Sanju Rakonde <sanju.rakonde@phonepe.com>
