### PR TITLE
Backport: Fix compat with older sh versions (#3951)

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -585,7 +585,7 @@ with_options()
             oom_score_adj=$value
             ;;
         "xlator-option")
-            xlator_options+=($value)
+            xlator_options+="$value"
             ;;
         "fuse-mountopts")
             fuse_mountopts=$value


### PR DESCRIPTION
Debian systems ship with a relatively older version of the sh shell and hence the bash concat syntax $() is not supported there. As we are dealing with strings in our case another method can be used which is supported and works well.

Fixes: #3960
Signed-off-by: black.dragon74 <nickk.2974@gmail.com>
(cherry picked from commit 758bfb607040a22817ffe15c3b45063fed99b2e0)
(Reviewed on https://github.com/gluster/glusterfs/pull/3951)

Change-Id: I19e999e3ae7fbbef7e3915df8dcf34a58024afc1

