### PR TITLE
Backport: [mount] fix handling of xlator-option (#3964)

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -306,11 +306,7 @@ start_glusterfs ()
         cmd_line=$(echo "$cmd_line --fuse-mountopts=$fuse_mountopts");
     fi
 
-    if [ -n "${xlator_options}" ]; then
-        for xlator_option in "${xlator_options[@]}"; do
-            cmd_line=$(echo "$cmd_line --xlator-option=$xlator_option");
-        done
-    fi
+    cmd_line="${cmd_line}${xlator_options}"
 
     if [ -n "$kernel_writeback_cache" ]; then
         cmd_line=$(echo "$cmd_line --kernel-writeback-cache=$kernel_writeback_cache");
@@ -585,7 +581,7 @@ with_options()
             oom_score_adj=$value
             ;;
         "xlator-option")
-            xlator_options+="$value"
+            xlator_options="${xlator_options} --xlator-option ${value}"
             ;;
         "fuse-mountopts")
             fuse_mountopts=$value
@@ -601,7 +597,7 @@ with_options()
             ;;
         "auto-invalidation")
             fuse_auto_invalidation=$value
-	    ;;
+            ;;
         "no-root-squash")
             if [ $value = "yes" ] ||
                 [ $value = "on" ] ||


### PR DESCRIPTION
* mount: fix handling of xlator-option

A previous patch (758bfb6070) changed the xlator_options shell variable from an array to a string. However the variable was not correctly processed as a string.

This patch fully handles this variable as a string.

Fixes: #3963
Signed-off-by: Xavi Hernandez <xhernandez@gmail.com>

(cherry picked from commit 81f267da4a5e998a219416a190506bab5213060e)
Reviewed At: #3964
Change-Id: Ia50457bcac8f77b8b8fd98e52d1c1e79f6c9ae9e

