### PR TITLE
Create cfg file in parallel without data truncation

### DIFF
--- a/events/src/peer_eventsapi.py
+++ b/events/src/peer_eventsapi.py
@@ -27,7 +27,7 @@ from gluster.cliutils import (Cmd, node_output_ok, node_output_notok,
                               sync_file_to_peers, GlusterCmdException,
                               output_error, execute_in_peers, runcli,
                               set_common_args_func)
-from gfevents.utils import LockedOpen, get_jwt_token, save_https_cert
+from gfevents.utils import LockedOpen, get_jwt_token, save_https_cert, NamedTempOpen
 
 from gfevents.eventsapiconf import (WEBHOOKS_FILE_TO_SYNC,
                                     WEBHOOKS_FILE,
@@ -78,8 +78,8 @@ def create_custom_config_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(CUSTOM_CONFIG_FILE):
-        with open(CUSTOM_CONFIG_FILE, "w") as f:
-            f.write("{}")
+        with NamedTempOpen(CUSTOM_CONFIG_FILE, "w") as f:
+            f.write(json.dumps({}))
 
 
 def create_webhooks_file_if_not_exists(args):
@@ -91,8 +91,8 @@ def create_webhooks_file_if_not_exists(args):
                             json_output=args.json)
 
     if not os.path.exists(WEBHOOKS_FILE):
-        with open(WEBHOOKS_FILE, "w") as f:
-            f.write("{}")
+        with NamedTempOpen(WEBHOOKS_FILE, "w") as f:
+           f.write(json.dumps({}))
 
 
 def boolify(value):

--- a/events/src/utils.py
+++ b/events/src/utils.py
@@ -27,6 +27,7 @@ import base64
 import hmac
 from hashlib import sha256
 from calendar import timegm
+from tempfile import NamedTemporaryFile
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -311,6 +312,45 @@ def plugin_webhook(message):
     message_json = json.dumps(message, sort_keys=True)
     logger.debug("EVENT: {0}".format(message_json))
     webhooks_pool.send(message["event"], message["ts"], message_json)
+
+
+class NamedTempOpen(object):
+    """
+        This class is used to create a temporary file which is then written to with contents.
+        The temp file is then persisted with the give name by calling os.rename().
+        This class is used to avoid the data loss or truncation in case of multiple processes
+        writing to the same file without the use of fcntl locks.
+        The temporary file is created in the dest dir of the file.
+    """
+
+    def __init__(self, filename, open_mode, *args, **kwagrs) -> None:
+        self.filename = filename
+        self.open_mode = open_mode
+        self.open_args = args
+        self.open_kwargs = kwagrs
+        self.working_dir = "."
+        self.fileobj = None
+
+        self.working_dir = os.path.dirname(os.path.realpath(self.filename))
+
+    def __enter__(self):
+        tfile = NamedTemporaryFile(mode=self.open_mode,
+                                   delete=False,
+                                   prefix='.',
+                                   dir=self.working_dir,
+                                   *self.open_args,
+                                   **self.open_kwargs)
+
+        self.fileobj = tfile
+        return self.fileobj
+
+    def __exit__(self, ex_type, ex_val, ex_tb):
+        self.fileobj.close()
+
+        if ex_type is not None:
+            os.unlink(self.fileobj.name)
+        else:
+            os.rename(self.fileobj.name, self.filename)
 
 
 class LockedOpen(object):


### PR DESCRIPTION
to prevent race cases that might occur when several nodes are trying to create the config file at the same time if it is non existent (first run).

Fixes: #3714
Reopens: #3826

Change-Id: I6439eea6838be8587caae01126797cf86d587a68
Signed-off-by: black-dragon74 <niryadav@redhat.com>

