### PR TITLE
api: Added missing fd_close call to glfs_close

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -741,8 +741,10 @@ pub_glfs_close(struct glfs_fd *glfd)
 out:
     fs = glfd->fs;
 
-    if (fd)
+    if (fd) {
+        fd_close(fd);
         fd_unref(fd);
+    }
     if (fop_attr)
         dict_unref(fop_attr);
 


### PR DESCRIPTION
Without this call, incomplete cleanup occurs. Open-behind xlator doesn't work as expected because it thinks the file has been opened multiple times.

Fixes: #3977
Signed-off-by: Aleksey Vasenev <margtu-fivt@ya.ru>

