### PR TITLE
[gidcache] Cast time values to 64 bit integer

### DIFF
--- a/libglusterfs/src/gidcache.c
+++ b/libglusterfs/src/gidcache.c
@@ -23,7 +23,7 @@
  * Initialize the cache.
  */
 int
-gid_cache_init(gid_cache_t *cache, uint32_t timeout)
+gid_cache_init(gid_cache_t *cache, uint64_t timeout)
 {
     if (!cache)
         return -1;
@@ -40,7 +40,7 @@ gid_cache_init(gid_cache_t *cache, uint32_t timeout)
  * Reconfigure the cache timeout.
  */
 int
-gid_cache_reconf(gid_cache_t *cache, uint32_t timeout)
+gid_cache_reconf(gid_cache_t *cache, uint64_t timeout)
 {
     if (!cache)
         return -1;

--- a/libglusterfs/src/glusterfs/gidcache.h
+++ b/libglusterfs/src/glusterfs/gidcache.h
@@ -41,15 +41,15 @@ typedef struct {
 
 typedef struct {
     gf_lock_t gc_lock;
-    uint32_t gc_max_age;
+    uint64_t gc_max_age;
     unsigned int gc_nbuckets;
     gid_list_t gc_cache[AUX_GID_CACHE_SIZE];
 } gid_cache_t;
 
 int
-gid_cache_init(gid_cache_t *, uint32_t);
+gid_cache_init(gid_cache_t *, uint64_t);
 int
-gid_cache_reconf(gid_cache_t *, uint32_t);
+gid_cache_reconf(gid_cache_t *, uint64_t);
 const gid_list_t *
 gid_cache_lookup(gid_cache_t *, uint64_t, uint64_t, uint64_t);
 void


### PR DESCRIPTION
`time_t` values were being cast to `uint32_t` values inside gidcache. This patch addresses this issue.

CID: 1493180

Signed-off-by: black-dragon74 <niryadav@redhat.com>

