### PR TITLE
Fixes: #3940 Don't use bash syntax in ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1933,8 +1933,9 @@ echo
 
 # dnl Note: ${X^^} capitalization assumes bash >= 4.x
 if test "x$SANITIZER" != "xnone"; then
+        UC_SANITIZER=$(echo ${SANITIZER} | tr 'a-z' 'A-Z')
         echo "Note: since glusterfs processes are daemon processes, use"
-        echo "'export ${SANITIZER^^}_OPTIONS=log_path=/path/to/xxx.log' to collect"
+        echo "'export ${UC_SANITIZER}_OPTIONS=log_path=/path/to/xxx.log' to collect"
         echo "sanitizer output. Further details and more options can be"
         echo "found at https://github.com/google/sanitizers."
 fi


### PR DESCRIPTION
This patch replaces the bash 4.0 syntax (for converting a string to upper case) in ./configure with /bin/sh compatible syntax. This avoids ./configure failing on systems where /bin/sh != /bin/bash (e.g. Debian & deriviates, BSDs).

Change-Id: I7839e7058b5b2f863dc1184ddde4429014e59faa
Fixes: #3940

