### PR TITLE
Fixes: #3940 Do not use bash in ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1931,10 +1931,10 @@ echo "Enable Brick Mux     : $USE_BRICKMUX"
 echo "Building with LTO    : $LTO_BUILD"
 echo
 
-# dnl Note: ${X^^} capitalization assumes bash >= 4.x
 if test "x$SANITIZER" != "xnone"; then
+        UC_SANITIZER=$(echo ${SANITIZER} | tr 'a-z' 'A-Z')
         echo "Note: since glusterfs processes are daemon processes, use"
-        echo "'export ${SANITIZER^^}_OPTIONS=log_path=/path/to/xxx.log' to collect"
+        echo "'export ${UC_SANITIZER}_OPTIONS=log_path=/path/to/xxx.log' to collect"
         echo "sanitizer output. Further details and more options can be"
         echo "found at https://github.com/google/sanitizers."
 fi


### PR DESCRIPTION
Switch from using bash 4.x syntax for upper-casing strings to /bin/sh compatible syntax. This avoids ./configure crashing on systems where /bin/sh != /bin/bash (e.g. Debian & derivatives, BSD versions).

Change-Id: Id66e65f9b72ca6fdb0df0ece3ce152257c7ec3a4
Fixes: #3940

