### PR TITLE
Fixes: #3942 Do not use __WORDSIZE as proxy for sizeof(time_t)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -563,6 +563,11 @@ AC_SUBST(SIZEOF_INT)
 AC_SUBST(SIZEOF_LONG)
 AC_SUBST(SIZEOF_LONG_LONG)
 
+# size of time_t
+AC_CHECK_SIZEOF(time_t)
+SIZEOF_TIME_T=$ac_cv_sizeof_time_t
+AC_SUBST(SIZEOF_TIME_T)
+
 # YACC needs a check
 AC_PROG_YACC
 if test "x${YACC}" = "xbyacc" -o "x${YACC}" = "xyacc" -o "x${YACC}" = "x"; then

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <pthread.h>
 
+#include "config.h"
 #include "glusterfs/common-utils.h"
 
 typedef struct _data data_t;
@@ -327,17 +328,17 @@ GF_MUST_CHECK int
 dict_set_uint64(dict_t *this, char *key, uint64_t val);
 
 /* POSIX-compliant systems requires the 'time_t' to be a signed integer. */
-#if __WORDSIZE == 64
+#if SIZEOF_TIME_T == 8
 #define dict_get_time(dict, key, val) dict_get_int64((dict), (key), (val))
 #define dict_set_time(dict, key, val) dict_set_int64((dict), (key), (val))
-#elif __WORDSIZE == 32
+#elif SIZEOF_TIME_T == 4
 #define dict_get_time(dict, key, val)                                          \
     dict_get_int32((dict), (key), ((int32_t *)(val)))
 #define dict_set_time(dict, key, val)                                          \
     dict_set_int32((dict), (key), ((int32_t)(val)))
 #else
-#error "unknown word size"
-#endif /* WORDSIZE check */
+#error "unknown time_t size"
+#endif /* SIZEOF_TIME_T check */
 
 GF_MUST_CHECK int
 dict_check_flag(dict_t *this, char *key, int flag);


### PR DESCRIPTION
Do not use __WORDSIZE as a proxy for size_of(time_t), because:
 - non-portable, __WORDSIZE only exists in glibc
 - unrelated information, there is at best some random overlap between the size of the machine word and the size of time_t (e.g. NetBSD has sizeof(time_t) == 8 even on 32bit systems)

Instead modify ./configure to correctly determine sizeof(time_t) at build time to set a #define and then use this correct value.

Change-Id: Ie8f955241582f56f888af3160fbaba46cdb66c0e
Fixes: #3942

