### PR TITLE
mount.glusterfs: Add missing `fi` for `if`

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -326,6 +326,7 @@ start_glusterfs ()
 
     if [ -n "$fuse_setlk_handle_interrupt" ]; then
         cmd_line=$(echo "$cmd_line --fuse-setlk-handle-interrupt=$fuse_setlk_handle_interrupt");
+    fi
 
     if [ -n "$fuse_handle_copy_file_range" ]; then
         cmd_line=$(echo "$cmd_line --fuse-handle-copy_file_range=$fuse_handle_copy_file_range");


### PR DESCRIPTION
Following error was seen while trying to mount GlusterFS volumes:

```
Error mounting /gluster/lock/: /sbin/mount.glusterfs: line 434: syntax
    error near unexpected token `}
/sbin/mount.glusterfs: line 434: `}'
```
