### PR TITLE
xdr: fix stack overflow when processing glx_dir(p)list structures

### DIFF
--- a/rpc/xdr/src/Makefile.am
+++ b/rpc/xdr/src/Makefile.am
@@ -28,10 +28,10 @@ libgfxdr_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la
 libgfxdr_la_LDFLAGS = -version-info $(LIBGFXDR_LT_VERSION) $(GF_LDFLAGS) \
 		      -export-symbols $(top_srcdir)/rpc/xdr/src/libgfxdr.sym
 
-libgfxdr_la_SOURCES = xdr-generic.c ${NFS_SRCS}
+libgfxdr_la_SOURCES = xdr-generic.c xdr-custom.c ${NFS_SRCS}
 nodist_libgfxdr_la_SOURCES = $(XDRSOURCES)
 
-libgfxdr_la_HEADERS = xdr-generic.h glusterfs3.h rpc-pragmas.h ${NFS_HDRS}
+libgfxdr_la_HEADERS = xdr-generic.h xdr-custom.h glusterfs3.h rpc-pragmas.h ${NFS_HDRS}
 nodist_libgfxdr_la_HEADERS = $(XDRHEADERS)
 
 libgfxdr_ladir = $(includedir)/glusterfs/rpc

--- a/rpc/xdr/src/glusterfs3.h
+++ b/rpc/xdr/src/glusterfs3.h
@@ -14,6 +14,7 @@
 #include <sys/uio.h>
 
 #include "xdr-generic.h"
+#include "xdr-custom.h"
 #include "glusterfs3-xdr.h"
 #include "glusterfs4-xdr.h"
 #include <glusterfs/iatt.h>

--- a/rpc/xdr/src/glusterfs4-xdr.x
+++ b/rpc/xdr/src/glusterfs4-xdr.x
@@ -16,62 +16,62 @@
 
 /* Need to consume iattx and new dict in all the fops */
 struct gfx_iattx {
-        opaque       ia_gfid[16];
+    opaque ia_gfid[16];
 
-        unsigned hyper     ia_flags;
-        unsigned hyper     ia_ino;        /* inode number */
-        unsigned hyper     ia_dev;        /* backing device ID */
-        unsigned hyper     ia_rdev;       /* device ID (if special file) */
-        unsigned hyper     ia_size;       /* file size in bytes */
-        unsigned hyper     ia_blocks;     /* number of 512B blocks allocated */
-        unsigned hyper     ia_attributes; /* chattr related:compressed, immutable,
-                                     * append only, encrypted etc.*/
-        unsigned hyper     ia_attributes_mask; /* Mask for the attributes */
+    unsigned hyper ia_flags;
+    unsigned hyper ia_ino;             /* inode number */
+    unsigned hyper ia_dev;             /* backing device ID */
+    unsigned hyper ia_rdev;            /* device ID (if special file) */
+    unsigned hyper ia_size;            /* file size in bytes */
+    unsigned hyper ia_blocks;          /* number of 512B blocks allocated */
+    unsigned hyper ia_attributes;      /* chattr related:compressed, immutable,
+                                        * append only, encrypted etc.*/
+    unsigned hyper ia_attributes_mask; /* Mask for the attributes */
 
-        hyper      ia_atime;      /* last access time */
-        hyper      ia_mtime;      /* last modification time */
-        hyper      ia_ctime;      /* last status change time */
-        hyper      ia_btime;      /* creation time. Fill using statx */
+    hyper ia_atime; /* last access time */
+    hyper ia_mtime; /* last modification time */
+    hyper ia_ctime; /* last status change time */
+    hyper ia_btime; /* creation time. Fill using statx */
 
-        unsigned int     ia_atime_nsec;
-        unsigned int     ia_mtime_nsec;
-        unsigned int     ia_ctime_nsec;
-        unsigned int     ia_btime_nsec;
-        unsigned int     ia_nlink;      /* Link count */
-        unsigned int     ia_uid;        /* user ID of owner */
-        unsigned int     ia_gid;        /* group ID of owner */
-        unsigned int     ia_blksize;    /* blocksize for filesystem I/O */
-        unsigned int     mode;          /* type of file and rwx mode */
+    unsigned int ia_atime_nsec;
+    unsigned int ia_mtime_nsec;
+    unsigned int ia_ctime_nsec;
+    unsigned int ia_btime_nsec;
+    unsigned int ia_nlink;   /* Link count */
+    unsigned int ia_uid;     /* user ID of owner */
+    unsigned int ia_gid;     /* group ID of owner */
+    unsigned int ia_blksize; /* blocksize for filesystem I/O */
+    unsigned int mode;       /* type of file and rwx mode */
 };
 
 struct gfx_mdata_iatt {
-        hyper      ia_atime;      /* last access time */
-        hyper      ia_mtime;      /* last modification time */
-        hyper      ia_ctime;      /* last status change time */
+    hyper ia_atime; /* last access time */
+    hyper ia_mtime; /* last modification time */
+    hyper ia_ctime; /* last status change time */
 
-        unsigned int     ia_atime_nsec;
-        unsigned int     ia_mtime_nsec;
-        unsigned int     ia_ctime_nsec;
+    unsigned int ia_atime_nsec;
+    unsigned int ia_mtime_nsec;
+    unsigned int ia_ctime_nsec;
 };
 
 union gfx_value switch (int type) {
-        case GF_DATA_TYPE_INT:
-                hyper value_int;
-        case GF_DATA_TYPE_UINT:
-                unsigned hyper value_uint;
-        case GF_DATA_TYPE_DOUBLE:
-                double value_dbl;
-        case GF_DATA_TYPE_STR:
-                opaque val_string<>;
-        case GF_DATA_TYPE_IATT:
-                gfx_iattx iatt;
-        case GF_DATA_TYPE_GFUUID:
-                opaque uuid[16];
-        case GF_DATA_TYPE_PTR:
-        case GF_DATA_TYPE_STR_OLD:
-                opaque other<>;
-        case GF_DATA_TYPE_MDATA:
-                gfx_mdata_iatt mdata_iatt;
+    case GF_DATA_TYPE_INT:
+        hyper value_int;
+    case GF_DATA_TYPE_UINT:
+        unsigned hyper value_uint;
+    case GF_DATA_TYPE_DOUBLE:
+        double value_dbl;
+    case GF_DATA_TYPE_STR:
+        opaque val_string<>;
+    case GF_DATA_TYPE_IATT:
+        gfx_iattx iatt;
+    case GF_DATA_TYPE_GFUUID:
+        opaque uuid[16];
+    case GF_DATA_TYPE_PTR:
+    case GF_DATA_TYPE_STR_OLD:
+        opaque other<>;
+    case GF_DATA_TYPE_MDATA:
+        gfx_mdata_iatt mdata_iatt;
 };
 
 /* AUTH */
@@ -81,105 +81,105 @@ union gfx_value switch (int type) {
    this is also handled in xdr-common.h
 */
 struct auth_glusterfs_params_v3 {
-        int pid;
-        unsigned int uid;
-        unsigned int gid;
+    int pid;
+    unsigned int uid;
+    unsigned int gid;
 
-        /* flags */
-        /* Makes sense to use it for each bits */
-        /* 0x1 == IS_INTERNAL? */
-        /* Another 31 bits are reserved */
-        unsigned int flags;
+    /* flags */
+    /* Makes sense to use it for each bits */
+    /* 0x1 == IS_INTERNAL? */
+    /* Another 31 bits are reserved */
+    unsigned int flags;
 
-        /* birth time of the frame / call */
-        unsigned int ctime_nsec; /* good to have 32bit for this */
-        unsigned hyper ctime_sec;
+    /* birth time of the frame / call */
+    unsigned int ctime_nsec; /* good to have 32bit for this */
+    unsigned hyper ctime_sec;
 
-        unsigned int groups<>;
-        opaque lk_owner<>;
+    unsigned int groups<>;
+    opaque lk_owner<>;
 };
 
 struct gfx_dict_pair {
-       opaque key<>;
-       gfx_value value;
+    opaque key<>;
+    gfx_value value;
 };
 
 struct gfx_dict {
-       unsigned int xdr_size;
-       int count;
-       gfx_dict_pair pairs<>;
+    unsigned int xdr_size;
+    int count;
+    gfx_dict_pair pairs<>;
 };
 
 /* FOPS */
 struct gfx_common_rsp {
-       int    op_ret;
-       int    op_errno;
-       gfx_dict xdata; /* Extra data */
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_common_iatt_rsp {
-       int op_ret;
-       int op_errno;
-       gfx_dict xdata;
-       gfx_iattx stat;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata;
+    gfx_iattx stat;
 };
 
 struct gfx_common_2iatt_rsp {
-       int op_ret;
-       int op_errno;
-       gfx_dict xdata;
-       gfx_iattx prestat;
-       gfx_iattx poststat;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata;
+    gfx_iattx prestat;
+    gfx_iattx poststat;
 };
 
 struct gfx_common_3iatt_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gfx_iattx stat;
-        gfx_iattx preparent;
-        gfx_iattx postparent;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_iattx stat;
+    gfx_iattx preparent;
+    gfx_iattx postparent;
 };
 
 struct gfx_fsetattr_req {
-        opaque gfid[16];
-        hyper        fd;
-        gfx_iattx stbuf;
-        int        valid;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    hyper fd;
+    gfx_iattx stbuf;
+    int valid;
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_rchecksum_req {
-        opaque gfid[16];
-        hyper   fd;
-        unsigned hyper  offset;
-        unsigned int  len;
-        unsigned int  flags;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    hyper fd;
+    unsigned hyper offset;
+    unsigned int len;
+    unsigned int flags;
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_icreate_req {
-       opaque gfid[16];
-       unsigned int mode;
-       gfx_dict xdata;
+    opaque gfid[16];
+    unsigned int mode;
+    gfx_dict xdata;
 };
 
 struct gfx_put_req {
-        opaque       pargfid[16];
-        string       bname<>;
-        unsigned int mode;
-        unsigned int umask;
-        unsigned int flag;
-        u_quad_t     offset;
-        unsigned int size;
-        gfx_dict     xattr;
-        gfx_dict     xdata;
+    opaque pargfid[16];
+    string bname<>;
+    unsigned int mode;
+    unsigned int umask;
+    unsigned int flag;
+    u_quad_t offset;
+    unsigned int size;
+    gfx_dict xattr;
+    gfx_dict xdata;
 };
 
 struct gfx_namelink_req {
-       opaque pargfid[16];
-       string bname<>;
-       gfx_dict xdata;
+    opaque pargfid[16];
+    string bname<>;
+    gfx_dict xdata;
 };
 
 /* Define every fops */
@@ -189,609 +189,593 @@ struct gfx_namelink_req {
   3. gfid has 4 extra bytes so it can be used for future
 */
 struct gfx_stat_req {
-        opaque gfid[16];
-        gfx_dict xdata;
+    opaque gfid[16];
+    gfx_dict xdata;
 };
 
 struct gfx_readlink_req {
-        opaque gfid[16];
-        unsigned int   size;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    unsigned int size;
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_readlink_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gfx_iattx buf;
-        string path<>; /* NULL terminated */
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_iattx buf;
+    string path<>; /* NULL terminated */
 };
 
 struct gfx_mknod_req {
-        opaque  pargfid[16];
-        u_quad_t dev;
-        unsigned int mode;
-        unsigned int umask;
-        string     bname<>; /* NULL terminated */
-        gfx_dict xdata; /* Extra data */
+    opaque pargfid[16];
+    u_quad_t dev;
+    unsigned int mode;
+    unsigned int umask;
+    string bname<>; /* NULL terminated */
+    gfx_dict xdata; /* Extra data */
 };
 
-struct  gfx_mkdir_req {
-        opaque  pargfid[16];
-        unsigned int mode;
-        unsigned int umask;
-        string     bname<>; /* NULL terminated */
-        gfx_dict xdata; /* Extra data */
+struct gfx_mkdir_req {
+    opaque pargfid[16];
+    unsigned int mode;
+    unsigned int umask;
+    string bname<>; /* NULL terminated */
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_unlink_req {
-        opaque  pargfid[16];
-        string     bname<>; /* NULL terminated */
-        unsigned int xflags;
-        gfx_dict xdata; /* Extra data */
+    opaque pargfid[16];
+    string bname<>; /* NULL terminated */
+    unsigned int xflags;
+    gfx_dict xdata; /* Extra data */
 };
 
-
 struct gfx_rmdir_req {
-        opaque  pargfid[16];
-        int        xflags;
-        string     bname<>; /* NULL terminated */
-        gfx_dict xdata; /* Extra data */
+    opaque pargfid[16];
+    int xflags;
+    string bname<>; /* NULL terminated */
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_symlink_req {
-        opaque  pargfid[16];
-        string     bname<>;
-        unsigned int umask;
-        string     linkname<>;
-        gfx_dict xdata; /* Extra data */
+    opaque pargfid[16];
+    string bname<>;
+    unsigned int umask;
+    string linkname<>;
+    gfx_dict xdata; /* Extra data */
 };
 
-struct  gfx_rename_req {
-        opaque  oldgfid[16];
-        opaque  newgfid[16];
-        string       oldbname<>; /* NULL terminated */
-        string       newbname<>; /* NULL terminated */
-        gfx_dict xdata; /* Extra data */
+struct gfx_rename_req {
+    opaque oldgfid[16];
+    opaque newgfid[16];
+    string oldbname<>; /* NULL terminated */
+    string newbname<>; /* NULL terminated */
+    gfx_dict xdata;    /* Extra data */
 };
 
-struct   gfx_rename_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gfx_iattx stat;
-        gfx_iattx preoldparent;
-        gfx_iattx postoldparent;
-        gfx_iattx prenewparent;
-        gfx_iattx postnewparent;
+struct gfx_rename_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_iattx stat;
+    gfx_iattx preoldparent;
+    gfx_iattx postoldparent;
+    gfx_iattx prenewparent;
+    gfx_iattx postnewparent;
 };
 
-
- struct  gfx_link_req {
-        opaque  oldgfid[16];
-        opaque  newgfid[16];
-        string       newbname<>;
-        gfx_dict xdata; /* Extra data */
+struct gfx_link_req {
+    opaque oldgfid[16];
+    opaque newgfid[16];
+    string newbname<>;
+    gfx_dict xdata; /* Extra data */
 };
 
- struct   gfx_truncate_req {
-        opaque gfid[16];
-        u_quad_t offset;
-        gfx_dict xdata; /* Extra data */
+struct gfx_truncate_req {
+    opaque gfid[16];
+    u_quad_t offset;
+    gfx_dict xdata; /* Extra data */
 };
 
- struct   gfx_open_req {
-        opaque gfid[16];
-        unsigned int flags;
-        gfx_dict xdata; /* Extra data */
+struct gfx_open_req {
+    opaque gfid[16];
+    unsigned int flags;
+    gfx_dict xdata; /* Extra data */
 };
 
-struct   gfx_open_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        quad_t fd;
+struct gfx_open_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    quad_t fd;
 };
 
 struct gfx_opendir_req {
-        opaque gfid[16];
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
- struct   gfx_read_req {
-        opaque gfid[16];
-        quad_t  fd;
-        u_quad_t offset;
-        unsigned int size;
-        unsigned int flag;
-        gfx_dict xdata; /* Extra data */
-};
- struct  gfx_read_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_iattx stat;
-        unsigned int size;
-        gfx_dict xdata; /* Extra data */
-} ;
-
-struct   gfx_lookup_req {
-        opaque gfid[16];
-        opaque  pargfid[16];
-        unsigned int flags;
-        string     bname<>;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    gfx_dict xdata; /* Extra data */
 };
 
-
- struct   gfx_write_req {
-        opaque gfid[16];
-        quad_t  fd;
-        u_quad_t offset;
-        unsigned int size;
-        unsigned int flag;
-        gfx_dict xdata; /* Extra data */
+struct gfx_read_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    unsigned int size;
+    unsigned int flag;
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_read_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_iattx stat;
+    unsigned int size;
+    gfx_dict xdata; /* Extra data */
 };
 
- struct gfx_statfs_req  {
-        opaque gfid[16];
-        gfx_dict xdata; /* Extra data */
-}  ;
- struct gfx_statfs_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gf_statfs statfs;
-}  ;
+struct gfx_lookup_req {
+    opaque gfid[16];
+    opaque pargfid[16];
+    unsigned int flags;
+    string bname<>;
+    gfx_dict xdata; /* Extra data */
+};
 
- struct gfx_lk_req {
-        opaque gfid[16];
-        int64_t         fd;
-        unsigned int        cmd;
-        unsigned int        type;
-        gf_proto_flock flock;
-        gfx_dict xdata; /* Extra data */
-}  ;
- struct gfx_lk_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gf_proto_flock flock;
-}  ;
+struct gfx_write_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    unsigned int size;
+    unsigned int flag;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_statfs_req {
+    opaque gfid[16];
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_statfs_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gf_statfs statfs;
+};
+
+struct gfx_lk_req {
+    opaque gfid[16];
+    int64_t fd;
+    unsigned int cmd;
+    unsigned int type;
+    gf_proto_flock flock;
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_lk_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gf_proto_flock flock;
+};
 
 struct gfx_lease_req {
-        opaque gfid[16];
-        gf_proto_lease lease;
-        gfx_dict xdata; /* Extra data */
-}  ;
+    opaque gfid[16];
+    gf_proto_lease lease;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_lease_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gf_proto_lease lease;
-}  ;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gf_proto_lease lease;
+};
 
 struct gfx_recall_lease_req {
-        opaque       gfid[16];
-        unsigned int lease_type;
-        opaque       tid[16];
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct gfx_inodelk_req {
-        opaque gfid[16];
-        unsigned int cmd;
-        unsigned int type;
-        gf_proto_flock flock;
-        string     volume<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-struct   gfx_finodelk_req {
-        opaque gfid[16];
-        quad_t  fd;
-        unsigned int cmd;
-        unsigned int type;
-        gf_proto_flock flock;
-        string volume<>;
-        gfx_dict xdata; /* Extra data */
-} ;
-
-
- struct gfx_flush_req {
-        opaque gfid[16];
-        quad_t  fd;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
- struct gfx_fsync_req {
-        opaque gfid[16];
-        quad_t  fd;
-        unsigned int data;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct gfx_setxattr_req {
-        opaque gfid[16];
-        unsigned int flags;
-        gfx_dict dict;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
-
- struct gfx_fsetxattr_req {
-        opaque gfid[16];
-        int64_t  fd;
-        unsigned int flags;
-        gfx_dict dict;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
-
- struct gfx_xattrop_req {
-        opaque gfid[16];
-        unsigned int flags;
-        gfx_dict dict;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-struct gfx_common_dict_rsp  {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gfx_dict dict;
-        gfx_iattx prestat;
-        gfx_iattx poststat;
+    opaque gfid[16];
+    unsigned int lease_type;
+    opaque tid[16];
+    gfx_dict xdata; /* Extra data */
 };
 
-
- struct gfx_fxattrop_req {
-        opaque gfid[16];
-        quad_t  fd;
-        unsigned int flags;
-        gfx_dict dict;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct gfx_getxattr_req  {
-        opaque gfid[16];
-        unsigned int namelen;
-        string     name<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
- struct gfx_fgetxattr_req  {
-        opaque gfid[16];
-        quad_t  fd;
-        unsigned int namelen;
-        string     name<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct gfx_removexattr_req {
-        opaque gfid[16];
-        string     name<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct gfx_fremovexattr_req {
-        opaque gfid[16];
-        quad_t  fd;
-        string     name<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-
- struct gfx_fsyncdir_req {
-        opaque gfid[16];
-        quad_t  fd;
-        int  data;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
- struct   gfx_readdir_req  {
-        opaque gfid[16];
-        quad_t  fd;
-        u_quad_t offset;
-        unsigned int size;
-        gfx_dict xdata; /* Extra data */
+struct gfx_inodelk_req {
+    opaque gfid[16];
+    unsigned int cmd;
+    unsigned int type;
+    gf_proto_flock flock;
+    string volume<>;
+    gfx_dict xdata; /* Extra data */
 };
 
- struct gfx_readdirp_req {
-        opaque gfid[16];
-        quad_t  fd;
-        u_quad_t offset;
-        unsigned int size;
-        gfx_dict xdata;
-}  ;
+struct gfx_finodelk_req {
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int cmd;
+    unsigned int type;
+    gf_proto_flock flock;
+    string volume<>;
+    gfx_dict xdata; /* Extra data */
+};
 
+struct gfx_flush_req {
+    opaque gfid[16];
+    quad_t fd;
+    gfx_dict xdata; /* Extra data */
+};
 
-struct gfx_access_req  {
-        opaque gfid[16];
-        unsigned int mask;
-        gfx_dict xdata; /* Extra data */
-} ;
+struct gfx_fsync_req {
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int data;
+    gfx_dict xdata; /* Extra data */
+};
 
+struct gfx_setxattr_req {
+    opaque gfid[16];
+    unsigned int flags;
+    gfx_dict dict;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_fsetxattr_req {
+    opaque gfid[16];
+    int64_t fd;
+    unsigned int flags;
+    gfx_dict dict;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_xattrop_req {
+    opaque gfid[16];
+    unsigned int flags;
+    gfx_dict dict;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_common_dict_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_dict dict;
+    gfx_iattx prestat;
+    gfx_iattx poststat;
+};
+
+struct gfx_fxattrop_req {
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int flags;
+    gfx_dict dict;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_getxattr_req {
+    opaque gfid[16];
+    unsigned int namelen;
+    string name<>;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_fgetxattr_req {
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int namelen;
+    string name<>;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_removexattr_req {
+    opaque gfid[16];
+    string name<>;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_fremovexattr_req {
+    opaque gfid[16];
+    quad_t fd;
+    string name<>;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_fsyncdir_req {
+    opaque gfid[16];
+    quad_t fd;
+    int data;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_readdir_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    unsigned int size;
+    gfx_dict xdata; /* Extra data */
+};
+
+struct gfx_readdirp_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    unsigned int size;
+    gfx_dict xdata;
+};
+
+struct gfx_access_req {
+    opaque gfid[16];
+    unsigned int mask;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_create_req {
-        opaque  pargfid[16];
-        unsigned int flags;
-        unsigned int mode;
-        unsigned int umask;
-        string     bname<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
-struct  gfx_create_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        gfx_iattx stat;
-        u_quad_t       fd;
-        gfx_iattx preparent;
-        gfx_iattx postparent;
-} ;
+    opaque pargfid[16];
+    unsigned int flags;
+    unsigned int mode;
+    unsigned int umask;
+    string bname<>;
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_create_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_iattx stat;
+    u_quad_t fd;
+    gfx_iattx preparent;
+    gfx_iattx postparent;
+};
 
-struct   gfx_ftruncate_req  {
-        opaque gfid[16];
-        quad_t  fd;
-        u_quad_t offset;
-        gfx_dict xdata; /* Extra data */
-} ;
-
+struct gfx_ftruncate_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_fstat_req {
-        opaque gfid[16];
-        quad_t  fd;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
+    opaque gfid[16];
+    quad_t fd;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_entrylk_req {
-        opaque gfid[16];
-        unsigned int  cmd;
-        unsigned int  type;
-        u_quad_t  namelen;
-        string      name<>;
-        string      volume<>;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    unsigned int cmd;
+    unsigned int type;
+    u_quad_t namelen;
+    string name<>;
+    string volume<>;
+    gfx_dict xdata; /* Extra data */
 };
 
 struct gfx_fentrylk_req {
-        opaque gfid[16];
-        quad_t   fd;
-        unsigned int  cmd;
-        unsigned int  type;
-        u_quad_t  namelen;
-        string      name<>;
-        string      volume<>;
-        gfx_dict xdata; /* Extra data */
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int cmd;
+    unsigned int type;
+    u_quad_t namelen;
+    string name<>;
+    string volume<>;
+    gfx_dict xdata; /* Extra data */
 };
 
- struct gfx_setattr_req {
-        opaque gfid[16];
-        gfx_iattx stbuf;
-        int        valid;
-        gfx_dict xdata; /* Extra data */
-}  ;
+struct gfx_setattr_req {
+    opaque gfid[16];
+    gfx_iattx stbuf;
+    int valid;
+    gfx_dict xdata; /* Extra data */
+};
 
- struct gfx_fallocate_req {
-        opaque          gfid[16];
-        quad_t          fd;
-        unsigned int    flags;
-        u_quad_t        offset;
-        u_quad_t        size;
-        gfx_dict xdata; /* Extra data */
-}  ;
+struct gfx_fallocate_req {
+    opaque gfid[16];
+    quad_t fd;
+    unsigned int flags;
+    u_quad_t offset;
+    u_quad_t size;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_discard_req {
-        opaque          gfid[16];
-        quad_t          fd;
-        u_quad_t        offset;
-        u_quad_t        size;
-        gfx_dict xdata; /* Extra data */
-}  ;
-
-struct gfx_zerofill_req {
-        opaque          gfid[16];
-        quad_t           fd;
-        u_quad_t  offset;
-        u_quad_t  size;
-        gfx_dict xdata;
-}  ;
-
-struct gfx_rchecksum_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict xdata; /* Extra data */
-        unsigned int flags;
-        unsigned int weak_checksum;
-        opaque   strong_checksum<>;
-}  ;
-
-
-struct gfx_ipc_req {
-        int     op;
-        gfx_dict xdata;
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    u_quad_t size;
+    gfx_dict xdata; /* Extra data */
 };
 
+struct gfx_zerofill_req {
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    u_quad_t size;
+    gfx_dict xdata;
+};
+
+struct gfx_rchecksum_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    unsigned int flags;
+    unsigned int weak_checksum;
+    opaque strong_checksum<>;
+};
+
+struct gfx_ipc_req {
+    int op;
+    gfx_dict xdata;
+};
 
 struct gfx_seek_req {
-        opaque    gfid[16];
-        quad_t    fd;
-        u_quad_t  offset;
-        int       what;
-        gfx_dict xdata;
+    opaque gfid[16];
+    quad_t fd;
+    u_quad_t offset;
+    int what;
+    gfx_dict xdata;
 };
 
 struct gfx_seek_rsp {
-        int       op_ret;
-        int       op_errno;
-        gfx_dict xdata;
-        u_quad_t  offset;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata;
+    u_quad_t offset;
 };
 
-
- struct gfx_setvolume_req {
-        gfx_dict dict;
-}  ;
-
- struct   gfx_copy_file_range_req {
-        opaque gfid1[16];
-        opaque gfid2[16];
-        quad_t  fd_in;
-        quad_t  fd_out;
-        u_quad_t   off_in;
-        u_quad_t   off_out;
-        unsigned int size;
-        unsigned int flag;
-        gfx_dict xdata; /* Extra data */
+struct gfx_setvolume_req {
+    gfx_dict dict;
 };
 
- struct  gfx_setvolume_rsp {
-        int    op_ret;
-        int    op_errno;
-        gfx_dict dict;
-} ;
+struct gfx_copy_file_range_req {
+    opaque gfid1[16];
+    opaque gfid2[16];
+    quad_t fd_in;
+    quad_t fd_out;
+    u_quad_t off_in;
+    u_quad_t off_out;
+    unsigned int size;
+    unsigned int flag;
+    gfx_dict xdata; /* Extra data */
+};
 
+struct gfx_setvolume_rsp {
+    int op_ret;
+    int op_errno;
+    gfx_dict dict;
+};
 
- struct gfx_getspec_req {
-        unsigned int flags;
-        string     key<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
- struct  gfx_getspec_rsp {
-        int    op_ret;
-        int    op_errno;
-        string spec<>;
-        gfx_dict xdata; /* Extra data */
-} ;
+struct gfx_getspec_req {
+    unsigned int flags;
+    string key<>;
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_getspec_rsp {
+    int op_ret;
+    int op_errno;
+    string spec<>;
+    gfx_dict xdata; /* Extra data */
+};
 
-
- struct gfx_notify_req {
-        unsigned int  flags;
-        string buf<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
- struct gfx_notify_rsp {
-        int    op_ret;
-        int    op_errno;
-        unsigned int  flags;
-        string buf<>;
-        gfx_dict xdata; /* Extra data */
-}  ;
+struct gfx_notify_req {
+    unsigned int flags;
+    string buf<>;
+    gfx_dict xdata; /* Extra data */
+};
+struct gfx_notify_rsp {
+    int op_ret;
+    int op_errno;
+    unsigned int flags;
+    string buf<>;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_releasedir_req {
-        opaque gfid[16];
-        quad_t  fd;
-        gfx_dict xdata; /* Extra data */
-}  ;
+    opaque gfid[16];
+    quad_t fd;
+    gfx_dict xdata; /* Extra data */
+};
 
 struct gfx_release_req {
-        opaque gfid[16];
-        quad_t  fd;
-        gfx_dict xdata; /* Extra data */
-}  ;
+    opaque gfid[16];
+    quad_t fd;
+    gfx_dict xdata; /* Extra data */
+};
 
+/* This structure cannot be modified without also modifying the corresponding
+ * functions in xdr-custom.c. */
 struct gfx_dirlist {
-       u_quad_t d_ino;
-       u_quad_t d_off;
-       unsigned int d_len;
-       unsigned int d_type;
-       string name<>;
-       gfx_dirlist *nextentry;
+    u_quad_t d_ino;
+    u_quad_t d_off;
+    unsigned int d_len;
+    unsigned int d_type;
+    string name<>;
+    gfx_dirlist *nextentry;
 };
 
-
+/* This structure cannot be modified without also modifying the corresponding
+ * functions in xdr-custom.c. */
 struct gfx_readdir_rsp {
-       int op_ret;
-       int op_errno;
-       gfx_dict xdata; /* Extra data */
-       gfx_dirlist *reply;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_dirlist *reply;
 };
 
+/* This structure cannot be modified without also modifying the corresponding
+ * functions in xdr-custom.c. */
 struct gfx_dirplist {
-       u_quad_t d_ino;
-       u_quad_t d_off;
-       unsigned int d_len;
-       unsigned int d_type;
-       string name<>;
-       gfx_iattx stat;
-       gfx_dict dict;
-       gfx_dirplist *nextentry;
+    u_quad_t d_ino;
+    u_quad_t d_off;
+    unsigned int d_len;
+    unsigned int d_type;
+    string name<>;
+    gfx_iattx stat;
+    gfx_dict dict;
+    gfx_dirplist *nextentry;
 };
 
+/* This structure cannot be modified without also modifying the corresponding
+ * functions in xdr-custom.c. */
 struct gfx_readdirp_rsp {
-       int op_ret;
-       int op_errno;
-       gfx_dict xdata; /* Extra data */
-       gfx_dirplist *reply;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata; /* Extra data */
+    gfx_dirplist *reply;
 };
 
 struct gfx_set_lk_ver_rsp {
-       int op_ret;
-       int op_errno;
-       gfx_dict xdata;
-       int lk_ver;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata;
+    int lk_ver;
 };
 
 struct gfx_set_lk_ver_req {
-       string uid<>;
-       int lk_ver;
+    string uid<>;
+    int lk_ver;
 };
 
 struct gfx_event_notify_req {
-        int op;
-        gfx_dict dict;
+    int op;
+    gfx_dict dict;
 };
 
-
 struct gfx_getsnap_name_uuid_req {
-        gfx_dict dict;
+    gfx_dict dict;
 };
 
 struct gfx_getsnap_name_uuid_rsp {
-        int op_ret;
-        int op_errno;
-        gfx_dict dict;
-        string op_errstr<>;
+    int op_ret;
+    int op_errno;
+    gfx_dict dict;
+    string op_errstr<>;
 };
 
 struct gfx_getactivelk_rsp {
-        int op_ret;
-        int op_errno;
-        gfx_dict xdata;
-        gfs3_locklist *reply;
+    int op_ret;
+    int op_errno;
+    gfx_dict xdata;
+    gfs3_locklist *reply;
 };
 
 struct gfx_getactivelk_req {
-        opaque gfid[16];
-        gfx_dict xdata;
+    opaque gfid[16];
+    gfx_dict xdata;
 };
 
 struct gfx_setactivelk_req {
-        opaque gfid[16];
-        gfs3_locklist *request;
-        gfx_dict xdata;
+    opaque gfid[16];
+    gfs3_locklist *request;
+    gfx_dict xdata;
 };
 
 struct gfs4_inodelk_contention_req {
-        opaque                gfid[16];
-        struct gf_proto_flock flock;
-        unsigned int          pid;
-        string                domain<>;
-        opaque                xdata<>;
+    opaque gfid[16];
+    struct gf_proto_flock flock;
+    unsigned int pid;
+    string domain<>;
+    opaque xdata<>;
 };
 
 struct gfs4_entrylk_contention_req {
-        opaque                gfid[16];
-        unsigned int          type;
-        unsigned int          pid;
-        string                name<>;
-        string                domain<>;
-        opaque                xdata<>;
+    opaque gfid[16];
+    unsigned int type;
+    unsigned int pid;
+    string name<>;
+    string domain<>;
+    opaque xdata<>;
 };

--- a/rpc/xdr/src/libgfxdr.sym
+++ b/rpc/xdr/src/libgfxdr.sym
@@ -330,10 +330,10 @@ xdr_gfx_notify_req
 xdr_gfx_notify_rsp
 xdr_gfx_releasedir_req
 xdr_gfx_release_req
-xdr_gfx_dirlist
-xdr_gfx_readdir_rsp
-xdr_gfx_dirplist
-xdr_gfx_readdirp_rsp
+xdr_gfx_dirlist_custom
+xdr_gfx_readdir_rsp_custom
+xdr_gfx_dirplist_custom
+xdr_gfx_readdirp_rsp_custom
 xdr_gfx_set_lk_ver_rsp
 xdr_gfx_set_lk_ver_req
 xdr_gfx_event_notify_req

--- a/rpc/xdr/src/xdr-custom.c
+++ b/rpc/xdr/src/xdr-custom.c
@@ -1,0 +1,92 @@
+
+#include "glusterfs4-xdr.h"
+#include "rpc-pragmas.h"
+#include <glusterfs/glusterfs-fops.h>
+
+/* These functions are necessary to avoid huge stack utilization when the
+ * list of entries is large because rpcgen creates a simple recursive
+ * implementation to encode the entire list.
+ *
+ * It's possible to modify the XDR structures to represent the entries as
+ * a variable length array instead of a linked list of items to avoid this
+ * problem. However this won't be backward compatible. We can't introduce
+ * such a change in a minor release bur we need to fix this in all maintained
+ * versions.
+ *
+ * With this hack we can immediately fix the issue in all existing versions
+ * without breaking anythings, and we can wait for a major release to
+ * introduce the backward incompatible changes.
+ *
+ * The code generated in glusterfs-xdr.c can be used as a reference to
+ * implement this non-recursive version. */
+
+/* TODO: Remove this once the XDR changes can be implemented. */
+
+bool_t
+xdr_gfx_dirlist_custom(XDR *xdrs, gfx_dirlist *objp)
+{
+    if (xdr_u_quad_t(xdrs, &objp->d_ino) && xdr_u_quad_t(xdrs, &objp->d_off) &&
+        xdr_u_int(xdrs, &objp->d_len) && xdr_u_int(xdrs, &objp->d_type) &&
+        xdr_string(xdrs, &objp->name, ~0)) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+bool_t
+xdr_gfx_readdir_rsp_custom(XDR *xdrs, gfx_readdir_rsp *objp)
+{
+    struct gfx_dirlist **pentry;
+
+    if (!xdr_int(xdrs, &objp->op_ret) || !xdr_int(xdrs, &objp->op_errno) ||
+        !xdr_gfx_dict(xdrs, &objp->xdata)) {
+        return FALSE;
+    }
+
+    pentry = &objp->reply;
+    while (xdr_pointer(xdrs, (char **)pentry, sizeof(gfx_dirlist),
+                       (xdrproc_t)xdr_gfx_dirlist_custom)) {
+        if (*pentry == NULL) {
+            return TRUE;
+        }
+        pentry = &(*pentry)->nextentry;
+    }
+
+    return FALSE;
+}
+
+bool_t
+xdr_gfx_dirplist_custom(XDR *xdrs, gfx_dirplist *objp)
+{
+    if (xdr_u_quad_t(xdrs, &objp->d_ino) && xdr_u_quad_t(xdrs, &objp->d_off) &&
+        xdr_u_int(xdrs, &objp->d_len) && xdr_u_int(xdrs, &objp->d_type) &&
+        xdr_string(xdrs, &objp->name, ~0) && xdr_gfx_iattx(xdrs, &objp->stat) &&
+        xdr_gfx_dict(xdrs, &objp->dict)) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+bool_t
+xdr_gfx_readdirp_rsp_custom(XDR *xdrs, gfx_readdirp_rsp *objp)
+{
+    struct gfx_dirplist **pentry;
+
+    if (!xdr_int(xdrs, &objp->op_ret) || !xdr_int(xdrs, &objp->op_errno) ||
+        !xdr_gfx_dict(xdrs, &objp->xdata)) {
+        return FALSE;
+    }
+
+    pentry = &objp->reply;
+    while (xdr_pointer(xdrs, (char **)pentry, sizeof(gfx_dirplist),
+                       (xdrproc_t)xdr_gfx_dirplist_custom)) {
+        if (*pentry == NULL) {
+            return TRUE;
+        }
+        pentry = &(*pentry)->nextentry;
+    }
+
+    return FALSE;
+}

--- a/rpc/xdr/src/xdr-custom.h
+++ b/rpc/xdr/src/xdr-custom.h
@@ -1,0 +1,21 @@
+
+#ifndef _XDR_CUSTOM_H
+#define _XDR_CUSTOM_H
+
+#include <rpc/xdr.h>
+#include "glusterfs4-xdr.h"
+#include "rpc-pragmas.h"
+
+bool_t
+xdr_gfx_dirlist_custom(XDR *xdrs, gfx_dirlist *objp);
+
+bool_t
+xdr_gfx_readdir_rsp_custom(XDR *xdrs, gfx_readdir_rsp *objp);
+
+bool_t
+xdr_gfx_dirplist_custom(XDR *xdrs, gfx_dirplist *objp);
+
+bool_t
+xdr_gfx_readdirp_rsp_custom(XDR *xdrs, gfx_readdirp_rsp *objp);
+
+#endif

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -2253,7 +2253,7 @@ client4_0_readdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdir_rsp);
+    ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdir_rsp_custom);
     if (ret < 0) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
@@ -2311,7 +2311,7 @@ client4_0_readdirp_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdirp_rsp);
+    ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdirp_rsp_custom);
     if (ret < 0) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
@@ -4984,7 +4984,7 @@ client4_0_readdir(call_frame_t *frame, xlator_t *this, void *data)
     args = data;
     conf = this->private;
 
-    readdir_rsp_size = xdr_sizeof((xdrproc_t)xdr_gfx_readdir_rsp, &rsp) +
+    readdir_rsp_size = xdr_sizeof((xdrproc_t)xdr_gfx_readdir_rsp_custom, &rsp) +
                        args->size;
 
     local = mem_get0(this->local_pool);
@@ -5104,7 +5104,8 @@ client4_0_readdirp(call_frame_t *frame, xlator_t *this, void *data)
         goto unwind;
     }
 
-    readdirp_rsp_size = xdr_sizeof((xdrproc_t)xdr_gfx_readdirp_rsp, &rsp) +
+    readdirp_rsp_size = xdr_sizeof((xdrproc_t)xdr_gfx_readdirp_rsp_custom,
+                                   &rsp) +
                         args->size;
 
     if ((readdirp_rsp_size + GLUSTERFS_RPC_REPLY_SIZE +

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -630,7 +630,7 @@ out:
 
     req = frame->local;
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
-                        (xdrproc_t)xdr_gfx_readdir_rsp);
+                        (xdrproc_t)xdr_gfx_readdir_rsp_custom);
 
     GF_FREE(rsp.xdata.pairs.pairs_val);
 
@@ -1805,7 +1805,7 @@ out:
 
     req = frame->local;
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
-                        (xdrproc_t)xdr_gfx_readdirp_rsp);
+                        (xdrproc_t)xdr_gfx_readdirp_rsp_custom);
 
     GF_FREE(rsp.xdata.pairs.pairs_val);
 


### PR DESCRIPTION
The glx_dirlist and glx_dirplist XDR structures are defined as a linked list of objects. When rpcgen generates code to encode and decode these structures, it does so by implementing a simple recursive function.

When the list of entries to encode is large, the recursive call could cause a stack overflow.

The best way to fix this is by transforming the linked list into a variable length array in the XDR definition. However this would break backward compatibility, making this change impossible to backport to older releases.

This fix uses a hack by implementing custom encoding/decoding functions that don't use recursivity and ignores the ones generated by rpcgen.

Fixes: #3346

