### PR TITLE
hashfn: fix inconsistencies on big-endian architectures

### DIFF
--- a/libglusterfs/src/hashfn.c
+++ b/libglusterfs/src/hashfn.c
@@ -11,7 +11,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define get16bits(d) (*((const uint16_t *)(d)))
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+
+#define get16bits(d) le16toh(*((const uint16_t *)(d)))
 
 #define DM_DELTA 0x9E3779B9
 #define DM_FULLROUNDS 10 /* 32 is overkill, 16 is strong crypto */


### PR DESCRIPTION
The computation of the SuperFashHash function did assume that the code was run on a little-endian machine, causing a different result when it's run on a big-endian machine.

This patch explicitly accesses the memory using little-endian mode to keep backwards compatibility but to produce the same result on big-endian architectures.

Fixes: #3345

