### PR TITLE
Quota: Use list_first_entry() to get the right parent entry

### DIFF
--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -4369,7 +4369,7 @@ quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
         goto out;
     }
 
-    entry = list_entry(parents, quota_dentry_t, next);
+    entry = list_first_entry(parents, quota_dentry_t, next);
     parent = inode_find(inode->table, entry->par);
 
     quota_get_limit_dir(frame, parent, this);


### PR DESCRIPTION
In function quota_get_limit_dir_continuation(), list_entry() might return null, the head of the linked list of parents is misused as the first item. It will exit directly at goto out in quota_get_limit_dir(), so that the callback function is not called. Cause the fuse to get stuck.
Using list_first_entry can solve this problem.
entry = list_first_entry(parents, quota_dentry_t,  next);

Fixes:#4009

@ShyamsundarR @harigowtham 