### PR TITLE
fuse: Resolve asan bug in during receive event notification

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -6486,15 +6486,13 @@ notify(xlator_t *this, int32_t event, void *data, ...)
     int32_t ret = 0;
     fuse_private_t *private = NULL;
     gf_boolean_t start_thread = _gf_false;
+    gf_boolean_t event_graph = _gf_true;
     glusterfs_graph_t *graph = NULL;
     struct pollfd pfd = {0};
 
     private = this->private;
 
     graph = data;
-
-    gf_log("fuse", GF_LOG_DEBUG, "got event %d on graph %d", event,
-           ((graph) ? graph->id : 0));
 
     switch (event) {
         case GF_EVENT_GRAPH_NEW:
@@ -6581,8 +6579,18 @@ notify(xlator_t *this, int32_t event, void *data, ...)
         }
 
         default:
+            /* Set the event_graph to false so that event
+               debug msg would not try to access invalid graph->id
+               while data object is not matched to graph object
+               for ex in case of upcall event data object represents
+               gf_upcall object
+            */
+            event_graph = _gf_false;
             break;
     }
+
+    gf_log("fuse", GF_LOG_DEBUG, "got event %d on graph %d", event,
+           ((graph && event_graph) ? graph->id : -1));
 
     return ret;
 }


### PR DESCRIPTION
The fuse xlator notify function tries to assign data object to graph object without checking an event. In case of upcall event data object represents upcall object so during access of graph object the process crashed for asan build.

Solution: Access the graph->id only while an event is associated
          specifically to fuse xlator

> Fixes: #3954
> Change-Id: I6b2869256b26d22163879737dcf163510d1cd8bf
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/4019)

Fixes: #3954
Change-Id: I6b2869256b26d22163879737dcf163510d1cd8bf

