### PR TITLE
configure: force 'char' type to be signed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,9 @@ if test "x$RPCGEN" = "xno"; then
    AC_MSG_ERROR([`rpcgen` not found, glusterfs needs `rpcgen` exiting..])
 fi
 
+# Force 'char' type to be signed
+CFLAGS="${CFLAGS} -fsigned-char"
+
 # Initialize CFLAGS before usage
 AC_ARG_ENABLE([debug],
               AS_HELP_STRING([--enable-debug],[Enable debug build options.]))


### PR DESCRIPTION
On some systems, the 'char' type is interpreted as an unsigned char. This may cause some issues as Gluster code assumes that 'char' is signed.

This patch adds the '-fsigned-char' option during compilation to make sure it works as expected.

Updates: #1000

