### PR TITLE
snapview-server: mark the end of the directory

### DIFF
--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1402,7 +1402,8 @@ out:
 }
 
 static int
-svs_fill_readdir(xlator_t *this, gf_dirent_t *entries, size_t size, off_t off)
+svs_fill_readdir(xlator_t *this, gf_dirent_t *entries, int32_t *op_errno,
+                 size_t size, off_t off)
 {
     gf_dirent_t *entry = NULL;
     svs_private_t *priv = NULL;
@@ -1454,6 +1455,10 @@ svs_fill_readdir(xlator_t *this, gf_dirent_t *entries, size_t size, off_t off)
     }
 unlock:
     UNLOCK(&priv->snaplist_lock);
+
+    if (count == 0) {
+        *op_errno = ENOENT;
+    }
 
 out:
     return count;
@@ -1705,7 +1710,7 @@ svs_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     if (parent_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
         LOCK(&fd->lock);
         {
-            count = svs_fill_readdir(this, &entries, size, off);
+            count = svs_fill_readdir(this, &entries, &op_errno, size, off);
         }
         UNLOCK(&fd->lock);
 
@@ -1797,7 +1802,7 @@ svs_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     if (inode_ctx->type == SNAP_VIEW_ENTRY_POINT_INODE) {
         LOCK(&fd->lock);
         {
-            count = svs_fill_readdir(this, &entries, size, off);
+            count = svs_fill_readdir(this, &entries, &op_errno, size, off);
         }
         UNLOCK(&fd->lock);
     } else {


### PR DESCRIPTION
Several Gluster components expect that op_errno is set to ENOENT when there are no more entries in a directory being read.

Previously, snapview-server returned EINVAL in this case, causing an infinite loop in some cases.

Updates: #4029

