### PR TITLE
posix-aio: fix iocb contents for writev

### DIFF
--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -352,9 +352,13 @@ posix_aio_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     paiocb->iobref = iobref_ref(iobref);
     paiocb->iocb.aio_lio_opcode = IO_CMD_PWRITEV;
-    paiocb->iocb.u.v.vec = iov;
-    paiocb->iocb.u.v.nr = count;
-    paiocb->iocb.u.v.offset = offset;
+    /* There's an iocb.u.v structure that could seem more appropriate for
+     * passing an iovec. However this structure is only compatible with what
+     * the kernel expects for little-endian architectures. So, we just pass
+     * the iovec using the generic structure to avoid problems. */
+    paiocb->iocb.u.c.buf = iov;
+    paiocb->iocb.u.c.nbytes = count;
+    paiocb->iocb.u.c.offset = offset;
 
     iocb = &paiocb->iocb;
 


### PR DESCRIPTION
The structure defined for iocb for user-space contains a union with a vector based substructure that seems created to pass iovec-based operations to the kernel. However this structure is not supported by the kernel and the library doesn't translate it.

In little-endian architectures, this structure is binary compatible with the one expected by the kernel, but this is not true for big-endian architectures.

To avoid this problem, instead of using the iovec-based substructure, the common structure is used to also pass the vectors.

Fixes: #4031

