### PR TITLE
[rpc] Avoid truncation of 64bit time values

### DIFF
--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -1754,6 +1754,51 @@ err:
 }
 
 int
+dict_get_int64n(dict_t *this, char *key, const int keylen, int64_t *val)
+{
+    data_t *data = NULL;
+    int ret = 0;
+
+    if (!this || !key || !val) {
+        ret = -EINVAL;
+        goto err;
+    }
+
+    ret = dict_get_with_refn(this, key, &data);
+    if (ret != 0) {
+        goto err;
+    }
+
+    VALIDATE_DATA_AND_LOG(data, GF_DATA_TYPE_INT, key, -EINVAL);
+
+    ret = data_to_int64_ptr(data, val);
+
+err:
+    if (data)
+        data_unref(data);
+    return ret;
+}
+
+int
+dict_set_int64n(dict_t *this, char *key, const int keylen, int64_t val)
+{
+    data_t *data = data_from_int64(val);
+    int ret = 0;
+
+    if (!data) {
+        ret = -EINVAL;
+        goto err;
+    }
+
+    ret = dict_setn(this, key, keylen, data);
+    if (ret < 0)
+        data_destroy(data);
+
+err:
+    return ret;
+}
+
+int
 dict_get_uint16(dict_t *this, char *key, uint16_t *val)
 {
     data_t *data = NULL;

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -42,6 +42,12 @@ typedef struct _data_pair data_pair_t;
 #define dict_set_int32_sizen(this, key, val)                                   \
     dict_set_int32n(this, key, SLEN(key), val)
 
+#define dict_get_int64_sizen(this, key, val)                                   \
+    dict_get_int64n(this, key, SLEN(key), val)
+
+#define dict_set_int64_sizen(this, key, val)                                   \
+    dict_set_int64n(this, key, SLEN(key), val)
+
 #define GF_PROTOCOL_DICT_SERIALIZE(this, from_dict, to, len, ope, labl)        \
     do {                                                                       \
         int _ret = 0;                                                          \
@@ -309,7 +315,11 @@ dict_set_int32n(dict_t *this, char *key, const int keylen, int32_t val);
 GF_MUST_CHECK int
 dict_get_int64(dict_t *this, char *key, int64_t *val);
 GF_MUST_CHECK int
+dict_get_int64n(dict_t *this, char *key, const int keylen, int64_t *val);
+GF_MUST_CHECK int
 dict_set_int64(dict_t *this, char *key, int64_t val);
+GF_MUST_CHECK int
+dict_set_int64n(dict_t *this, char *key, const int keylen, int64_t val);
 
 GF_MUST_CHECK int
 dict_get_uint16(dict_t *this, char *key, uint16_t *val);

--- a/rpc/rpc-lib/src/rpc-transport.c
+++ b/rpc/rpc-lib/src/rpc-transport.c
@@ -555,7 +555,7 @@ out:
 
 int
 rpc_transport_unix_options_build(dict_t *dict, char *filepath,
-                                 int frame_timeout)
+                                 time_t frame_timeout)
 {
     char *fpath = NULL;
     int ret = -1;
@@ -592,7 +592,7 @@ rpc_transport_unix_options_build(dict_t *dict, char *filepath,
         goto out;
 
     if (frame_timeout > 0) {
-        ret = dict_set_int32_sizen(dict, "frame-timeout", frame_timeout);
+        ret = dict_set_time(dict, "frame-timeout", frame_timeout);
         if (ret)
             goto out;
     }

--- a/rpc/rpc-lib/src/rpc-transport.h
+++ b/rpc/rpc-lib/src/rpc-transport.h
@@ -283,7 +283,7 @@ rpc_transport_keepalive_options_set(dict_t *options, int32_t interval,
 
 int
 rpc_transport_unix_options_build(dict_t *options, char *filepath,
-                                 int frame_timeout);
+                                 time_t frame_timeout);
 
 int
 rpc_transport_inet_options_build(dict_t *options, const char *hostname,


### PR DESCRIPTION
Additionally, I have added the dict_get/set_int64n methods for future use.

CID: 1502257

