### PR TITLE
[cli-cmd] Fix return type

### DIFF
--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -28,7 +28,7 @@ static pthread_mutex_t conn_mutex = PTHREAD_MUTEX_INITIALIZER;
 int cli_op_ret = 0;
 static gf_boolean_t connected = _gf_false;
 
-static int64_t
+static time_t
 cli_cmd_needs_connection(struct cli_state *state, struct cli_cmd_word *word)
 {
     if (!strcasecmp("quit", word->word))

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -28,7 +28,7 @@ static pthread_mutex_t conn_mutex = PTHREAD_MUTEX_INITIALIZER;
 int cli_op_ret = 0;
 static gf_boolean_t connected = _gf_false;
 
-static unsigned
+static int64_t
 cli_cmd_needs_connection(struct cli_state *state, struct cli_cmd_word *word)
 {
     if (!strcasecmp("quit", word->word))

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -141,7 +141,7 @@ struct cli_state {
     char *remote_host;
     int remote_port;
     int mode;
-    int64_t await_connected;
+    time_t await_connected;
 
     time_t default_conn_timeout;
 

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -141,7 +141,7 @@ struct cli_state {
     char *remote_host;
     int remote_port;
     int mode;
-    int await_connected;
+    int64_t await_connected;
 
     time_t default_conn_timeout;
 


### PR DESCRIPTION
CID: 1502261

time_t is signed on UNIX/POSIX compliant systems.

