### PR TITLE
posix: fix directory gfid handle if a rename fails

### DIFF
--- a/tests/bugs/posix/issue-2752.t
+++ b/tests/bugs/posix/issue-2752.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+. $(dirname ${0})/../../include.rc
+. $(dirname ${0})/../../volume.rc
+
+cleanup
+
+TEST glusterd
+TEST ${CLI} volume create ${V0} ${H0}:${B0}/${V0}
+TEST ${CLI} volume start ${V0}
+TEST ${GFS} -s ${H0} --volfile-id ${V0} ${M0}
+
+TEST mkdir -p ${M0}/test/dir{1,2}
+TEST touch ${M0}/test/dir{1,2}/file
+
+gfid1="$(gf_get_gfid_backend_file_path ${B0}/${V0} /test/dir1)"
+gfid2="$(gf_get_gfid_backend_file_path ${B0}/${V0} /test/dir2)"
+
+TEST [[ -h "${gfid1}" ]]
+EXPECT "${B0}/${V0}/test/dir1" realpath "${gfid1}"
+TEST [[ -h "${gfid2}" ]]
+EXPECT "${B0}/${V0}/test/dir2" realpath "${gfid2}"
+
+TEST ! mv -T ${M0}/test/dir1 ${M0}/test/dir2
+
+TEST [[ -h "${gfid1}" ]]
+EXPECT "${B0}/${V0}/test/dir1" realpath "${gfid1}"
+TEST [[ -h "${gfid2}" ]]
+EXPECT "${B0}/${V0}/test/dir2" realpath "${gfid2}"
+
+TEST rm -f ${M0}/test/dir2/file
+
+TEST mv -T ${M0}/test/dir1 ${M0}/test/dir2
+
+TEST [[ -h "${gfid1}" ]]
+EXPECT "${B0}/${V0}/test/dir2" realpath "${gfid1}"
+TEST [[ ! -e "${gfid2}" ]]
+
+cleanup
+

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -1991,9 +1991,6 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         }
     }
 
-    if (IA_ISDIR(oldloc->inode->ia_type))
-        posix_handle_unset_gfid(this, oldloc->inode->gfid);
-
     pthread_mutex_lock(&ctx_old->pgfid_lock);
     {
         if (!IA_ISDIR(oldloc->inode->ia_type) && priv->update_pgfid_nlinks) {
@@ -2090,6 +2087,7 @@ unlock:
         posix_handle_unset_gfid(this, victim);
 
     if (IA_ISDIR(oldloc->inode->ia_type)) {
+        posix_handle_unset_gfid(this, oldloc->inode->gfid);
         posix_handle_soft(this, real_newpath, newloc, oldloc->inode->gfid,
                           NULL);
     }


### PR DESCRIPTION
* posix: fix directory gfid handle if a rename fails

When a directory is renamed to a non-empty existing directory, the rename will fail. However, the gfid handle of the old directory was removed before attempting the rename, at it was not restored in case of failure.

This patch only removes the gfid handle once the rename has succeeded.

Fixes: #2752

