### PR TITLE
afr: fix size of stack-allocated array

### DIFF
--- a/tests/basic/fencing/afr-lock-heal-advanced.c
+++ b/tests/basic/fencing/afr-lock-heal-advanced.c
@@ -90,7 +90,7 @@ acquire_mandatory_lock(glfs_t *fs, glfs_fd_t *fd)
     lock.l_start = 0;
     lock.l_len = 100;
 
-    ret = glfs_fsetxattr(fd, GF_ENFORCE_MANDATORY_LOCK, "set", 8, 0);
+    ret = glfs_fsetxattr(fd, GF_ENFORCE_MANDATORY_LOCK, "set", 4, 0);
     if (ret < 0) {
         LOG_ERR("glfs_fsetxattr", errno);
         ret = -1;

--- a/tests/basic/fencing/afr-lock-heal-basic.c
+++ b/tests/basic/fencing/afr-lock-heal-basic.c
@@ -92,7 +92,7 @@ acquire_mandatory_lock(glfs_t *fs, char *fname)
     lock.l_start = 0;
     lock.l_len = 100;
 
-    ret = glfs_fsetxattr(fd, GF_ENFORCE_MANDATORY_LOCK, "set", 8, 0);
+    ret = glfs_fsetxattr(fd, GF_ENFORCE_MANDATORY_LOCK, "set", 4, 0);
     if (ret < 0) {
         LOG_ERR("glfs_fsetxattr", errno);
         ret = -1;

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -170,7 +170,7 @@ wc() {
 ;;
 esac
 
-testcnt=`egrep '^[[:space:]]*(EXPECT|EXPECT_NOT|TEST|EXPECT_WITHIN|EXPECT_KEYWORD)[[:space:]]' $0 | wc -l`
+testcnt=`egrep '^[[:space:]]*(EXPECT|EXPECT_NOT|TEST|TEST_WITHIN|EXPECT_WITHIN|EXPECT_KEYWORD)[[:space:]]' $0 | wc -l`
 expect_tests=`egrep '^[[:space:]]*TESTS_EXPECTED_IN_LOOP[[:space:]]*' $0`
 
 x_ifs=$IFS
@@ -345,6 +345,44 @@ function _TEST()
         eval "$@" >/dev/null $redirect
 
         test_footer "$TESTLINE";
+}
+
+
+function _TEST_WITHIN()
+{
+        local res output
+
+        TESTLINE=$1
+        shift;
+
+        local timeout=$1
+        shift;
+
+        G_LOG $TESTLINE "$@";
+        test_header "$@"
+
+        local endtime="$(( ${timeout}000000000 + $(date +%s%N) ))"
+
+        # We *want* this to be globally visible.
+        EW_RETRIES=0
+
+        output=""
+        res="1"
+        while [[ "$(date +%s%N)" < "$endtime" ]]; do
+                output="$("${@}" 2>/dev/null)"
+                res="${?}"
+                if [[ "${res}" == "0" ]]; then
+                        break
+                fi
+                sleep 0.25;
+                EW_RETRIES=$((EW_RETRIES+1))
+        done
+
+        ! [[ "${res}" != "0" ]]
+
+        test_footer "$TESTLINE"
+
+        TEST_OUTPUT="${output}"
 }
 
 #This function should be used carefully.
@@ -990,6 +1028,7 @@ if [ -n "$GF_INTERACTIVE" ]; then
 else
 	alias TEST='_TEST $LINENO'
 fi
+alias TEST_WITHIN='_TEST_WITHIN $LINENO'
 alias EXPECT_WITHIN='_EXPECT_WITHIN $LINENO'
 alias EXPECT_KEYWORD='_EXPECT_KEYWORD $LINENO'
 alias TEST_IN_LOOP='_TEST_IN_LOOP $LINENO'

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -517,7 +517,7 @@ afr_lock_heal_do(call_frame_t *frame, afr_private_t *priv,
         wind_on[i] = 1;
     }
 
-    current_event_gen = alloca(priv->child_count);
+    current_event_gen = alloca(priv->child_count * sizeof(*current_event_gen));
     memcpy(current_event_gen, info->child_up_event_gen,
            priv->child_count * sizeof *current_event_gen);
     AFR_ONLIST(wind_on, frame, afr_lock_heal_cbk, lk, info->fd, info->cmd,


### PR DESCRIPTION
One array allocated using alloca() was not using the right size, corrupting adjacent memory when the array was used.

Also updated the related tests since they were not working correctly. The test tried to pass some data through a variable that was created in a child subshell, so the variable was empty in the parent.

To implement the same functionality but supporting passing data between subshells, a new test command has been created: TEST_WITHIN.

It works like TEST but if the test is not successful, it waits for some time before marking the test as bad. Once the test succeeds, whatever data the test has returned during its execution will be available in the variable TEST_OUTPUT.

Fixes: #4042

