### PR TITLE
interrupt.t: make it more robust

### DIFF
--- a/tests/features/interrupt.t
+++ b/tests/features/interrupt.t
@@ -43,7 +43,7 @@ function test_interrupt {
         # If the test helper fails (which is considered a setup error, not failure of the test
         # case itself), kill will be invoked without argument, and that will be the actual
         # error which is caught.
-        TEST "./$(dirname $0)/open_and_sleep $M0/testfile-$handlebool | { sleep 0.1; xargs -n1 kill -INT; }"
+        TEST "./$(dirname $0)/open_and_sleep $M0/testfile-$handlebool | xargs -n1 -I{} bash -c 'sleep 1; kill -TERM {}'"
 
         TEST "grep -E '$logpattern' $log_file"
         # Basic sanity check, making sure filesystem has not crashed.

--- a/tests/features/open_and_sleep.c
+++ b/tests/features/open_and_sleep.c
@@ -20,8 +20,9 @@ main(int argc, char **argv)
     printf("%d\n", pid);
     fflush(stdout);
 
-    for (;;)
-        sleep(1);
+    /* The test shouldn't take more than few seconds. If it takes too much
+     * it's better to finish with an error. */
+    sleep(30);
 
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
The test has been updated to avoid infinite waits in case that something goes wrong.

It also uses TERM signal instead of INT signal because INT signal may be masked in some cases by bash (background processes for example). TERM always works.

Updates: #4020

