### PR TITLE
tests: increase timeout of some tests

### DIFF
--- a/tests/bugs/readdir-ahead/bug-1436090.t
+++ b/tests/bugs/readdir-ahead/bug-1436090.t
@@ -4,6 +4,8 @@
 . $(dirname $0)/../../volume.rc
 . $(dirname $0)/../../cluster.rc
 
+SCRIPT_TIMEOUT=300
+
 cleanup;
 
 TEST launch_cluster 2;

--- a/tests/bugs/shard/parallel-truncate-read.t
+++ b/tests/bugs/shard/parallel-truncate-read.t
@@ -5,6 +5,8 @@
 
 . $(dirname $0)/../../include.rc
 
+SCRIPT_TIMEOUT=300
+
 function keep_writing {
         cd $M0;
         while [ -f /tmp/parallel-truncate-read ]

--- a/tests/features/worm.t
+++ b/tests/features/worm.t
@@ -3,6 +3,8 @@
 . $(dirname $0)/../include.rc
 . $(dirname $0)/../volume.rc
 
+SCRIPT_TIMEOUT=300
+
 cleanup;
 
 TEST glusterd


### PR DESCRIPTION
Some tests are failing spuriously because of a timeout, or running very near of the default 200 seconds limit.

The timeout of some of the detected tests has been increased to 300 seconds.

Updates: #4020

