### PR TITLE
bug-1650403.t: increase timemout

### DIFF
--- a/tests/bugs/core/bug-1650403.t
+++ b/tests/bugs/core/bug-1650403.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_TIMEOUT=500
+SCRIPT_TIMEOUT=600
 
 . $(dirname $0)/../../include.rc
 . $(dirname $0)/../../volume.rc


### PR DESCRIPTION
This tests creates 5 volums and enbales and disables self-heal 50 time for each one. Each enable/disable operation takes around 1 second, so the total time this will take is around 5 * 50 * 2 = 500 seconds.

The script timeout is set to 500 seconds, which is too close to the required time, causing a lot of spurious failures.

Updates: #4020

