### PR TITLE
snapview-server: make timestamps stable

### DIFF
--- a/xlators/features/snapview-server/src/snapview-server-helpers.c
+++ b/xlators/features/snapview-server/src/snapview-server-helpers.c
@@ -396,9 +396,6 @@ out:
 void
 svs_iatt_fill(uuid_t gfid, struct iatt *buf)
 {
-    struct timespec ts = {
-        0,
-    };
     xlator_t *this = NULL;
 
     this = THIS;
@@ -419,9 +416,12 @@ svs_iatt_fill(uuid_t gfid, struct iatt *buf)
 
     buf->ia_prot = ia_prot_from_st_mode(0755);
 
-    timespec_now_realtime(&ts);
-    buf->ia_mtime = buf->ia_atime = buf->ia_ctime = ts.tv_sec;
-    buf->ia_mtime_nsec = buf->ia_atime_nsec = buf->ia_ctime_nsec = ts.tv_nsec;
+    /* TODO: it would be better to use real times, but they need to be stable
+     *       once created (i.e. mtime should only change when an entry has
+     *       been added or removed for example. Otherwise the returned time
+     *       should always be the same). */
+    buf->ia_mtime = buf->ia_atime = buf->ia_ctime = 0;
+    buf->ia_mtime_nsec = buf->ia_atime_nsec = buf->ia_ctime_nsec = 0;
 out:
     return;
 }


### PR DESCRIPTION
In the previous implementation, when the mtime, ctime and atime of an snapshot virtual directory was requested, the returned time was the current time.

Apparently, the old versions of kernel's nfs client did ignore this change during a readdir operation. However, newer versions are checking it and retrying the whole readdir operation when these times differ from the previous request (I guess that it assumes that the directory contents have been changed and tries to get the new contents). This causes a long delay or even an infinite loop.

The optimal change would be to keep the time of modification and changes in the inode context of the virtual directories to always return stable and consistent data, but this requires a significant amount of changes.

For now, just return a constant value for these specific entries.

Fixes: #4071

