### PR TITLE
include.rc: use fstrim on cleanup

### DIFF
--- a/tests/include.rc
+++ b/tests/include.rc
@@ -764,6 +764,9 @@ function cleanup()
                 return 1;
         fi >&2
 
+        # Physically release unused space
+        fstrim /d
+
         mkdir -p $WORKDIRS
 	# This is usually the last thing a test script calls, so our return
 	# value becomes their exit value.  While it's not great for the mkdir


### PR DESCRIPTION
The 'fstrim' command has been added to the cleanup function to help release unused space for devices that support discard operation.

Updates: #4020

