### PR TITLE
AFR: Set the value of lock ->release to true when lock ->owners is empty

### DIFF
--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -2577,8 +2577,6 @@ afr_changelog_post_op(call_frame_t *frame, xlator_t *this)
 
         if (!afr_is_delayed_changelog_post_op_needed(frame, this,
                                                      delta.tv_sec)) {
-            if (list_empty(&lock->owners))
-                lock->release = _gf_true;
             goto unlock;
         }
 
@@ -2592,6 +2590,8 @@ afr_changelog_post_op(call_frame_t *frame, xlator_t *this)
         }
     }
 unlock:
+    if (list_empty(&lock->owners))
+        lock->release = _gf_true;
     UNLOCK(&local->inode->lock);
 
     if (!list_empty(&shared)) {


### PR DESCRIPTION
In the afr_writev_wind_cbk process, when lock ->owners is empty, set the value of lock ->release to true .
So that in the following AFR_ writev_unwrind process, the fuse process does not crash in debug mode.

Fixes: #4091

Signed-off-by: JamesWSWu