### PR TITLE
Coverity: Fix several coverity warnings

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -3782,6 +3782,9 @@ glfs_discard_async_common(struct glfs_fd *glfd, off_t offset, size_t len,
 
     ret = 0;
 out:
+    if (fop_attr)
+        dict_unref(fop_attr);
+
     if (ret) {
         if (fd)
             fd_unref(fd);

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -580,6 +580,8 @@ cli_cmd_copy_file_cbk(struct cli_state *state, struct cli_cmd_word *word,
         ret = proc->fn(frame, THIS, (void *)dict);
     }
 out:
+    if (dict)
+        dict_unref(dict);
     return ret;
 }
 

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -297,7 +297,7 @@ out:
 }
 
 int32_t
-cli_cmd_await_connected(unsigned conn_timo)
+cli_cmd_await_connected(time_t conn_timo)
 {
     int32_t ret = 0;
     struct timespec ts = {

--- a/cli/src/cli.h
+++ b/cli/src/cli.h
@@ -344,7 +344,7 @@ gf_boolean_t
 cli_cmd_connected(void);
 
 int32_t
-cli_cmd_await_connected(unsigned timeout);
+cli_cmd_await_connected(time_t timeout);
 
 int32_t
 cli_cmd_broadcast_connected(gf_boolean_t status);

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -129,7 +129,7 @@ dict_setn(dict_t *this, char *key, const int keylen, data_t *value);
 static inline int32_t
 dict_set(dict_t *this, char *key, data_t *value)
 {
-    return dict_setn(this, key, key ? strlen(key) : 0, value);
+    return dict_setn(this, key, strlen(key), value);
 }
 
 /* function to set a new key/value pair (without checking for duplicate) */

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -4055,10 +4055,8 @@ gf_defrag_estimates_init(xlator_t *this, loc_t *loc, pthread_t *filecnt_thread)
                            (void *)defrag, "dhtfcnt");
 
     if (ret) {
-        gf_msg(this->name, GF_LOG_ERROR, ret, 0,
-               "Failed to "
-               "create the file counter thread ");
-        ret = -1;
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to create the file counter thread ");
         goto out;
     }
     ret = 0;

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -2719,7 +2719,7 @@ ec_eager_lock_used(ec_t *ec, ec_fop_data_t *fop)
     return ec->other_eager_lock;
 }
 
-static uint32_t
+static time_t
 ec_eager_lock_timeout(ec_t *ec, ec_lock_t *lock)
 {
     if (lock->loc.inode->ia_type == IA_IFREG) {

--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -983,10 +983,8 @@ gf_history_changelog(char *changelog_dir, unsigned long start,
             ret = gf_thread_create(&consume_th, &attr, gf_history_consume,
                                    hist_data, "cloghcon");
             if (ret) {
-                gf_msg(this->name, GF_LOG_ERROR, ret,
-                       CHANGELOG_LIB_MSG_THREAD_CREATION_FAILED,
-                       "creation of consume parent-thread"
-                       " failed.");
+                gf_log(this->name, GF_LOG_ERROR,
+                       "creation of consume parent-thread failed.");
                 ret = -1;
                 goto out;
             }

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -3178,6 +3178,8 @@ marker_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 unwind:
     MARKER_STACK_UNWIND(readdirp, frame, -1, ENOMEM, NULL, NULL);
+    if (dict)
+        dict_unref(dict);
     return 0;
 }
 

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -1738,9 +1738,11 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    GF_VALIDATE_OR_GOTO("snapview-client", this, out);
-
+    /* Initialize list ptr before GF_VALIDATE to avoid coverity
+       warning
+    */
     INIT_LIST_HEAD(&entries.list);
+    GF_VALIDATE_OR_GOTO("snapview-client", this, out);
 
     local = frame->local;
 

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -1681,12 +1681,14 @@ svs_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     svs_fd_t *svs_fd = NULL;
     call_stack_t *root = NULL;
 
+    /* Initialize list ptr before GF_VALIDATE to avoid coverity
+       warning
+     */
+    INIT_LIST_HEAD(&entries.list);
     GF_VALIDATE_OR_GOTO("snap-view-daemon", this, unwind);
     GF_VALIDATE_OR_GOTO(this->name, frame, unwind);
     GF_VALIDATE_OR_GOTO(this->name, fd, unwind);
     GF_VALIDATE_OR_GOTO(this->name, fd->inode, unwind);
-
-    INIT_LIST_HEAD(&entries.list);
 
     root = frame->root;
     op_ret = gf_setcredentials(&root->uid, &root->gid, root->ngrps,

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -1413,7 +1413,7 @@ mnt3_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* Resolving into absolute path */
     ret = gf_build_absolute_path(parent_path, relative_path, &absolute_path);
     if (ret < 0) {
-        gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SYMLINK_ERROR,
+        gf_msg(GF_MNT, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_SYMLINK_ERROR,
                "Cannot resolve symlink, path is out of boundary "
                "from current location %s and with relative path "
                "%s pointed by symlink",
@@ -1722,7 +1722,7 @@ mnt3_resolve_export_subdir(rpcsvc_request_t *req, struct mount3_state *ms,
 
     ret = mnt3_resolve_subdir(req, ms, exp, volume_subdir, _gf_true);
     if (ret < 0) {
-        gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SUBDIR_FAIL,
+        gf_msg(GF_MNT, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_SUBDIR_FAIL,
                "Failed to resolve export dir: %s", exp->expname);
         goto err;
     }
@@ -3680,8 +3680,7 @@ __mnt3_init_volume_export(struct mount3_state *ms, dict_t *opts)
 
     ret = gf_string2boolean(optstr, &boolt);
     if (ret < 0) {
-        gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_STR2BOOL_FAIL,
-               "Failed to convert string to boolean");
+        gf_log(GF_MNT, GF_LOG_ERROR, "Failed to convert string to boolean");
     }
 
 err:
@@ -4154,7 +4153,7 @@ _mnt3_init_auth_params(struct mount3_state *mstate)
 
     ret = mnt3_auth_set_netgroups_auth(mstate->auth_params, ng_file_path);
     if (ret < 0) {
-        gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_SET_EXP_AUTH_PARAM_FAIL,
+        gf_msg(GF_MNT, GF_LOG_ERROR, -ret, NFS_MSG_SET_EXP_AUTH_PARAM_FAIL,
                "Failed to set netgroup auth params.");
         goto out;
     }

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2048,8 +2048,7 @@ overwrite:
 
     ret = posix_fd_ctx_get(fd, this, &pfd, &op_errno);
     if (ret < 0) {
-        gf_msg(this->name, GF_LOG_WARNING, ret, P_MSG_PFD_NULL,
-               "pfd is NULL from fd=%p", fd);
+        gf_log(this->name, GF_LOG_WARNING, "pfd is NULL from fd=%p", fd);
         goto out;
     }
 
@@ -5725,8 +5724,7 @@ posix_fill_readdir(fd_t *fd, struct posix_fd *pfd, off_t off, size_t size,
             continue;
 #endif /* __NetBSD__ */
 
-        if (is_root_gfid &&
-            (!strcmp(GF_HIDDEN_PATH, entry->d_name))) {
+        if (is_root_gfid && (!strcmp(GF_HIDDEN_PATH, entry->d_name))) {
             continue;
         }
 
@@ -5932,11 +5930,13 @@ posix_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     gf_dirent_t entries;
     int32_t skip_dirs = 0;
 
+    /* Initialize the list ptr before call VALIDATE to avoid coverity
+       warning
+     */
+    INIT_LIST_HEAD(&entries.list);
     VALIDATE_OR_GOTO(frame, out);
     VALIDATE_OR_GOTO(this, out);
     VALIDATE_OR_GOTO(fd, out);
-
-    INIT_LIST_HEAD(&entries.list);
 
     ret = posix_fd_ctx_get(fd, this, &pfd, &op_errno);
     if (ret < 0) {

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -570,14 +570,14 @@ posix_acl_unref(xlator_t *this, struct posix_acl *acl)
 
     conf = this->private;
     if (!conf)
-        goto out;
+        return;
 
     LOCK(&conf->acl_lock);
     {
         refcnt = --acl->refcnt;
     }
     UNLOCK(&conf->acl_lock);
-out:
+
     if (!refcnt)
         posix_acl_destroy(this, acl);
 }


### PR DESCRIPTION
CID 1506829  Use of 32-bit time_t
  cli/src/cli-cmd.c
CID 1504519  DEADCODE
  xlators/mgmt/glusterd/src/glusterd-syncop.c
CID 1502328  Improper use of -ve
  xlators/nfs/server/src/mount3.c
CID 1502327  Uninitialized scalar variable
  xlators/storage/posix/src/posix-inode-fd-ops.c
CID 1502326  Improper use of -ve
  xlators/nfs/server/src/mount3.c
CID 1502325  Improper use of -ve
  xlators/nfs/server/src/mount3.c
CID 1502324  Resource leak
  xlators/features/marker/src/marker.c
CID 1502323  Improper use of -ve
  xlators/cluster/dht/src/dht-rebalance.c
CID 1502322  Improper use of -ve
  xlators/features/changelog/lib/src/gf-history-changelog.c
CID 1502321  Double free
  xlators/system/posix-acl/src/posix-acl.c
CID 1502320  Improper use of -ve
  xlators/storage/posix/src/posix-inode-fd-ops.c
CID 1502317  Improper use of -ve
  xlators/nfs/server/src/mount3.c
CID 1502316  Dereference after NULL check
  libglusterfs/src/glusterfs/dict.h
CID 1502315  Uninitialized scalar variable
  xlators/features/snapview-client/src/snapview-client.c
CID 1502314  Uninitialized scalar variable
  xlators/features/snapview-server/src/snapview-server.c
CID 1502313  Resource leak
  cli/src/cli-cmd-system.c
CID 1502312  Resource leak
  api/src/glfs-fops.c
CID 1502311  Use of 32-bit time_t
  xlators/cluster/ec/src/ec-common.c

Updates #1060
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Change-Id: Ic0a939d0bb4f568b5c3f60a5930c90ebeb6a28d4

