### PR TITLE
build,configure.ac,extras: fix EC dynamic support detection for aarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1770,7 +1770,7 @@ if test "x$enable_ec_dynamic" != "xno"; then
         fi
       fi
       ;;
-    arm*)
+    arm*|aarch64*)
       if test "x$enable_ec_dynamic_arm" != "xno"; then
         if test "x$enable_ec_dynamic_neon" != "xno"; then
           EC_DYNAMIC_SUPPORT="$EC_DYNAMIC_SUPPORT neon"


### PR DESCRIPTION
EC dynamic support is not detected properly when we try to build under aarch64 environment.

This patch adds 'aarch64*' glob during compilation to make sure it works expected.

Change-Id: I98b19f42ef325780adcae8f0d2ae6dee515d63a6
Fixes: #4105

