### PR TITLE
copy-file-range.t: handle ENOSYS

### DIFF
--- a/tests/000-flaky/features_copy-file-range.c
+++ b/tests/000-flaky/features_copy-file-range.c
@@ -27,7 +27,7 @@
 */
 
 /*
- * Baed on sample code from copy_file_range(2).
+ * Based on sample code from copy_file_range(2).
  */
 
 #define _GNU_SOURCE
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#include <errno.h>
 
 #if (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 27))
 /* On versions of glibc before 2.27, we must invoke copy_file_range()
@@ -86,6 +87,9 @@ main(int argc, char **argv)
     do {
         ret = copy_file_range(fd_in, NULL, fd_out, NULL, len, 0);
         if (ret == -1) {
+            if (errno == ENOSYS) {
+                exit(2);
+            }
             perror("copy_file_range");
             exit(EXIT_FAILURE);
         }

--- a/tests/000-flaky/features_copy-file-range.t
+++ b/tests/000-flaky/features_copy-file-range.t
@@ -15,13 +15,6 @@ Linux)
         ;;
 esac
 
-grep -q copy_file_range /proc/kallsyms
-if [ $? -ne 0 ]; then
-    echo "Skip test: copy_file_range(2) is not supported by current kernel" >&2
-    SKIP_TESTS
-    exit 0
-fi
-
 TEST glusterd
 
 TEST mkdir $B0/bricks
@@ -55,7 +48,15 @@ tester=${0%.t}
 
 TEST build_tester ${tester}.c
 
-TEST $tester $M0/file $M0/new
+$tester $M0/file $M0/new
+res="${?}"
+if [[ ${res} -eq 2 ]]; then
+    echo "Skip test: copy_file_range(2) is not supported by current kernel" >&2
+    SKIP_TESTS
+    exit 0
+fi
+
+TEST [[ ${res} -eq 0 ]]
 
 # check whether the destination file is created or not
 TEST stat $M0/new


### PR DESCRIPTION
On some systems, the previous method to try to determine if copy_file_range() is supported was to check the symbol in /proc/kallsyms. However there are some cases where the symbol can be found, but still it's not supported, like if fuse doesn't implement it.

To avoid all possible combinations, just run the test normally and check for system call availability on first execution. If it's not there, just skip the remaining tests. Otherwise continue the test.

Updates: #4020

