### PR TITLE
cli: The cli is not showing correct volume type

### DIFF
--- a/rpc/rpc-lib/src/protocol-utils.h
+++ b/rpc/rpc-lib/src/protocol-utils.h
@@ -6,11 +6,11 @@
 static inline int
 get_vol_type(int type, int dist_count, int brick_count)
 {
-    if ((type != GF_CLUSTER_TYPE_TIER) && (type > 0) &&
-        (dist_count < brick_count))
-        type = type + GF_CLUSTER_TYPE_MAX - 1;
+    if ((type == GF_CLUSTER_TYPE_TIER) || (type <= 0) || (dist_count <= 1) ||
+        (dist_count >= brick_count))
+        return type;
 
-    return type;
+    return (type + GF_CLUSTER_TYPE_MAX - 1);
 }
 
 static inline char *


### PR DESCRIPTION
The commit 5118f1a0011d7cdd18abef0d4b62cad2b92d44b4 corrects the distCount value but due to that voltype has changed because the function get_vol_type is not updated.

Solution: No need to measure voltype if distCount is 1

Fixes: #4107
Change-Id: I16e7e906d64b01398b40c0a634924a5bf9069b58

