### PR TITLE
tests: add delay after killing brick

### DIFF
--- a/tests/volume.rc
+++ b/tests/volume.rc
@@ -320,6 +320,15 @@ function kill_brick {
         local deadline="$(($(date +%s%N) + ${PROCESS_UP_TIMEOUT}000000000))"
         while [[ "$(date +%s%N)" < "$deadline" ]]; do
                 if [[ "$(brick_up_status $vol $host $brick)" == "0" ]]; then
+                        # The brick termination code is run from an
+                        # asynchronous thread, so even after glusterd
+                        # considers it stopped, the brick may still be
+                        # alive. We need to make sure it's stopped before
+                        # returning, otherwise an immediate restart could
+                        # fail. Unfortunately there's no easy way to know
+                        # when the brick has really been stopped. For now
+                        # just add some delay.
+                        sleep 1
                         break
                 fi
         done


### PR DESCRIPTION
The kill_brick code uses gf_attach to force the brick process to detach the brick. For non brick-mux tests this is equivalent to stopping the process. For brick-mux, the selected brick is stopped using an asynhronous thread. In some cases glusterd may report the brick as stopped even before the stop has completed.

To avoid races with future restarts, kill_brick needs to wait until the brick is really stopped, but there's no easy way to know that. For now I've just added a small delay.

Updates: #4020

