### PR TITLE
Optimized the mdcache return error attribute bug (for devel)

### DIFF
--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -1647,6 +1647,10 @@ mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
 
     if (local->loc.parent) {
+        if (postparent && postparent->ia_nlink == 0) {
+            // return from afr consistent-metadata, do not cache
+            goto out;
+        }
         mdc_inode_iatt_set(this, local->loc.parent, postparent,
                            local->incident_time);
     }


### PR DESCRIPTION
    mdcache : xlators/performance/md-cache/src/md-cache.c

    Problem:
    In the distributed replication volume scenario, when a single host node
    breaks down or the brick goes offline, mdcache returns an error
    attribute: stale file handle when an NFS client creates a folder and
    immediately searches for the folder

    Solution:
    Return from afr consistent-metadata,do not cache

    Fixes: #4117

    Change-Id: I00b72fb9b0dc73eebefdd8110947883774cc14c9
    Signed-off-by: Hu Ping <huping@cmss.chinamobile.com>

Change-Id: If9ef3a77b2738f6d7f881c122b6d6bcbd23ca14c

