### PR TITLE
readdir-ahead: Improve readdir performance for fuse

### DIFF
--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -93,6 +93,7 @@ enum {
     GD_OP_VERSION2( 9,  0),
     GD_OP_VERSION2(10,  0),
     GD_OP_VERSION2(11,  0),
+    GD_OP_VERSION2(12,  0),
 
 /* NOTE: Add new versions above this line. */
     GD_OP_VERSION_END

--- a/tests/bugs/readdir-ahead/readdir-ahead-perf.t
+++ b/tests/bugs/readdir-ahead/readdir-ahead-perf.t
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../dht.rc
+
+cleanup;
+
+count_files () {
+        ls $1 | wc -l
+}
+
+TEST glusterd
+
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{1,2,3,4,5,6,7,8,9};
+
+#Disable readdirp completely
+TEST $CLI volume set $V0 dht.force-readdirp no
+TEST $CLI volume set $V0 performance.force-readdirp no
+
+#Start the volume
+TEST $CLI volume start $V0
+EXPECT 'Started' volinfo_field $V0 'Status';
+EXPECT_WITHIN ${PROCESS_UP_TIMEOUT} "9" online_brick_count
+
+#Mount the volume
+TEST glusterfs --use-readdirp=no --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#Create a newdir
+TEST mkdir $M0/newdir
+
+#Create 1600 2k files
+for i in {1..1600}; do dd if=/dev/zero of=$M0/newdir/file$i bs=64 count=32; done 
+
+#Run readdir for newdir
+TEST [ $(count_files $M0/newdir) = "1600" ]
+
+statedump_file=$(generate_mount_statedump $V0);
+totcnt=$(grep -i latency $statedump_file | grep -iw readdir | grep dht | awk -F " " '{print $2}' | awk -F ":" '{print $2}')
+TEST rm -rf $staedump_file
+
+#Now enable performance-readdir-ahead
+TEST $CLI volume set $V0 performance.readdir-ahead on
+
+TEST umount $M0
+#Again mount the volume
+TEST glusterfs --use-readdirp=no --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#Again readdir for newdir
+TEST [ $(count_files $M0/newdir) = "1600" ]
+
+#Because force-readdir is not disabled for readdir-ahead so readdir-ahead wind
+#a readdirp call instead of readdir
+statedump_file=$(generate_mount_statedump $V0);
+newcnt=$(grep -i latency $statedump_file | grep -iw readdirp | grep dht | awk -F " " '{print $2}' | awk -F ":" '{print $2}')
+TEST rm -rf $statedump_file
+
+TEST umount $M0
+#Again mount the volume
+TEST glusterfs --use-readdirp=no --volfile-id=$V0 --volfile-server=$H0 $M0;
+
+#Now disable readdirp for readdir-ahead sothat readdir-ahead wind a readdir call
+TEST $CLI volume set $V0 readdir-ahead.force-readdirp no
+
+#Again readdir for newdir
+TEST [ $(count_files $M0/newdir) = "1600" ]
+
+statedump_file=$(generate_mount_statedump $V0);
+newcnt_readdir=$(grep -i latency $statedump_file | grep -iw readdir | grep dht | awk -F " " '{print $2}' | awk -F ":" '{print $2}')
+TEST rm -rf $statedump_file
+
+TEST [ $((newcnt * 30)) -le $totcnt ]
+TEST [ $((newcnt_readdir * 30)) -le $totcnt ]
+
+cleanup
+
+
+

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -2805,6 +2805,15 @@ struct volopt_map_entry glusterd_volopt_map[] = {
      .op_version = GD_OP_VERSION_3_9_1,
      .validate_fn = validate_rda_cache_limit},
     {
+        .key = "readdir-ahead.force-readdirp",
+        .voltype = "performance/readdir-ahead",
+        .option = "force-readdirp",
+        .value = "on",
+        .flags = VOLOPT_FLAG_CLIENT_OPT,
+        .type = NO_DOC,
+        .op_version = GD_OP_VERSION_12_0,
+    },
+    {
         .key = "performance.nl-cache-positive-entry",
         .voltype = "performance/nl-cache",
         .type = DOC,

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.h
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.h
@@ -88,6 +88,7 @@ struct rda_priv {
     uint64_t rda_cache_limit;
     gf_atomic_t rda_cache_size;
     gf_boolean_t parallel_readdir;
+    gf_boolean_t force_readdirp;
 };
 
 typedef struct rda_inode_ctx {


### PR DESCRIPTION
Currently readdir-ahead only supports readdirp so
in case of readdir the performance is not similar
to readdirp after load readdir-ahead xlator so add readdir fop also in readdir-ahead.

Fixes: #4141
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

Note: For specific to measure performance improvement the
      test case is already added. As we can see after enable
      readdir-ahead the number of readdir call is significantly
      reduced (30x) so eventually ls performance will improve.

Change-Id: I0c0a62dd32ea3bde22e9c4f8cdc99fb6f4575772

