### PR TITLE
dht/rebalance: Fix a problem deleting data file

### DIFF
--- a/tests/bugs/distribute/missing-files-rebalance.t
+++ b/tests/bugs/distribute/missing-files-rebalance.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TESTS_EXPECTED_IN_LOOP=100
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume info
+
+#Create a distributed volume
+TEST $CLI volume create $V0 $H0:$B0/${V0}{1..2};
+TEST $CLI volume start $V0
+
+# Mount FUSE
+TEST glusterfs -s $H0 --volfile-id $V0 $M0
+
+#Create files
+TEST mkdir $M0/dir
+TEST touch $M0/dir/foo{1..100}
+for i in {1..100}; do
+    TEST_IN_LOOP mv $M0/dir/foo$i $M0/dir/new$i;
+done
+
+TEST $CLI volume add-brick $V0 $H0:$B0/${V0}3 $H0:$B0/${V0}4
+TEST $CLI volume rebalance $V0 start
+EXPECT_WITHIN $REBALANCE_TIMEOUT "completed" rebalance_status_field $V0
+
+#Check if the mount contains all the files after rebalance
+numFiles=(`ls $M0/dir/|grep -v '^\.'| wc -l`)
+#Check if all the files has the same permission
+wrongPerm=(`ls -l $M0/dir/| grep -v "\-rw\-r" | grep -v "total" | wc -l`)
+EXPECT "^100$" echo $numFiles
+EXPECT "^0$" echo $wrongPerm
+
+cleanup;


### PR DESCRIPTION
Rebalance daemon is deleting a data file instead of linkfile which causes an entire file to be deleted from gluster namespace leading to a complete data loss.

This data loss occurs in the following situations:-
 1) Entire file is deleted
    This happens when there is a linkfile on the hashed
    subvol. In this case, rebalance daemon will add both
    linkfile and data file to the queue. Let's say the
    data file entry picked up first to migrate and let's
    say the entry is migrated successfully. When the linkfile
    is picked up from the queue, when they check that the
    added linkfile has both hashed and cached to the same
    subvol, then they assume that it is a linfile and then
    it got deleted. They check for the linkfile is performed
    on the stbuf populated during the rebalance readdir.
    So by the time when the check are done, the file is now
    migrated and had a datafile
 2) Wrong permission and Incorrect size:
    Similar to above case, this happens when a linkfile and
    data file are picked up to migrate at the same time,
    in this case, a failure can happen at different stages of
    rebalance process and due to this rebalance failure,
    a cleanup might be done on the destination where the rebalance
    has incomplete, but by the time the first one might be completed
    and the cleanup would have been done on an actual file due to this
    either we may end up with the wrong permissions
    like "----------." or a data file with incomplete
    information.

Change-Id: I22f1c9b35811be83bde08c4f30db9d5582d2d2fc
Fixes: #4148

