### PR TITLE
socket: fix error not supported for ipv6

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -3283,7 +3283,8 @@ socket_connect(rpc_transport_t *this, int port)
          */
 #ifdef IPV6_DEFAULT
         int disable_v6only = 0;
-        if (setsockopt(priv->sock, IPPROTO_IPV6, IPV6_V6ONLY,
+        if (sa_family == AF_INET6 &&
+            setsockopt(priv->sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (void *)&disable_v6only, sizeof(disable_v6only)) < 0) {
             gf_log(this->name, GF_LOG_WARNING,
                    "Error disabling sockopt IPV6_V6ONLY: \"%s\"",


### PR DESCRIPTION
When glusterfs is complied with --with-ipv6-default option it results in warning operation not supported when glusterd started, which is fixed here.

> Fixes: #3701
> Change-Id: I5221431309311da3008f41db77fb0e48ff448746
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Reviwed on upstream https://github.com/gluster/glusterfs/pull/4150)
> (Cherry pick from commit 36c58ca71865a685e21db2a85a74453a79facc8c)

Fixes: #3701
Change-Id: I5221431309311da3008f41db77fb0e48ff448746

