### PR TITLE
cluster/afr: Correct the parameter type of afr_zerofill

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -2198,7 +2198,7 @@ afr_zerofill_wind(call_frame_t *frame, xlator_t *this, int subvol)
 
 int
 afr_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
-             size_t len, dict_t *xdata)
+             off_t len, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     call_frame_t *transaction_frame = NULL;


### PR DESCRIPTION
The len parameter passed to the afr_zerofill() function has type mismatch in the function prototype and the definition. Correcting it to use the appropriate type.

Fixes: #3822

