### PR TITLE
Revert "posix: posix xlator does not respects storage.reserve (#3637)"

### DIFF
--- a/tests/bugs/posix/bug-1651445.t
+++ b/tests/bugs/posix/bug-1651445.t
@@ -20,21 +20,16 @@ TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0
 #Setting the size in bytes
 TEST $CLI volume set $V0 storage.reserve 40MB
 
-disk_size=$(df -k $L1 | tail -1 | awk -F " " '{print $2}')
-TEST dd if=/dev/zero of=$M0/a bs=90M count=1
-# LVM has reseved different space on the partition in case of centos-7/8 so in
-# case of centos-8 the 2nd dd is failed because no sufficient
-# space is available. To avoid the test failure change the block size
-# if disk_size is not matching ~150M
-if [[ $disk_size -eq "152576" ]]
-then
-   bsize="10M"
-else
-   bsize="4M"
-fi
+#wait 5s to reset disk_space_full flag
+sleep 5
 
-TEST dd if=/dev/zero of=$M0/b bs=${bsize} count=1
+TEST dd if=/dev/zero of=$M0/a bs=100M count=1
+TEST dd if=/dev/zero of=$M0/b bs=10M count=1
 
+# Wait 5s to update disk_space_full flag because thread check disk space
+# after every 5s
+
+sleep 5
 # setup_lvm create lvm partition of 150M and 40M are reserve so after
 # consuming more than 110M next dd should fail
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1
@@ -45,12 +40,12 @@ rm -rf $M0/*
 #Setting the size in percent and repeating the above steps
 TEST $CLI volume set $V0 storage.reserve 40
 
-# Wait 5s to update disk_space_full flag because thread check disk space
-# after every 5s
 sleep 5
-TEST dd if=/dev/zero of=$M0/a bs=70M count=1
-TEST dd if=/dev/zero of=$M0/b bs=${bsize} count=1
 
+TEST dd if=/dev/zero of=$M0/a bs=80M count=1
+TEST dd if=/dev/zero of=$M0/b bs=10M count=1
+
+sleep 5
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1
 
 TEST $CLI volume stop $V0

--- a/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
+++ b/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
@@ -9,9 +9,8 @@ function create_files {
         local i=1
         while (true)
         do
-                touch $M0/file$i
+                dd if=/dev/zero of=$M0/file$i bs=1M count=10
                 if [ -e $B0/${V0}0/file$i ] || [ -e $B0/${V0}1/file$i ]; then
-                        dd if=/dev/zero of=$M0/file$i bs=1M count=10 2>/dev/null
                         ((i++))
                 else
                         break
@@ -48,20 +47,13 @@ TEST $CLI volume set $V0 performance.write-behind off
 TEST $CLI volume set $V0 self-heal-daemon off
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
 
-# Create some data on backend to test dirty xattr in case
-# while entry is created successfully on 1 node
-dd if=/dev/zero of=$B0/${V0}0/testfile bs=1M count=10
-dd if=/dev/zero of=$B0/${V0}1/testfile bs=1M count=10
-
 i=$(create_files)
-((i++))
-touch $M0/file$i
 TEST ! ls $B0/${V0}0/file$i
 TEST ! ls $B0/${V0}1/file$i
 TEST ls $B0/${V0}2/file$i
-
 dirty=$(get_hex_xattr trusted.afr.dirty $B0/${V0}2)
-TEST [ $dirty != "000000000000000000000000" ]
+TEST [ "$dirty" != "000000000000000000000000" ]
+
 TEST $CLI volume set $V0 self-heal-daemon on
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" glustershd_up_status
 EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0

--- a/tests/bugs/shard/issue-2038.t
+++ b/tests/bugs/shard/issue-2038.t
@@ -26,28 +26,26 @@ $CLI volume info
 TEST $CLI volume set $V0 features.shard on
 TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0
 
-total="$(stat -fc "%b" "${M0}")"
-total="$((${total} * 4096))"
-
-# Fill 75% of the total space
-TEST fallocate -l "$((${total} * 3 / 4))" "${M0}/a"
-
-gfid_new=$(get_gfid_string $M0/a)
-
 #Setting the size in percentage
 TEST $CLI volume set $V0 storage.reserve 40
 
-# Wait 5s to update disk_space_full flag because thread check disk space
-# after every 5s
+#wait 5s to reset disk_space_full flag
 sleep 5
 
-# The available available space is below 40%, so creating new files shouldn't
-# be allowed.
-TEST ! touch $M0/test
+TEST touch $M0/test
+TEST unlink $M0/test
 
-# setup_lvm create lvm partition of 150M and 40% is reserved so after
-# consuming more than 75% next unlink should not fail.
+TEST dd if=/dev/zero of=$M0/a bs=80M count=1
+TEST dd if=/dev/zero of=$M0/b bs=10M count=1
 
+gfid_new=$(get_gfid_string $M0/a)
+
+# Wait 5s to update disk_space_full flag because thread check disk space
+# after every 5s
+
+sleep 5
+# setup_lvm create lvm partition of 150M and 40M are reserve so after
+# consuming more than 110M next unlink should not fail
 # Delete the base shard and check shards get cleaned up
 TEST unlink $M0/a
 TEST ! stat $M0/a

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -4086,15 +4086,6 @@ server4_0_writev(rpcsvc_request_t *req)
         goto out;
     }
 
-    if (state->xdata) {
-        ret = dict_set_int32_sizen(state->xdata, "buffer-size", len);
-        if (ret) {
-            gf_msg(THIS->name, GF_LOG_INFO, ENOMEM, 0,
-                   "%zu: dict set (buffer-size) failed, continuing", len);
-            goto out;
-        }
-    }
-
 #ifdef GF_TESTING_IO_XDATA
     dict_dump_to_log(state->xdata);
 #endif

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -1530,10 +1530,6 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
     unwind_dict = posix_dict_set_nlink(xdata, unwind_dict, stbuf.ia_nlink);
-    if (IA_ISREG(loc->inode->ia_type) && (stbuf.ia_nlink <= 2)) {
-        GF_ATOMIC_SUB(priv->write_value, ((stbuf.ia_blocks) * 512));
-    }
-
     op_ret = 0;
 out:
     SET_TO_OLD_FS_ID();

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1576,10 +1576,6 @@ posix_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
     posix_set_ctime(frame, this, real_path, -1, loc->inode, &postbuf);
 
-    if (postbuf.ia_blocks < prebuf.ia_blocks)
-        GF_ATOMIC_SUB(priv->write_value,
-                      ((prebuf.ia_blocks - postbuf.ia_blocks) * 512));
-
     op_ret = 0;
 out:
     SET_TO_OLD_FS_ID();
@@ -2033,7 +2029,7 @@ posix_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     priv = this->private;
 
     VALIDATE_OR_GOTO(priv, unwind);
-    DISK_SPACE_CHECK_WRITEV_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out);
+    DISK_SPACE_CHECK_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out);
 
 overwrite:
 
@@ -2175,9 +2171,7 @@ overwrite:
         }
     }
 
-    if (preop.ia_blocks < postop.ia_blocks)
-        GF_ATOMIC_ADD(priv->write_value,
-                      ((postop.ia_blocks - preop.ia_blocks) * 512));
+    GF_ATOMIC_ADD(priv->write_value, op_ret);
 
 out:
 

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -77,41 +77,6 @@
         }                                                                      \
     } while (0)
 
-#define DISK_SPACE_CHECK_WRITEV_AND_GOTO(frame, priv, xdata, op_ret, op_errno, \
-                                         out)                                  \
-    do {                                                                       \
-        gf_boolean_t flag = _gf_false;                                         \
-        int32_t buffer_size = 0;                                               \
-        int64_t write_val = 0;                                                 \
-        int64_t disk_free = 0;                                                 \
-        if (frame->root->pid >= 0 &&                                           \
-            !dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY)) {              \
-            if (priv->disk_space_full) {                                       \
-                flag = _gf_true;                                               \
-            } else {                                                           \
-                if (dict_get_int32(xdata, "buffer-size", &buffer_size)) {      \
-                    gf_log(frame->this->name, GF_LOG_TRACE,                    \
-                           "failed to get "                                    \
-                           " buffer-size");                                    \
-                }                                                              \
-                write_val = GF_ATOMIC_GET(priv->write_value);                  \
-                disk_free = priv->disk_size_after_reserve;                     \
-                if ((buffer_size + write_val) > disk_free) {                   \
-                    flag = _gf_true;                                           \
-                }                                                              \
-            }                                                                  \
-            if (flag) {                                                        \
-                op_ret = -1;                                                   \
-                op_errno = ENOSPC;                                             \
-                gf_msg_debug("posix", ENOSPC,                                  \
-                             "disk space utilization reached limits"           \
-                             " for path %s ",                                  \
-                             priv->base_path);                                 \
-                goto out;                                                      \
-            }                                                                  \
-        }                                                                      \
-    } while (0)
-
 /* Setting microseconds or nanoseconds depending on what's supported:
    The passed in `tv` can be
        struct timespec
@@ -204,7 +169,6 @@ struct posix_private {
 
     gf_atomic_t read_value;  /* Total read, from init */
     gf_atomic_t write_value; /* Total write, from init */
-    uint64_t disk_size_after_reserve;
 
     /* janitor task which cleans up /.trash (created by replicate) */
     struct gf_tw_timer_list *janitor;


### PR DESCRIPTION
After upgrade on 10.3 and release-11 the gluster is throwing ENOSPC error. To fix the original issue we have not received any reproducer so i have decided to revert the patch.

This reverts commit 9621e3e94c05f579e1615e66eacd701e7a797adf.

> Fixes: #3636
> Change-Id: Ief1f8a486699895d040bd467c121a33ce2a79acd
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Reviewed on upstream link
https://github.com/gluster/glusterfs/pull/4179)

Fixes: #3636
Change-Id: Ief1f8a486699895d040bd467c121a33ce2a79acd
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
