### PR TITLE
Remove '\' from grep command

### DIFF
--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -549,7 +549,7 @@ EOF
         exit 1;
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..


### PR DESCRIPTION
In grep v3.8-3 will raise warning when use glusterfs fuse mount Warning log:

/usr/bin/mount -t glusterfs -o acl 169.254.0.23:/home /tmp/test grep: warning: stray \ before -

Fixes: #4198

