### PR TITLE
glusterd:  The "old_volinfo->refcnt" is calculated once

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -4903,7 +4903,6 @@ glusterd_import_friend_volume(dict_t *peer_data, int count,
         (void)glusterd_volinfo_copy_brickinfo(old_volinfo, new_volinfo);
 
         (void)glusterd_delete_stale_volume(old_volinfo, new_volinfo);
-        glusterd_volinfo_unref(old_volinfo);
     }
 
     ret = glusterd_store_volinfo(new_volinfo, GLUSTERD_VOLINFO_VER_AC_NONE);


### PR DESCRIPTION
Remove redundant  reference counting  in the function glusterd_delete_stale_volume.
So the old_volinfo->refcnt is accurate.

fixes: #4212 