### PR TITLE
mount: fuse mount raise warning log: "grep: warning: stray \ before -"

### DIFF
--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -549,7 +549,7 @@ EOF
         exit 1;
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..


### PR DESCRIPTION
Correct the grep command syntex in mount_glusterfs.in to avoid a warning

> Fixes: #4198
> Cherry picked from commit aa841e21b86eac2d2de86536e00f2dae67f8e1cd
> (Signed-off-by: coyang <yangcongxue@126.com>)
> (Reviwed on upstream link https://github.com/gluster/glusterfs/pull/4199)

Fixes: #4198
Change-Id: I5ecc489efe0136a255004a5232d380aeffde891b

