### PR TITLE
checksum.c: Use the EVP API to compute the MD5 checksum

### DIFF
--- a/libglusterfs/src/checksum.c
+++ b/libglusterfs/src/checksum.c
@@ -8,7 +8,7 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <zlib.h>
 #include <stdint.h>
@@ -40,5 +40,13 @@ gf_rsync_strong_checksum(unsigned char *data, size_t len,
 void
 gf_rsync_md5_checksum(unsigned char *data, size_t len, unsigned char *md5)
 {
-    MD5(data, len, md5);
+    EVP_MD_CTX *mdctx;
+    // Use the MD5 digest algorithm
+    const EVP_MD *md = EVP_md5();
+
+    mdctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(mdctx, md, NULL);
+    EVP_DigestUpdate(mdctx, data, len);
+    EVP_DigestFinal_ex(mdctx, md5, NULL);
+    EVP_MD_CTX_free(mdctx);
 }

--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -598,7 +598,7 @@ gf_client_dump_fdtables(xlator_t *this)
                 clienttable->cliententries[count].next_free)
                 continue;
             client = clienttable->cliententries[count].client;
-            if (client->client_uid) {
+            if (client) {
                 gf_proc_dump_build_key(key, "conn", "%d.id", count);
                 gf_proc_dump_write(key, "%s", client->client_uid);
             }


### PR DESCRIPTION
As MD5 function has been marked as deprecated in OpenSSL 3.0, this change uses EVP (Envelope) API to compute the MD5 checksum. 
Reference:
https://www.openssl.org/docs/man1.0.2/man3/EVP_md5.html

Fixes: #4243

