### PR TITLE
dht: fix asan use-after-free bug

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -3963,28 +3963,29 @@ dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     for (i = 0; i < conf->subvolume_cnt; i++) {
         if (mds_subvol && (mds_subvol == conf->subvolumes[i]))
             continue;
-        if (local->fop == GF_FOP_SETXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->setxattr, &local->loc,
-                       local->xattr, local->flags, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_FSETXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->fsetxattr, local->fd,
-                       local->xattr, local->flags, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_REMOVEXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->removexattr, &local->loc,
-                       local->key, local->xattr_req);
-        }
-
-        if (local->fop == GF_FOP_FREMOVEXATTR) {
-            STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
-                       conf->subvolumes[i]->fops->fremovexattr, local->fd,
-                       local->key, local->xattr_req);
+        switch (local->fop) {
+            case GF_FOP_SETXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->setxattr, &local->loc,
+                           local->xattr, local->flags, local->xattr_req);
+                break;
+            case GF_FOP_FSETXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->fsetxattr, local->fd,
+                           local->xattr, local->flags, local->xattr_req);
+                break;
+            case GF_FOP_REMOVEXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->removexattr, &local->loc,
+                           local->key, local->xattr_req);
+                break;
+            case GF_FOP_FREMOVEXATTR:
+                STACK_WIND(frame, dht_setxattr_non_mds_cbk, conf->subvolumes[i],
+                           conf->subvolumes[i]->fops->fremovexattr, local->fd,
+                           local->key, local->xattr_req);
+                break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
The client is throwing below stacktrace while asan is enabled. The client is facing an issue while application is trying to call removexattr in 2x1 subvol and non-mds subvol is down. As we can see in below stacktrace dht_setxattr_mds_cbk is calling dht_setxattr_non_mds_cbk and dht_setxattr_non_mds_cbk is trying to wipe local because call_cnt is 0 but dht_setxattr_mds_cbk is trying to access frame->local that;s why it is crashed.

x621000051c34 is located 1844 bytes inside of 4164-byte region [0x621000051500,0x621000052544) freed by thread T7 here:

Solution: Use switch instead of using if statement to wind a operation, in case of switch
          the code will not try to access local after wind a operation for last dht subvol.

> Fixes: #3732
> Change-Id: I031bc814d6df98058430ef4de7040e3370d1c677
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/4242)

Fixex: #3732
Change-Id: I031bc814d6df98058430ef4de7040e3370d1c677
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>

