### PR TITLE
core: glusterfs encounter a SIGSEGV in __gf_free

### DIFF
--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -202,6 +202,7 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
     struct iobuf *iobuf = NULL;
     struct iobref *iobref = NULL;
     ssize_t xdr_size = 0;
+    gf_boolean_t frame_cleanup = _gf_true;
 
     iobref = iobref_new();
     if (!iobref) {
@@ -235,13 +236,15 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
     /* Send the msg */
     ret = rpc_clnt_submit(ctx->mgmt, prog, procnum, cbkfn, &iov, count, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
-
+    frame_cleanup = _gf_false;
 out:
     if (iobref)
         iobref_unref(iobref);
 
     if (iobuf)
         iobuf_unref(iobuf);
+    if (frame_cleanup)
+        STACK_DESTROY(frame->root);
     return ret;
 }
 

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2086,6 +2086,7 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
     struct iobuf *iobuf = NULL;
     struct iobref *iobref = NULL;
     ssize_t xdr_size = 0;
+    gf_boolean_t frame_cleanup = _gf_true;
 
     iobref = iobref_new();
     if (!iobref) {
@@ -2119,12 +2120,17 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
     ret = rpc_clnt_submit(ctx->mgmt, prog, procnum, cbkfn, &iov, count, NULL, 0,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
 
+    frame_cleanup = _gf_false;
 out:
     if (iobref)
         iobref_unref(iobref);
 
     if (iobuf)
         iobuf_unref(iobuf);
+
+    if (frame_cleanup)
+        STACK_DESTROY(frame->root);
+
     return ret;
 }
 
@@ -2471,6 +2477,8 @@ glusterfs_volfile_fetch_one(glusterfs_ctx_t *ctx, char *volfile_id)
                               GF_HNDSK_GETSPEC, mgmt_getspec_cbk,
                               (xdrproc_t)xdr_gf_getspec_req);
 
+    /*  In case of error the frame will be destroy by rpc_clnt_submit */
+    frame = NULL;
 out:
     GF_FREE(req.xdata.xdata_val);
     if (dict)
@@ -3004,6 +3012,7 @@ mgmt_pmap_signin_cbk(struct rpc_req *req, struct iovec *iov, int count,
     char brick_name[PATH_MAX] = {
         0,
     };
+    gf_boolean_t frame_cleanup = _gf_true;
 
     frame = myframe;
     ctx = glusterfsd_ctx;
@@ -3044,6 +3053,7 @@ mgmt_pmap_signin_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = mgmt_submit_request(&pmap_req, frame, ctx, &clnt_pmap_prog,
                               GF_PMAP_SIGNIN, mgmt_pmap_signin2_cbk,
                               (xdrproc_t)xdr_pmap_signin_req);
+    frame_cleanup = _gf_false;
     if (ret)
         goto out;
 
@@ -3053,7 +3063,9 @@ out:
     if (need_emancipate && (ret < 0 || !cmd_args->brick_port2))
         emancipate(ctx, emancipate_ret);
 
-    STACK_DESTROY(frame->root);
+    if (frame_cleanup)
+        STACK_DESTROY(frame->root);
+
     return 0;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -221,6 +221,8 @@ gd_syncop_submit_request(struct rpc_clnt *rpc, void *req, void *local,
                           iobref, frame, NULL, 0, NULL, 0, NULL);
 
     /* TODO: do we need to start ping also? */
+    /* In case of error the frame will be destroy by rpc_clnt_submit */
+    frame = NULL;
 
 out:
     iobref_unref(iobref);


### PR DESCRIPTION
glusterfs encounter a SIGSEGV in __gf_free called from glusterfs_volfile_fetch_on

The glusterfs(fuse client) is showing a below stacktrace

Program terminated with signal 11, Segmentation fault. 326 if (!num_allocs) {
(gdb) bt
at ../../libglusterfs/src/glusterfs/stack.h:199
at glusterfsd-mgmt.c:2269
at glusterfsd-mgmt.c:2293
at ../sysdeps/unix/sysv/linux/makedev.c:37
(gdb)

Solution: Avoid frame cleanup in case of error return by mgmt_submit_request.

> Fixes: #4190
> Change-Id: I49602280e857108cfe2db7a548818a81d6c605e0
> Credits: Xavi Hernandez <xhernandez@gmail.com>
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Reviwed on upstream link https://github.com/gluster/glusterfs/pull/4191)

Fixes: #4190
Change-Id: I49602280e857108cfe2db7a548818a81d6c605e0
Fixes: #4190

