### PR TITLE
fuse: FUSE Crashing with "Assertion failed: inode_lookup >= nlookup"

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -765,7 +765,19 @@ inode_forget_atomic(inode_t *inode, uint64_t nlookup)
         GF_ATOMIC_INIT(inode->nlookup, 0);
     } else {
         inode_lookup = GF_ATOMIC_FETCH_SUB(inode->nlookup, nlookup);
-        GF_ASSERT(inode_lookup >= nlookup);
+        /*
+          GF_ASSERT(inode_lookup >= nlookup) assert may fail due to kernel bug
+          more details can found on links:
+          https://github.com/gluster/glusterfs/pull/4081
+          https://github.com/gluster/glusterfs/issues/4074
+        */
+        if (inode_lookup < nlookup) {
+            GF_ATOMIC_FETCH_ADD(inode->nlookup, nlookup - inode_lookup);
+            gf_msg_callingfn(THIS->name, GF_LOG_CRITICAL, 0,
+                             LG_MSG_ASSERTION_FAILED,
+                             "GF_ASSERT(inode_lookup >= nlookup) may fail due "
+                             "to kernel bug, reset inode->nlookup to 0");
+        }
     }
 
     return inode;


### PR DESCRIPTION
In ideal case the nlookup in kernel and fuse should be consistent but there is a case that fuse_direntplus_link would do nlookup++ and return fail due to that the counter is not consistent.

To avoid a crash remove assertion and in case of value mismatch decrese the counter.

> Fixes: #4074
> Signed-off-by: ruanmeisi <ruan.meisi@zte.com.cn>
> Reviwed on upstream link https://github.com/gluster/glusterfs/pull/4081
> Cherry picked from commit a8486b9ff992e642b3d1c96f76c7875b320081f3

Fixes: #4074
Change-Id: Idd767cf1793dba6a4f6fd52f00dfb6810bbe4a8d

