### PR TITLE
core: The brick process is getting crash during upcall event

### DIFF
--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -1470,6 +1470,12 @@ server_process_event_upcall(xlator_t *this, void *data)
             if (!client || strcmp(client->client_uid, client_uid))
                 continue;
 
+            /* Avoid upcall notification to client if disconnect is in
+               progress
+             */
+            if (GF_ATOMIC_GET(xprt->disconnect_progress))
+                continue;
+
             xprt_found = _gf_true;
             rpc_transport_ref(xprt);
             break;


### PR DESCRIPTION
A brick process may crash while it try to send upcall notification to the client and client disconnect is being process.

Solution: Avoid upcall event notification to the client if disconnect
        is being process for the same client.

> Fixes: #4255
> Change-Id: I80478d7f4a038b04a10fb21a1290b4309e9fe4dd
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Cherry picked from commit b98d0d71c194bdc7c9ff791a0310abca347dd3be)
> (Reviewed on upstream release https://github.com/gluster/glusterfs/pull/4256)

Fixes: #4255
Change-Id: I80478d7f4a038b04a10fb21a1290b4309e9fe4dd

