### PR TITLE
mount.glusterfs: Remove `\` from grep command

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -853,7 +853,7 @@ EOF
         }
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..


### PR DESCRIPTION
GNU grep [v3.8 release notes](https://savannah.gnu.org/forum/forum.php?forum_id=10227) has the following mention about the usage of backslahes:

"Regular expressions with stray backslashes now cause warnings, as their unspecified behavior can lead to unexpected results."

As a result we see the warning "grep: warning: stray \ before -" during script execution. Therefore remove the extra `\` from grep command.

Please note that this exact change was committed into _mount_glusterfs.in_ via 162d007dae167ec961b4a0970f6c37c6a2f9f641 but not here.

