### PR TITLE
mount.glusterfs: Remove `\` from grep command (#4275)

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -839,7 +839,7 @@ EOF
         }
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..


### PR DESCRIPTION
GNU grep [v3.8 release notes](https://savannah.gnu.org/forum/forum.php?forum_id=10227) has the following mention about the usage of backslahes:

"Regular expressions with stray backslashes now cause warnings, as their unspecified behavior can lead to unexpected results."

As a result we see the warning "grep: warning: stray \ before -" during script execution. Therefore remove the extra `\` from grep command.

Please note that this exact change was committed into mount_glusterfs.in via 0ca99f0409ebc9f5082fbae20c1b8902296ac357 but not here.

(cherry picked from commit 42e3cb18f5d1f9692615e55c82e7a7c83f0f3a04)

