### PR TITLE
mount/utils: Remove `\` from grep command (#4275, #4199)

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -834,7 +834,7 @@ EOF
         }
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..

--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -549,7 +549,7 @@ EOF
         exit 1;
     }
 
-    grep_ret=$(echo ${mount_point} | grep '^\-o');
+    grep_ret=$(echo ${mount_point} | grep '^-o');
     [ "x" != "x${grep_ret}" ] && {
         cat <<EOF >&2
 ERROR: -o options cannot be specified in either first two arguments..


### PR DESCRIPTION
GNU grep [v3.8 release notes](https://savannah.gnu.org/forum/forum.php?forum_id=10227) has the following mention about the usage of backslahes:
 
"Regular expressions with stray backslashes now cause warnings, as their unspecified behavior can lead to unexpected results."

As a result we see the warning "grep: warning: stray \ before -" during script execution. Therefore remove the extra `\` from grep command.

(cherry picked from commit 42e3cb18f5d1f9692615e55c82e7a7c83f0f3a04)
(cherry picked from commit 162d007dae167ec961b4a0970f6c37c6a2f9f641)
