### PR TITLE
Backport: Marker Optimize the size of the stack #3711

### DIFF
--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1120,8 +1120,8 @@ mq_synctask1(xlator_t *this, synctask_fn_t task, gf_boolean_t spawn, loc_t *loc,
     }
 
     if (spawn) {
-        ret = synctask_new1(this->ctx->env, 1024 * 16, task,
-                            mq_synctask_cleanup, NULL, args);
+        ret = synctask_new1(this->ctx->env, 0, task, mq_synctask_cleanup, NULL,
+                            args);
         if (ret) {
             gf_log(this->name, GF_LOG_ERROR,
                    "Failed to spawn "


### PR DESCRIPTION
The main purpose of this PR is to backport the fixes merged in #3711 to glusterfs `v10.x`. This issue affects gluster installations using 10.x

Fixes #3710 for glusterfs v10.x