### PR TITLE
fuse: Allow default ACLs to be geo-replicated

### DIFF
--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -670,6 +670,7 @@ fuse_ignore_xattr_set(fuse_private_t *priv, char *key)
           (fnmatch("*.glusterfs.volume-mark", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.volume-mark.*", key, FNM_PERIOD) == 0) ||
           (fnmatch("system.posix_acl_access", key, FNM_PERIOD) == 0) ||
+          (fnmatch("system.posix_acl_default", key, FNM_PERIOD) == 0) ||
           (fnmatch("glusterfs.gfid.newfile", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.shard.block-size", key, FNM_PERIOD) == 0) ||
           (fnmatch("*.glusterfs.lockinfo", key, FNM_PERIOD) == 0) ||


### PR DESCRIPTION
Before this patch, the trusted.posix_acl_default xattr was not allowed to be set or modified on a geo-replicated volume.

This patch allows setting/modifying this xattr.

