### PR TITLE
core: brick process is getting SIGSEGV during inode_unref

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -351,9 +351,19 @@ __inode_ctx_free(inode_t *inode)
 static void
 __inode_destroy(inode_t *inode)
 {
-    inode_unref(inode->ns_inode);
-    __inode_ctx_free(inode);
+    inode_table_t *table = NULL;
+    inode_t *ns_inode = inode->ns_inode;
 
+    if (ns_inode) {
+        table = ns_inode->table;
+        pthread_mutex_lock(&table->lock);
+        {
+            __inode_unref(ns_inode, false);
+        }
+        pthread_mutex_unlock(&table->lock);
+    }
+
+    __inode_ctx_free(inode);
     LOCK_DESTROY(&inode->lock);
     //  memset (inode, 0xb, sizeof (*inode));
     GF_FREE(inode);


### PR DESCRIPTION
The brick process is getting crashed due to stack overflow while unref namespace inode, the ns inode was introduced by the patch ((https://github.com/gluster/glusterfs/pull/1763)

Solution: __inode_destroy is calling inode_unref that is again calling inode_unref become a recursive call and eventually a brick process is getting crashed. To avoid a crash for namespace inode call only __inode_ref.

> Fixes: #4295
> Change-Id: If5deb06b726a5e7dfedd2784bddcef81e6e5d7d9
> Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>
> (Cherry picked from commit 80ecbbac0cfb4d45684d132f78a41fcaaafeb2ea)
> (Reviewed on upstream link https://github.com/gluster/glusterfs/pull/4302)

Fixes: #4295
Change-Id: If5deb06b726a5e7dfedd2784bddcef81e6e5d7d9

