### PR TITLE
prevent gnfs IO Errors on smaller files

### DIFF
--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -4931,8 +4931,11 @@ shard_readv_do_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (local->op_ret >= 0)
+    if (local->op_ret >= 0) {
         local->op_ret += op_ret;
+        /* gnfs requires op_errno to determine is_eof */
+        local->op_errno = op_errno;
+    }
 
     shard_inode_ctx_get(anon_fd->inode, this, &ctx);
     block_num = ctx->block_num;

--- a/xlators/performance/io-cache/src/page.c
+++ b/xlators/performance/io-cache/src/page.c
@@ -789,6 +789,8 @@ ioc_frame_unwind(call_frame_t *frame)
     GF_ASSERT(frame);
 
     local = frame->local;
+    /* gnfs requires op_errno to determine is_eof */
+    op_errno = local->op_errno;
     if (local == NULL) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOMEM,
                 IO_CACHE_MSG_LOCAL_NULL, NULL);


### PR DESCRIPTION
In certain situations, smaller files will report I/O errors when accessed from NFS using Gluster NFS. With our settings, files up to 170M could report this in some cases. It was not a consistent failure.

Disbling the NFS performance I/O cache seemed to work around the instances of the problem observed for non-sharded volumes.

Research showed that gluster NFS is relying on an errno return value of EINVAL to detect EOF and set is_eof. However, in some paths this value was not retained or was reset to zero.

This change passes the errno along so it can be used by gluster NFS. We found the issue in the shard xlator and the io-cache xlator.

