### PR TITLE
nfs: avoid 1-byte atomics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1314,18 +1314,6 @@ fi
 
 AC_SUBST(GF_DISTRIBUTION)
 
-AC_CHECK_FILE([/etc/os-release])
-
-if test "x$ac_cv_file__etc_os_release" = "xyes"; then
-   AC_CANONICAL_HOST
-
-   if test "x${host_cpu}" = "xs390x" || test "x${host_cpu}" = "xs390" ; then
-      if grep "Red Hat Enterprise Linux 8\|SUSE Linux Enterprise Server 15" /etc/os-release ; then
-         AC_DEFINE(REDHAT8_OR_SLES15_ON_S390X, 1, [Red Hat 8 or SLES 15 on s390x])
-      fi
-   fi
-fi
-
 GF_HOST_OS=""
 GF_LDFLAGS="${GF_LDFLAGS} -rdynamic"
 

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -1679,15 +1679,9 @@ nfs_start_rpc_poller(struct nfs_state *state)
  *     all registered services, from any thread.
  */
 #ifdef HAVE_LIBTIRPC
-#ifdef REDHAT8_OR_SLES15_ON_S390X
     if (uatomic_xchg(&state->svc_running, 1)) {
         return;
     }
-#else
-    if (uatomic_xchg(&state->svc_running, true)) {
-        return;
-    }
-#endif
 #endif
 
     svc_run();

--- a/xlators/nfs/server/src/nfs.h
+++ b/xlators/nfs/server/src/nfs.h
@@ -103,11 +103,7 @@ struct nfs_state {
     gf_boolean_t rdirplus;
 
 #ifdef HAVE_LIBTIRPC
-#ifdef REDHAT8_OR_SLES15_ON_S390X
     int svc_running;
-#else
-    bool svc_running;
-#endif
 #endif
 };
 


### PR DESCRIPTION
Some architectures, like s390x don't support 1-byte atomic operations. In the past this was already fixed by using a 4-byte integer instead of a boolean, but only for the s390x architecture and only for RHEL8 and SLES15 operating systems.

This means that the problem has appeared again when RHEL9 has been tested.

Since there's virtually no difference between using a boolean or an integer, this patch just removes all conditional checks and uses a 4-bytes integer in all architectures and operating systems.

