### PR TITLE
rpc: Improve rpc clnt connection cleanup process

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -429,7 +429,6 @@ int
 rpc_clnt_reconnect_cleanup(rpc_clnt_connection_t *conn)
 {
     struct rpc_clnt *clnt = NULL;
-    int ret = 0;
     gf_boolean_t reconnect_unref = _gf_false;
 
     if (!conn) {
@@ -441,11 +440,9 @@ rpc_clnt_reconnect_cleanup(rpc_clnt_connection_t *conn)
     pthread_mutex_lock(&conn->lock);
     {
         if (conn->reconnect) {
-            ret = gf_timer_call_cancel(clnt->ctx, conn->reconnect);
-            if (!ret) {
-                reconnect_unref = _gf_true;
-                conn->cleanup_gen++;
-            }
+            gf_timer_call_cancel(clnt->ctx, conn->reconnect);
+            conn->cleanup_gen++;
+            reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
     }
@@ -469,7 +466,6 @@ rpc_clnt_connection_cleanup(rpc_clnt_connection_t *conn)
     struct saved_frames *saved_frames = NULL;
     struct rpc_clnt *clnt = NULL;
     int unref = 0;
-    int ret = 0;
     gf_boolean_t timer_unref = _gf_false;
     gf_boolean_t reconnect_unref = _gf_false;
 
@@ -486,15 +482,13 @@ rpc_clnt_connection_cleanup(rpc_clnt_connection_t *conn)
 
         /* bailout logic cleanup */
         if (conn->timer) {
-            ret = gf_timer_call_cancel(clnt->ctx, conn->timer);
-            if (!ret)
-                timer_unref = _gf_true;
+            gf_timer_call_cancel(clnt->ctx, conn->timer);
+            timer_unref = _gf_true;
             conn->timer = NULL;
         }
         if (conn->reconnect) {
-            ret = gf_timer_call_cancel(clnt->ctx, conn->reconnect);
-            if (!ret)
-                reconnect_unref = _gf_true;
+            gf_timer_call_cancel(clnt->ctx, conn->reconnect);
+            reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
 
@@ -1816,20 +1810,18 @@ rpc_clnt_disable(struct rpc_clnt *rpc)
         rpc->disabled = 1;
 
         if (conn->timer) {
-            ret = gf_timer_call_cancel(rpc->ctx, conn->timer);
+            gf_timer_call_cancel(rpc->ctx, conn->timer);
             /* If the event is not fired and it actually cancelled
              * the timer, do the unref else registered call back
              * function will take care of it.
              */
-            if (!ret)
-                timer_unref = _gf_true;
+            timer_unref = _gf_true;
             conn->timer = NULL;
         }
 
         if (conn->reconnect) {
-            ret = gf_timer_call_cancel(rpc->ctx, conn->reconnect);
-            if (!ret)
-                reconnect_unref = _gf_true;
+            gf_timer_call_cancel(rpc->ctx, conn->reconnect);
+            reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
         conn->status = RPC_STATUS_INITIALIZED;


### PR DESCRIPTION
During the first rpc clnt submission we take the rpc reference and register the call_bail function for the timer thread. The timer thread call call_bail function every 10s basis. In case if a client trigger a shutdown request it try to call rpc_clnt_connection_cleanup to cleanup the rpc connection.The rpc_clnt_connection would not be able to cleanup the rpc connection successfully due to the cleanup_started flag being set by the upper xlator. The rpc reference will be unref only after trigger a call_bail function so basically if somehow call_bail is triggered just before start a shutdown process the application has to wait for 10s to cleanup the rpc connection eventually the process becomes slow.

Solution: Unref the rpc object based on the conn->timer/conn->reconnect pointer value as we are doing the same for ping_timer. These pointer are always modified under the critical section so we can assume if pointer is valid it means rpc reference is also valid.

Fixes: #4320
credits: Xavi Hernandez <xhernandez@redhat.com>
Change-Id: Ib947b8bfcbe1b49e1ed05a50a84de6f92afbca13

