### PR TITLE
mount.glusterfs: Increase the max characters allow in the hostnames of glusterservers

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -26,7 +26,7 @@ _init ()
     LOG_DEBUG=DEBUG;
     LOG_TRACE=TRACE;
 
-    HOST_NAME_MAX=64;
+    HOST_NAME_MAX=255;
 
     prefix="@prefix@";
     exec_prefix=@exec_prefix@;

--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -35,7 +35,7 @@ _init ()
     LOG_DEBUG=DEBUG;
     LOG_TRACE=TRACE;
 
-    HOST_NAME_MAX=64;
+    HOST_NAME_MAX=255;
 
     prefix="@prefix@";
     exec_prefix=@exec_prefix@;


### PR DESCRIPTION
The mount scripts validate hostnames by checking that they are less than 64 characters long.  Host names on many cloud environments are generally much longer than this, but are still valid.

This change increases the hostname length to allow for these valid hostname.