### PR TITLE
Improve some calls around UUID

### DIFF
--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -887,11 +887,15 @@ inode_grep_for_gfid(inode_table_t *table, inode_t *parent, const char *name,
     return ret;
 }
 
-/* return 1 if gfid is of root, 0 if not */
+/* return true if gfid is of root, false if not */
 gf_boolean_t
 __is_root_gfid(uuid_t gfid)
 {
     static uuid_t root = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    const uint64_t *p = (uint64_t *)gfid;
+
+    if (*p) /*if it doesn't start with zero's, it's not root gfid */
+        return _gf_false;
 
     if (gf_uuid_compare(gfid, root) == 0)
         return _gf_true;

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -473,11 +473,10 @@ posix_handle_gfid_path(xlator_t *this, uuid_t gfid, char *buf, size_t buflen)
     if ((buflen < len) || !buf)
         return len;
 
-    uuid_str = uuid_utoa(gfid);
-
     if (__is_root_gfid(gfid)) {
         len = snprintf(buf, buflen, "%s", priv->base_path);
     } else {
+        uuid_str = uuid_utoa(gfid);
         len = snprintf(buf, buflen, "%s/%s/%02x/%02x/%s", priv->base_path,
                        GF_HIDDEN_PATH, gfid[0], gfid[1], uuid_str);
     }


### PR DESCRIPTION
1. Micro-optimization to test faster if a UUID is the root uuid
2. Call uuid_utoa() when needed.

Updates: #1000 