### PR TITLE
posix_handle_sort/hard() - restructure the code a bit

### DIFF
--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -2084,8 +2084,7 @@ unlock:
 
     if (IA_ISDIR(oldloc->inode->ia_type)) {
         posix_handle_unset_gfid(this, oldloc->inode->gfid);
-        posix_handle_soft(this, real_newpath, newloc, oldloc->inode->gfid,
-                          NULL);
+        posix_handle_soft(this, real_newpath, newloc, oldloc->inode->gfid);
     }
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -205,7 +205,7 @@ posix_handle_hard(xlator_t *this, const char *path, uuid_t gfid,
 
 int
 posix_handle_soft(xlator_t *this, const char *real_path, loc_t *loc,
-                  uuid_t gfid, struct stat *buf);
+                  uuid_t gfid);
 
 int
 posix_handle_unset_gfid(xlator_t *this, uuid_t gfid);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1046,7 +1046,7 @@ verify_handle:
     if (!S_ISDIR(stat.st_mode))
         ret = posix_handle_hard(this, path, uuid_curr, &stat);
     else
-        ret = posix_handle_soft(this, path, loc, uuid_curr, &stat);
+        ret = posix_handle_soft(this, path, loc, uuid_curr);
 
 out:
     if (ret && !(*op_errno))


### PR DESCRIPTION
- Make it more readable
- Remove unused parameters
- Reduce redunandat work (such as `snprintf(d2, sizeof(d2), "%02x", gfid[1]);`)
- Don't query errno if not needed

Updates: #1000
Signed-off-by: Yaniv Kaul <mykaul@gmail.com>

