### PR TITLE
write: try to fetch GLUSTERFS_WRITE_IS_APPEND once, not twice in writ…

### DIFF
--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -222,5 +222,6 @@ void
 posix_disk_space_check(struct posix_private *priv);
 
 dict_t *
-_fill_writev_xdata(fd_t *fd, dict_t *xdata, xlator_t *this, int is_append);
+_fill_writev_xdata(inode_t *inode, dict_t *xdata, xlator_t *this, int is_append,
+                   gf_boolean_t skip_fetch_write_is_append);
 #endif /* !_POSIX_HANDLE_H */


### PR DESCRIPTION
…e path

We fetch it once (in posix_writev() or posix_writev_fill_rsp_dict() in io_uring code) and then again in _fill_writev_xdata().

Updates: #1000
Signed-off-by: Yaniv Kaul <mykaul@gmail.com>
