### PR TITLE
fuse-bridge.c: fix compilation warning

### DIFF
--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -430,15 +430,13 @@ fuse_invalidate_entry(xlator_t *this, uint64_t fuse_ino)
         if (ENOTEMPTY < ERRNOMASK_MAX)
             MASK_ERRNO(node->errnomask, ENOTEMPTY);
 
-        if (dentry->name) {
-            nlen = strlen(dentry->name);
-            fouh->len = sizeof(*fouh) + sizeof(*fnieo) + nlen + 1;
-            fnieo->parent = inode_to_fuse_nodeid(dentry->parent);
+        nlen = strlen(dentry->name);
+        fouh->len = sizeof(*fouh) + sizeof(*fnieo) + nlen + 1;
+        fnieo->parent = inode_to_fuse_nodeid(dentry->parent);
 
-            fnieo->namelen = nlen;
-            strcpy((node->inval_buf + sizeof(*fouh) + sizeof(*fnieo)),
-                   dentry->name);
-        }
+        fnieo->namelen = nlen;
+        strcpy((node->inval_buf + sizeof(*fouh) + sizeof(*fnieo)),
+               dentry->name);
 
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "INVALIDATE entry: %" PRIu64 "/%s (gfid:%s)", fnieo->parent,


### PR DESCRIPTION
fuse-bridge.c:433:13: warning: the comparison will always evaluate as 'true' for the address of 'name' will never be NULL [-Waddress]
  433 |         if (dentry->name) {
      |             ^~~~~~
In file included from ../../../../libglusterfs/src/glusterfs/statedump.h:15,
                 from fuse-bridge.h:23,
                 from fuse-bridge.c:14:
../../../../libglusterfs/src/glusterfs/inode.h:76:10: note: 'name' declared here
   76 |     char name[];                  /* name of the directory entry */
      |          ^~~~

Updates: #1000

