### PR TITLE
nl-cache: Resolve the inode is not of type dir error

### DIFF
--- a/xlators/performance/nl-cache/src/nl-cache-helper.c
+++ b/xlators/performance/nl-cache/src/nl-cache-helper.c
@@ -397,11 +397,11 @@ __nlc_set_dir_state(nlc_ctx_t *nlc_ctx, uint64_t new_state)
 }
 
 void
-nlc_set_dir_state(xlator_t *this, inode_t *inode, uint64_t state)
+nlc_set_dir_state(xlator_t *this, inode_t *inode, uint64_t state, ia_type_t ia_type)
 {
     nlc_ctx_t *nlc_ctx = NULL;
 
-    if (inode->ia_type != IA_IFDIR) {
+    if (ia_type != IA_IFDIR) {
         gf_msg_callingfn(this->name, GF_LOG_ERROR, EINVAL, NLC_MSG_EINVAL,
                          "inode is not of type dir");
         goto out;

--- a/xlators/performance/nl-cache/src/nl-cache.h
+++ b/xlators/performance/nl-cache/src/nl-cache.h
@@ -87,10 +87,6 @@ typedef struct nlc_ctx nlc_ctx_t;
 struct nlc_local {
     loc_t loc;
     loc_t loc2;
-    inode_t *inode;
-    inode_t *parent;
-    fd_t *fd;
-    char *linkname;
     glusterfs_fop_t fop;
 };
 typedef struct nlc_local nlc_local_t;
@@ -132,7 +128,7 @@ gf_boolean_t
 nlc_is_negative_lookup(xlator_t *this, loc_t *loc);
 
 void
-nlc_set_dir_state(xlator_t *this, inode_t *inode, uint64_t state);
+nlc_set_dir_state(xlator_t *this, inode_t *inode, uint64_t state, ia_type_t ia_type);
 
 void
 nlc_dir_add_pe(xlator_t *this, inode_t *inode, inode_t *entry_ino,


### PR DESCRIPTION
During fop(mkdir)_cbk process by nl-cache it checks the inode type validation based on loc->inode though loc->inode is populated by first xlator like fuse/gfapi. The loc->inode does not have inode_type so it always throw an error.

Solution: Check the inode type based on inode attribute return by server xlator as an argument in callback function.

Fixes: #2521
Change-Id: Ibc4675ebe095d14310cdb2348c2f55a73f972046

