### PR TITLE
explicitly fail when ssl setup fails in socket_init

### DIFF
--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -4448,7 +4448,10 @@ socket_init(rpc_transport_t *this)
     priv->mgmt_ssl = this->ctx->secure_mgmt;
     priv->srvr_ssl = this->ctx->secure_srvr;
 
-    ssl_setup_connection_params(this);
+    if (ssl_setup_connection_params(this)) {
+        gf_log(this->name, GF_LOG_ERROR, "ssl setup failed");
+        return -1;
+    }
 out:
     this->private = priv;
     return 0;


### PR DESCRIPTION
Currently in socket_init(), it doesn't check the ret code on ssl_setup_connection_params() call. the initialization appears successful but the transport is not usable, ssl handshake all fails.

There are many failure scenarios like cert/key/ca file absence, or cert/key mismatch, that cause the ssl setup failing.

It's better to fail the initialization explicitly so that we can discover the problem much earlier. There are so many

