### PR TITLE
Replace obsoleted readfp() with read_file(), fixes gluster/glusterfs#4403

### DIFF
--- a/geo-replication/syncdaemon/gsyncdconfig.py
+++ b/geo-replication/syncdaemon/gsyncdconfig.py
@@ -96,7 +96,7 @@ class Gconf(object):
 
         cnf = RawConfigParser()
         with open(self.custom_conf_file) as f:
-            cnf.readfp(f)
+            cnf.read_file(f)
 
             # Nothing to Reset, Not configured
             if name != "all":
@@ -140,7 +140,7 @@ class Gconf(object):
 
         cnf = RawConfigParser()
         with open(self.custom_conf_file) as f:
-            cnf.readfp(f)
+            cnf.read_file(f)
 
         if not cnf.has_section("vars"):
             cnf.add_section("vars")
@@ -181,12 +181,12 @@ class Gconf(object):
         conf = RawConfigParser()
         # Default Template config file
         with open(self.default_conf_file) as f:
-            conf.readfp(f)
+            conf.read_file(f)
 
         # Custom Config file
         if self.custom_conf_file is not None:
             with open(self.custom_conf_file) as f:
-                conf.readfp(f)
+                conf.read_file(f)
 
         # Get version from default conf file
         self.version = conf.get("__meta__", "version")


### PR DESCRIPTION
As stated in the [deprecation/removal warning](https://github.com/python/cpython/blob/dd0e8a62df8be2a09ef6035b4c92bd9a68a7b918/Lib/configparser.py#L757-L764), readfp() is removed in python 3.12 which leads georeplication setup to fail with a traceback.

Official docs clearly state that [read_file()](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file) is the proper replacement.