### PR TITLE
afr: fix race between __afr_eager_lock_handle and afr_wakeup_same_fd_delayed_op (#4425)

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4205,6 +4205,7 @@ afr_wakeup_same_fd_delayed_op(xlator_t *this, afr_lock_t *lock, fd_t *fd)
             if (gf_timer_call_cancel(this->ctx, lock->delay_timer)) {
                 local = NULL;
             } else {
+                lock->release = _gf_true;
                 lock->delay_timer = NULL;
             }
         } else {


### PR DESCRIPTION
Race between `__afr_eager_lock_handle` and `afr_wakeup_same_fd_delayed_op` will lead to stale inodelks, which may cause subsequent IO blocked. To avoid this race, set `lock->release = _gf_true` also in `afr_wakeup_same_fd_delayed_op` so that a new transaction can be correctly handled as expected in `__afr_eager_lock_handle`.

Fixes: #4425

