### PR TITLE
events: avoid zombie processes after reloading

### DIFF
--- a/events/src/utils.py
+++ b/events/src/utils.py
@@ -467,6 +467,7 @@ class WebhookThreadPool(object):
         # In transit messages are skipped, since webhooks monitor process
         # is terminated.
         self.proc.terminate()
+        self.proc.join()
         self.start()
 
     def send(self, event_type, event_ts, message):


### PR DESCRIPTION
To prevent zombie processes after reloading by using join.

fix: #4437 

