### PR TITLE
Fixing compilation warnings in building glusterfs

### DIFF
--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -598,10 +598,8 @@ gf_client_dump_fdtables(xlator_t *this)
                 clienttable->cliententries[count].next_free)
                 continue;
             client = clienttable->cliententries[count].client;
-            if (client->client_uid) {
-                gf_proc_dump_build_key(key, "conn", "%d.id", count);
-                gf_proc_dump_write(key, "%s", client->client_uid);
-            }
+            gf_proc_dump_build_key(key, "conn", "%d.id", count);
+            gf_proc_dump_write(key, "%s", client->client_uid);
 
             if (client->subdir_mount) {
                 gf_proc_dump_build_key(key, "conn", "%d.subdir", count);

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -58,45 +58,56 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
 
         switch (op_code) {
             case GLUSTERD_MGMT_V3_LOCK: {
-                snprintf(op_err, sizeof(op_err), "Locking failed on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Locking failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_PRE_VALIDATE: {
-                snprintf(op_err, sizeof(op_err),
-                         "Pre Validation failed on %s. %s", peer_str,
-                         err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Pre Validation failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_BRICK_OP: {
-                snprintf(op_err, sizeof(op_err), "Brick ops failed on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Brick ops failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_COMMIT: {
-                snprintf(op_err, sizeof(op_err), "Commit failed on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Commit failed on %s. %s", peer_str, err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_POST_COMMIT: {
-                snprintf(op_err, sizeof(op_err), "Post commit failed on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Post commit failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_POST_VALIDATE: {
-                snprintf(op_err, sizeof(op_err),
-                         "Post Validation failed on %s. %s", peer_str,
-                         err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Post Validation failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             case GLUSTERD_MGMT_V3_UNLOCK: {
-                snprintf(op_err, sizeof(op_err), "Unlocking failed on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Unlocking failed on %s. %s", peer_str,
+                               err_string);
                 break;
             }
             default:
-                snprintf(op_err, sizeof(op_err), "Unknown error! on %s. %s",
-                         peer_str, err_string);
+                len = snprintf(op_err, sizeof(op_err),
+                               "Unknown error! on %s. %s", peer_str,
+                               err_string);
+        }
+
+        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_OP_FAIL, "%s",
+               op_err);
+        if (len >= sizeof(op_err)) {
+            strcpy(op_err, "Truncated error message, check logfile");
         }
 
         if (args->errstr) {
@@ -110,8 +121,6 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
         } else
             snprintf(err_str, sizeof(err_str), "%s", op_err);
 
-        gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_OP_FAIL, "%s",
-               op_err);
         args->errstr = gf_strdup(err_str);
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -271,7 +271,7 @@ void
 glusterd_svc_build_pidfile_path(char *server, char *workdir, char *path,
                                 size_t len)
 {
-    char dir[PATH_MAX] = {0};
+    char dir[VALID_GLUSTERD_PATHMAX] = {0};
 
     GF_ASSERT(len == PATH_MAX);
 
@@ -283,7 +283,7 @@ void
 glusterd_svc_build_volfile_path(char *server, char *workdir, char *volfile,
                                 size_t len)
 {
-    char dir[PATH_MAX] = {
+    char dir[VALID_GLUSTERD_PATHMAX] = {
         0,
     };
 
@@ -301,7 +301,7 @@ glusterd_svc_build_volfile_path(char *server, char *workdir, char *volfile,
 void
 glusterd_svc_build_svcdir(char *server, char *workdir, char *path, size_t len)
 {
-    GF_ASSERT(len == PATH_MAX);
+    GF_ASSERT(len == VALID_GLUSTERD_PATHMAX);
 
     snprintf(path, len, "%s/%s", workdir, server);
 }
@@ -309,7 +309,7 @@ glusterd_svc_build_svcdir(char *server, char *workdir, char *path, size_t len)
 void
 glusterd_svc_build_rundir(char *server, char *workdir, char *path, size_t len)
 {
-    char dir[PATH_MAX] = {0};
+    char dir[VALID_GLUSTERD_PATHMAX] = {0};
 
     GF_ASSERT(len == PATH_MAX);
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -7672,10 +7672,14 @@ out:
                 ret = -1;
             }
         } else {
-            snprintf(msg, sizeof(msg),
-                     "parent directory %s is "
-                     "already part of a volume",
-                     curdir);
+            int z = snprintf(msg, sizeof(msg),
+                             "parent directory %s is "
+                             "already part of a volume",
+                             curdir);
+            if (z < 0 || z >= sizeof(msg)) {
+                snprintf(msg, sizeof(msg), "path too big");
+                ret = -1;
+            }
         }
     }
 


### PR DESCRIPTION
```
client_t.c: In function 'gf_client_dump_fdtables':
client_t.c:601:17: warning: the comparison will always evaluate as 'true' for the address of 'client_uid' will never be NULL [-Waddress]
  601 |             if (client->client_uid) {
      |                 ^~~~~~
In file included from ./glusterfs/stack.h:31,
                 from ./glusterfs/xlator.h:53,
                 from ./glusterfs/fd.h:79,
                 from ./glusterfs/inode.h:33,
                 from glusterfs/statedump.h:15,
                 from client_t.c:12:
./glusterfs/client_t.h:59:10: note: 'client_uid' declared here
   59 |     char client_uid[];
      |          ^~~~~~~~~~
....
glusterd-svc-mgmt.c: In function 'glusterd_svc_build_volfile_path':
glusterd-svc-mgmt.c:298:38: warning: '-server.vol' directive output may be truncated writing 11 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  298 |         snprintf(volfile, len, "%s/%s-server.vol", dir, server);
      |                                      ^~~~~~~~~~~
glusterd-svc-mgmt.c:298:9: note: 'snprintf' output 13 or more bytes (assuming 4108) into a destination of size 4096
  298 |         snprintf(volfile, len, "%s/%s-server.vol", dir, server);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glusterd-svc-mgmt.c:296:38: warning: '.vol' directive output may be truncated writing 4 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  296 |         snprintf(volfile, len, "%s/%s.vol", dir, server);
      |                                      ^~~~
glusterd-svc-mgmt.c:296:9: note: 'snprintf' output 6 or more bytes (assuming 4101) into a destination of size 4096
  296 |         snprintf(volfile, len, "%s/%s.vol", dir, server);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glusterd-svc-mgmt.c: In function 'glusterd_svc_build_pidfile_path':
glusterd-svc-mgmt.c:279:31: warning: '.pid' directive output may be truncated writing 4 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  279 |     snprintf(path, len, "%s/%s.pid", dir, server);
      |                               ^~~~
glusterd-svc-mgmt.c:279:5: note: 'snprintf' output 6 or more bytes (assuming 4101) into a destination of size 4096
  279 |     snprintf(path, len, "%s/%s.pid", dir, server);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glusterd-utils.c: In function 'glusterd_is_path_in_use':
glusterd-utils.c:7676:40: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 2031 [-Wformat-truncation=]
 7676 |                      "parent directory %s is "
      |                                        ^~
glusterd-utils.c:7675:13: note: 'snprintf' output between 46 and 4141 bytes into a destination of size 2048
 7675 |             snprintf(msg, sizeof(msg),
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
 7676 |                      "parent directory %s is "
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~
 7677 |                      "already part of a volume",
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7678 |                      curdir);
      |                      ~~~~~~~
glusterd-mgmt.c: In function 'gd_mgmt_v3_collate_errors':
glusterd-mgmt.c:82:77: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4072 [-Wformat-truncation=]
   82 |                 snprintf(op_err, sizeof(op_err), "Post commit failed on %s. %s",
      |                                                                             ^~
glusterd-mgmt.c:82:17: note: 'snprintf' output 25 or more bytes (assuming 4120) into a destination of size 4096
   82 |                 snprintf(op_err, sizeof(op_err), "Post commit failed on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   83 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
glusterd-mgmt.c:93:75: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4074 [-Wformat-truncation=]
   93 |                 snprintf(op_err, sizeof(op_err), "Unlocking failed on %s. %s",
      |                                                                           ^~
glusterd-mgmt.c:93:17: note: 'snprintf' output 23 or more bytes (assuming 4118) into a destination of size 4096
   93 |                 snprintf(op_err, sizeof(op_err), "Unlocking failed on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   94 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
glusterd-mgmt.c:88:57: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4068 [-Wformat-truncation=]
   88 |                          "Post Validation failed on %s. %s", peer_str,
      |                                                         ^~
glusterd-mgmt.c:87:17: note: 'snprintf' output 29 or more bytes (assuming 4124) into a destination of size 4096
   87 |                 snprintf(op_err, sizeof(op_err),
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   88 |                          "Post Validation failed on %s. %s", peer_str,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   89 |                          err_string);
      |                          ~~~~~~~~~~~
glusterd-mgmt.c:77:72: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4077 [-Wformat-truncation=]
   77 |                 snprintf(op_err, sizeof(op_err), "Commit failed on %s. %s",
      |                                                                        ^~
glusterd-mgmt.c:77:17: note: 'snprintf' output 20 or more bytes (assuming 4115) into a destination of size 4096
   77 |                 snprintf(op_err, sizeof(op_err), "Commit failed on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   78 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
glusterd-mgmt.c:72:75: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4074 [-Wformat-truncation=]
   72 |                 snprintf(op_err, sizeof(op_err), "Brick ops failed on %s. %s",
      |                                                                           ^~
glusterd-mgmt.c:72:17: note: 'snprintf' output 23 or more bytes (assuming 4118) into a destination of size 4096
   72 |                 snprintf(op_err, sizeof(op_err), "Brick ops failed on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
glusterd-mgmt.c:67:56: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4069 [-Wformat-truncation=]
   67 |                          "Pre Validation failed on %s. %s", peer_str,
      |                                                        ^~
glusterd-mgmt.c:66:17: note: 'snprintf' output 28 or more bytes (assuming 4123) into a destination of size 4096
   66 |                 snprintf(op_err, sizeof(op_err),
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   67 |                          "Pre Validation failed on %s. %s", peer_str,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |                          err_string);
      |                          ~~~~~~~~~~~
glusterd-mgmt.c:61:73: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4076 [-Wformat-truncation=]
   61 |                 snprintf(op_err, sizeof(op_err), "Locking failed on %s. %s",
      |                                                                         ^~
glusterd-mgmt.c:61:17: note: 'snprintf' output 21 or more bytes (assuming 4116) into a destination of size 4096
   61 |                 snprintf(op_err, sizeof(op_err), "Locking failed on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   62 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
glusterd-mgmt.c:98:73: warning: '%s' directive output may be truncated writing up to 4095 bytes into a region of size 4076 [-Wformat-truncation=]
   98 |                 snprintf(op_err, sizeof(op_err), "Unknown error! on %s. %s",
      |                                                                         ^~
glusterd-mgmt.c:98:17: note: 'snprintf' output 21 or more bytes (assuming 4116) into a destination of size 4096
   98 |                 snprintf(op_err, sizeof(op_err), "Unknown error! on %s. %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   99 |                          peer_str, err_string);
      |                          ~~~~~~~~~~~~~~~~~~~~~
```
Change-Id: I327fb1826eda66ae283547d9319435b2aac3ada4

