### PR TITLE
Remove unused code from posix

### DIFF
--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -111,14 +111,12 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res)
     struct iovec iov;
     int ret = 0;
     off_t offset = 0;
-    struct posix_private *priv = NULL;
     fd_t *fd = NULL;
 
     GF_ASSERT(paiocb);
 
     frame = paiocb->frame;
     this = frame->this;
-    priv = this->private;
     iobuf = paiocb->iobuf;
     fd = paiocb->fd;
     _fd = paiocb->_fd;
@@ -161,8 +159,6 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res)
     /* Hack to notify higher layers of EOF. */
     if (!postbuf.ia_size || (offset + iov.iov_len) >= postbuf.ia_size)
         op_errno = ENOENT;
-
-    GF_ATOMIC_ADD(priv->read_value, op_ret);
 
 out:
     STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, &iov, 1, &postbuf,
@@ -269,14 +265,12 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res)
     int op_ret = -1;
     int op_errno = 0;
     int ret = 0;
-    struct posix_private *priv = NULL;
     fd_t *fd = NULL;
 
     GF_ASSERT(paiocb);
 
     frame = paiocb->frame;
     this = frame->this;
-    priv = this->private;
     prebuf = paiocb->prebuf;
     fd = paiocb->fd;
     _fd = paiocb->_fd;
@@ -302,8 +296,6 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res)
 
     op_ret = res;
     op_errno = 0;
-
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
 
 out:
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, &prebuf, &postbuf,

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -113,9 +113,6 @@ posix_priv(xlator_t *this)
 
     gf_proc_dump_write("base_path", "%s", priv->base_path);
     gf_proc_dump_write("base_path_length", "%d", priv->base_path_length);
-    gf_proc_dump_write("max_read", "%" PRId64, GF_ATOMIC_GET(priv->read_value));
-    gf_proc_dump_write("max_write", "%" PRId64,
-                       GF_ATOMIC_GET(priv->write_value));
 
     return 0;
 }
@@ -894,8 +891,6 @@ posix_init(xlator_t *this)
     }
 
     LOCK_INIT(&_private->lock);
-    GF_ATOMIC_INIT(_private->read_value, 0);
-    GF_ATOMIC_INIT(_private->write_value, 0);
 
     _private->export_statfs = 1;
     tmp_data = dict_get(this->options, "export-statfs-size");

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -1809,8 +1809,6 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto out;
     }
 
-    GF_ATOMIC_ADD(priv->read_value, op_ret);
-
     vec.iov_base = iobuf->ptr;
     vec.iov_len = op_ret;
 
@@ -2166,8 +2164,6 @@ overwrite:
         }
     }
 
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
-
 out:
 
     if (locked) {
@@ -2466,14 +2462,6 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
         pthread_mutex_unlock(&ctx->write_atomic_lock);
         locked = _gf_false;
     }
-
-    /*
-     * Record copy_file_range in priv->write_value for now.
-     * If not needed, remove below section of code along with
-     * this comment (or add comment to explain why it is not
-     * needed).
-     */
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
 
 out:
 
@@ -5888,7 +5876,8 @@ posix_readdirp_fill(xlator_t *this, fd_t *fd, gf_dirent_t *entries,
             ret = posix_pstat(this, inode, inode->gfid, hpath, &stbuf,
                               _gf_false, _gf_true);
         else
-            ret = posix_pstat(this, inode, zero_gfid, hpath, &stbuf, _gf_false, _gf_true);
+            ret = posix_pstat(this, inode, zero_gfid, hpath, &stbuf, _gf_false,
+                              _gf_true);
 
         if (ret == -1) {
             if (inode)

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -167,9 +167,6 @@ struct posix_private {
 
     time_t last_landfill_check;
 
-    gf_atomic_t read_value;  /* Total read, from init */
-    gf_atomic_t write_value; /* Total write, from init */
-
     /* janitor task which cleans up /.trash (created by replicate) */
     struct gf_tw_timer_list *janitor;
 


### PR DESCRIPTION
These two variables were helpful before io-stats was available. Now these are not as useful as io-stats. So removing this unnecessary code.

Change-Id: Iddc0ad51a77da84bca0f66040e3bf2f58c5b8339

