### PR TITLE
Fix unsigned type in posix_cs_set_state - addresses #4468

### DIFF
--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -3253,7 +3253,7 @@ posix_cs_set_state(xlator_t *this, dict_t **rsp, gf_cs_obj_state state,
 {
     int ret = 0;
     char *value = NULL;
-    size_t xattrsize = 0;
+    ssize_t xattrsize = 0;
 
     if (!rsp) {
         ret = -1;


### PR DESCRIPTION
To "xattrsize" is attributed the return values from sys_fgetxattr() and sys_lgetxattr(), both of which return a signed "ssize_t", and at the current stage, return negative values on error, thais, they return -1. But here "xattrsize" is of unsigned "size_t", and later is compared to "-1" yelding an always true or always false case. Examples:


1. always true case


    if (fd) {
        xattrsize = sys_fgetxattr(*fd, GF_CS_OBJECT_REMOTE, NULL, 0);
        if (xattrsize != -1) {



2. always false case


            xattrsize = sys_fgetxattr(*fd, GF_CS_OBJECT_REMOTE, value,
                                      xattrsize + 1);
            if (xattrsize == -1) {
                if (value)
                    GF_FREE(value);


	This commit changes it to the appropriate signed "ssize_t".

