### PR TITLE
Fix unsigned type "size_t" (#4470)

### DIFF
--- a/tests/utils/get-mdata-xattr.c
+++ b/tests/utils/get-mdata-xattr.c
@@ -73,7 +73,7 @@ posix_mdata_from_disk(posix_mdata_t *out, posix_mdata_disk_t *in)
 static int
 posix_fetch_mdata_xattr(const char *real_path, posix_mdata_t *metadata)
 {
-    size_t size = -1;
+    ssize_t size = -1;
     char *value = NULL;
     char gfid_str[64] = {0};
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2997,7 +2997,7 @@ posix_cs_heal_state(xlator_t *this, const char *realpath, int *fd,
     gf_boolean_t downloading = _gf_false;
     int ret = 0;
     gf_cs_obj_state state = GF_CS_ERROR;
-    size_t xattrsize = 0;
+    ssize_t xattrsize = 0;
 
     if (!buf) {
         ret = -1;
@@ -3147,7 +3147,7 @@ posix_cs_check_status(xlator_t *this, const char *realpath, int *fd,
     gf_boolean_t downloading = _gf_false;
     int ret = 0;
     gf_cs_obj_state state = GF_CS_LOCAL;
-    size_t xattrsize = 0;
+    ssize_t xattrsize = 0;
     int op_errno = 0;
 
     if (fd) {
@@ -3248,7 +3248,7 @@ posix_cs_set_state(xlator_t *this, dict_t **rsp, gf_cs_obj_state state,
 {
     int ret = 0;
     char *value = NULL;
-    size_t xattrsize = 0;
+    ssize_t xattrsize = 0;
 
     if (!rsp) {
         ret = -1;

--- a/xlators/storage/posix/src/posix-metadata.c
+++ b/xlators/storage/posix/src/posix-metadata.c
@@ -73,7 +73,7 @@ static int
 posix_fetch_mdata_xattr(xlator_t *this, const char *real_path_arg, int _fd,
                         inode_t *inode, posix_mdata_t *metadata, int *op_errno)
 {
-    size_t size = 256;
+    ssize_t size = 256;
     int op_ret = -1;
     char *value = NULL;
     gf_boolean_t fd_based_fop = _gf_false;


### PR DESCRIPTION
This commit addresses the wrong use of "size_t" instead of "ssize_t".

The functions that run xattr, like sys_lgetxattr() and sys_lgetxattr(),
return negative values on error, that is, they return -1.
But some of its users were found to capture this return in an unsigned "size_t" (implict type conversion).

This commit touches the posix xlator files posix-helpers.c and
posix-metadata.c, but also the tests get-mdata-xattr.c

In posix-helpers.c were found posix_cs_set_state, posix_cs_heal_state
and posix_cs_check_status the offending "size_t" in place of "ssize_t" for the variable "xattrsize".

In posix-metadata.c was found posix_fetch_mdata_xattr and the
variable "size" using an unsigned "size_t" in the exact same way..

In get-mdata-xattr.c, the posix_fetch_mdata_xattr incurs in the
exact same offense with the variable "size".

This commit changes these cases to the signed "ssize_t".

Examples:

always true case

	if (fd) {
	    xattrsize = sys_fgetxattr(*fd, GF_CS_OBJECT_REMOTE, NULL, 0);
	    if (xattrsize != -1) {

always false case

     xattrsize = sys_fgetxattr(*fd, GF_CS_OBJECT_REMOTE, value,
                               xattrsize + 1);
     if (xattrsize == -1) {
         if (value)
             GF_FREE(value);

