### PR TITLE
Pick the brick with minimum total inodes in statfs call

### DIFF
--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -879,7 +879,7 @@ ec_statvfs_combine(struct statvfs *dst, struct statvfs *src)
         dst->f_bavail = src->f_bavail;
     }
 
-    if (dst->f_files < src->f_files) {
+    if (dst->f_files > src->f_files) {
         dst->f_files = src->f_files;
     }
     if (dst->f_ffree > src->f_ffree) {


### PR DESCRIPTION
Problem:
In the steady state of disperse volume, for statfs call, total inodes should be the minimum number of total inodes in all of the subvolumes rather than the maximum one. Because it will lead to EC subvolume in degraded state once the brick with minimum number of inodes exhausts its inodes.

Fix:
In statfs calls, show the total inodes as the minimum number of total inodes in the subvolumes present.

