### PR TITLE
api/glfs: Fix use after free in readdir

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -48,6 +48,7 @@ glfs_mark_glfd_for_deletion(struct glfs_fd *glfd)
     LOCK(&glfd->lock);
     {
         glfd->state = GLFD_CLOSE;
+        glfd->next = NULL;
     }
     UNLOCK(&glfd->lock);
 
@@ -4014,6 +4015,11 @@ glfd_entry_refresh(struct glfs_fd *glfd, int plus)
         }
 
         list_splice_init(&glfd->entries, &old.list);
+        /* If glfd->next is non null means, this entry is from the old
+         * list, there is no point in keeping the free'ed data. Hence
+         * set to NULL;
+         */
+        glfd->next = NULL;
         list_splice_init(&entries.list, &glfd->entries);
 
         /* spurious errno is dangerous for glfd_entry_next() */


### PR DESCRIPTION
There is a code path in glfs readdir where we might end up using a free'ed memory. A possible case is when we use the fd to read the offset 0 after reading the content at least once, and the during the second time, the readdir return 0, probably due to the contents got deleted.

Change-Id: I08fa6cc9b924b90597ef4498e081cae9339fbd6a
Fixes: #3955

