### PR TITLE
Move to monotonic clock for time

### DIFF
--- a/libglusterfs/src/glusterfs/timespec.h
+++ b/libglusterfs/src/glusterfs/timespec.h
@@ -23,6 +23,8 @@ timespec_now(struct timespec *ts);
 void
 timespec_now_realtime(struct timespec *ts);
 void
+timespec_now_monotonic_raw(struct timespec *ts);
+void
 timespec_adjust_delta(struct timespec *ts, struct timespec delta);
 void
 timespec_sub(const struct timespec *begin, const struct timespec *end,

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -1060,6 +1060,7 @@ tbf_init
 tbf_throttle
 timespec_now
 timespec_now_realtime
+timespec_now_monotonic_raw
 timespec_sub
 timespec_adjust_delta
 timespec_cmp

--- a/libglusterfs/src/timespec.c
+++ b/libglusterfs/src/timespec.c
@@ -92,6 +92,18 @@ timespec_now_realtime(struct timespec *ts)
 }
 
 void
+timespec_now_monotonic_raw(struct timespec *ts)
+{
+#if defined GF_LINUX_HOST_OS
+    if (0 == clock_gettime(CLOCK_MONOTONIC_RAW, ts)) {
+        return;
+    }
+#endif
+    // fallback to monotonic if monotonic_raw is not available
+    timespec_now(ts);
+}
+
+void
 timespec_adjust_delta(struct timespec *ts, struct timespec delta)
 {
     ts->tv_nsec = ((ts->tv_nsec + delta.tv_nsec) % 1000000000);

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -1474,8 +1474,6 @@ posix_janitor_task(void *data)
     struct posix_private *priv = NULL;
     xlator_t *old_this = NULL;
 
-    time_t now;
-
     this = data;
     priv = this->private;
     /* We need THIS to be set for janitor_walker */
@@ -1485,7 +1483,9 @@ posix_janitor_task(void *data)
     if (!priv)
         goto out;
 
-    now = gf_time();
+    struct timespec ts = {0};
+    timespec_now_monotonic_raw(&ts);
+    time_t now = ts.tv_sec;
     if ((now - priv->last_landfill_check) > priv->janitor_sleep_duration) {
         if (priv->disable_landfill_purge) {
             gf_msg_debug(this->name, 0,


### PR DESCRIPTION
Problem:
`posix_janitor_task()` was using `time()` to get the time which is wall-clock time. Because of this the janitor task is not firing periodically as it is supposed to, when ntp is disabled.

Fix:
Use monotonic clock variant to get the time now.

Fixes: #3932
Change-Id: I13e48381495c97cd818161067ba43fe702318416

