### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -773,10 +773,16 @@ static int do_mount(const char *mnt, char **typep, mode_t rootmode,
 						flags |= flag;
 					else
 						flags  &= ~flag;
-				} else {
+				} else if (opt_eq(s, len, "default_permissions") ||
+					   opt_eq(s, len, "allow_other") ||
+					   begins_with(s, "max_read=") ||
+					   begins_with(s, "blksize=")) {
 					memcpy(d, s, len);
 					d += len;
 					*d++ = ',';
+				} else {
+					fprintf(stderr, "%s: unknown option '%.*s'\n", progname, len, s);
+					exit(1);
 				}
 			}
 		}


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in do_mount() that was cloned from libfuse but did not receive the security patch. The original issue was reported and fixed under https://github.com/libfuse/libfuse/commit/5018a0c016495155ee598b7e0167b43d5d902414.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2018-10906
https://github.com/libfuse/libfuse/commit/5018a0c016495155ee598b7e0167b43d5d902414
