### PR TITLE
Fix extra member in xlators/features/changelog/src/changelog-rpc.c

### DIFF
--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -435,7 +435,5 @@ static struct rpcsvc_program changelog_svc_prog = {
     .synctask = _gf_true,
 };
 
-static struct rpcsvc_program *changelog_programs[] = {
-    &changelog_svc_prog,
-    NULL,
-};
+static struct rpcsvc_program *changelog_programs[] = {&changelog_svc_prog,
+                                                      NULL};


### PR DESCRIPTION
The "static struct rpcsvc_program *changelog_programs[]"
includes an extra member by introducing a stray comma after "NULL".

This commit fixes that by removing the stray comma.

