### PR TITLE
Fix: use unsigned value to represent bytes

### DIFF
--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -381,7 +381,7 @@ afr_arbiter_writev_wind(call_frame_t *frame, xlator_t *this, int subvol)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
-    static char byte = 0xFF;
+    static unsigned char byte = 0xFF;
     static struct iovec vector = {&byte, 1};
     int32_t count = 1;
 

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -30,8 +30,8 @@
  * gzip_header is added only during debugging.
  * Refer to the function cdc_dump_iovec_to_disk
  */
-static const char gzip_header[10] = {'\037', '\213', Z_DEFLATED,  0, 0, 0, 0,
-                                     0,      0,      GF_CDC_OS_ID};
+static const unsigned char gzip_header[10] = {
+    '\037', '\213', Z_DEFLATED, 0, 0, 0, 0, 0, 0, GF_CDC_OS_ID};
 
 static int32_t
 cdc_next_iovec(cdc_info_t *ci)


### PR DESCRIPTION
Some variables that represent bytes were found using a signed char type.

Before 3fb3bb5d38r, "configure: force 'char' type to be signed (#4025),
char types could be unsigned, depending on the platform, but now thery are signed.

This intoduces a rough edge on variables that relied on the "unsignedness" of the type char to represent bytes, without actually enforcing it.

This PR addresses that by enforcing the use of "unsigned" type in those cases.