### PR TITLE
Support both ssl/non-ssl volumes on the same client node

### DIFF
--- a/xlators/mount/fuse/utils/mount.glusterfs.in
+++ b/xlators/mount/fuse/utils/mount.glusterfs.in
@@ -242,6 +242,10 @@ start_glusterfs ()
         cmd_line=$(echo "$cmd_line --direct-io-mode=$direct_io_mode");
     fi
 
+    if [ -n "$secure_mgmt" ]; then
+        cmd_line=$(echo "$cmd_line --secure-mgmt=$secure_mgmt");
+    fi
+
     if [ -n "$use_readdirp" ]; then
         cmd_line=$(echo "$cmd_line --use-readdirp=$use_readdirp");
     fi
@@ -533,6 +537,9 @@ with_options()
             ;;
         "direct-io-mode")
             direct_io_mode=$value
+            ;;
+        "secure-mgmt")
+            secure_mgmt=$value
             ;;
         "volume-name")
             volume_name=$value

--- a/xlators/mount/fuse/utils/mount_glusterfs.in
+++ b/xlators/mount/fuse/utils/mount_glusterfs.in
@@ -206,6 +206,10 @@ start_glusterfs ()
         cmd_line=$(echo "$cmd_line --direct-io-mode=$direct_io_mode");
     fi
 
+    if [ -n "$secure_mgmt" ]; then
+        cmd_line=$(echo "$cmd_line --secure-mgmt=$secure_mgmt");
+    fi
+
     if [ -n "$mac_compat" ]; then
         cmd_line=$(echo "$cmd_line --mac-compat=$mac_compat");
     fi
@@ -351,6 +355,9 @@ with_options()
             ;;
         "direct-io-mode")
             direct_io_mode=$value
+            ;;
+        "secure-mgmt")
+            secure_mgmt=$value
             ;;
         "mac-compat")
             mac_compat=$value


### PR DESCRIPTION
glusterfsd supports the '--secure-mgmt' cli option to specify management transport type (ssl or non ssl), when we start a fuse daemon, this option tells the daemon how to initialize the mamangement socket and establish the connection to the remote glusterd.

However, this option is missing in the mount.glusterfs script, as a result, we can only rely on the presence of the
/var/lib/glusterd/secure-access file to decide the tranport type. This is cumbersome, it literally makes it impossible to mount two volumes on the same client node: one from a regular glusterfs cluster, one from a "secure" cluster where glusterd runs on ssl transport.

We do have this use case due to data classification requirements. Adding this option into mount.glusterfs would resolve the issue: on the client side we properly set the secure-access file, and the cert files. To mount a regular volume, add the '-o secure-mgmt=false' option, to mount a secure volume, either leave this option not set, or set it to 'true'.

