### PR TITLE
Fix cluster.rc tests with a hack for now

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5406,8 +5406,13 @@ glusterd_remote_hostname_get(rpcsvc_request_t *req, char *remote_host, int len)
     }
 
     if ((gf_get_hostname_from_ip(hostname, &canon) == 0) && canon) {
-        GF_FREE(tmp_host);
-        tmp_host = hostname = canon;
+        if (strcmp(canon, "localhost") &&
+            strcmp(canon, "localhost.localdomain")) {
+            GF_FREE(tmp_host);
+            tmp_host = hostname = canon;
+        } else {
+            GF_FREE(canon);
+        }
     }
 
     (void)snprintf(remote_host, len, "%s", hostname);


### PR DESCRIPTION
On the latest version of ubuntu all tests that have cluster.rc are failing. Mostly because of this:
https://datatracker.ietf.org/doc/html/rfc6890

The following patch fixes it for now. But we may need to change the framework to fix it properly I think. Ideally localhost or loopback ip range shouldn't be allowed as hostname. This part we may have to address separately.

Fixes: #4457
Change-Id: Iee3e6710c301cde4d5bb250ff45fd84031a878be

