### PR TITLE
Trigger read txn to trigger heal

### DIFF
--- a/tests/basic/afr/client-side-heal.t
+++ b/tests/basic/afr/client-side-heal.t
@@ -11,6 +11,7 @@ TEST $CLI volume set $V0 cluster.self-heal-daemon off
 TEST $CLI volume set $V0 cluster.entry-self-heal off
 TEST $CLI volume set $V0 cluster.data-self-heal off
 TEST $CLI volume set $V0 cluster.metadata-self-heal off
+TEST $CLI volume set $V0 performance.quick-read off
 
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
@@ -34,6 +35,12 @@ TEST chmod +x $B0/${V0}0/mdatafile-backend-direct-modify
 
 #pending entry heal. Also causes pending metadata/data heals on file{1..5}
 TEST touch $M0/dir/file{1..5}
+#Add some data so that reads will come to afr
+TEST `echo "abc" > $M0/dir/file1`
+TEST `echo "abc" > $M0/dir/file2`
+TEST `echo "abc" > $M0/dir/file3`
+TEST `echo "abc" > $M0/dir/file4`
+TEST `echo "abc" > $M0/dir/file5`
 
 EXPECT 8 get_pending_heal_count $V0
 


### PR DESCRIPTION
```
ok  47 [     32/     68] <  86> '5 get_pending_heal_count patchy'
ok  48 [     24/      2] <  88> 'cat /mnt/glusterfs/0/dir/file1'
ok  49 [     26/      4] <  89> 'cat /mnt/glusterfs/0/dir/file2'
ok  50 [     28/      2] <  90> 'cat /mnt/glusterfs/0/dir/file3'
ok  51 [     26/      2] <  91> 'cat /mnt/glusterfs/0/dir/file4'
ok  52 [     25/      2] <  92> 'cat /mnt/glusterfs/0/dir/file5'
not ok  53 [     25/  80272] <  94> '0 get_pending_heal_count patchy' -> 'Got "5" instead of "0"'
Failed 1/53 subtests
```

`afr_readv()` is not being hit in gdb when the test is run, so the heal code is not being triggered. It could be because the file size is 0. Added extra data so that a read comes till afr_readv(). I also disabled quick-read to avoid perf xlators handling the readv.

Fixes: #4509
Change-Id: Iadaa908578f5fdbeffa567c40bfbec9cc0f95f52

