### PR TITLE
Trigger read txn to trigger heal

### DIFF
--- a/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
+++ b/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
@@ -25,6 +25,7 @@ TEST $CLI volume set $V0 cluster.quorum-count 1
 TEST $CLI volume set $V0 cluster.metadata-self-heal on
 TEST $CLI volume set $V0 cluster.data-self-heal on
 TEST $CLI volume set $V0 cluster.entry-self-heal on
+TEST $CLI volume set $V0 performance.quick-read off
 
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
@@ -81,6 +82,7 @@ TEST [ "$LATEST_MTIME_MD5" == "$B1_MD5" ]
 TEST $CLI volume reset $V0 cluster.favorite-child-policy
 TEST kill_brick $V0 $H0 $B0/${V0}0
 TEST touch $M0/data/test
+TEST `echo "abc" > $M0/data/test`
 files=$(count_files $M0/data)
 EXPECT "2" echo $files
 TEST $CLI volume start $V0 force
@@ -88,6 +90,7 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
 TEST touch $M0/data/test1
+TEST `echo "abc" > $M0/data/test1`
 files=$(count_files $M0/data)
 EXPECT "2" echo $files
 


### PR DESCRIPTION
```
ok  55 [     31/     79] < 112> '^2$ get_pending_heal_count patchy'

not ok  56 [     31/  80228] < 117> '^0$ get_pending_heal_count patchy' -> 'Got "2" instead of "^0$"'
ok  57 [     25/      1] < 119> '3 echo 3'
ok  58 [     22/      6] < 121> 'force_umount /mnt/glusterfs/0'
ok  59 [     18/      1] < 122> 'rm tests/basic/afr/../../utils/get-mdata-xattr'
Failed 1/59 subtests

Test Summary Report
-------------------
tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t (Wstat: 0 Tests: 59 Failed: 1)
  Failed test:  56
Files=1, Tests=59, 102 wallclock secs ( 0.03 usr  0.00 sys + 13.53 cusr 10.36 csys = 23.92 CPU)
Result: FAIL
```
`afr_readv()` is not being hit in gdb when the test is run, so the heal code is not being triggered. It could be because the file size is 0. Added extra data so that a read comes till afr_readv(). I also disabled quick-read to avoid perf xlators handling the readv.

Fixes: #4511
Change-Id: Id6ef2b65202561588a6e31b797c2566589c6bb12

