### PR TITLE
Fix compilation error for test run

### DIFF
--- a/tests/basic/ec/ec-fast-fgetxattr.c
+++ b/tests/basic/ec/ec-fast-fgetxattr.c
@@ -30,8 +30,8 @@ fill_iov(struct iovec *iov, char fillchar, int count)
 }
 
 void
-write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         fprintf(stderr, "glfs_write failed");


### PR DESCRIPTION
It expects `struct glfs_struct *` now.

Fixes: #4517
Change-Id: I4862d7e51446e17d358bfbc9c010bdd84e44e4c5

