### PR TITLE
create home directory for user

### DIFF
--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -123,7 +123,7 @@ TEST /usr/sbin/groupadd $grp
 clean_lock_files
 ##Del if exists and create non-root user and assign it to newly created group
 userdel -r -f $usr
-TEST /usr/sbin/useradd -G $grp $usr
+TEST /usr/sbin/useradd -m -G $grp $usr
 
 export PASS=$( (echo $RANDOM ; date +%s) | sha256sum | base64 | head -c 32)
 ##Modify password for non-root user to have control over distributing ssh-key


### PR DESCRIPTION
while creating a user for non root geo-rep session testing, we need to create home directory for user,
to store the ssh keys in .ssh directory of home directory

