### PR TITLE
extras: use "grep -E" instead of egrep to resolve warning

### DIFF
--- a/extras/command-completion/gluster.bash
+++ b/extras/command-completion/gluster.bash
@@ -506,8 +506,8 @@ _gluster_handle_list ()
 _gluster_completion ()
 {
         GLUSTER_FINAL_LIST=`echo $GLUSTER_COMMAND_TREE |                      \
-                egrep -ao --color=never "([A-Za-z0-9_.-]+)|[[:space:]]+|." |  \
-                        egrep -v --color=never "^[[:space:]]*$" |             \
+                grep -E -ao --color=never "([A-Za-z0-9_.-]+)|[[:space:]]+|." |  \
+                        grep -E -v --color=never "^[[:space:]]*$" |             \
                                 _gluster_parse`
 
         ARG="GLUSTER_FINAL_LIST"


### PR DESCRIPTION
When grep uses version 3.8 and higher, gluster command auto comletion will print waring message in command lines.
Now, use "grep -E" instead of egrep to fix the problem.

fixes:#4528

