### PR TITLE
Adjust min xfs fs size

### DIFF
--- a/tests/features/weighted-rebalance.t
+++ b/tests/features/weighted-rebalance.t
@@ -35,11 +35,11 @@ TEST $CLI volume info
 
 TEST mkdir ${B0}/${V0}{1,2}
 
-TEST truncate -s $((40*1024*1024)) ${B0}/disk1
+TEST truncate -s $((300*1024*1024)) ${B0}/disk1
 TEST MKFS_LOOP -i 512 ${B0}/disk1
 TEST MOUNT_LOOP ${B0}/disk1 ${B0}/${V0}1
 
-TEST truncate -s $((80*1024*1024)) ${B0}/disk2
+TEST truncate -s $((600*1024*1024)) ${B0}/disk2
 TEST MKFS_LOOP -i 512 ${B0}/disk2
 TEST MOUNT_LOOP ${B0}/disk2 ${B0}/${V0}2
 


### PR DESCRIPTION
Adjusted min xfs size to 300M, so the other brick has to be double the size of the first brick.

Fixes: #4537
Change-Id: I3fe241ba00adfe9f5ed3b363e800ac8f8258dbb9

