### PR TITLE
shard: ensure each deletion process uses a separate local->op_ret

### DIFF
--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -3812,8 +3812,9 @@ shard_delete_shards(void *opaque)
 
                 gf_msg_debug(this->name, 0,
                              "Initiating deletion of "
-                             "shards of gfid %s",
+                             "shards of gfid %s. Reset local->op_ret = 0",
                              entry->d_name);
+                local->op_ret = 0;
                 ret = shard_delete_shards_of_entry(cleanup_frame, this, entry,
                                                    link_inode);
                 inode_unlink(link_inode, local->fd->inode, entry->d_name);


### PR DESCRIPTION
At present, local->op_ret is common to all continuous shard deletions. Once a deletion fails, local->op_ret was set to -1, and all the subsequent deletions will be affected since op_ret is kept unchange until all shard deletions finish.

In this case, subsequent shards cannot be deleted, resulting in space of backend disk not being released as expected.

So, it is necessary to use a separate local->op_ret to indicate the shard deletion result. to avoid spillover effects.

Fixes: #4550
Signed-off-by: chenjinhao \<chen.jinhao@zte.com.cn\>
