### PR TITLE
Logic for Healing of Sparse Files

### DIFF
--- a/tests/00-geo-rep/00-georep-verify-non-root-setup.t
+++ b/tests/00-geo-rep/00-georep-verify-non-root-setup.t
@@ -123,7 +123,7 @@ TEST /usr/sbin/groupadd $grp
 clean_lock_files
 ##Del if exists and create non-root user and assign it to newly created group
 userdel -r -f $usr
-TEST /usr/sbin/useradd -G $grp $usr
+TEST /usr/sbin/useradd -m -G $grp $usr
 
 export PASS=$( (echo $RANDOM ; date +%s) | sha256sum | base64 | head -c 32)
 ##Modify password for non-root user to have control over distributing ssh-key

--- a/tests/basic/afr/arbiter-statfs.t
+++ b/tests/basic/afr/arbiter-statfs.t
@@ -12,7 +12,7 @@ TEST glusterd
 TEST truncate -s 1G $B0/brick1
 TEST truncate -s 1G $B0/brick2
 #Arbiter brick is of a lesser size.
-TEST truncate -s 90M $B0/brick3
+TEST truncate -s 300M $B0/brick3
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1

--- a/tests/basic/afr/client-side-heal.t
+++ b/tests/basic/afr/client-side-heal.t
@@ -11,6 +11,7 @@ TEST $CLI volume set $V0 cluster.self-heal-daemon off
 TEST $CLI volume set $V0 cluster.entry-self-heal off
 TEST $CLI volume set $V0 cluster.data-self-heal off
 TEST $CLI volume set $V0 cluster.metadata-self-heal off
+TEST $CLI volume set $V0 performance.quick-read off
 
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
@@ -34,6 +35,12 @@ TEST chmod +x $B0/${V0}0/mdatafile-backend-direct-modify
 
 #pending entry heal. Also causes pending metadata/data heals on file{1..5}
 TEST touch $M0/dir/file{1..5}
+#Add some data so that reads will come to afr
+TEST `echo "abc" > $M0/dir/file1`
+TEST `echo "abc" > $M0/dir/file2`
+TEST `echo "abc" > $M0/dir/file3`
+TEST `echo "abc" > $M0/dir/file4`
+TEST `echo "abc" > $M0/dir/file5`
 
 EXPECT 8 get_pending_heal_count $V0
 

--- a/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
+++ b/tests/basic/afr/split-brain-favorite-child-policy-client-side-healing.t
@@ -25,6 +25,7 @@ TEST $CLI volume set $V0 cluster.quorum-count 1
 TEST $CLI volume set $V0 cluster.metadata-self-heal on
 TEST $CLI volume set $V0 cluster.data-self-heal on
 TEST $CLI volume set $V0 cluster.entry-self-heal on
+TEST $CLI volume set $V0 performance.quick-read off
 
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
@@ -81,6 +82,7 @@ TEST [ "$LATEST_MTIME_MD5" == "$B1_MD5" ]
 TEST $CLI volume reset $V0 cluster.favorite-child-policy
 TEST kill_brick $V0 $H0 $B0/${V0}0
 TEST touch $M0/data/test
+TEST `echo "abc" > $M0/data/test`
 files=$(count_files $M0/data)
 EXPECT "2" echo $files
 TEST $CLI volume start $V0 force
@@ -88,6 +90,7 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
 TEST kill_brick $V0 $H0 $B0/${V0}1
 TEST touch $M0/data/test1
+TEST `echo "abc" > $M0/data/test1`
 files=$(count_files $M0/data)
 EXPECT "2" echo $files
 

--- a/tests/basic/distribute/file-create.t
+++ b/tests/basic/distribute/file-create.t
@@ -23,8 +23,8 @@ TEST pidof glusterd
 # We want fixed size bricks to test min-free-disk
 
 # Create 2 loop devices, one per brick.
-TEST   truncate -s 25M $B0/brick1
-TEST   truncate -s 25M $B0/brick2
+TEST   truncate -s 300M $B0/brick1
+TEST   truncate -s 300M $B0/brick2
 
 TEST   L1=`SETUP_LOOP $B0/brick1`
 TEST   MKFS_LOOP $L1
@@ -61,7 +61,7 @@ TEST dht_first_filename_with_hashsubvol "$hashed" $M0/dir1 "big-"
 firstfile=$fn_return_val
 
 #Create a large file to fill up $hashed past the min-free-disk limits
-TEST  dd if=/dev/zero of=$M0/dir1/$firstfile bs=1M count=15
+TEST  dd if=/dev/zero of=$M0/dir1/$firstfile bs=1M count=180
 
 brickpath_0=$(cat "$M0/.meta/graphs/active/$hashed/options/remote-subvolume")
 brickpath_1=$(cat "$M0/.meta/graphs/active/$V0-client-1/options/remote-subvolume")
@@ -87,7 +87,7 @@ echo $newfile
 
 # Create $newfile - it should be created on the other subvol as its hash subvol
 # has crossed the min-free-disk limit
-TEST  dd if=/dev/zero of=$M0/dir1/$newfile bs=1024 count=20
+TEST  dd if=/dev/zero of=$M0/dir1/$newfile bs=1024 count=240
 TEST stat "$brickpath_0/dir1/$newfile"
 EXPECT "1" is_dht_linkfile "$brickpath_0/dir1/$newfile"
 
@@ -103,7 +103,7 @@ EXPECT "1" is_dht_linkfile "$brickpath_0/dir1/$newfile"
 TEST dht_first_filename_with_hashsubvol $V0-client-1 $M0/dir1 "filter-"
 newfile=$fn_return_val
 echo $newfile
-TEST dd if=/dev/zero of="$M0/dir1/$newfile@$V0-dht:$hashed" bs=1024 count=20
+TEST dd if=/dev/zero of="$M0/dir1/$newfile@$V0-dht:$hashed" bs=1024 count=240
 TEST stat $M0/dir1/$newfile
 TEST stat "$brickpath_0/dir1/$newfile"
 EXPECT "1" is_dht_linkfile "$brickpath_1/dir1/$newfile"

--- a/tests/basic/ec/ec-fast-fgetxattr.c
+++ b/tests/basic/ec/ec-fast-fgetxattr.c
@@ -30,8 +30,8 @@ fill_iov(struct iovec *iov, char fillchar, int count)
 }
 
 void
-write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct stat *prestat,
-                struct stat *poststat, void *cookie)
+write_async_cbk(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat,
+                struct glfs_stat *poststat, void *cookie)
 {
     if (ret < 0) {
         fprintf(stderr, "glfs_write failed");

--- a/tests/basic/ec/ec-sparsefile-heal.t
+++ b/tests/basic/ec/ec-sparsefile-heal.t
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../ec.rc
+
+function compare_brick_stats {
+    file_name=$1
+
+    SIZE=$(stat -c%s $B0/${V0}0/$file_name)
+    BLOCKS=$(stat -c%b $B0/${V0}0/$file_name)
+
+    echo $SIZE
+    echo $BLOCKS
+
+    for b in {0..5}; do
+        SIZE_IN_BRICK=$(stat -c%s $B0/${V0}${b}/$file_name)
+        BLOCKS_IN_BRICK=$(stat -c%b $B0/${V0}${b}/$file_name)
+
+        if [[ "$SIZE" -ne "$SIZE_IN_BRICK" || "$BLOCKS" -ne "$BLOCKS_IN_BRICK" ]]; then
+            return  1
+        fi
+    done
+
+    return 0
+}
+
+function compare_md5sum {
+
+    if [[ "$1" == "$2" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+
+cleanup
+
+
+TEST_DIR="/tmp/glusterfs-sparse-test"
+mkdir -p $TEST_DIR
+
+
+TEST glusterd
+TEST pidof glusterd
+
+
+TEST $CLI volume create $V0 disperse 6 redundancy 2 $H0:$B0/${V0}{0..5}
+TEST $CLI volume start $V0
+
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+
+TEST kill_brick $V0 $H0 $B0/${V0}0
+TEST kill_brick $V0 $H0 $B0/${V0}1
+
+TEST_FILE="sparse_test_file"
+
+TEST dd if=/dev/zero of=$M0/$TEST_FILE bs=1024 count=1024 seek=0
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE bs=1024 count=1 seek=0 conv=notrunc
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE bs=1024 count=1 seek=512 conv=notrunc
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE bs=1024 count=1 seek=1023 conv=notrunc
+
+# Create another sparse file with different pattern
+TEST_FILE2="sparse_test_file2"
+TEST truncate -s 5M $M0/$TEST_FILE2
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE2 bs=4096 count=1 seek=100 conv=notrunc
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE2 bs=4096 count=1 seek=500 conv=notrunc
+
+sleep 2
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "0" get_pending_heal_count $V0
+
+TEST compare_brick_stats $TEST_FILE
+TEST compare_brick_stats $TEST_FILE2
+
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=5:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum1=$(md5sum $M0/$TEST_FILE | cut -d' ' -f1)
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=0:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum2=$(md5sum $M0/$TEST_FILE | cut -d' ' -f1)
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=1:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum3=$(md5sum $M0/$TEST_FILE | cut -d' ' -f1)
+
+TEST compare_md5sum $checksum1 $checksum2
+TEST compare_md5sum $checksum1 $checksum3
+
+
+#Test hole punching case
+TEST_FILE3="to_be_sparsefile"
+TEST dd if=/dev/urandom of=$M0/$TEST_FILE3 bs=1M count=100
+
+TEST kill_brick $V0 $H0 $B0/${V0}0
+TEST kill_brick $V0 $H0 $B0/${V0}1
+
+TEST fallocate --punch-hole --keep-size -o 6144 -l 15728640 $M0/$TEST_FILE3
+
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "0" get_pending_heal_count $V0
+
+TEST compare_brick_stats $TEST_FILE3
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=5:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum1=$(md5sum $M0/$TEST_FILE3 | cut -d' ' -f1)
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=0:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum2=$(md5sum $M0/$TEST_FILE3 | cut -d' ' -f1)
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+$GFS --xlator-option="*.ec-read-mask=1:2:3:4" -s $H0 --volfile-id $V0 $M0
+TEST $GFS -s $H0 --volfile-id $V0 $M0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "6" ec_child_up_count $V0 0
+checksum3=$(md5sum $M0/$TEST_FILE3 | cut -d' ' -f1)
+
+TEST compare_md5sum $checksum1 $checksum2
+TEST compare_md5sum $checksum1 $checksum3
+
+
+# Cleanup
+rm -rf $TEST_DIR
+cleanup

--- a/tests/basic/posix/shared-statfs.t
+++ b/tests/basic/posix/shared-statfs.t
@@ -7,9 +7,9 @@
 cleanup;
 TEST glusterd
 
-#Create brick partitions
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 100M $B0/brick2
+#Create brick partitions - xfs min is 300M
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1
@@ -29,9 +29,9 @@ TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "2" online_brick_count
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
 total_mount_blocks=$(df -P $M0 | tail -1 | awk '{ print $2}')
-# Keeping the size less than 200M mainly because XFS will use
+# Keeping the size less than 600M mainly because XFS will use
 # some storage in brick to keep its own metadata.
-TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 200000 ]
+TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 600000 ]
 
 
 TEST force_umount $M0
@@ -45,7 +45,7 @@ TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "6" online_brick_count
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
 total_mount_blocks=$(df -P $M0 | tail -1 | awk '{ print $2}')
-TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 200000 ]
+TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 600000 ]
 
 TEST force_umount $M0
 TEST $CLI volume stop $V0

--- a/tests/basic/posix/zero-fill-enospace.t
+++ b/tests/basic/posix/zero-fill-enospace.t
@@ -9,7 +9,7 @@ cleanup;
 TEST glusterd;
 TEST pidof glusterd;
 
-TEST truncate -s 100M $B0/brick1
+TEST truncate -s 300M $B0/brick1
 
 TEST L1=`SETUP_LOOP $B0/brick1`
 TEST MKFS_LOOP $L1
@@ -25,7 +25,9 @@ TEST $CLI volume start $V0;
 TEST glusterfs -s $H0 --volfile-id=$V0 $M0
 TEST touch $M0/foo
 TEST build_tester $(dirname $0)/zero-fill-enospace.c -lgfapi -Wall -O2
-TEST ! $(dirname $0)/zero-fill-enospace $H0 $V0 /foo `gluster --print-logdir`/glfs-$V0.log 104857600
+
+# Last argument is the brick size in bytes
+TEST ! $(dirname $0)/zero-fill-enospace $H0 $V0 /foo `gluster --print-logdir`/glfs-$V0.log 314572800
 
 TEST force_umount $M0
 TEST $CLI volume stop $V0

--- a/tests/bugs/distribute/bug-1099890.t
+++ b/tests/bugs/distribute/bug-1099890.t
@@ -18,8 +18,8 @@ TEST   glusterd;
 TEST   pidof glusterd;
 
 # Create 2 loop devices, one per brick.
-TEST   truncate -s 100M $B0/brick1
-TEST   truncate -s 100M $B0/brick2
+TEST   truncate -s 300M $B0/brick1
+TEST   truncate -s 300M $B0/brick2
 
 TEST   L1=`SETUP_LOOP $B0/brick1`
 TEST   MKFS_LOOP $L1
@@ -42,25 +42,25 @@ TEST   $CLI volume quota $V0 enable;
 
 TEST   $CLI volume set $V0 features.quota-deem-statfs on
 
-TEST   $CLI volume quota $V0 limit-usage / 150MB;
+TEST   $CLI volume quota $V0 limit-usage / 450MB;
 
 TEST   $CLI volume set $V0 cluster.min-free-disk 50%
 
 TEST   glusterfs -s $H0 --volfile-id=$V0 $M0
 
 # Make sure quota-deem-statfs is working as expected
-EXPECT "150M" echo `df -h $M0 -P | tail -1 | awk {'print $2'}`
+EXPECT "450M" echo `df -h $M0 -P | tail -1 | awk {'print $2'}`
 
 # Create a new file 'foo' under the root of the volume, which hashes to subvol-0
-# of DHT, that consumes 40M
-TEST $QDD $M0/foo 256 160
+# of DHT, that consumes 120M
+TEST $QDD $M0/foo 256 480
 
 TEST   stat $B0/${V0}1/foo
 TEST ! stat $B0/${V0}2/foo
 
 # Create a new file 'bar' under the root of the volume, which hashes to subvol-1
-# of DHT, that consumes 40M
-TEST $QDD $M0/bar 256 160
+# of DHT, that consumes 120M
+TEST $QDD $M0/bar 256 480
 
 TEST ! stat $B0/${V0}1/bar
 TEST   stat $B0/${V0}2/bar
@@ -70,15 +70,15 @@ TEST   stat $B0/${V0}2/bar
 sleep 1;
 TEST   touch $M0/empty1;
 
-# At this point, the available space on each subvol {60M,60M} is greater than
-# their min-free-disk {50M,50M}, but if this bug still exists, then
+# At this point, the available space on each subvol {160M,160M} is greater than
+# their min-free-disk {150M,150M}, but if this bug still exists, then
 # the total available space on the volume as perceived by DHT should be less
 # than min-free-disk, i.e.,
 #
-# consumed space returned per subvol by quota = (40M + 40M) = 80M
+# consumed space returned per subvol by quota = (120M + 120M) = 240M
 #
 # Therefore, consumed space per subvol computed by DHT WITHOUT the fix would be:
-# (80M/150M)*100 = 53%
+# (240M/450M)*100 = 53%
 #
 # Available space per subvol as perceived by DHT with the bug = 47%
 # which is less than min-free-disk

--- a/tests/bugs/distribute/bug-1786679.t
+++ b/tests/bugs/distribute/bug-1786679.t
@@ -19,7 +19,7 @@ cleanup
 
 function get_layout () {
 
-layout=`getfattr -n trusted.glusterfs.dht -e hex $1 2>&1 | grep dht | gawk -F"=" '{print $2}'`
+layout=`getfattr -n trusted.glusterfs.dht -e hex $1 2>&1 | grep dht | awk -F"=" '{print $2}'`
 
 echo $layout
 

--- a/tests/bugs/fuse/bug-858488-min-free-disk.t
+++ b/tests/bugs/fuse/bug-858488-min-free-disk.t
@@ -11,8 +11,8 @@ TEST pidof glusterd;
 TEST $CLI volume info;
 
 ## Lets create partitions for bricks
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 200M $B0/brick2
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 400M $B0/brick2
 TEST LO1=`SETUP_LOOP $B0/brick1`
 TEST MKFS_LOOP $LO1
 TEST LO2=`SETUP_LOOP $B0/brick2`
@@ -69,7 +69,7 @@ done
 
 ## Bring free space on one of the bricks to less than minfree value by
 ## creating one big file.
-dd if=/dev/zero of=$M0/fillonebrick.data bs=1024 count=25600 1>/dev/null 2>&1
+dd if=/dev/zero of=$M0/fillonebrick.data bs=4096 count=25600 1>/dev/null 2>&1
 
 #Lets find out where it was created
 if [ -f $B0/${V0}1/fillonebrick.data ]

--- a/tests/bugs/glusterd/bug-1091935-brick-order-check-from-cli-to-glusterd.t
+++ b/tests/bugs/glusterd/bug-1091935-brick-order-check-from-cli-to-glusterd.t
@@ -11,10 +11,10 @@ function check_peers {
 cleanup;
 
 ## Lets create partitions for bricks
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 200M $B0/brick2
-TEST truncate -s 200M $B0/brick3
-TEST truncate -s 200M $B0/brick4
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
+TEST truncate -s 300M $B0/brick3
+TEST truncate -s 300M $B0/brick4
 
 
 TEST LO1=`SETUP_LOOP $B0/brick1`

--- a/tests/bugs/glusterd/bug-1595320.t
+++ b/tests/bugs/glusterd/bug-1595320.t
@@ -30,16 +30,15 @@ TEST $CLI v set all cluster.brick-multiplex on
 TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT 3 count_up_bricks
 EXPECT 1 count_brick_processes
-
 # Kill volume ungracefully
 brick_pid=`pgrep glusterfsd`
 
 # Make sure every brick root should be consumed by a brick process
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
 
 b1_pid_file=$(ls $GLUSTERD_PIDFILEDIR/vols/$V0/*d-backends-1*.pid)
@@ -61,11 +60,11 @@ EXPECT 1 count_brick_processes
 brick_pid=`pgrep glusterfsd`
 
 # Make sure only two brick root should be consumed by a brick process
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 0 ]
 
 # Mount the brick root
@@ -82,11 +81,11 @@ EXPECT_WITHIN $PROCESS_UP_TIMEOUT 3 count_up_bricks
 EXPECT 1 count_brick_processes
 
 # Make sure every brick root should be consumed by a brick process
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L1 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L2 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
-n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v ".glusterfs" | wc -l`
+n=`ls -lrth /proc/$brick_pid/fd | grep -iw $L3 | grep -v "/.glusterfs" | wc -l`
 TEST [ $n -eq 1 ]
 
 cleanup

--- a/tests/bugs/glusterd/bug-948729/bug-948729-force.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-force.t
@@ -29,12 +29,12 @@ B6=/d/backends/6
 
 mkdir -p $B3 $B4 $B5 $B6
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
-TEST truncate -s 16M $B4/brick4
-TEST truncate -s 16M $B5/brick5
-TEST truncate -s 16M $B6/brick6
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
+TEST truncate -s 300M $B4/brick4
+TEST truncate -s 300M $B5/brick5
+TEST truncate -s 300M $B6/brick6
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
@@ -23,9 +23,9 @@ EXPECT_WITHIN $PROBE_TIMEOUT 1 check_peers;
 B3=/d/backends/3
 mkdir -p $B3
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/bug-948729/bug-948729.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729.t
@@ -24,9 +24,9 @@ B3=/d/backends/3
 
 mkdir -p $B3
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
+++ b/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
@@ -7,11 +7,11 @@ cleanup
 TEST glusterd
 
 #Create brick partitions
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 100M $B0/brick2
-TEST truncate -s 100M $B0/brick3
-TEST truncate -s 100M $B0/brick4
-TEST truncate -s 100M $B0/brick5
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
+TEST truncate -s 300M $B0/brick3
+TEST truncate -s 300M $B0/brick4
+TEST truncate -s 300M $B0/brick5
 
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]

--- a/tests/bugs/posix/bug-1651445.t
+++ b/tests/bugs/posix/bug-1651445.t
@@ -23,15 +23,14 @@ TEST $CLI volume set $V0 storage.reserve 40MB
 #wait 5s to reset disk_space_full flag
 sleep 5
 
-TEST dd if=/dev/zero of=$M0/a bs=100M count=1
-TEST dd if=/dev/zero of=$M0/b bs=10M count=1
+free_space_in_mb=$(df -h $L1 | grep $L1 | awk '{print $4}' | cut -f1 -d'M')
+max_writeable_space_in_mb=$((free_space_in_mb-1))
+TEST dd if=/dev/zero of=$M0/a bs=1M count=$max_writeable_space_in_mb
 
 # Wait 5s to update disk_space_full flag because thread check disk space
 # after every 5s
 
 sleep 5
-# setup_lvm create lvm partition of 150M and 40M are reserve so after
-# consuming more than 110M next dd should fail
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1
 TEST dd if=/dev/urandom of=$M0/a  bs=1022 count=1  oflag=seek_bytes,sync seek=102 conv=notrunc
 
@@ -41,9 +40,10 @@ rm -rf $M0/*
 TEST $CLI volume set $V0 storage.reserve 40
 
 sleep 5
+free_space_60_percent_in_mb=$((free_space_in_mb * 60 / 100))
+max_writeable_space_in_mb=$((free_space_60_percent_in_mb - 1))
 
-TEST dd if=/dev/zero of=$M0/a bs=80M count=1
-TEST dd if=/dev/zero of=$M0/b bs=10M count=1
+TEST dd if=/dev/zero of=$M0/a bs=1M count=$max_writeable_space_in_mb
 
 sleep 5
 TEST ! dd if=/dev/zero of=$M0/c bs=5M count=1

--- a/tests/bugs/replicate/bug-1561129-enospc.t
+++ b/tests/bugs/replicate/bug-1561129-enospc.t
@@ -6,7 +6,7 @@
 
 cleanup;
 
-TEST truncate -s 128M $B0/xfs_image
+TEST truncate -s 300M $B0/xfs_image
 TEST mkfs.xfs -f $B0/xfs_image
 TEST mkdir $B0/bricks
 TEST mount -t xfs -o loop $B0/xfs_image $B0/bricks
@@ -17,8 +17,8 @@ TEST $CLI volume create $V0 replica 3 $H0:$B0/bricks/brick{0,1,3}
 TEST $CLI volume start $V0
 TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0;
 
-# Write 50MB of data, which will try to consume 50x3=150MB on $B0/bricks.
+# Write 150MB of data, which will try to consume 150x3=450MB on $B0/bricks.
 # Before that, we hit ENOSPC in pre-op cbk, which should not crash the mount.
-TEST ! dd if=/dev/zero of=$M0/a bs=1M count=50
+TEST ! dd if=/dev/zero of=$M0/a bs=1M count=150
 TEST stat $M0/a
 cleanup;

--- a/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
+++ b/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
@@ -22,11 +22,11 @@ function create_files {
 TEST glusterd
 
 #Create brick partitions
-TEST truncate -s 100M $B0/brick0
-TEST truncate -s 100M $B0/brick1
+TEST truncate -s 300M $B0/brick0
+TEST truncate -s 300M $B0/brick1
 #Have the 3rd brick of a higher size to test the scenario of entry transaction
 #passing on only one brick and not on other bricks.
-TEST truncate -s 110M $B0/brick2
+TEST truncate -s 310M $B0/brick2
 LO1=`SETUP_LOOP $B0/brick0`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1

--- a/tests/bugs/replicate/issue-1254-prioritize-enospc.t
+++ b/tests/bugs/replicate/issue-1254-prioritize-enospc.t
@@ -6,9 +6,9 @@
 cleanup
 
 function create_bricks {
-    TEST truncate -s 100M $B0/brick0
-    TEST truncate -s 100M $B0/brick1
-    TEST truncate -s 20M $B0/brick2
+    TEST truncate -s 1G $B0/brick0
+    TEST truncate -s 1G $B0/brick1
+    TEST truncate -s 300M $B0/brick2
     LO1=`SETUP_LOOP $B0/brick0`
     TEST [ $? -eq 0 ]
     TEST MKFS_LOOP $LO1

--- a/tests/bugs/replicate/issue-4064-softlink-entry-recreation.t
+++ b/tests/bugs/replicate/issue-4064-softlink-entry-recreation.t
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../afr.rc
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 replica 3 $H0:$B0/${V0}{0,1,2};
+TEST $CLI volume set $V0 cluster.self-heal-daemon off
+TEST $CLI volume start $V0
+
+TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 --attribute-timeout=0 --entry-timeout=0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2
+echo "Data">$M0/FILE
+ret=$?
+TEST [ $ret -eq 0 ]
+
+TEST kill_brick $V0 $H0 $B0/${V0}2
+
+TEST ln -s $M0/FILE $M0/SOFT
+TEST ln  $M0/FILE $M0/HARD
+#hardlink to a softlink
+TEST ln $M0/SOFT $M0/SOFTHARD
+
+#Set a metadata heal on the softlink
+TEST chown -h root:root $M0/SOFT
+
+#start the brick
+TEST $CLI volume start $V0 force
+
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}2
+
+TEST $CLI volume set $V0 cluster.self-heal-daemon on
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+TEST $CLI volume heal $V0
+EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+cleanup;

--- a/tests/bugs/shard/unlinks-and-renames.t
+++ b/tests/bugs/shard/unlinks-and-renames.t
@@ -157,6 +157,7 @@ TEST pidof glusterd
 TEST $CLI volume create $V0 replica 2 $H0:$B0/${V0}{0,1}
 TEST $CLI volume set $V0 features.shard on
 TEST $CLI volume set $V0 features.shard-block-size 4MB
+TEST $CLI volume set $V0 performance.write-behind off
 TEST $CLI volume start $V0
 TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 $M0
 

--- a/tests/features/weighted-rebalance.t
+++ b/tests/features/weighted-rebalance.t
@@ -35,11 +35,11 @@ TEST $CLI volume info
 
 TEST mkdir ${B0}/${V0}{1,2}
 
-TEST truncate -s $((40*1024*1024)) ${B0}/disk1
+TEST truncate -s $((300*1024*1024)) ${B0}/disk1
 TEST MKFS_LOOP -i 512 ${B0}/disk1
 TEST MOUNT_LOOP ${B0}/disk1 ${B0}/${V0}1
 
-TEST truncate -s $((80*1024*1024)) ${B0}/disk2
+TEST truncate -s $((600*1024*1024)) ${B0}/disk2
 TEST MKFS_LOOP -i 512 ${B0}/disk2
 TEST MOUNT_LOOP ${B0}/disk2 ${B0}/${V0}2
 

--- a/tests/snapshot.rc
+++ b/tests/snapshot.rc
@@ -5,7 +5,7 @@ LVM_DEFINED=0
 # the device (it replaces '-' by '--' in /dev/mapper)
 LVM_PREFIX="patchy_snap_${GFREG_ID//-/_}"
 LVM_COUNT=0
-VHD_SIZE="300M"
+VHD_SIZE="600M"
 
 #This function will init B# bricks
 #This is used when launch_cluster is
@@ -138,8 +138,8 @@ function _create_lv() {
     local dir=$1
     local num=$2
     local vg="VG$num"
-    local thinpoolsize="200M"
-    local virtualsize="150M"
+    local thinpoolsize="400M"
+    local virtualsize="300M"
     local path="$(realpath "${dir}/${LVM_PREFIX}_loop")"
 
     wipefs -a "${path}"

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -181,10 +181,12 @@ out:
 static int
 afr_new_entry_mark_status(call_frame_t *frame, loc_t *loc,
                           struct afr_reply *lookup_replies,
-                          unsigned char *sources, int source, int dst)
+                          unsigned char *sources, int source, int dst,
+                          gf_boolean_t *dst_hardlink)
 {
     xlator_t *this = frame->this;
     afr_private_t *priv = this->private;
+    struct iatt *iatt = NULL;
     int pending = 0;
     int metadata_idx = 0;
     int idx = -1;
@@ -194,6 +196,8 @@ afr_new_entry_mark_status(call_frame_t *frame, loc_t *loc,
     if (source == -1) {
         goto lookup;
     }
+
+    iatt = &lookup_replies[source].poststat;
 
     if (IA_ISDIR(lookup_replies[source].poststat.ia_type)) {
         goto lookup;
@@ -230,12 +234,25 @@ afr_new_entry_mark_status(call_frame_t *frame, loc_t *loc,
             goto lookup;
         }
     }
+    if (iatt->ia_type == IA_IFLNK && dst_hardlink) {
+        ret = syncop_lookup(priv->children[dst], loc, 0, 0, 0, 0);
+        if (ret == 0) {
+            *dst_hardlink = _gf_true;
+        }
+        /* If it is a soft link, we need to check if a hardlink to
+         * this softlink present in the dst, hence we perform a
+         * lookup here*/
+    }
     /*Pending is marked on all source bricks, we definitely know that new entry
      * marking is not needed*/
     return 0;
 
 lookup:
     ret = syncop_lookup(priv->children[dst], loc, 0, 0, 0, 0);
+    if (ret == 0 && dst_hardlink) {
+        *dst_hardlink = _gf_true;
+    }
+
     return ret;
 }
 
@@ -267,6 +284,7 @@ afr_selfheal_recreate_entry(call_frame_t *frame, int dst, int source,
     unsigned char *newentry = NULL;
     char iatt_uuid_str[64] = {0};
     char dir_uuid_str[64] = {0};
+    gf_boolean_t dst_hardlink = _gf_false;
 
     priv = this->private;
     iatt = &replies[source].poststat;
@@ -302,7 +320,7 @@ afr_selfheal_recreate_entry(call_frame_t *frame, int dst, int source,
     srcloc.inode = inode_ref(inode);
     gf_uuid_copy(srcloc.gfid, iatt->ia_gfid);
     ret = afr_new_entry_mark_status(frame, &srcloc, replies, sources, source,
-                                    dst);
+                                    dst, &dst_hardlink);
     if (ret == -ENOENT || ret == -ESTALE) {
         newentry[dst] = 1;
         ret = afr_selfheal_newentry_mark(frame, this, inode, source, replies,
@@ -329,7 +347,7 @@ afr_selfheal_recreate_entry(call_frame_t *frame, int dst, int source,
             ret = syncop_mkdir(priv->children[dst], &loc, mode, 0, xdata, NULL);
             break;
         case IA_IFLNK:
-            if (!newentry[dst]) {
+            if (dst_hardlink) {
                 ret = syncop_link(priv->children[dst], &srcloc, &loc, &newent,
                                   NULL, NULL);
             } else {

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -1839,8 +1839,7 @@ __ec_heal_data_prepare(call_frame_t *frame, ec_t *ec, fd_t *fd,
 
     for (i = 0; i < ec->nodes; i++) {
         if (healed_sinks[i]) {
-            if (replies[i].stat.ia_size)
-                trim[i] = 1;
+            trim[i] = 1;
         }
     }
 
@@ -2045,9 +2044,90 @@ ec_sync_heal_block(call_frame_t *frame, xlator_t *this, ec_heal_t *heal)
     return 0;
 }
 
+void
+ec_heal_seek_hole_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+    int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+{
+    ec_fop_data_t *fop = cookie;
+    ec_heal_t *heal = fop->data;
+
+    if (op_ret < 0) {
+        heal->error = op_errno;
+        goto out;
+    }
+    heal->hole_offset = offset;
+
+out:
+    syncbarrier_wake(&heal->barrier);
+}
+
+void
+ec_heal_seek_data_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+		    int32_t op_ret, int32_t op_errno, off_t offset, dict_t * xdata)
+{
+    ec_fop_data_t *fop = cookie;
+    ec_heal_t *heal = fop->data;
+
+    if (op_ret < 0){
+        heal->done = _gf_true;
+        goto out;
+    }
+    heal->offset = offset;
+
+out:
+    syncbarrier_wake(&heal->barrier);
+}
+
+int32_t
+ec_sync_heal_sparse_region(call_frame_t *frame, ec_t *ec, ec_heal_t *heal)
+{
+    int ret = 0;
+    ec_seek(frame, ec->xl, heal->good, EC_MINIMUM_ONE,
+            ec_heal_seek_data_cbk, heal, heal->fd, heal->offset,
+            GF_SEEK_DATA, NULL);
+    syncbarrier_wait(&heal->barrier, 1);
+
+    if (heal->done)
+        goto out;
+
+    ec_seek(frame, ec->xl, heal->good, EC_MINIMUM_ONE,
+            ec_heal_seek_hole_cbk, heal, heal->fd, heal->offset,
+            GF_SEEK_HOLE, NULL);
+    syncbarrier_wait(&heal->barrier,1);
+    
+    if (heal->error != 0) {
+        ret = -heal->error;
+        goto out;
+    }
+
+    for (; (heal->offset < heal->hole_offset) && (!heal->done);
+            heal->offset += heal->size) {
+
+        uint64_t data_block_size = heal->hole_offset - heal->offset;
+        data_block_size = (data_block_size > ec->stripe_size)?
+                            data_block_size : ec->stripe_size;
+
+        uint64_t original_heal_size = heal->size;
+
+        if(data_block_size < heal->size)
+            heal->size = data_block_size;
+        
+        ret = ec_sync_heal_block(frame, ec->xl, heal);
+        if (ret < 0)
+            goto out;
+
+        heal->size = original_heal_size;
+    }
+    heal->offset = heal->hole_offset;
+
+out:
+    return ret;
+    
+}
+
 int
 ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
-                unsigned char *sources, unsigned char *healed_sinks)
+                unsigned char *sources, unsigned char *healed_sinks, int hole_exists)
 {
     ec_heal_t obj, *heal = &obj;
     int ret = 0;
@@ -2072,29 +2152,47 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
     heal->ia_type = IA_IFREG;
     LOCK_INIT(&heal->lock);
 
-    for (heal->offset = 0; (heal->offset < size) && !heal->done;
-         heal->offset += heal->size) {
-        /* We immediately abort any heal if a shutdown request has been
-         * received to avoid delays. The healing of this file will be
-         * restarted by another SHD or other client that accesses the
-         * file. */
-        if (ec->shutdown) {
+    if (!hole_exists) {
+        for (heal->offset = 0; (heal->offset < size) && !heal->done;
+            heal->offset += heal->size) {
+            /* We immediately abort any heal if a shutdown request has been
+            * received to avoid delays. The healing of this file will be
+            * restarted by another SHD or other client that accesses the
+            * file. */
+            if (ec->shutdown) {
+                gf_msg_debug(ec->xl->name, 0,
+                            "Cancelling heal because "
+                            "EC is stopping.");
+                ret = -ENOTCONN;
+                break;
+            }
+
             gf_msg_debug(ec->xl->name, 0,
-                         "Cancelling heal because "
-                         "EC is stopping.");
-            ret = -ENOTCONN;
-            break;
+                        "%s: sources: %d, sinks: "
+                        "%d, offset: %" PRIu64 " bsize: %" PRIu64,
+                        uuid_utoa(fd->inode->gfid), EC_COUNT(sources, ec->nodes),
+                        EC_COUNT(healed_sinks, ec->nodes), heal->offset,
+                        heal->size);
+            ret = ec_sync_heal_block(frame, ec->xl, heal);
+            if (ret < 0)
+                break;
+        }
+    
+    } else {
+        heal->offset = 0;
+        while (!heal->done) {
+            if (ec->shutdown) {
+                gf_msg_debug(ec->xl->name, 0,
+                            "Cancelling heal because "
+                            "EC is stopping.");
+                ret = -ENOTCONN;
+    
+            }
+            ret = ec_sync_heal_sparse_region(frame, ec, heal);
+            if (ret < 0)
+                break;
         }
 
-        gf_msg_debug(ec->xl->name, 0,
-                     "%s: sources: %d, sinks: "
-                     "%d, offset: %" PRIu64 " bsize: %" PRIu64,
-                     uuid_utoa(fd->inode->gfid), EC_COUNT(sources, ec->nodes),
-                     EC_COUNT(healed_sinks, ec->nodes), heal->offset,
-                     heal->size);
-        ret = ec_sync_heal_block(frame, ec->xl, heal);
-        if (ret < 0)
-            break;
     }
     memset(healed_sinks, 0, ec->nodes);
     ec_mask_to_char_array(heal->bad, healed_sinks, ec->nodes);
@@ -2103,14 +2201,14 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
     syncbarrier_destroy(&heal->barrier);
     if (ret < 0)
         gf_msg_debug(ec->xl->name, -ret, "%s: heal failed",
-                     uuid_utoa(fd->inode->gfid));
+                    uuid_utoa(fd->inode->gfid));
     return ret;
 }
 
 int
 __ec_heal_trim_sinks(call_frame_t *frame, ec_t *ec, fd_t *fd,
                      unsigned char *healed_sinks, unsigned char *trim,
-                     uint64_t size)
+                     uint64_t size, int file_has_holes)
 {
     default_args_cbk_t *replies = NULL;
     unsigned char *output = NULL;
@@ -2127,6 +2225,10 @@ __ec_heal_trim_sinks(call_frame_t *frame, ec_t *ec, fd_t *fd,
     }
     trim_offset = size;
     ec_adjust_offset_up(ec, &trim_offset, _gf_true);
+    if (file_has_holes) {
+        ret = cluster_ftruncate(ec->xl_list, trim, ec->nodes, replies, output,
+                                frame, ec->xl, fd, 0, NULL);
+    }
     ret = cluster_ftruncate(ec->xl_list, trim, ec->nodes, replies, output,
                             frame, ec->xl, fd, trim_offset, NULL);
     for (i = 0; i < ec->nodes; i++) {
@@ -2348,6 +2450,8 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
     default_args_cbk_t *replies = NULL;
     int ret = 0;
     int source = 0;
+    int file_has_holes = 0;
+    struct iatt source_buf = {0};
 
     locked_on = alloca0(ec->nodes);
     output = alloca0(ec->nodes);
@@ -2371,9 +2475,13 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
         }
 
         ret = __ec_heal_data_prepare(frame, ec, fd, locked_on, versions, dirty,
-                                     size, sources, healed_sinks, trim, NULL);
+                                     size, sources, healed_sinks, trim, &source_buf);
         if (ret < 0)
             goto unlock;
+        
+        if (source_buf.ia_blocks * source_buf.ia_blksize != source_buf.ia_size) {
+                file_has_holes = 1;
+        }
 
         if (EC_COUNT(healed_sinks, ec->nodes) == 0) {
             ret = __ec_fd_data_adjust_versions(
@@ -2387,7 +2495,7 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
             goto unlock;
 
         ret = __ec_heal_trim_sinks(frame, ec, fd, healed_sinks, trim,
-                                   size[source]);
+                                   size[source], file_has_holes);
     }
 unlock:
     cluster_uninodelk(ec->xl_list, locked_on, ec->nodes, replies, output, frame,
@@ -2404,7 +2512,7 @@ unlock:
                  uuid_utoa(fd->inode->gfid), EC_COUNT(sources, ec->nodes),
                  EC_COUNT(healed_sinks, ec->nodes));
 
-    ret = ec_rebuild_data(frame, ec, fd, size[source], sources, healed_sinks);
+    ret = ec_rebuild_data(frame, ec, fd, size[source], sources, healed_sinks, file_has_holes);
     if (ret < 0)
         goto out;
 

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -577,6 +577,7 @@ struct _ec_heal {
     uint64_t offset;
     uint64_t size;
     uint64_t total_size;
+    uint64_t hole_offset;
 };
 
 struct subvol_healer {

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -5406,8 +5406,13 @@ glusterd_remote_hostname_get(rpcsvc_request_t *req, char *remote_host, int len)
     }
 
     if ((gf_get_hostname_from_ip(hostname, &canon) == 0) && canon) {
-        GF_FREE(tmp_host);
-        tmp_host = hostname = canon;
+        if (strcmp(canon, "localhost") &&
+            strcmp(canon, "localhost.localdomain")) {
+            GF_FREE(tmp_host);
+            tmp_host = hostname = canon;
+        } else {
+            GF_FREE(canon);
+        }
     }
 
     (void)snprintf(remote_host, len, "%s", hostname);


### PR DESCRIPTION
Problem:
Sparse files were not handled in the healing logic, causing them to occupy their full size after healing.

Fix:
Similar to how sparse files are handled in dht-rebalance, holes and data regions are found using ec_seek() and only the data segments are written to the healed file.

Fixes: #3546

