### PR TITLE
afr: fix race between __afr_eager_lock_handle and afr_wakeup_same_fd_…

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -4205,6 +4205,7 @@ afr_wakeup_same_fd_delayed_op(xlator_t *this, afr_lock_t *lock, fd_t *fd)
             if (gf_timer_call_cancel(this->ctx, lock->delay_timer)) {
                 local = NULL;
             } else {
+                lock->release = _gf_true;
                 lock->delay_timer = NULL;
             }
         } else {


### PR DESCRIPTION
…delayed_op (#4425) (#4426)

Race between __afr_eager_lock_handle and afr_wakeup_same_fd_delayed_op will lead to stale inodelks, which may cause subsequent IO blocked. To avoid this race, set lock->release = _gf_true also in afr_wakeup_same_fd_delayed_op so that a new transaction can be correctly handled as expected in __afr_eager_lock_handle.

> Fixes: #4425

> Signed-off-by: chenjinhao <chen.jinhao@zte.com.cn>
> Co-authored-by: 陈瑾浩 10307298 <chen.jinhao@zte.com.cn>
backport-of: 9c3dfd91157a771533255d88e087335885fe3fd3
Signed-off-by: Pranith Kumar Karampuri <pranith.karampuri@phonepe.com>

Change-Id: Idf0c4f3e4d91353f7c8144cb67126c467d962377

