### PR TITLE
tests: robustness enhancement of regression tests (#4433)

### DIFF
--- a/tests/basic/ctime/ctime-heal-symlinks.t
+++ b/tests/basic/ctime/ctime-heal-symlinks.t
@@ -22,6 +22,9 @@ TEST rm -f $B0/${V0}2/SOFTLINK
 TEST stat SOFTLINK
 
 # To heal and clear new-entry mark on source bricks.
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
 TEST $CLI volume heal $V0
 EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
 
@@ -49,6 +52,7 @@ TEST rm -f $B0/${V0}2/SOFTLINK
 TEST stat SOFTLINK
 
 # To heal and clear new-entry mark on source bricks.
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count_shd $V0 0
 TEST $CLI volume heal $V0
 EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
 

--- a/tests/basic/global-threading.t
+++ b/tests/basic/global-threading.t
@@ -56,6 +56,8 @@ TEST check_threads $(get_brick_pid $V0 $H0 $B0/b0) glfs_iotwr 1
 TEST check_threads $(get_brick_pid $V0 $H0 $B0/b1) glfs_iotwr 1
 
 # Self-heal should be using global threads
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
 TEST check_threads $(get_shd_process_pid) glfs_tpw 1
 TEST check_threads $(get_shd_process_pid) glfs_iotwr 0 0
 

--- a/tests/basic/graph-cleanup-brick-down-shd-mux.t
+++ b/tests/basic/graph-cleanup-brick-down-shd-mux.t
@@ -15,6 +15,8 @@ TEST $CLI volume set $V0 cluster.eager-lock off
 TEST $CLI volume set $V0 performance.flush-behind off
 TEST $CLI volume start $V0
 
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "^6$" number_healer_threads_shd $V0 "afr_shd_index_healer"
+
 for i in $(seq 1 2); do
    TEST $CLI volume create ${V0}_afr$i replica 3 $H0:$B0/${V0}_afr${i}{0,1,2,3,4,5}
    TEST $CLI volume start ${V0}_afr$i

--- a/tests/bugs/fuse/bug-858215.t
+++ b/tests/bugs/fuse/bug-858215.t
@@ -40,17 +40,8 @@ TEST touch $M0/newfile;
 TEST stat $M0/newfile;
 TEST rm $M0/newfile;
 
-nfs_pid=$(cat $GLUSTERD_PIDFILEDIR/nfs/nfs.pid || echo -1);
-glustershd_pid=`ps auxwww | grep glustershd | grep -v grep | awk -F " " '{print $2}'`
-TEST [ $glustershd_pid != 0 ];
-pids=$(pidof glusterfs);
-for i in $pids
-do
-        if [ $i -ne $nfs_pid ] && [ $i -ne $glustershd_pid ]; then
-                mount_pid=$i;
-                break;
-        fi
-done
+mount_pid=`ps auxwww | grep glusterfs| grep $M0 | grep -v grep | awk -F " " '{print $2}'`
+TEST [ $mount_pid != 0 ];
 
 dump_dir='/tmp/gerrit_glusterfs'
 cat >$statedumpdir/glusterdump.options <<EOF

--- a/tests/bugs/heal-symlinks.t
+++ b/tests/bugs/heal-symlinks.t
@@ -22,6 +22,9 @@ TEST rm -f $B0/${V0}2/SOFTLINK
 TEST stat SOFTLINK
 
 # To heal and clear new-entry mark on source bricks.
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
 TEST $CLI volume heal $V0
 EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
 
@@ -49,6 +52,7 @@ TEST rm -f $B0/${V0}2/SOFTLINK
 TEST stat SOFTLINK
 
 # To heal and clear new-entry mark on source bricks.
+EXPECT_WITHIN $CHILD_UP_TIMEOUT "3" ec_child_up_count_shd $V0 0
 TEST $CLI volume heal $V0
 EXPECT_WITHIN $HEAL_TIMEOUT "^0$" get_pending_heal_count $V0
 

--- a/tests/bugs/replicate/bug-1325792.t
+++ b/tests/bugs/replicate/bug-1325792.t
@@ -11,10 +11,10 @@ TEST $CLI volume start $V0
 
 TEST glusterfs --volfile-id=$V0 --volfile-server=$H0 --entry-timeout=0 $M0;
 
-EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 0
-EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 1
-EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 2
-EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status $V0 3
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 2
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" afr_child_up_status_in_shd $V0 3
 
 
 EXPECT 1 echo `$CLI volume heal $V0 statistics heal-count replica $H0:$B0/${V0}0 | grep -A 1 ${V0}0 | grep "entries" | wc -l`

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -1,4 +1,5 @@
 # clang-format off
+export LANG=en_US.UTF-8
 checkpoint_time="$(date +%s%N)"
 
 M0=${M0:=/mnt/glusterfs/0};   # 0th mount point for FUSE


### PR DESCRIPTION
Results of some regression tests may vary on diffirent env, due to the unready status of shd process or unexpected output language of key commands in test case.

So, it should be made sure that shd process has got ready before a `gluster v heal` cmd is triggered in testcase. And if the output of command is the judge standard of sub-testcase, we also shuold assure it is shown in specified language as expected.

> Fixes: #4432

> Signed-off-by: chenjinhao <chen.jinhao@zte.com.cn>
> Co-authored-by: chenjinhao <chen.jinhao@zte.com.cn>
backport-of: 3dc314933bf238315691f074a3b6a3107288a4b5
Signed-off-by: Pranith Kumar Karampuri <pranith.karampuri@phonepe.com>

Change-Id: I6614cff5aa375deab04065270d0b2270fb0a4e71

