### PR TITLE
events: avoid zombie processes after reloading (#4436)

### DIFF
--- a/events/src/utils.py
+++ b/events/src/utils.py
@@ -427,6 +427,7 @@ class WebhookThreadPool(object):
         # In transit messages are skipped, since webhooks monitor process
         # is terminated.
         self.proc.terminate()
+        self.proc.join()
         self.start()
 
     def send(self, event_type, event_ts, message):


### PR DESCRIPTION
To prevent zombie processes after reloading by using join.

> Signed-off-by: zhangxyue <zhang.yue5@zte.com.cn>
backport-of: 909a01f351b01bd68789c1f3073eff006fc21a3a


Change-Id: Id2ba0a33064298c425a3d60b09fa4abf10075255

