### PR TITLE
tests: address XFS 300M minimum size (#4361) (#4487)

### DIFF
--- a/tests/basic/afr/arbiter-statfs.t
+++ b/tests/basic/afr/arbiter-statfs.t
@@ -12,7 +12,7 @@ TEST glusterd
 TEST truncate -s 1G $B0/brick1
 TEST truncate -s 1G $B0/brick2
 #Arbiter brick is of a lesser size.
-TEST truncate -s 90M $B0/brick3
+TEST truncate -s 300M $B0/brick3
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1

--- a/tests/basic/distribute/file-create.t
+++ b/tests/basic/distribute/file-create.t
@@ -23,8 +23,8 @@ TEST pidof glusterd
 # We want fixed size bricks to test min-free-disk
 
 # Create 2 loop devices, one per brick.
-TEST   truncate -s 25M $B0/brick1
-TEST   truncate -s 25M $B0/brick2
+TEST   truncate -s 300M $B0/brick1
+TEST   truncate -s 300M $B0/brick2
 
 TEST   L1=`SETUP_LOOP $B0/brick1`
 TEST   MKFS_LOOP $L1
@@ -61,7 +61,7 @@ TEST dht_first_filename_with_hashsubvol "$hashed" $M0/dir1 "big-"
 firstfile=$fn_return_val
 
 #Create a large file to fill up $hashed past the min-free-disk limits
-TEST  dd if=/dev/zero of=$M0/dir1/$firstfile bs=1M count=15
+TEST  dd if=/dev/zero of=$M0/dir1/$firstfile bs=1M count=180
 
 brickpath_0=$(cat "$M0/.meta/graphs/active/$hashed/options/remote-subvolume")
 brickpath_1=$(cat "$M0/.meta/graphs/active/$V0-client-1/options/remote-subvolume")
@@ -87,7 +87,7 @@ echo $newfile
 
 # Create $newfile - it should be created on the other subvol as its hash subvol
 # has crossed the min-free-disk limit
-TEST  dd if=/dev/zero of=$M0/dir1/$newfile bs=1024 count=20
+TEST  dd if=/dev/zero of=$M0/dir1/$newfile bs=1024 count=240
 TEST stat "$brickpath_0/dir1/$newfile"
 EXPECT "1" is_dht_linkfile "$brickpath_0/dir1/$newfile"
 
@@ -103,7 +103,7 @@ EXPECT "1" is_dht_linkfile "$brickpath_0/dir1/$newfile"
 TEST dht_first_filename_with_hashsubvol $V0-client-1 $M0/dir1 "filter-"
 newfile=$fn_return_val
 echo $newfile
-TEST dd if=/dev/zero of="$M0/dir1/$newfile@$V0-dht:$hashed" bs=1024 count=20
+TEST dd if=/dev/zero of="$M0/dir1/$newfile@$V0-dht:$hashed" bs=1024 count=240
 TEST stat $M0/dir1/$newfile
 TEST stat "$brickpath_0/dir1/$newfile"
 EXPECT "1" is_dht_linkfile "$brickpath_1/dir1/$newfile"

--- a/tests/basic/posix/shared-statfs.t
+++ b/tests/basic/posix/shared-statfs.t
@@ -7,9 +7,9 @@
 cleanup;
 TEST glusterd
 
-#Create brick partitions
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 100M $B0/brick2
+#Create brick partitions - xfs min is 300M
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1
@@ -29,9 +29,9 @@ TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "2" online_brick_count
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
 total_mount_blocks=$(df -P $M0 | tail -1 | awk '{ print $2}')
-# Keeping the size less than 200M mainly because XFS will use
+# Keeping the size less than 600M mainly because XFS will use
 # some storage in brick to keep its own metadata.
-TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 200000 ]
+TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 600000 ]
 
 
 TEST force_umount $M0
@@ -45,7 +45,7 @@ TEST $CLI volume start $V0
 EXPECT_WITHIN $PROCESS_UP_TIMEOUT "6" online_brick_count
 TEST $GFS --volfile-server=$H0 --volfile-id=$V0 $M0
 total_mount_blocks=$(df -P $M0 | tail -1 | awk '{ print $2}')
-TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 200000 ]
+TEST [ $total_mount_blocks -gt $brick_blocks_two_percent_less -a $total_mount_blocks -lt 600000 ]
 
 TEST force_umount $M0
 TEST $CLI volume stop $V0

--- a/tests/basic/posix/zero-fill-enospace.t
+++ b/tests/basic/posix/zero-fill-enospace.t
@@ -9,7 +9,7 @@ cleanup;
 TEST glusterd;
 TEST pidof glusterd;
 
-TEST truncate -s 100M $B0/brick1
+TEST truncate -s 300M $B0/brick1
 
 TEST L1=`SETUP_LOOP $B0/brick1`
 TEST MKFS_LOOP $L1
@@ -25,7 +25,9 @@ TEST $CLI volume start $V0;
 TEST glusterfs -s $H0 --volfile-id=$V0 $M0
 TEST touch $M0/foo
 TEST build_tester $(dirname $0)/zero-fill-enospace.c -lgfapi -Wall -O2
-TEST ! $(dirname $0)/zero-fill-enospace $H0 $V0 /foo `gluster --print-logdir`/glfs-$V0.log 104857600
+
+# Last argument is the brick size in bytes
+TEST ! $(dirname $0)/zero-fill-enospace $H0 $V0 /foo `gluster --print-logdir`/glfs-$V0.log 314572800
 
 TEST force_umount $M0
 TEST $CLI volume stop $V0

--- a/tests/bugs/distribute/bug-1099890.t
+++ b/tests/bugs/distribute/bug-1099890.t
@@ -18,8 +18,8 @@ TEST   glusterd;
 TEST   pidof glusterd;
 
 # Create 2 loop devices, one per brick.
-TEST   truncate -s 100M $B0/brick1
-TEST   truncate -s 100M $B0/brick2
+TEST   truncate -s 300M $B0/brick1
+TEST   truncate -s 300M $B0/brick2
 
 TEST   L1=`SETUP_LOOP $B0/brick1`
 TEST   MKFS_LOOP $L1
@@ -42,25 +42,25 @@ TEST   $CLI volume quota $V0 enable;
 
 TEST   $CLI volume set $V0 features.quota-deem-statfs on
 
-TEST   $CLI volume quota $V0 limit-usage / 150MB;
+TEST   $CLI volume quota $V0 limit-usage / 450MB;
 
 TEST   $CLI volume set $V0 cluster.min-free-disk 50%
 
 TEST   glusterfs -s $H0 --volfile-id=$V0 $M0
 
 # Make sure quota-deem-statfs is working as expected
-EXPECT "150M" echo `df -h $M0 -P | tail -1 | awk {'print $2'}`
+EXPECT "450M" echo `df -h $M0 -P | tail -1 | awk {'print $2'}`
 
 # Create a new file 'foo' under the root of the volume, which hashes to subvol-0
-# of DHT, that consumes 40M
-TEST $QDD $M0/foo 256 160
+# of DHT, that consumes 120M
+TEST $QDD $M0/foo 256 480
 
 TEST   stat $B0/${V0}1/foo
 TEST ! stat $B0/${V0}2/foo
 
 # Create a new file 'bar' under the root of the volume, which hashes to subvol-1
-# of DHT, that consumes 40M
-TEST $QDD $M0/bar 256 160
+# of DHT, that consumes 120M
+TEST $QDD $M0/bar 256 480
 
 TEST ! stat $B0/${V0}1/bar
 TEST   stat $B0/${V0}2/bar
@@ -70,15 +70,15 @@ TEST   stat $B0/${V0}2/bar
 sleep 1;
 TEST   touch $M0/empty1;
 
-# At this point, the available space on each subvol {60M,60M} is greater than
-# their min-free-disk {50M,50M}, but if this bug still exists, then
+# At this point, the available space on each subvol {160M,160M} is greater than
+# their min-free-disk {150M,150M}, but if this bug still exists, then
 # the total available space on the volume as perceived by DHT should be less
 # than min-free-disk, i.e.,
 #
-# consumed space returned per subvol by quota = (40M + 40M) = 80M
+# consumed space returned per subvol by quota = (120M + 120M) = 240M
 #
 # Therefore, consumed space per subvol computed by DHT WITHOUT the fix would be:
-# (80M/150M)*100 = 53%
+# (240M/450M)*100 = 53%
 #
 # Available space per subvol as perceived by DHT with the bug = 47%
 # which is less than min-free-disk

--- a/tests/bugs/fuse/bug-858488-min-free-disk.t
+++ b/tests/bugs/fuse/bug-858488-min-free-disk.t
@@ -11,8 +11,8 @@ TEST pidof glusterd;
 TEST $CLI volume info;
 
 ## Lets create partitions for bricks
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 200M $B0/brick2
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 400M $B0/brick2
 TEST LO1=`SETUP_LOOP $B0/brick1`
 TEST MKFS_LOOP $LO1
 TEST LO2=`SETUP_LOOP $B0/brick2`
@@ -69,7 +69,7 @@ done
 
 ## Bring free space on one of the bricks to less than minfree value by
 ## creating one big file.
-dd if=/dev/zero of=$M0/fillonebrick.data bs=1024 count=25600 1>/dev/null 2>&1
+dd if=/dev/zero of=$M0/fillonebrick.data bs=4096 count=25600 1>/dev/null 2>&1
 
 #Lets find out where it was created
 if [ -f $B0/${V0}1/fillonebrick.data ]

--- a/tests/bugs/glusterd/bug-1091935-brick-order-check-from-cli-to-glusterd.t
+++ b/tests/bugs/glusterd/bug-1091935-brick-order-check-from-cli-to-glusterd.t
@@ -11,10 +11,10 @@ function check_peers {
 cleanup;
 
 ## Lets create partitions for bricks
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 200M $B0/brick2
-TEST truncate -s 200M $B0/brick3
-TEST truncate -s 200M $B0/brick4
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
+TEST truncate -s 300M $B0/brick3
+TEST truncate -s 300M $B0/brick4
 
 
 TEST LO1=`SETUP_LOOP $B0/brick1`

--- a/tests/bugs/glusterd/bug-948729/bug-948729-force.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-force.t
@@ -29,12 +29,12 @@ B6=/d/backends/6
 
 mkdir -p $B3 $B4 $B5 $B6
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
-TEST truncate -s 16M $B4/brick4
-TEST truncate -s 16M $B5/brick5
-TEST truncate -s 16M $B6/brick6
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
+TEST truncate -s 300M $B4/brick4
+TEST truncate -s 300M $B5/brick5
+TEST truncate -s 300M $B6/brick6
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729-mode-script.t
@@ -23,9 +23,9 @@ EXPECT_WITHIN $PROBE_TIMEOUT 1 check_peers;
 B3=/d/backends/3
 mkdir -p $B3
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/bug-948729/bug-948729.t
+++ b/tests/bugs/glusterd/bug-948729/bug-948729.t
@@ -24,9 +24,9 @@ B3=/d/backends/3
 
 mkdir -p $B3
 
-TEST truncate -s 16M $B1/brick1
-TEST truncate -s 16M $B2/brick2
-TEST truncate -s 16M $B3/brick3
+TEST truncate -s 300M $B1/brick1
+TEST truncate -s 300M $B2/brick2
+TEST truncate -s 300M $B3/brick3
 
 TEST LD1=`SETUP_LOOP $B1/brick1`
 TEST MKFS_LOOP $LD1

--- a/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
+++ b/tests/bugs/glusterd/df-results-post-replace-brick-operations.t
@@ -7,11 +7,11 @@ cleanup
 TEST glusterd
 
 #Create brick partitions
-TEST truncate -s 100M $B0/brick1
-TEST truncate -s 100M $B0/brick2
-TEST truncate -s 100M $B0/brick3
-TEST truncate -s 100M $B0/brick4
-TEST truncate -s 100M $B0/brick5
+TEST truncate -s 300M $B0/brick1
+TEST truncate -s 300M $B0/brick2
+TEST truncate -s 300M $B0/brick3
+TEST truncate -s 300M $B0/brick4
+TEST truncate -s 300M $B0/brick5
 
 LO1=`SETUP_LOOP $B0/brick1`
 TEST [ $? -eq 0 ]

--- a/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
+++ b/tests/bugs/replicate/bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t
@@ -22,11 +22,11 @@ function create_files {
 TEST glusterd
 
 #Create brick partitions
-TEST truncate -s 100M $B0/brick0
-TEST truncate -s 100M $B0/brick1
+TEST truncate -s 300M $B0/brick0
+TEST truncate -s 300M $B0/brick1
 #Have the 3rd brick of a higher size to test the scenario of entry transaction
 #passing on only one brick and not on other bricks.
-TEST truncate -s 110M $B0/brick2
+TEST truncate -s 310M $B0/brick2
 LO1=`SETUP_LOOP $B0/brick0`
 TEST [ $? -eq 0 ]
 TEST MKFS_LOOP $LO1

--- a/tests/bugs/replicate/issue-1254-prioritize-enospc.t
+++ b/tests/bugs/replicate/issue-1254-prioritize-enospc.t
@@ -6,9 +6,9 @@
 cleanup
 
 function create_bricks {
-    TEST truncate -s 100M $B0/brick0
-    TEST truncate -s 100M $B0/brick1
-    TEST truncate -s 20M $B0/brick2
+    TEST truncate -s 1G $B0/brick0
+    TEST truncate -s 1G $B0/brick1
+    TEST truncate -s 300M $B0/brick2
     LO1=`SETUP_LOOP $B0/brick0`
     TEST [ $? -eq 0 ]
     TEST MKFS_LOOP $LO1


### PR DESCRIPTION
* tests: shared-statfs.t XFS 300M minimum (#4361)

	A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: bug-1091935-brick-order-check-from-cli-to-glusterd.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: df-results-post-replace-brick-operations.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: bug-1586020-mark-dirty-for-entry-txn-on-quorum-failure.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: bug-948729-force.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: bug-948729.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: bug-948729-mode-script.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: distribute/file-create.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: arbiter-statfs.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: zero-fill-enospace.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: issue-1254-prioritize-enospc.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests: fuse/bug-858488-min-free-disk.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* tests:  tests/bugs/distribute/bug-1099890.t XFS 300M minimum (#4361)

        A commit in xfsprogs raised the minimun size of a xfs filesystem
to 300M, causing the tests to fail because they were trying to build even smaller filesystems. This commit adjust the size parameters to fit.



* Update tests/bugs/fuse/bug-858488-min-free-disk.t

]

Change-Id: I76e449fda1892dec15021ddfa354e32daadebb13
backport-of: 97071145669b22ea1030dc65b1baa68b91433079

