### PR TITLE
s/gawk/awk (#4544)

### DIFF
--- a/tests/bugs/distribute/bug-1786679.t
+++ b/tests/bugs/distribute/bug-1786679.t
@@ -19,7 +19,7 @@ cleanup
 
 function get_layout () {
 
-layout=`getfattr -n trusted.glusterfs.dht -e hex $1 2>&1 | grep dht | gawk -F"=" '{print $2}'`
+layout=`getfattr -n trusted.glusterfs.dht -e hex $1 2>&1 | grep dht | awk -F"=" '{print $2}'`
 
 echo $layout
 


### PR DESCRIPTION
Most of the places we used awk, so moving to that to avoid extra dependency.

> Fixes: #4543
> Change-Id: I085041ef32da5cb0dfa78a0741e8edda3f39ca64

Change-Id: Iabbe7ff752fe2b8cf73888c66b1e35da082418cf
backport-of: 2c1428bca9a80d7c7df2ab43932323e265e63e78

