### PR TITLE
glfs/open: dentry lists are not initialized (#4284)

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -713,6 +713,7 @@ pub_glfs_close(struct glfs_fd *glfd)
     DECLARE_OLD_THIS;
     __GLFS_ENTRY_VALIDATE_FD(glfd, invalid_fs);
 
+    gf_dirent_free(list_entry(&glfd->entries, gf_dirent_t, list));
     subvol = glfs_active_subvol(glfd->fs);
     if (!subvol) {
         ret = -1;
@@ -3590,7 +3591,6 @@ pub_glfs_opendir(struct glfs *fs, const char *path)
     if (!glfd)
         goto out;
 
-    INIT_LIST_HEAD(&glfd->entries);
 retry:
     ret = glfs_resolve(fs, subvol, path, &loc, &iatt, reval);
 

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -707,6 +707,7 @@ glfs_fd_new(struct glfs *fs)
     glfd->fs = fs;
 
     INIT_LIST_HEAD(&glfd->openfds);
+    INIT_LIST_HEAD(&glfd->entries);
 
     GF_REF_INIT(glfd, glfs_fd_destroy);
 


### PR DESCRIPTION
Now that we are using glfs_open to open directory fd, we should initialize the dentry list.

  > cherry-picked from commit d53ce415fa
Change-Id: I6193eb83d80220ebef6ac4331bf984c8b4d6c49d

