### PR TITLE
glusterd: fix the update order of hostnames

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-peer-utils.c
@@ -789,7 +789,7 @@ gd_update_peerinfo_from_dict(glusterd_peerinfo_t *peerinfo, dict_t *dict,
                    key);
             goto out;
         }
-        ret = gd_add_address_to_peer(peerinfo, hostname, _gf_true);
+        ret = gd_add_address_to_peer(peerinfo, hostname, _gf_false);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_ADD_ADDRESS_TO_PEER_FAIL,
                    "Could not add address to peer");


### PR DESCRIPTION
After updating the latest hoatname, the old hostname is at the
top of peer file when probing a new node. Which may affect
DNS resolution when glusterd restart.

Fix: commit 607d85d121280337478dcb25e545d9e371308f7f

