### PR TITLE
linkfile: use fops->create in dht_linkfile_create

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -2426,12 +2426,20 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                 gf_msg_debug(this->name, 0,
                              "No Cached was found and "
                              "unlink on hashed was skipped"
-                             " so performing now: %s",
-                             local->loc.path);
-                FRAME_SU_DO(frame, dht_local_t);
-                STACK_WIND(frame, dht_lookup_unlink_stale_linkto_cbk,
-                           hashed_subvol, hashed_subvol->fops->unlink,
-                           &local->loc, 0, local->xattr_req);
+                             " so performing now: %s. fd_count = %d",
+                             local->loc.path,
+                             local->skip_unlink.opend_fd_count);
+                if (local->skip_unlink.opend_fd_count == 0) {
+                    FRAME_SU_DO(frame, dht_local_t);
+                    STACK_WIND(frame, dht_lookup_unlink_stale_linkto_cbk,
+                               hashed_subvol, hashed_subvol->fops->unlink,
+                               &local->loc, 0, local->xattr_req);
+                } else {
+                    /* Skip linkfile deletion, this linkfile may be in used
+                     * because its fd_count > 0 */
+                    DHT_STACK_UNWIND(lookup, frame, -1, ENOENT, NULL, NULL,
+                                     NULL, NULL);
+                }
             }
 
         } else {

--- a/xlators/cluster/dht/src/dht-linkfile.c
+++ b/xlators/cluster/dht/src/dht-linkfile.c
@@ -8,6 +8,7 @@
   cases as published by the Free Software Foundation.
 */
 
+#include <fcntl.h>
 #include <glusterfs/compat.h>
 #include "dht-common.h"
 
@@ -45,7 +46,7 @@ out:
 
 static int
 dht_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        int op_ret, int op_errno, fd_t *fd, inode_t *inode,
                         struct iatt *stbuf, struct iatt *preparent,
                         struct iatt *postparent, dict_t *xdata)
 {
@@ -147,9 +148,15 @@ dht_linkfile_create(call_frame_t *frame, fop_mknod_cbk_t linkfile_cbk,
     /* Always create as root:root. dht_linkfile_attr_heal fixes the
      * ownsership */
     FRAME_SU_DO(frame, dht_local_t);
+
+    if (!local->fd) {
+        local->fd = fd_create(loc->inode, frame->root->pid);
+        local->flags |= (O_CREAT | O_EXCL);
+    }
+
     STACK_WIND_COOKIE(frame, dht_linkfile_create_cbk, fromvol, fromvol,
-                      fromvol->fops->mknod, loc, S_IFREG | DHT_LINKFILE_MODE, 0,
-                      0, dict);
+                      fromvol->fops->create, loc, local->flags,
+                      S_IFREG | DHT_LINKFILE_MODE, 0, local->fd, dict);
 
     if (need_unref && dict)
         dict_unref(dict);

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -2462,6 +2462,17 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                                                   loc->inode->table);
         if (!op_ret) {
             linked = _gf_true;
+            /* A vaild _fd is required in posix_fdstat, which is after post_op label.
+             * So, we should open this existing linkfile here.
+             */
+            _fd = sys_open(real_path, _flags & ~O_EXCL, mode);
+            if (_fd == -1) {
+                op_errno = errno;
+                op_ret = -1;
+                gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_OPEN_FAILED,
+                       "open on %s failed", real_path);
+                goto out;
+            }
             goto post_op;
         }
     }

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -2362,6 +2362,7 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     dict_t *xdata_rsp = dict_ref(xdata);
     gf_boolean_t linked = _gf_false;
+    posix_inode_ctx_t *ctx = NULL;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -2510,15 +2511,26 @@ post_op:
     if (priv->update_pgfid_nlinks) {
         MAKE_PGFID_XATTR_KEY(pgfid_xattr_key, PGFID_XATTR_KEY_PREFIX,
                              loc->pargfid);
-        nlink_samepgfid = 1;
-        SET_PGFID_XATTR(real_path, pgfid_xattr_key, nlink_samepgfid,
-                        XATTR_CREATE, op_ret, this, ignore);
+        op_ret = posix_inode_ctx_get_all (loc->inode, this, &ctx);
+        if (op_ret < 0) {
+            op_errno = ENOMEM;
+            goto out;
+        }
+
+        pthread_mutex_lock (&ctx->pgfid_lock);
+        {
+            LINK_MODIFY_PGFID_XATTR (real_path, pgfid_xattr_key,
+                                     nlink_samepgfid, 0, op_ret,
+                                     this, unlock);
+        }
+unlock:
+        pthread_mutex_unlock (&ctx->pgfid_lock);
     }
 
     if (priv->gfid2path) {
         posix_set_gfid2path_xattr(this, real_path, loc->pargfid, loc->name);
     }
-ignore:
+
     op_ret = posix_entry_create_xattr_set(this, loc, real_path, xdata);
     if (op_ret) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -2436,11 +2436,22 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     mode_bit = (priv->create_mask & mode) | priv->force_create_mode;
     mode = posix_override_umask(mode, mode_bit);
+
+real_op:
     _fd = sys_open(real_path, _flags, mode);
 
     if (_fd == -1) {
         op_errno = errno;
         op_ret = -1;
+        if (op_errno == EEXIST) {
+            if (dict_get_sizen(xdata, GF_FORCE_REPLACE_KEY)) {
+                dict_del_sizen(xdata, GF_FORCE_REPLACE_KEY);
+                op_ret = posix_unlink_stale_linkto(frame, this, real_path, &op_errno, loc);
+
+                if (op_ret == 0)
+                    goto real_op;
+            }
+        }
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_OPEN_FAILED,
                "open on %s failed", real_path);
         goto out;

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -2361,6 +2361,7 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     };
 
     dict_t *xdata_rsp = dict_ref(xdata);
+    gf_boolean_t linked = _gf_false;
 
     DECLARE_OLD_FS_ID_VAR;
 
@@ -2437,6 +2438,32 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     mode_bit = (priv->create_mask & mode) | priv->force_create_mode;
     mode = posix_override_umask(mode, mode_bit);
 
+    /* Check if the 'gfid' already exists, because this create may be an
+       internal call from distribute for creating 'linkfile', and that
+       linkfile may be for a hardlinked file */
+    if (dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY)) {
+        dict_del_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY);
+        /* trash xlator did not bring the uuid_via the call
+         * to GFID_NULL_CHECK_AND_GOTO() above.
+         * Fetch it explicitly here.
+         */
+        if (frame->root->pid == GF_SERVER_PID_TRASH) {
+            op_ret = dict_get_gfuuid(xdata, "gfid-req", &uuid_req);
+            if (op_ret) {
+                gf_msg_debug(this->name, 0,
+                             "failed to get the gfid from dict for %s",
+                             loc->path);
+                goto real_op;
+            }
+        }
+
+        op_ret = posix_create_link_if_gfid_exists(this, uuid_req, real_path,
+                                                  loc->inode->table);
+        if (!op_ret) {
+            linked = _gf_true;
+            goto post_op;
+        }
+    }
 real_op:
     _fd = sys_open(real_path, _flags, mode);
 
@@ -2472,6 +2499,8 @@ real_op:
                "chown on %s failed", real_path);
     }
 #endif
+
+post_op:
     op_ret = posix_acl_xattr_set(real_path, xdata);
     if (op_ret) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_ACL_FAILED,
@@ -2497,14 +2526,16 @@ ignore:
     }
 
 fill_stat:
-    op_ret = posix_gfid_set(this, real_path, loc, xdata, frame->root->pid,
-                            &op_errno);
-    if (op_ret) {
-        gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_GFID_FAILED,
-               "setting gfid on %s failed", real_path);
-        goto out;
-    } else {
-        gfid_set = _gf_true;
+    if (!linked) {
+        op_ret = posix_gfid_set(this, real_path, loc, xdata, frame->root->pid,
+                                &op_errno);
+        if (op_ret) {
+            gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_GFID_FAILED,
+                   "setting gfid on %s failed", real_path);
+            goto out;
+        } else {
+            gfid_set = _gf_true;
+        }
     }
 
     op_ret = posix_fdstat(this, loc->inode, _fd, &stbuf, _gf_true);


### PR DESCRIPTION
A newly created linkfile will be deleted for the race, after this, the gfid between linkfile and datafile may get mismatched. And shards deletion process is also affected by such a mismatch, most shards in BRICK_PATH/.shard cannot be removed correctly and space cannot be release.

To fix this race, replace mknod with create during linkfile creation, in this case, we can keep this linkfile opening during the whole linkfile and datafile creations.

A linkfile will not be regarded as stale and deleted then, because its fd is opened and posix_unlink can handle it properly.

Fixes: #4548

