### PR TITLE
Fix remove subdir-objects is disabled warnings #4591

### DIFF
--- a/api/examples/Makefile.am
+++ b/api/examples/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 # The bits needed for glfsxmp
 EXTRA_PROGRAMS = glfsxmp
 glfsxmp_SOURCES = glfsxmp.c

--- a/contrib/fuse-util/Makefile.am
+++ b/contrib/fuse-util/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 bin_PROGRAMS = fusermount-glusterfs
 
 fusermount_glusterfs_SOURCES = fusermount.c mount_util.c $(CONTRIBDIR)/fuse-lib/mount-common.c

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 noinst_PYTHON = generator.py gen-defaults.py $(top_srcdir)/events/eventskeygen.py
 
 libglusterfs_la_CFLAGS = $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \

--- a/xlators/cluster/afr/src/Makefile.am
+++ b/xlators/cluster/afr/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = afr.la
 xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
 

--- a/xlators/cluster/dht/src/Makefile.am
+++ b/xlators/cluster/dht/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = dht.la nufa.la switch.la
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)

--- a/xlators/cluster/ec/src/Makefile.am
+++ b/xlators/cluster/ec/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = ec.la
 xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
 

--- a/xlators/features/changelog/src/Makefile.am
+++ b/xlators/features/changelog/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = changelog.la
 
 xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features

--- a/xlators/features/cloudsync/src/Makefile.am
+++ b/xlators/features/cloudsync/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 SUBDIRS = cloudsync-plugins
 
 xlator_LTLIBRARIES = cloudsync.la

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/Makefile.am
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 csp_LTLIBRARIES = cloudsyncs3.la
 cspdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/cloudsync-plugins
 

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/Makefile.am
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 csp_LTLIBRARIES = cloudsynccvlt.la
 cspdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/cloudsync-plugins
 

--- a/xlators/features/thin-arbiter/src/Makefile.am
+++ b/xlators/features/thin-arbiter/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = thin-arbiter.la
 
 xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features

--- a/xlators/features/utime/src/Makefile.am
+++ b/xlators/features/utime/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 xlator_LTLIBRARIES = utime.la
 xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
 

--- a/xlators/mgmt/glusterd/src/Makefile.am
+++ b/xlators/mgmt/glusterd/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 if WITH_SERVER
 xlator_LTLIBRARIES = glusterd.la
 endif

--- a/xlators/mount/fuse/src/Makefile.am
+++ b/xlators/mount/fuse/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 noinst_HEADERS_linux = $(CONTRIBDIR)/fuse-include/fuse_kernel.h\
 	$(CONTRIBDIR)/fuse-include/mount_util.h\
 	$(CONTRIBDIR)/fuse-lib/mount-gluster-compat.h


### PR DESCRIPTION
Warnings are generated when running autogen. Add
AUTOMAKE_OPTIONS = subdir-objects
to the top of Makefile.am files following
https://darmawan-salihun.blogspot.com/2015/09/makefileam-option-subdir-objects-is.html

fixes: #4591



