### PR TITLE
Fix remove subdir-objects is disabled warnings

### DIFF
--- a/xlators/features/changelog/lib/src/Makefile.am
+++ b/xlators/features/changelog/lib/src/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 libgfchangelog_la_CFLAGS = -Wall $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 	-DDATADIR=\"$(localstatedir)\"
 


### PR DESCRIPTION
Adding changelog to https://github.com/gluster/glusterfs/pull/4593

fixes: #4591 
Change-Id: Iae484e4f764db6a3e236dff7e70cf0c1a036ae45

