### PR TITLE
tests: make sure cleanup is called as expect when tests time out

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,7 @@ force="no"
 head="yes"
 retry="yes"
 tests=""
+interruptible="no"
 exit_on_failure="yes"
 skip_bad_tests="yes"
 skip_known_bugs="yes"
@@ -395,13 +396,17 @@ function run_tests()
             echo "[$(date +%H:%M:%S)] Running tests in file $t"
             starttime="$(date +%s)"
 
+            local timeout_cmd="timeout"
+            if [ ${interruptible} == "yes" ]; then
+                timeout_cmd=$(echo "$timeout_cmd --foreground")
+            fi
             local cmd_timeout=$run_timeout;
             if [ ${timeout_cmd_exists} == "yes" ]; then
                 if [ $(grep -c "SCRIPT_TIMEOUT=" ${t}) == 1 ] ; then
                     cmd_timeout=$(grep "SCRIPT_TIMEOUT=" ${t} | cut -f2 -d'=');
                     echo "Timeout set is ${cmd_timeout}, default ${run_timeout}"
                 fi
-                timeout --foreground -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
+                $timeout_cmd -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
             else
                 prove -vmfe '/bin/bash' ${t}
             fi
@@ -425,7 +430,7 @@ function run_tests()
                 echo ""
 
                 if [ ${timeout_cmd_exists} == "yes" ]; then
-                    timeout --foreground -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
+                    $timeout_cmd -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
                 else
                     prove -vmfe '/bin/bash' ${t}
                 fi
@@ -559,6 +564,7 @@ Options:
 -t  TIMEOUT
 -n  skip NFS tests
 -l  list tests that should be executed
+-i  make the running test interruptible
 --help
 EOF
 }
@@ -567,7 +573,7 @@ usage="no"
 
 function parse_args ()
 {
-    args=`getopt -u -l help frRcbkphHnlo:t: "$@"`
+    args=`getopt -u -l help frRcbkphHnlio:t: "$@"`
     if ! [ $? -eq 0 ]; then
 	show_usage
 	exit 1
@@ -588,6 +594,7 @@ function parse_args ()
         -t)    run_timeout="$2"; shift;;
         -n)    nfs_tests="no";;
         -l)    list_only="yes";;
+        -i)    interruptible="yes" ;;
         --help) usage="yes" ;;
         --)    shift; break;;
         esac

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -780,8 +780,11 @@ function cleanup()
 
 function force_terminate () {
         local ret=$?;
-        >&2 echo -e "\nreceived external"\
-                        "signal --`kill -l $ret`--, calling 'cleanup' ...\n";
+
+        # Run this cmd as a subshell and flush stdout buffer to stderr
+        # immediately.
+        (>&2 echo -e "\nreceived external"\
+                        "signal --`kill -l $ret`--, calling 'cleanup' ...\n");
         cleanup;
         exit $ret;
 }


### PR DESCRIPTION
Modification includes:
1. change 'echo' cmd in function force_terminate as a subshell, to ensure immediate buffer flush. Otherwise, extra stdout buffer in function cleanup may be redirected to stderr, in such a case, function call in cleanup may get something wrong.
2. change --foreground as a optional setting, since it affects signal detection and cleanup procedure.

With this patch, by default, even if the use case times out, the cleanup process will proceed as expected. And the test env always keep clean after testcase exits.

Fixes: #4610

Related patches:
run-tests.sh: stop test on Ctrl-C
https://github.com/gluster/glusterfs/commit/1f03309f3f7a251de26c10cfc8a64650a20a2790

tests: call cleanup on receiving external signals INT, TERM and HUP
https://github.com/gluster/glusterfs/commit/ea980a8a55238f50089a2adcd938a55443249d23

