### PR TITLE
Fix: Correct initialization of size_t variable to avoid overflow

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -6323,7 +6323,7 @@ glfs_anonymous_pwritev(struct glfs *fs, struct glfs_object *object,
     inode_t *inode = NULL;
     fd_t *fd = NULL;
     int ret = -1;
-    size_t size = -1;
+    size_t size = 0;
 
     DECLARE_OLD_THIS;
     __GLFS_ENTRY_VALIDATE_FS(fs, invalid_fs);

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -981,7 +981,7 @@ iobuf_copy(struct iobuf_pool *iobuf_pool, const struct iovec *iovec_src,
            int iovcnt, struct iobref **iobref, struct iobuf **iobuf,
            struct iovec *iov_dst)
 {
-    size_t size = -1;
+    size_t size = 0;
     int ret = 0;
 
     size = iov_length(iovec_src, iovcnt);


### PR DESCRIPTION
In the functions `glfs_anonymous_pwritev` and `iobuf_copy`, the `size_t` variable `size` was incorrectly initialized to `-1`, causing an overflow when assigned to a `size_t` (an unsigned type).

This commit updates the initialization to `0`, ensuring proper handling of size values and preventing potential bugs related to the overflow.

