### PR TITLE
Fix memleak in syncargs errstr

### DIFF
--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -1353,6 +1353,7 @@ ec_manager_readv(ec_fop_data_t *fop, int32_t state)
 {
     ec_cbk_data_t *cbk;
     ec_t *ec = fop->xl->private;
+    uintptr_t inode_read_mask;
 
     switch (state) {
         case EC_STATE_INIT:
@@ -1372,8 +1373,8 @@ ec_manager_readv(ec_fop_data_t *fop, int32_t state)
             return EC_STATE_DISPATCH;
 
         case EC_STATE_DISPATCH:
-            uintptr_t inode_read_mask = ec_inode_readmask_get(fop->fd->inode,
-                                                              fop->xl);
+            inode_read_mask = ec_inode_readmask_get(fop->fd->inode,
+                                                    fop->xl);
             if (inode_read_mask != 0) {
                 fop->mask &= inode_read_mask;
             } else if (ec->read_mask) {

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5513,8 +5513,7 @@ out:
     }
     if (args.dict)
         dict_unref(args.dict);
-    if (args.errstr)
-        GF_FREE(args.errstr);
+    gd_syncargs_fini(&args);
 
     return ret;
 }

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -1595,8 +1595,10 @@ gd_syncop_mgmt_brick_op(struct rpc_clnt *rpc, glusterd_pending_node_t *pnode,
     if (args.errstr) {
         if ((strlen(args.errstr) > 0) && errstr)
             *errstr = args.errstr;
-        else
+        else {
             GF_FREE(args.errstr);
+            args.errstr = NULL;
+        }
     }
 
     if (GD_OP_STATUS_VOLUME == op) {
@@ -1646,6 +1648,7 @@ out:
         }
     }
     gd_brick_op_req_free(req);
+    gd_syncargs_fini(&args);
     return args.op_ret;
 }
 
@@ -1873,6 +1876,7 @@ gd_lock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, dict_t *op_ctx,
                  "to %d peers. Returning %d",
                  gd_op_list[op], peer_cnt, ret);
 out:
+    gd_syncargs_fini(&args);
     return ret;
 }
 

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -130,6 +130,10 @@ gd_syncargs_fini(struct syncargs *args)
         pthread_mutex_destroy(&args->lock_dict);
         syncbarrier_destroy(&args->barrier);
     }
+    if (args->errstr) {
+        GF_FREE(args->errstr);
+        args->errstr = NULL;
+    }
 }
 
 static void


### PR DESCRIPTION
The memory allocated for `args->errstr` via `gf_strdup` must be explicitly freed before the function returns or at the appropriate cleanup point.