### PR TITLE
afr:prevent null pointer access in afr_notify

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -6397,7 +6397,6 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
             }
         }
     }
-    UNLOCK(&priv->lock);
 
     if (priv->quorum_count) {
         has_quorum = afr_has_quorum(priv->child_up, priv, NULL);
@@ -6414,6 +6413,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
                      this->ctx->cmd_args.client_pid, this->name);
         }
     }
+    UNLOCK(&priv->lock);
 
     /* if all subvols have reported status, no need to hide anything
        or wait for anything else. Just propagate blindly */


### PR DESCRIPTION
Add a check for the `this->cleanup_starting` flag at the beginning of `afr_notify()` to skip notifications for volumes that are undergoing finalization (`fini`). This prevents `afr_has_quorum` from accessing already freed `this->private`.

Fix: #4644 