### PR TITLE
Fix memory leak in gfapi pub_glfs_h_acl_set()

### DIFF
--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -2412,9 +2412,10 @@ pub_glfs_h_acl_set(struct glfs *fs, struct glfs_object *object,
     ret = pub_glfs_h_setxattrs(fs, new_object, acl_key, acl_s,
                                strlen(acl_s) + 1, 0);
 
-    acl_free(acl_s);
 
 out:
+    if (acl_s)
+        acl_free(acl_s);
     if (IA_ISLNK(object->inode->ia_type) && new_object)
         glfs_h_close(new_object);
 


### PR DESCRIPTION
One of the code paths in **pub_glfs_h_acl_set()** can allocate memory for the acl string representation but not free it. This is caused when the IA\_ISLNK condition is true then **new\_object** is false, and the flow jumps to the label out.

We move the string cleanup to it's proper position, under the
label, and guard it with the non-null check. This way all the paths should deallocate the acl string properly.

