### PR TITLE
Fix dangling pointer glusterd_ac_send_friend_remove_req()

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -1391,6 +1391,8 @@ glusterd_destroy_friend_event_context(glusterd_friend_sm_event_t *event)
     if (!event)
         return;
 
+    GF_FREE(event->peername);
+
     switch (event->event) {
         case GD_FRIEND_EVENT_RCVD_FRIEND_REQ:
         case GD_FRIEND_EVENT_RCVD_REMOVE_FRIEND:
@@ -1463,6 +1465,7 @@ glusterd_friend_sm(void)
                        " event %s with empty peer info",
                        glusterd_friend_sm_event_name_get(event_type));
 
+                glusterd_destroy_friend_event_context(event);
                 GF_FREE(event);
                 continue;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -479,7 +479,7 @@ glusterd_ac_send_friend_remove_req(glusterd_friend_sm_event_t *event,
         ret = glusterd_friend_sm_new_event(event_type, &new_event);
 
         if (!ret) {
-            new_event->peername = peerinfo->hostname;
+            new_event->peername = gf_strdup(peerinfo->hostname);
             gf_uuid_copy(new_event->peerid, peerinfo->uuid);
             ret = glusterd_friend_sm_inject_event(new_event);
         } else {


### PR DESCRIPTION
In `glusterd-sm.c` we always use use gf_strdup when assigning
the peername, preventing a potential crash or invalid memory access

But glusterd_ac_send_friend_remove_req() was inadvertely
assigning directly, without using `strdup`, causing a dangling pointer
problem which could potentially crash the application.

Since glusterd_ac_send_friend_remove_req() now uses gf_strdup()
to assign event->peername, the event destructor must free it.
Add GF_FREE(event->peername) to glusterd_destroy_friend_event_context()
which is the canonical cleanup path for all friend SM events.

Also call glusterd_destroy_friend_event_context() on the early-exit
path in glusterd_friend_sm() (peerinfo not found), which was calling
GF_FREE(event) directly and leaking the peername string.

The first commit fixes that problem by using the `strdup()` pattern
instead of the dangerous direct assignment.

The second address the memory leak introduced by the first, with a
consistend pattern.

