### PR TITLE
Fix dead assignemnt in glfs_h_create_from_handle (clang-check)

### DIFF
--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -1501,7 +1501,6 @@ found:
     object = GF_CALLOC(1, sizeof(struct glfs_object), glfs_mt_glfs_object_t);
     if (object == NULL) {
         errno = ENOMEM;
-        ret = -1;
         goto out;
     }
 


### PR DESCRIPTION

A dead asssignment flagged by clang in glfs_h_create_from_handle
occurs under the label 'found' when GF_CALLOC fails, when 'ret = -1' but
in that path we end up bailing out and never using that value. Since we
do not even return this value, the fix is just remove this dead line.
