### PR TITLE
Fix dead assignment in glfs_h_poll_cache_invalidation (clang-check)

### DIFF
--- a/api/src/glfs-handleops.c
+++ b/api/src/glfs-handleops.c
@@ -2117,7 +2117,6 @@ glfs_h_poll_cache_invalidation(struct glfs *fs, struct glfs_upcall *up_arg,
              * have got removed. We still need to send upcall
              * for the file/dir and current parent handles. */
             up_inode_arg->oldp_object = NULL;
-            ret = 0;
         }
 
         glfs_iatt_to_stat(fs, &ca_data->oldp_stat, &up_inode_arg->oldp_buf);


### PR DESCRIPTION

A dead asssignment flagged by clang in glfs_h_poll_cache_invalidation
when 'ret = 0' but in the succes path we assign the same value again,
without ever using the previous value. We fix by remove this dead line.