### PR TITLE
Fix dead assignment in glfs_h_resolve_symlink (clang-check)

### DIFF
--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -1204,7 +1204,6 @@ glfs_h_resolve_symlink(struct glfs *fs, struct glfs_object *object)
 
     subvol = glfs_active_subvol(fs);
     if (!subvol) {
-        ret = -1;
         errno = EIO;
         goto out;
     }


### PR DESCRIPTION

When `glfs_active_subvol(fs)` fails, we set `ret = -1` but then
go to out: without ever using the assigned value again. The fix removes
this dead line because the  exit path which follows does not use it.

Signed-off-by: Thales Antunes de Oliveira Barretto <thales.barretto.git@gmail.com>