### PR TITLE
Fix dead assignment in glfs_resolve_component (clang-check)

### DIFF
--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -400,7 +400,6 @@ glfs_resolve_component(struct glfs *fs, xlator_t *subvol, inode_t *parent,
 
     glret = priv_glfs_loc_touchup(&loc);
     if (glret < 0) {
-        ret = -1;
         goto out;
     }
 


### PR DESCRIPTION

In the path were priv_glfs_loc_touchup(&loc) fails, we goto out
and the value we have just assigned, 'ret = -1' is actually never used
in this path again. This fixes it by just removing the dead code line.