### PR TITLE
ci: reconstruct former external jobs for GitLab runners

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,68 @@
+name: PR Commands
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  recheck-smoke:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/recheck smoke' &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch smoke workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.issue.number;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'smoke.yml',
+              ref: pr.data.base.ref,
+              inputs: {
+                git_ref: pr.data.head.sha
+              }
+            });
+
+  run-regression:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/run regression' &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch regression workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.issue.number;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'regression.yml',
+              ref: pr.data.base.ref,
+              inputs: {
+                git_ref: pr.data.head.sha,
+                mode: 'full'
+              }
+            });

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,110 @@
+name: Regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Git ref to test
+        required: false
+        type: string
+      mode:
+        description: Regression mode
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+
+permissions:
+  contents: read
+
+jobs:
+  full-regression:
+    if: inputs.mode == 'full'
+    name: regression / ubuntu
+    runs-on: ubuntu-latest
+    env:
+      HEAL_TIMEOUT: 160
+      IO_HEAL_TIMEOUT: 240
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.sha }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            acl \
+            attr \
+            automake \
+            bison \
+            build-essential \
+            dbench \
+            flex \
+            gettext \
+            libacl1-dev \
+            libaio-dev \
+            libattr1-dev \
+            libcurl4-openssl-dev \
+            libgoogle-perftools-dev \
+            libibverbs-dev \
+            libreadline-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libtirpc-dev \
+            libtool \
+            liburing-dev \
+            liburcu-dev \
+            libxml2-dev \
+            libxxhash-dev \
+            lvm2 \
+            nfs-common \
+            pkg-config \
+            python3 \
+            python3-pip \
+            rpcsvc-proto \
+            sqlite3 \
+            uuid-dev \
+            xfsprogs \
+            yajl-tools
+
+      - name: Configure build
+        run: |
+          ./autogen.sh
+          ./configure --prefix=/usr/local
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Install
+        run: |
+          if [ "$(id -u)" -eq 0 ]; then
+            make install
+          else
+            sudo -E make install
+          fi
+
+      - name: Run full regression
+        run: |
+          if [ "$(id -u)" -eq 0 ]; then
+            ./run-tests.sh
+          else
+            sudo -E ./run-tests.sh
+          fi
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          mkdir -p ci-artifacts
+          test -f /tmp/gluster_regression.txt && cp /tmp/gluster_regression.txt ci-artifacts/ || true
+          test -d /var/log/glusterfs && cp -a /var/log/glusterfs ci-artifacts/ || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-ubuntu-artifacts
+          path: ci-artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -1,0 +1,96 @@
+name: RPM Build
+
+on:
+  pull_request:
+    branches:
+      - devel
+  push:
+    branches:
+      - devel
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Git ref to test
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-fedora-rpm:
+    name: rpm / fedora-container
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:39
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.event.pull_request.head.sha || github.sha }}
+
+      - name: Locate source root
+        run: |
+          src_dir="$(dirname "$(find "${PWD}" -name configure.ac | head -n1)")"
+          test -n "$src_dir"
+          echo "GLUSTER_SRC_DIR=$src_dir" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: |
+          cd "$GLUSTER_SRC_DIR"
+          dnf install -y \
+            autoconf \
+            automake \
+            bison \
+            dnf-plugins-core \
+            diffutils \
+            flex \
+            gcc \
+            gcc-c++ \
+            gperftools-devel \
+            libacl-devel \
+            libaio-devel \
+            libattr-devel \
+            libcurl-devel \
+            libtool \
+            libtirpc-devel \
+            liburing-devel \
+            libuuid-devel \
+            libxml2-devel \
+            make \
+            ncurses-devel \
+            openssl \
+            openssl-devel \
+            python3 \
+            rpm-build \
+            rpcgen \
+            readline-devel \
+            userspace-rcu-devel \
+            which
+
+      - name: Build source tarball
+        run: |
+          cd "$GLUSTER_SRC_DIR"
+          ./autogen.sh
+          ./configure --prefix=/usr/local
+          dnf builddep -y ./glusterfs.spec
+          make dist
+
+      - name: Build RPMs
+        run: |
+          cd "$GLUSTER_SRC_DIR"
+          make -C extras/LinuxRPM glusterrpms_without_autogen
+
+      - name: Collect RPM artifacts
+        if: always()
+        run: |
+          mkdir -p ci-artifacts
+          find "$GLUSTER_SRC_DIR/extras/LinuxRPM" -type f \( -name '*.rpm' -o -name '*.src.rpm' \) -exec cp {} ci-artifacts/ \; || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-fedora-artifacts
+          path: ci-artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,169 @@
+name: Smoke
+
+on:
+  pull_request:
+    branches:
+      - devel
+  push:
+    branches:
+      - devel
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Git ref to test
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: smoke / ubuntu
+    runs-on: ubuntu-latest
+    env:
+      HEAL_TIMEOUT: 160
+      IO_HEAL_TIMEOUT: 240
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            acl \
+            attr \
+            automake \
+            bison \
+            build-essential \
+            dbench \
+            flex \
+            gettext \
+            libacl1-dev \
+            libaio-dev \
+            libattr1-dev \
+            libcurl4-openssl-dev \
+            libgoogle-perftools-dev \
+            libibverbs-dev \
+            libreadline-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libtirpc-dev \
+            libtool \
+            liburing-dev \
+            liburcu-dev \
+            libxml2-dev \
+            libxxhash-dev \
+            lvm2 \
+            nfs-common \
+            pkg-config \
+            python3 \
+            python3-pip \
+            rpcsvc-proto \
+            sqlite3 \
+            uuid-dev \
+            xfsprogs \
+            yajl-tools
+
+      - name: Configure build
+        run: |
+          ./autogen.sh
+          ./configure --prefix=/usr/local
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Install
+        run: |
+          if [ "$(id -u)" -eq 0 ]; then
+            make install
+          else
+            sudo -E make install
+          fi
+
+      - name: Run smoke tests
+        run: |
+          mapfile -t smoke_tests < <(
+            for pattern in \
+              tests/basic/*.t \
+              tests/basic/afr/*.t \
+              tests/basic/distribute/*.t \
+              tests/bugs/fb*.t \
+              tests/features/brick-min-free-space.t
+            do
+              for test_file in $pattern
+              do
+                [ -f "$test_file" ] || continue
+                if grep -q '^#G_TESTDEF_TEST_STATUS_CENTOS6=NFS_TEST$' "$test_file"; then
+                  continue
+                fi
+                if grep -q 'nfs\.disable' "$test_file"; then
+                  continue
+                fi
+                if grep -q 'thin-arbiter\.rc' "$test_file"; then
+                  continue
+                fi
+                if grep -q '/tmp/cdcdump\.gz' "$test_file"; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/exports_parsing.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/afr/gfid-mismatch-resolution-with-cli.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/gfproxy.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/graph-cleanup-brick-down-shd-mux.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/ios-dump.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/multiple-volume-shd-mux.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/netgroup_parsing.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/op_errnos.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/shd-mux-afr.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/shd-mux-ec.t" ]; then
+                  continue
+                fi
+                if [ "$test_file" = "tests/basic/quick-read-with-upcall.t" ]; then
+                  continue
+                fi
+                printf '%s\n' "$test_file"
+              done
+            done | sort -u
+          )
+
+          if [ "$(id -u)" -eq 0 ]; then
+            ./run-tests.sh "${smoke_tests[@]}"
+          else
+            sudo -E ./run-tests.sh "${smoke_tests[@]}"
+          fi
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          mkdir -p ci-artifacts
+          test -f /tmp/gluster_regression.txt && cp /tmp/gluster_regression.txt ci-artifacts/ || true
+          test -d /var/log/glusterfs && cp -a /var/log/glusterfs ci-artifacts/ || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-ubuntu-artifacts
+          path: ci-artifacts/
+          if-no-files-found: ignore

--- a/doc/ci/github-actions.md
+++ b/doc/ci/github-actions.md
@@ -1,0 +1,113 @@
+# GitHub Actions CI
+
+This document describes the GitHub Actions workflows in `.github/workflows/`.
+
+## What it does
+
+The repository uses three workflow entrypoints:
+
+- `Smoke`
+  - runs smoke tests on pull requests targeting `devel`
+  - runs the same smoke jobs on pushes to `devel`
+- `RPM Build`
+  - validates the RPM build path in a Fedora container on pull requests targeting `devel`
+  - runs again on pushes to `devel`
+- `Regression`
+  - runs heavier jobs only when dispatched manually
+
+There is also a `PR Commands` workflow that turns pull request comments into
+workflow dispatches.
+
+## Workflows
+
+### `smoke.yml`
+
+Runs one smoke job on `ubuntu-latest`.
+
+Each job:
+
+1. checks out the requested ref
+2. runs `autogen.sh`
+3. installs the development libraries needed for the default shipped configure path
+4. runs `configure --prefix=/usr/local`
+5. builds Gluster
+6. installs it
+7. runs the smoke selection with `run-tests.sh`
+8. uploads regression output and Gluster logs when available
+
+The smoke selection is:
+
+- `tests/basic/*.t`
+- `tests/basic/afr/*.t`
+- `tests/basic/distribute/*.t`
+- `tests/bugs/fb*.t`
+- `tests/features/brick-min-free-space.t`
+
+### `rpm-build.yml`
+
+Runs the packaging validation path in a Fedora container on `ubuntu-latest`:
+
+1. checks out the requested ref
+2. installs Fedora build dependencies from `glusterfs.spec`
+3. runs `autogen.sh`
+4. runs `configure --prefix=/usr/local`
+5. runs `make dist`
+6. runs `make -C extras/LinuxRPM glusterrpms_without_autogen`
+7. uploads generated RPMs when present
+
+### `regression.yml`
+
+Runs only by manual dispatch and currently supports one mode:
+
+- `full`
+
+`full` runs local `run-tests.sh` on `ubuntu-latest`.
+
+## PR comment commands
+
+`pr-commands.yml` accepts these pull request comments:
+
+- `/recheck smoke`
+  - dispatches `smoke.yml` against the PR head SHA
+- `/run regression`
+  - dispatches `regression.yml` with `mode=full` against the PR head SHA
+
+Only trusted users can trigger these commands:
+
+- `/recheck smoke`
+  - `OWNER`, `MEMBER`, or `COLLABORATOR`
+- `/run regression`
+  - `OWNER` or `MEMBER`
+
+## Trigger policy
+
+- Pull requests to `devel`
+  - run smoke and RPM validation automatically
+- Pushes to `devel`
+  - run smoke and RPM validation automatically
+- Full regression
+  - manual only
+
+## Runner requirements
+
+The workflows use GitHub-hosted runners:
+
+- `ubuntu-latest` for build, smoke, and manual regression
+- a Fedora container inside `ubuntu-latest` for RPM validation
+
+These jobs still require:
+
+- `sudo` for install and test steps on Ubuntu jobs
+- local daemon startup and mount operations required by `run-tests.sh`
+
+## Current scope
+
+These workflows cover the GitHub-hosted subset of the old CI model:
+
+- automatic smoke on pull requests
+- automatic smoke and RPM validation on pushes to `devel`
+- comment-triggered smoke rechecks
+- comment-triggered manual full regression
+
+They do not attempt to recreate the former dedicated multi-host regression
+hardware inside GitHub-hosted Actions.


### PR DESCRIPTION
## What this does
Adds a `.gitlab-ci.yml` and a short reconstruction note that map the repository's documented historical CI flow onto GitLab runners.

## Why this shape
The repository still contains several strong hints about the former system:
- `README.md` still links to the CentOS CI `gluster_build-rpms` job.
- `CONTRIBUTING.md` says smoke tests were auto-triggered, while regression required `/run regression`.
- `extras/distributed-testing/` documents a multi-host regression runner because the full suite was too slow on one machine.
- `geo-replication/tox.ini` still has a Jenkins profile.

From that, the most defensible reconstruction is:
- auto smoke jobs on maintained OS targets
- RPM/build validation on CentOS-backed runners
- manual full regression on dedicated hardware
- optional sanitizer/valgrind runs on the distributed pool

## Notes
This does not claim exact parity with the retired CentOS CI/Jenkins wiring. It reconstructs the control flow and job split that the repository still documents.