### PR TITLE
libglusterfs: fix memory leak in gf_set_volfile_server_common

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -3089,6 +3089,9 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
             /* Duplicate option given, log and ignore */
             gf_smsg("gluster", GF_LOG_INFO, EEXIST, LG_MSG_DUPLICATE_ENTRY,
                     NULL);
+            GF_FREE(server->volfile_server);
+            GF_FREE(server->transport);
+            GF_FREE(server);
             ret = 0;
             goto out;
         }


### PR DESCRIPTION
Problem:
When gf_set_volfile_server_common() is called with a duplicate volfile server configuration, the function detects the duplicate and returns success (ret = 0). However, the newly allocated memory for server struct (server->volfile_server, server->transport, and server itself) is not freed before returning, causing a memory leak.

Solution:
Add GF_FREE() calls to release the allocated memory before returning on duplicate detection path.

