### PR TITLE
gfapi: prevent use-after-free from concurrent open during fini

### DIFF
--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -208,6 +208,7 @@ struct glfs {
     struct list_head openfds;
 
     gf_boolean_t migration_in_progress;
+    gf_boolean_t shutting_down; /* set at glfs_fini entry, before drain */
 
     gf_boolean_t cache_upcalls; /* add upcalls to the upcall_list? */
     struct list_head upcall_list;
@@ -435,6 +436,10 @@ glfs_process_upcall_event(struct glfs *fs, void *data)
     do {                                                                       \
         if (!fs) {                                                             \
             errno = EINVAL;                                                    \
+            goto label;                                                        \
+        }                                                                      \
+        if (fs->shutting_down) {                                               \
+            errno = ESHUTDOWN;                                                 \
             goto label;                                                        \
         }                                                                      \
         old_THIS = THIS;                                                       \

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -1042,6 +1042,17 @@ priv_glfs_active_subvol(struct glfs *fs)
 
     glfs_lock(fs, _gf_true);
     {
+        /* Authoritative shutdown check under mutex.  The early check
+         * in __GLFS_ENTRY_VALIDATE_FS is racy (no mutex); this one
+         * is the gate that prevents any operation from proceeding
+         * after glfs_fini sets shutting_down.
+         */
+        if (fs->shutting_down) {
+            glfs_unlock(fs);
+            errno = ESHUTDOWN;
+            return NULL;
+        }
+
         subvol = __glfs_active_subvol(fs);
 
         if (subvol)

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -1272,6 +1272,22 @@ pub_glfs_fini(struct glfs *fs)
 
     call_pool = fs->ctx->pool;
 
+    /* Prevent new operations from entering the xlator stack.
+     * Without this, glfs_open() and other entry points can create
+     * file descriptors on a graph that is about to be torn down,
+     * leading to use-after-free.  The flag is checked (without the
+     * mutex) in __GLFS_ENTRY_VALIDATE_FS for fast rejection and
+     * (under the mutex) in priv_glfs_active_subvol as the
+     * authoritative gate.
+     */
+    pthread_mutex_lock(&fs->mutex);
+    {
+        fs->shutting_down = _gf_true;
+        pthread_cond_broadcast(&fs->cond);
+        __GLFS_SYNCTASK_WAKE(fs);
+    }
+    pthread_mutex_unlock(&fs->mutex);
+
     /* Wake up any suspended synctasks */
     while (!list_empty(&fs->waitq)) {
         waittask = list_entry(fs->waitq.next, struct synctask, waitq);
@@ -1313,7 +1329,32 @@ pub_glfs_fini(struct glfs *fs)
     pthread_mutex_unlock(&fs->mutex);
 
     if (fs_init != 0) {
-        subvol = glfs_active_subvol(fs);
+        /* Read active_subvol directly — priv_glfs_active_subvol
+         * would reject us because shutting_down is set.  We only
+         * need the current graph for teardown, not a graph switch.
+         * Mirror the old_subvol handling from priv_glfs_active_subvol
+         * so a pending old graph still gets its PARENT_DOWN.
+         */
+        {
+            xlator_t *old_subvol = NULL;
+
+            pthread_mutex_lock(&fs->mutex);
+            {
+                subvol = fs->active_subvol;
+                if (subvol)
+                    subvol->winds++;
+                if (fs->old_subvol) {
+                    old_subvol = fs->old_subvol;
+                    fs->old_subvol = NULL;
+                    old_subvol->switched = 1;
+                }
+            }
+            pthread_mutex_unlock(&fs->mutex);
+
+            if (old_subvol)
+                glfs_subvol_done(fs, old_subvol);
+        }
+
         if (subvol) {
             /* PARENT_DOWN within glfs_subvol_done() is issued
                only on graph switch (new graph should activiate


### PR DESCRIPTION
## Summary

Add a `shutting_down` flag to `struct glfs` that prevents new gfapi operations from entering the xlator stack after `glfs_fini()` begins teardown. Without this, `glfs_open()` and 30+ other entry points can create file descriptors on a graph being torn down, causing use-after-free.

Fixes: #4666

## Problem

`__GLFS_ENTRY_VALIDATE_FS` checks only `if (!fs)` — there is no shutdown gate. `glfs_fini()` does not set any flag at entry; `ctx->cleanup_started` is set inside the drain loop only after `call_pool->cnt` reaches 0. A concurrent `glfs_open()` passes validation, gets a subvol reference, and creates an fd on inodes that `inode_table_destroy_all` is about to destroy.

This race has been known informally for 10+ years (see #404, filed 2018, closed stale). The drain loop comment at `glfs.c:1303` — "leaked frames may exist, we ignore" — acknowledges the symptom. A TLA+ formal model proves the race exists at protocol level (invariant violation at depth 5 with 19 distinct states). The real C code is worse than the model — no flag is set at fini entry at all.

## Changes

**`api/src/glfs-internal.h`**
- Add `gf_boolean_t shutting_down` to `struct glfs`
- Check `fs->shutting_down` in `__GLFS_ENTRY_VALIDATE_FS` (fast path, no mutex — safe because the flag is monotonic: only transitions false to true)

**`api/src/glfs-resolve.c`**
- Check `fs->shutting_down` under mutex in `priv_glfs_active_subvol` (authoritative gate — every gfapi entry point flows through here)

**`api/src/glfs.c`**
- Set `fs->shutting_down = _gf_true` at the top of `pub_glfs_fini`, before the drain loop, under mutex with cond broadcast to wake any waiting threads
- Replace `glfs_fini`'s call to `glfs_active_subvol` (which would now be rejected) with a direct `fs->active_subvol` read under mutex, mirroring the `old_subvol` handling from `priv_glfs_active_subvol`

Cleanup paths (`glfs_fd_destroy`, `glfs_subvol_done`) use `glfs_lock` with `_gf_false` and are unaffected.

## Scope

This patch addresses **Bug A** from #4666 (no new operations after fini starts). **Bug B** (in-flight operations between drain-loop exit and graph destruction) is a separate, more complex fix requiring a barrier or re-check mechanism.

## Test plan

- [ ] Verify `make check` passes (cmocka unit tests)
- [ ] Verify regression test `tests/basic/gfapi/` suite passes
- [ ] Multi-threaded gfapi test: concurrent `glfs_open`/`glfs_fini` from two threads no longer crashes
- [ ] Verify `glfs_open` after `glfs_fini` returns `NULL` with `errno == ESHUTDOWN`
- [ ] Verify normal single-threaded lifecycle (`glfs_new` -> `glfs_init` -> `glfs_open` -> `glfs_close` -> `glfs_fini`) is unaffected

## Related

- #404 — "Implement proper cleanup sequence" (the 2018 design issue, closed stale)
- #4644 — `afr_notify` null deref during fini (open, same family)
- #4527 — Don't fire timer callback during cleanup (open, different layer — timer infrastructure vs gfapi entry points)
- Samba MR !4474 — Samba-side fix that enforces the fd-close-before-fini contract; this patch provides the libgfapi-side enforcement

## Formal verification

The TLA+ model and verification instructions are in the issue: #4666

## Update (2026-09-21)

**Update (2026-09-21, reopened):** rebased onto current `devel`; the change itself is unchanged.

What has been learned since this was filed, so the claim is stated precisely:

- The race this gate closes needs a caller that is still issuing gfapi calls while another thread runs
  `glfs_fini()`. `glfs.h` does not document that ordering requirement and the entry-point validation does not
  enforce it, so the failure mode is a use-after-free inside the library rather than an error return. The race
  was shown reachable in the TLA+ model referenced in #4666; it has not been reproduced as a crash on hardware
  (the runtime races found in this area since are different defects, below).
- Two other teardown defects in `glfs_fini()` were found while verifying this fix under ThreadSanitizer and are
  handled separately: the CHILD_DOWN handshake reads `graph->used` under `fs->mutex` while protocol/client writes
  it under `graph->mutex` (a data race with benign effect, fix to follow as its own series), and a timer-cancel
  refcount error in rpc-clnt that can free the connection under `glfs_fini()` (the cause of the observed hangs;
  addressed by the timer-cancel work referenced from #4679). This gate neither causes nor fixes those; it composes
  with both fixes (the combination was built and run through the gfapi test set).
- The fd drain (#4669) does not depend on this gate; the two can be reviewed and merged independently.
