### PR TITLE
Fixes: #4673 dht: fix wrong free of borrowed pointer in init error path

### DIFF
--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -838,7 +838,6 @@ err:
 
         GF_FREE(conf->defrag);
 
-        GF_FREE(conf->xattr_name);
         GF_FREE(conf->link_xattr_name);
         GF_FREE(conf->wild_xattr_name);
         GF_FREE(conf->mds_xattr_key);


### PR DESCRIPTION
Fixes: #4673

`dht_init()` error path calls `GF_FREE(conf->xattr_name)` on a pointer that was
never heap-allocated. `GF_OPTION_INIT("xattr-name", conf->xattr_name, str, err)`
stores a borrowed pointer via the `pass()` conversion function
(`libglusterfs/src/options.c:1314: *out = in`) — it points either to
`opt->default_value` (a `.rodata` string literal `"trusted.glusterfs.dht"`) or to
dict-internal storage from `dict_get_str()`. Neither is caller-owned.

When `__gf_free()` is called on this pointer, it subtracts `GF_MEM_HEADER_SIZE`
and interprets the preceding memory as a `struct mem_header` — reading garbage.
The `GF_ASSERT` on the magic field fires but continues (SIGCONT), leading to heap
metadata corruption.

`dht_fini()` correctly does not free this pointer. The four derived xattr names
(`link_xattr_name`, `wild_xattr_name`, `mds_xattr_key`, `commithash_xattr_name`)
are allocated via `gf_asprintf` and correctly freed in both paths — the asymmetry
between the borrowed base name and the owned derived names is what caused the bug.

The line was introduced in 76bc5d1b2d (2013, "dht: make DHT xattr names
configurable") when the `xattr-name` option was added for a tiering vision. That
commit added `conf->xattr_name` alongside two `gf_asprintf`'d derived names and
freed all three uniformly in the error block — not realizing `GF_OPTION_INIT str`
returns a borrowed pointer while `gf_asprintf` returns an owned one. The tiering
feature was later removed (2019–2020) but the option itself cannot be deleted
because `dht_init` calls `GF_OPTION_INIT("xattr-name", ...)` unconditionally —
removing it from `dht_options[]` would break volume startup.

Fix: delete the wrong `GF_FREE`. One-line change, no functional impact.