### PR TITLE
cli: fix memory leak in volume status detail (#4292)

### DIFF
--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -7601,8 +7601,12 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
             cli_print_brick_status(&status);
         }
 
-        /* Allocatated memory using gf_asprintf*/
         GF_FREE(status.pid_str);
+        status.pid_str = NULL;
+        GF_FREE(status.free);
+        status.free = NULL;
+        GF_FREE(status.total);
+        status.total = NULL;
     }
     cli_out(" ");
 
@@ -7615,6 +7619,9 @@ out:
     if (dict)
         dict_unref(dict);
     GF_FREE(status.brick);
+    GF_FREE(status.pid_str);
+    GF_FREE(status.free);
+    GF_FREE(status.total);
     if (local && wipe_local) {
         cli_local_wipe(local);
     }


### PR DESCRIPTION
## Ownership model

[`cli_volume_status_t`](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli.h#L174-L189) has seven pointer fields with two different ownership models:

**Owned** (heap-allocated, caller must free):
- `brick` — `GF_MALLOC` before the loop
- `pid_str` — `gf_asprintf` [each iteration](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-rpc-ops.c#L7587-L7589)
- `free`, `total` — [`gf_uint64_2human_readable`](https://github.com/gluster/glusterfs/blob/ae1d69672f/libglusterfs/src/common-utils.c#L1396-L1429) inside [`cli_get_detail_status`](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-cmd-volume.c#L2336-L2345)

**Borrowed** (point into dict internals, released by `dict_unref` at `out:`):
- `fs_name`, `mount_options`, `device`, `inode_size` — all from `dict_get_str`

## The bug

`status` is [declared once](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-rpc-ops.c#L7343) outside the loop with `= {0}`. Each iteration overwrites the owned pointers with new heap allocations. Before this fix, only `pid_str` was freed inside the loop body and only `brick` at the [`out:` label](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-rpc-ops.c#L7614-L7618). The other two owned fields (`free`, `total`) were overwritten each iteration — previous values lost, two strings leaked per brick. The reporter's ASan trace confirms 144 bytes in 4 allocations (2 calls × 2 bricks).

## What the fix does

1. **`free` and `total` freed in the loop** — matching what was already done for `pid_str`.

2. **`pid_str`, `free`, `total` freed at `out:`** — covers the two `goto out` error paths mid-iteration ([`gf_asprintf` failure](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-rpc-ops.c#L7591-L7592) and [`cli_get_detail_status` failure](https://github.com/gluster/glusterfs/blob/ae1d69672f/cli/src/cli-rpc-ops.c#L7596-L7597)) where the current iteration's allocations haven't been freed yet.

3. **Explicit NULLing after each in-loop `GF_FREE`** — on the normal path the loop finishes, execution falls through `cont:` to `out:`, which calls `GF_FREE` on the same pointers. Without NULLing that's a double-free; with it, `GF_FREE(NULL)` is a no-op.

Fixes: #4292