### PR TITLE
afr: fix heard_from_all aggregation using child_up[] instead of last_event[]

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -6227,7 +6227,6 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
 {
     afr_private_t *priv = NULL;
     xlator_t *child_xlator = NULL;
-    int i = -1;
     int propagate = 0;
     int had_heard_from_all = 0;
     int have_heard_from_all = 0;
@@ -6383,18 +6382,10 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
                of events from all subvolumes. If at least one subvol
                had come up, propagate CHILD_UP, but only this time
             */
-            event = GF_EVENT_CHILD_DOWN;
-            for (i = 0; i < priv->child_count; i++) {
-                if (priv->last_event[i] == GF_EVENT_CHILD_UP) {
-                    event = GF_EVENT_CHILD_UP;
-                    break;
-                }
-
-                if (priv->last_event[i] == GF_EVENT_CHILD_CONNECTING) {
-                    event = GF_EVENT_CHILD_CONNECTING;
-                    /* continue to check other events for CHILD_UP */
-                }
-            }
+            if (__afr_get_up_children_count(priv) > 0)
+                event = GF_EVENT_CHILD_UP;
+            else
+                event = GF_EVENT_CHILD_DOWN;
         }
     }
     UNLOCK(&priv->lock);


### PR DESCRIPTION
### Problem

The ["heard from all" aggregation](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L6386-L6397) in `afr_notify()` scans `last_event[]` for `GF_EVENT_CHILD_UP` to decide the initial propagation event. However, [`__afr_handle_child_up_event()`](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L6033-L6036) stores `SOME_DESCENDENT_UP` (not `CHILD_UP`) for children that connect after another is already up. If the first-to-connect child disconnects before heard_from_all completes, the scan finds no `CHILD_UP` and defaults to `CHILD_DOWN`, even though other children are UP.

Trigger: replica-3, staggered startup, transient failure on the first brick to connect. After heard_from_all fires incorrectly, DHT permanently considers the subvolume DOWN until an external event generates a new notify.

### Fix

Replace the `last_event[]` scan with a `child_up[]` count via [`__afr_get_up_children_count(priv)`](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L5714-L5724), matching the [timer fallback path](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L5763-L5767) (`__afr_transform_event_from_state`) which already uses this function correctly.

The removed `CHILD_CONNECTING` aggregation case is intentional — a connecting-but-not-yet-up child has `child_up[i] = 0` and should not count as UP. This matches the timer path behavior.

### Verification

- Build: `make -C xlators/cluster/afr/src` — zero errors, zero warnings
- TLA+ model checking: bug found at depth 6 (139 states), fix verified across 1.53 billion states (0 violations)

Fixes: https://github.com/gluster/glusterfs/issues/4680