### PR TITLE
afr: remove unreachable halo threshold override branch

### DIFF
--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -5884,22 +5884,15 @@ __afr_handle_ping_event(xlator_t *this, xlator_t *child_xlator, const int idx,
 
     if (child_latency_msec > halo_max_latency_msec &&
         priv->child_up[idx] == 1 && up_children > priv->halo_min_replicas) {
-        if ((up_children - 1) < priv->halo_min_replicas) {
-            gf_log(child_xlator->name, GF_LOG_INFO,
-                   "Overriding halo threshold, "
-                   "min replicas: %d",
-                   priv->halo_min_replicas);
-        } else {
-            gf_log(child_xlator->name, GF_LOG_INFO,
-                   "Child latency (%" PRId64
-                   " ms) "
-                   "exceeds halo threshold (%" PRId64
-                   "), "
-                   "marking child down.",
-                   child_latency_msec, halo_max_latency_msec);
-            if (priv->halo_child_up[idx]) {
-                *event = GF_EVENT_CHILD_DOWN;
-            }
+        gf_log(child_xlator->name, GF_LOG_INFO,
+               "Child latency (%" PRId64
+               " ms) "
+               "exceeds halo threshold (%" PRId64
+               "), "
+               "marking child down.",
+               child_latency_msec, halo_max_latency_msec);
+        if (priv->halo_child_up[idx]) {
+            *event = GF_EVENT_CHILD_DOWN;
         }
     } else if (child_latency_msec < halo_max_latency_msec &&
                priv->child_up[idx] == 0) {


### PR DESCRIPTION
Fixes: #4683

In [`__afr_handle_ping_event()`](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L5885-L5903), the inner check `(up_children - 1) < priv->halo_min_replicas` is algebraically unreachable when the outer guard `up_children > priv->halo_min_replicas` holds. The "Overriding halo threshold" log message is never emitted.

## Algebraic proof

The outer guard requires `up_children > halo_min_replicas`. For non-negative integers, this implies `up_children >= halo_min_replicas + 1`, therefore `up_children - 1 >= halo_min_replicas`. The inner check `(up_children - 1) < halo_min_replicas` is the negation of this — always FALSE.

**Signed/unsigned:** `up_children` is [`int`](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr-common.c#L5873) (computed by counting `child_up[i] == 1`, always non-negative). `halo_min_replicas` is [`uint32_t`](https://github.com/gluster/glusterfs/blob/ae1d69672fe0271265ab6f09ec2c2f93d4208511/xlators/cluster/afr/src/afr.h#L269). The implicit `int→unsigned` promotion is safe because `up_children` is non-negative and both values are bounded by `child_count`. No overflow or sign-conversion hazard.

## Provenance

Dead from birth. The outer guard has been `>` (strict greater-than) since the first halo prototype in 2014. See #4683 for the full git archaeology.

| Date | Commit | Author | What happened |
|------|--------|--------|---------------|
| 2014-04-29 | bbceb48f0fe8b1fc2604fd3fcd347e143cab600a | Richard Wareing (FB) | First halo prototype. Outer guard `>` with inner check `< min`. **Dead from birth.** |
| 2014-09-08 | 7a6ead5c03e9f62fe8726b141c94cc7d31a79c39 | Richard Wareing (FB) | Replaced the dead branch with `find_worst_up_child(this) == idx` — a reachable check. |
| 2017-03-21 | ca101390c055f94c6d566d435c1d3bb333e3805f | Kevin Vigor (FB) | Squash-merged halo to upstream (Gerrit [16099](http://review.gluster.org/16099) / [16177](https://review.gluster.org/16177)). Based on a version that **predated** Wareing's 7a6ead5c03 fix — the dead branch was re-introduced. |
| 2020-02-04 | 4bb65d6b6ee3b48130d8aaaee4a4ddb85897a5a9 | Pranith Kumar K (RH) | `cluster/afr: Fixes for halo` (bz#1800583). Added `halo_child_up[]` guards to the live branch but did not touch the dead branch. |

## Fix

Remove the dead branch, collapse the if/else. No behavior change — the dead branch only logged and never executed.

Build verified: `make -C xlators/cluster/afr/src` — zero errors, zero warnings.