### PR TITLE
glusterd/snapshot: fix use-after-scope in glusterd_zfs_dataset() (CWE-562)

### DIFF
--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -31,7 +31,7 @@
 extern char snap_mount_dir[VALID_GLUSTERD_PATHMAX];
 
 int32_t
-glusterd_zfs_dataset(char *brick_path, char **pool_name)
+glusterd_zfs_dataset(char *brick_path, char *pool_name, size_t pool_name_size)
 {
     char msg[1024] = "";
     char dataset[PATH_MAX] = "";
@@ -40,7 +40,9 @@ glusterd_zfs_dataset(char *brick_path, char **pool_name)
         0,
     };
     char *ptr = NULL;
+    char *token = NULL;
     int32_t ret = 0;
+    int len = 0;
 
     this = THIS;
     GF_ASSERT(this);
@@ -74,7 +76,27 @@ glusterd_zfs_dataset(char *brick_path, char **pool_name)
     }
     runner_end(&runner);
 
-    *pool_name = strtok(dataset, "\n");
+    token = strtok(dataset, "\n");
+    if (!token) {
+        gf_log(this->name, GF_LOG_ERROR,
+               "Failed to parse dataset name "
+               "for the brick_path %s",
+               brick_path);
+        ret = -1;
+        goto out;
+    }
+
+    /* Copy into the caller-owned buffer: the previous code returned a pointer
+       into the function-local `dataset`, which is out of scope on return. */
+    len = snprintf(pool_name, pool_name_size, "%s", token);
+    if (len < 0 || (size_t)len >= pool_name_size) {
+        gf_log(this->name, GF_LOG_ERROR,
+               "dataset name too long "
+               "for the brick_path %s",
+               brick_path);
+        ret = -1;
+        goto out;
+    }
 
 out:
     return ret;
@@ -149,12 +171,13 @@ glusterd_zfs_snapshot_create_or_clone(glusterd_brickinfo_t *snap_brickinfo,
     xlator_t *this = THIS;
     char snap_device[NAME_MAX] = "";
     char clone_device[NAME_MAX] = "";
-    char *dataset = NULL;
+    char dataset[PATH_MAX] = "";
     int32_t len = 0;
 
     GF_ASSERT(snap_brickinfo);
 
-    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, &dataset);
+    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, dataset,
+                               sizeof(dataset));
     if (ret)
         goto out;
 
@@ -236,7 +259,7 @@ glusterd_zfs_brick_details(dict_t *rsp_dict,
     glusterd_conf_t *priv = NULL;
     xlator_t *this = THIS;
     char key[160] = ""; /* key_prefix is 128 bytes at most */
-    char *dataset = NULL;
+    char dataset[PATH_MAX] = "";
 
     GF_ASSERT(rsp_dict);
     GF_ASSERT(snap_brickinfo);
@@ -244,7 +267,8 @@ glusterd_zfs_brick_details(dict_t *rsp_dict,
     priv = this->private;
     GF_ASSERT(priv);
 
-    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, &dataset);
+    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, dataset,
+                               sizeof(dataset));
     if (ret)
         goto out;
 
@@ -253,7 +277,7 @@ glusterd_zfs_brick_details(dict_t *rsp_dict,
         goto out;
     }
 
-    ret = dict_set_str(rsp_dict, key, dataset);
+    ret = dict_set_dynstr_with_alloc(rsp_dict, key, dataset);
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                "Could not save vgname ");
@@ -304,14 +328,15 @@ glusterd_zfs_snapshot_remove(glusterd_brickinfo_t *snap_brickinfo,
     char msg[1024] = "";
     int len;
     char snap_device[NAME_MAX] = "";
-    char *dataset = NULL;
+    char dataset[PATH_MAX] = "";
 
     priv = this->private;
     GF_ASSERT(priv);
 
     GF_ASSERT(snap_brickinfo);
 
-    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, &dataset);
+    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, dataset,
+                               sizeof(dataset));
     if (ret)
         goto out;
 
@@ -396,14 +421,15 @@ glusterd_zfs_snapshot_restore(glusterd_brickinfo_t *snap_brickinfo,
     char snap_device[NAME_MAX] = "";
     char clone_device[NAME_MAX] = "";
     char mnt_pt[PATH_MAX] = "";
-    char *dataset = NULL;
+    char dataset[PATH_MAX] = "";
 
     priv = this->private;
     GF_ASSERT(priv);
 
     GF_ASSERT(snap_brickinfo);
 
-    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, &dataset);
+    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, dataset,
+                               sizeof(dataset));
     if (ret)
         goto out;
 


### PR DESCRIPTION
Fixes: #4687

## Summary

`glusterd_zfs_dataset()` returns, through its `char **pool_name` out-parameter, a pointer
**into its own stack-local** `char dataset[PATH_MAX]`:

```c
int32_t
glusterd_zfs_dataset(char *brick_path, char **pool_name)
{
    char dataset[PATH_MAX] = "";
    ...
    *pool_name = strtok(dataset, "\n");   /* pointer into the local */
    return ret;                            /* `dataset` goes out of scope here */
}
```

All four callers (`…_create_or_clone`, `…_brick_details`, `…_remove`, `…_restore`) then use
the returned pointer **after** the function has returned — i.e. they dereference a pointer
into a deallocated stack frame (CWE-562, use-after-scope).

## Impact — operator-visible corruption

The `details` path is the most exposed: `glusterd_zfs_brick_details()` stores the returned
pointer into the status response dict with `dict_set_str()`, which stores the pointer
**without copying** (`str_to_data()` → `strn_to_data()` sets `data->data = value;
data->is_static = _gf_true`). The dangling pointer is therefore read much later, at
`dict_serialize()` time.

On a **multi-brick** volume this is directly visible. `glusterd_zfs_dataset()` is called at
the same stack depth for every brick, so `dataset[PATH_MAX]` lands at the same address and
`strtok()` returns the same pointer each call; every brick's `<brick>.vgname` entry ends up
aliasing that one dead address, which by serialize time holds only the **last** brick's
value. `gluster snapshot status` then reports the wrong Volume Group for every brick:

```
# bricks on distinct ZFS datasets pool/aaa, pool/bbb, pool/ccc
Brick … pool/aaa …   Volume Group : pool/ccc     <-- should be pool/aaa
Brick … pool/bbb …   Volume Group : pool/ccc     <-- should be pool/bbb
Brick … pool/ccc …   Volume Group : pool/ccc
```

The create/remove/restore paths consume the pointer immediately (no intervening call), so
they appear to work today — classic latent undefined behaviour that breaks as soon as any
new code, or a different ABI/stack layout, reuses the frame between the return and the
dereference.

## Root cause / why it was not caught earlier

The address escapes **indirectly** — through `strtok()`'s return value and a `char **`
out-parameter — rather than as a direct `return &local;`. That launders it past
`-Wreturn-local-addr` and Coverity (both report nothing on this pattern), which is why two
earlier CWE-562 passes over these files missed it:

- `d9b57691a9` *"glusterd: Fix coverity issue (CWE-562)"* converted the sibling
  `glusterd_zfs_snap_clone_brick_path()` from returning a local's address to writing into the
  caller-owned `brickinfo->path`.
- `05b0264903` *"glusterd: do not return address of local variable"* fixed the same class in
  the LVM provider.

`glusterd_zfs_dataset()` is the third instance of the pattern.

## Fix

Make `glusterd_zfs_dataset()` write into a **caller-owned buffer** (no pointer escapes the
function), and have the `details` caller hand the dict an **owned** string. This mirrors the
`d9b57691a9` precedent and the existing LVM sibling, which already does
`value = gf_strdup(token); … dict_set_dynstr(rsp_dict, key, value);` for its `vgname`.

- `glusterd_zfs_dataset(char *brick_path, char *pool_name, size_t pool_name_size)` copies the
  parsed dataset name into the caller's buffer (with NULL and truncation guards).
- The four callers pass a local `char dataset[PATH_MAX]`.
- `glusterd_zfs_brick_details()` uses `dict_set_dynstr_with_alloc()` so the dict owns a copy.

The change is confined to `xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c`
(`glusterd_zfs_dataset` has no other callers and no header declaration).

## Testing

Verified on a GlusterFS 11.2 + ZFS 2.4.2 host with a 3-brick volume on distinct ZFS datasets
(`gluster snapshot status` after activate). Three-way, swapping only `glusterd.so` and
restarting glusterd:

| `glusterd.so` build | Volume Group reported per brick |
|---|---|
| stock (shipping) | `ccc`, `ccc`, `ccc` — **corrupted (aliased)** |
| rebuilt, unpatched (control) | `ccc`, `ccc`, `ccc` — **still corrupted** (rules out a rebuild/layout artifact) |
| rebuilt, **patched** | `aaa`, `bbb`, `ccc` — **correct** |

The other three callers (`…_create_or_clone`, `…_remove`, `…_restore`) — which consume the
parsed name synchronously and so already work even unfixed — were additionally exercised on the
patched build (`gluster snapshot create` / `delete` / `restore` on the same volume): all three
operations succeed and `glusterd` does not regress.

A standalone reproducer of the exact pattern (caller buffer + owned copy) compiles clean and
runs clean under AddressSanitizer (`-fsanitize=address`, `detect_stack_use_after_return=1`),
which reports `stack-use-after-return` on the unfixed pattern — usable as a regression check;
the upstream `.t` suite has no ZFS-backed snapshot test (ZFS is not in CI), and the precedent
CWE-562 fixes shipped without a dedicated test.

## Note for reviewers

PR #4450 (Alpine/musl support) also edits `glusterd_zfs_dataset()`, but a different line
(making `ZFS_COMMAND` overridable and using it in the `runner_add_args()` call). The two
changes are orthogonal and rebase trivially; this PR is independent of #4450.
