### PR TITLE
glusterd/snapshot (ZFS): refuse snapshot delete when a dependent clone exists

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -5479,6 +5479,13 @@ glusterd_snapshot_remove_prevalidate(dict_t *dict, char **op_errstr,
     char *snapname = NULL;
     xlator_t *this = THIS;
     glusterd_snap_t *snap = NULL;
+    glusterd_volinfo_t *snap_vol = NULL;
+    glusterd_brickinfo_t *brickinfo = NULL;
+    struct glusterd_snap_ops *snap_ops = NULL;
+    int32_t brick_count = -1;
+    gf_boolean_t has_dependent = _gf_false;
+    char dependent_info[4096] = "";
+    char err_str[4096] = "";
 
     GF_VALIDATE_OR_GOTO(this->name, op_errno, out);
 
@@ -5503,6 +5510,50 @@ glusterd_snapshot_remove_prevalidate(dict_t *dict, char **op_errstr,
         *op_errno = EG_NOSNAP;
         ret = -1;
         goto out;
+    }
+
+    /* A backend snapshot that still has a dependent clone (created via
+     * `zfs clone` for snapshot clone/restore) cannot be removed by the
+     * provider's plain `zfs destroy`. Refuse the delete here, before any
+     * decommission state is written, rather than letting it fail at commit
+     * time and report success. Providers that do not track dependents (e.g.
+     * LVM) leave .dependents NULL and are skipped, so their behaviour is
+     * unchanged. The check is per-brick and only the node owning a brick can
+     * query its backend, so each peer validates its local bricks. */
+    cds_list_for_each_entry(snap_vol, &snap->volumes, vol_list)
+    {
+        snap_ops = NULL;
+        glusterd_snapshot_plugin_by_name(snap_vol->snap_plugin, &snap_ops);
+        if (!snap_ops || !snap_ops->dependents)
+            continue;
+
+        brick_count = -1;
+        cds_list_for_each_entry(brickinfo, &snap_vol->bricks, brick_list)
+        {
+            brick_count++;
+            if (gf_uuid_compare(brickinfo->uuid, MY_UUID))
+                continue;
+
+            has_dependent = _gf_false;
+            dependent_info[0] = '\0';
+            ret = snap_ops->dependents(brickinfo, snap_vol->snapshot->snapname,
+                                       snap_vol->volname, brick_count,
+                                       &has_dependent, dependent_info,
+                                       sizeof(dependent_info));
+            if (ret == 0 && has_dependent) {
+                snprintf(err_str, sizeof(err_str),
+                         "Snapshot %s cannot be deleted: its backend snapshot "
+                         "still has a dependent clone (%s). Remove the "
+                         "dependent clone before deleting this snapshot.",
+                         snapname, dependent_info);
+                gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_REMOVE_FAIL,
+                       "%s", err_str);
+                *op_errstr = gf_strdup(err_str);
+                *op_errno = EG_OPNOTSUP;
+                ret = -1;
+                goto out;
+            }
+        }
     }
 
     ret = dict_set_dynstr_with_alloc(dict, "snapuuid",

--- a/xlators/mgmt/glusterd/src/glusterd-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.h
@@ -147,6 +147,21 @@ struct glusterd_snap_ops {
                                 char *snap_clone_volume_id,
                                 char *snap_brick_dir, int brick_num,
                                 glusterd_brickinfo_t *brickinfo, int restore);
+
+    /* Optional. Reports whether the backend snapshot of this brick still has
+     * a dependent that prevents its removal (e.g. a ZFS clone created from
+     * it). Lets a snapshot delete be refused in prevalidate rather than
+     * failing at commit time. *has_dependent is set _gf_true only on a
+     * positive, confirmed dependency; dependent_info (if non-NULL) receives a
+     * short, human-readable description of the dependent for the error
+     * message. Returns 0 when the check ran (regardless of the result) and
+     * non-zero only when the check itself could not be performed. Providers
+     * that do not track dependents leave this NULL. */
+    int32_t (*const dependents)(glusterd_brickinfo_t *snap_brickinfo,
+                                char *snapname, char *snap_volume_id,
+                                int32_t brick_num, gf_boolean_t *has_dependent,
+                                char *dependent_info,
+                                size_t dependent_info_len);
 };
 
 extern struct glusterd_snap_ops lvm_snap_ops;

--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -345,6 +345,108 @@ out:
     return ret;
 }
 
+/* Report whether the backend ZFS snapshot of this brick still has a dependent
+ * clone (a dataset created from it via `zfs clone`, e.g. by snapshot clone or
+ * restore). Such a snapshot cannot be removed by the provider's plain
+ * `zfs destroy`, so a delete that proceeds would silently leave it behind. Used
+ * by the delete prevalidate to refuse the operation up front.
+ *
+ * *has_dependent is set _gf_true only on a positive, confirmed dependency. Any
+ * inconclusive result -- dataset not resolvable, snapshot already gone, zfs not
+ * runnable -- is treated as "no confirmed dependent" so the check never becomes
+ * a new way to block a legitimate delete (this preserves the existing tolerant
+ * behaviour for an already-removed backend snapshot).
+ */
+int32_t
+glusterd_zfs_snapshot_dependents(glusterd_brickinfo_t *snap_brickinfo,
+                                 char *snapname, char *snap_volume_id,
+                                 int32_t brick_num, gf_boolean_t *has_dependent,
+                                 char *dependent_info, size_t dependent_info_len)
+{
+    int32_t ret = -1;
+    xlator_t *this = THIS;
+    runner_t runner = {
+        0,
+    };
+    char msg[1024] = "";
+    int len;
+    char snap_device[NAME_MAX] = "";
+    char *dataset = NULL;
+    char clones[4096] = "";
+    char *ptr = NULL;
+
+    GF_ASSERT(snap_brickinfo);
+    GF_VALIDATE_OR_GOTO(this->name, has_dependent, out);
+
+    *has_dependent = _gf_false;
+
+    ret = glusterd_zfs_dataset(snap_brickinfo->origin_path, &dataset);
+    if (ret) {
+        /* Cannot resolve the dataset (e.g. the brick/backend is already
+         * gone). Do not block the delete on an inconclusive check. */
+        ret = 0;
+        goto out;
+    }
+
+    /* glusterd_zfs_dataset() returns a pointer into a stack buffer, so the
+     * dataset name must be consumed immediately, before any other call can
+     * clobber it (mirrors glusterd_zfs_snapshot_remove). */
+    len = snprintf(snap_device, sizeof(snap_device), "%s@%s_%d", dataset,
+                   snap_volume_id, brick_num);
+    if ((len < 0) || (len >= sizeof(snap_device))) {
+        ret = 0;
+        goto out;
+    }
+
+    runinit(&runner);
+    len = snprintf(msg, sizeof(msg),
+                   "check dependent clones of the snapshot of brick %s, "
+                   "snap name: %s",
+                   snap_brickinfo->origin_path, snapname);
+    if (len < 0) {
+        strcpy(msg, "<error>");
+    }
+    runner_add_args(&runner, ZFS_COMMAND, "get", "-H", "-o", "value", "clones",
+                    snap_device, NULL);
+    runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
+    runner_log(&runner, "", GF_LOG_DEBUG, msg);
+
+    ret = runner_start(&runner);
+    if (ret == -1) {
+        /* zfs could not be run, or the snapshot does not exist. Treat as
+         * "no confirmed dependent" and let the delete proceed. */
+        runner_end(&runner);
+        ret = 0;
+        goto out;
+    }
+
+    ptr = fgets(clones, sizeof(clones), runner_chio(&runner, STDOUT_FILENO));
+    (void)runner_end(&runner); /* reap the child */
+
+    if (!ptr) {
+        /* No output -> no clones reported. */
+        ret = 0;
+        goto out;
+    }
+
+    /* Drop the trailing newline. */
+    clones[strcspn(clones, "\n")] = '\0';
+
+    /* ZFS prints "-" (or nothing) for the `clones` property when the snapshot
+     * has no clones. Only a non-empty, non-"-" value is a confirmed dependent.
+     */
+    if (clones[0] != '\0' && strcmp(clones, "-") != 0) {
+        *has_dependent = _gf_true;
+        if (dependent_info && dependent_info_len > 0)
+            snprintf(dependent_info, dependent_info_len, "%s", clones);
+    }
+
+    ret = 0;
+
+out:
+    return ret;
+}
+
 /* No op since .zfs directory is used */
 int32_t
 glusterd_zfs_snapshot_activate(glusterd_brickinfo_t *snap_brickinfo,
@@ -516,4 +618,5 @@ struct glusterd_snap_ops zfs_snap_ops = {
     .activate = glusterd_zfs_snapshot_activate,
     .deactivate = glusterd_zfs_snapshot_deactivate,
     .restore = glusterd_zfs_snapshot_restore,
-    .brick_path = glusterd_zfs_snap_clone_brick_path};
+    .brick_path = glusterd_zfs_snap_clone_brick_path,
+    .dependents = glusterd_zfs_snapshot_dependents};


### PR DESCRIPTION
Fixes: #4689

## Summary

On a ZFS-backed volume, `gluster snapshot clone` (and `snapshot restore`) build the backend with
`zfs clone` and never `zfs promote`, so the clone keeps `origin == <snapshot>`. A later
`snapshot delete` of that source snapshot runs a plain `zfs destroy` (no `-R`), which ZFS correctly
refuses while a dependent clone exists. glusterd logs that failure but does **not** propagate it — the
return code is overwritten by the subsequent directory-cleanup `sys_rmdir` — so the CLI reports
`snap removed successfully` (exit 0), glusterd drops the snapshot object, and the backend ZFS snapshot is
left behind, now untracked. See #4689 for the full root-cause walk.

This change makes the delete **fail before any state change**, with a clear, actionable error, instead of
silently reporting success.

## Fix

- Add an **optional** `dependents` method to the snapshot-provider vtable `struct glusterd_snap_ops`.
  Providers that do not track dependents leave the slot NULL (LVM is unchanged — designated-init).
- Implement it for the ZFS provider (`glusterd_zfs_snapshot_dependents`): reconstruct the snapshot handle
  `<dataset>@<volname>_<brick_num>` (mirroring `glusterd_zfs_snapshot_remove`) and run
  `zfs get -H -o value clones <snap_device>`.
- Gate the **delete prevalidate** (`glusterd_snapshot_remove_prevalidate`): walk the snap's volumes →
  local bricks (`MY_UUID`) and refuse the op (`op_errstr` + `op_errno`, return −1) when a dependent clone
  is confirmed.

**Why prevalidate** (not commit-phase error propagation): `glusterd_snapshot_remove_commit` marks the snap
for decommission *before* the brick-remove runs, so failing at commit time would leave a
half-decommissioned snapshot. Prevalidate refuses before any state is written. (The cluster-wide op-sm
lock serializes snapshot ops, so there is no prevalidate→commit TOCTOU.)

**Conservative by design:** `*has_dependent` is set true *only* on a positively-confirmed, non-empty
`clones` value. Every inconclusive result — dataset unresolvable, snapshot already gone, `zfs` not
runnable, output empty or `-` — returns "no dependent", so the check can never become a *new* way to block
a legitimate delete and preserves the existing tolerant "already gone" behavior.

## Testing (GlusterFS 11.2 + ZFS 2.4.2, single node)

Built on-node and verified with a three-way control (swap only `glusterd.so`):

| `glusterd.so` | `delete` of a clone-held snapshot | backend snapshot |
|---|---|---|
| stock | reports success (exit 0), snap dropped | **orphaned** |
| rebuilt, UNPATCHED (control) | reports success (exit 0), snap dropped | **orphaned** — rebuild alone doesn't change it |
| rebuilt, **PATCHED** | **refused** (exit 1), snap retained | retained |

The unpatched-rebuild control reproduces identically to stock, so the patched result is attributable to
the source change. Positive controls on the patched build:

- delete-with-dependent → refused, snap + backend retained, error names the clone (no state change);
- independent snapshot (no clone) → still deletes and frees its backend snapshot (no regression);
- after the dependency is removed → the snapshot deletes and the backend snapshot is genuinely gone
  (so only the dependent case is blocked).

The patch applies cleanly to both `devel` and the 11.2 source.

## Regression test

`tests/basic/volume-snapshot-clone-zfs.t` deleted `${V0}_snap`/`${V1}_snap` while the re-created clones still
depended on them, i.e. it asserted the behaviour this PR turns into an error. (Upstream CI never runs the ZFS
twins: they skip where no `zfs` binary exists, so CI is green either way; anyone running the suite on a ZFS host
saw the red.) The PR therefore carries two commits:

1. `tests/snapshot: make volume-snapshot-clone-zfs.t query the cluster CLI` -- the ZFS twin called
   `volinfo_field`/`volume_exists` (plain `$CLI`, which reaches no glusterd in a `launch_cluster` test) where
   its LVM twin calls `volinfo_field_1`/`volume_exists_1`, so 14 of its checks fail on any ZFS host. The test was
   correct when added (8a17e531c0): `snapshot.rc` then shadowed both helpers with `$CLI_1` copies; d009ce27bf (#3475)
   removed those copies and renamed the callers, but only in the tests it touched, and this twin kept the old names.
   Independent of the fix and kept as its own commit so it can be split out on request.
   The same drift exists in four other ZFS twins (`basic/volume-snapshot-zfs`, `bugs/snapshot/bug-1049834-zfs`,
   `bug-1202436-…-zfs`, `bug-1512451-…-zfs`); those belong in a separate hygiene PR.
2. The fix. Its test amendment asserts the refusal (`TEST ! delete_snapshot`, both snapshots still listed),
   releases the dependents (`volume delete` of the clone volumes plus `zfs destroy` of the clone datasets that
   `volume delete` leaves behind -- see the operator-remedy note below), and then checks that the deletes go
   through and the volumes can be removed, as the test did before.

## Known limitations / disclosures (deliberately out of scope here)

- **`snapshot delete all` becomes fail-fast at a clone-held snapshot.** The CLI already issues one delete
  per snapshot and aborts on the first failure (`gf_cli_snapshot_for_delete`, by design — *"Fail the
  operation if deleting one of the snapshots is failed"*). With this fix, a clone-held snapshot makes its
  delete fail in prevalidate, so `delete all` stops there: snapshots processed before it are deleted,
  the clone-held one and any after it remain (tested). This is the same fail-fast behavior as for any
  un-deletable snapshot — and strictly better than the previous silent-orphan-and-continue. Making
  `delete all` skip-and-continue past a refused snapshot is a possible follow-up, intentionally not done
  here to keep the change minimal.
- **Operator remedy needs backend action.** `gluster volume delete <clone>` does **not** free the backend
  ZFS clone dataset (verified); the dependent clone has to be removed at the backend (e.g.
  `zfs destroy <clone_dataset>`) before the snapshot can be deleted. This is a related gap (the clone
  volume's backend dataset outliving `volume delete`) worth tracking separately; the error message here is
  deliberately worded as "remove the dependent clone" rather than prescribing `volume delete`.
- **LVM:** unchanged (NULL vtable slot; the LVM TU compiles clean against the new struct). Not exercised
  on a live LVM brick.
- **Multi-brick / multi-peer:** the check is per-brick and runs on each peer for its local bricks; any
  peer confirming a dependent aborts the op. Verified on a single brick; the per-brick logic is identical
  to the (multi-brick-correct) remove path.
- **auto-delete / restart-GC** reach the removal sink via `glusterd_snap_remove` directly, bypassing this
  delete prevalidate; they are neither covered nor changed by this fix. **Verified:** soft-limit
  auto-delete of a clone-held oldest snapshot still drops it from glusterd and orphans the backend ZFS
  snapshot, hitting the same swallow in `glusterd_snapshot_remove`. The shared root cause is that swallow
  (every `glusterd_snap_remove` caller is exposed); a focused follow-up could guard the sink or make
  auto-delete skip clone-held snapshots. Kept out of this PR because it changes auto-delete's "always frees
  space" contract and warrants its own design + testing - that is now #4692 (which uses a replicated-metadata
  check rather than this `dependents()` method, for the reasons explained there).
- **Synchronous backend probe:** the check shells `zfs get` in prevalidate, so a hung pool blocks the
  delete in prevalidate. This is the same synchronous-`zfs` exposure glusterd already has in these
  snapshot ops (`zfs list`/`zfs destroy`), just surfaced earlier — not a new failure class.
- **#4688** (the `glusterd_zfs_dataset` use-after-scope fix) has been merged; `dependents()` is rebased onto its
  caller-owned buffer signature and consumes the result immediately (the established pattern in
  create/remove/restore).

## Note

This is not data loss (no `-R` is issued); it is a correctness bug (success reported for a failed
operation) plus an invisible, accumulating consumer of pool space. `zfs promote` is **not** a safe
alternative (it re-parents the live brick onto the snapshot-clone, after which a `zfs destroy -R` of the
clone would also destroy the live brick) — see #4689.
