### PR TITLE
cluster/dht: fix SIGFPE when brick f_bsize exceeds the 1MB chunk size

### DIFF
--- a/tests/bugs/distribute/zfs-recordsize-sigfpe.t
+++ b/tests/bugs/distribute/zfs-recordsize-sigfpe.t
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# DHT normalizes brick sizes into 1MB chunks in dht_du_info_cbk():
+#
+#   bpc = (1 << 20) / statvfs->f_bsize;
+#   chunks = (f_blocks + bpc - 1) / bpc;
+#
+# A brick filesystem reporting f_bsize larger than 1MB made bpc
+# truncate to zero and the chunks division kill the client with
+# SIGFPE on the first statfs reply after mount. ZFS reports
+# f_bsize == recordsize, and large_blocks allows recordsize up to
+# 16MB, so any recordsize above 1m triggered the crash.
+#
+# This test puts a distribute volume on two recordsize=2m ZFS bricks
+# and checks that a client survives the operations that trigger the
+# DHT disk-usage refresh.
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../snapshot.rc
+. $(dirname $0)/../../snapshot_zfs.rc
+
+if ! verify_zfs_version; then
+    SKIP_TESTS
+    exit 0;
+fi
+
+cleanup;
+
+# a crashed previous run (unfixed code crashes the client here) can
+# leave the loopback pools imported and defeat the rc cleanup;
+# destroy leftovers best-effort before setting up
+zpool destroy -f ${ZFS_PREFIX}_pool_1 2>/dev/null
+zpool destroy -f ${ZFS_PREFIX}_pool_2 2>/dev/null
+
+TEST init_n_bricks 2
+TEST setup_zfs 2
+
+# recordsize above 1M needs the large_blocks pool feature and a
+# permitting zfs_max_recordsize (both defaults since OpenZFS 2.2);
+# skip on a ZFS that refuses the value rather than fail
+if ! zfs set recordsize=2M ${ZFS_PREFIX}_pool_1/bricks 2>/dev/null; then
+    SKIP_TESTS
+    exit 0;
+fi
+TEST zfs set recordsize=2M ${ZFS_PREFIX}_pool_2/bricks
+
+# guard against a vacuous pass: the brick filesystems must actually
+# report a block size above DHT's 1MB chunk unit
+EXPECT "2097152" stat -f -c %s /${ZFS_PREFIX}_pool_1/bricks
+EXPECT "2097152" stat -f -c %s /${ZFS_PREFIX}_pool_2/bricks
+
+TEST glusterd
+TEST pidof glusterd
+
+TEST $CLI volume create $V0 $H0:$L1 $H0:$L2
+
+# the brick directories themselves must sit on the 2MB-block
+# filesystem, not just the dataset mountpoint checked above
+EXPECT "2097152" stat -f -c %s $L1
+EXPECT "2097152" stat -f -c %s $L2
+
+TEST $CLI volume start $V0
+
+# truncate any log left by a previous run: the fingerprint count
+# below must only see lines from this mount
+MOUNT_LOG=$LOGDIR/zfs-recordsize-sigfpe-$V0.log
+rm -f $MOUNT_LOG
+TEST $GFS -s $H0 --volfile-id=/$V0 --log-level=DEBUG \
+    --log-file=$MOUNT_LOG $M0
+
+# mkdir triggers dht_get_du_info(): a statfs is wound to every
+# subvolume and dht_du_info_cbk() runs the chunk arithmetic on each
+# reply
+TEST mkdir $M0/dir1
+TEST touch $M0/dir1/file1
+
+# dht_du_info_cbk() logs "avail_percent" right after the chunk
+# computation - on broken code SIGFPE fires in the same function
+# before the line can log, so this also proves the repaired path ran
+# for both large-bsize subvolumes
+function du_cbk_completed() {
+    local count
+    count=$(grep -c "avail_percent" $MOUNT_LOG 2>/dev/null)
+    if [ "${count:-0}" -ge 2 ]; then
+        echo "Y"
+    else
+        echo "N"
+    fi
+}
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Y" du_cbk_completed
+
+# the client survived the statfs replies: the mount still answers
+TEST stat $M0/dir1/file1
+TEST ls $M0/dir1
+
+# both bricks received a layout range from the chunk-weighted
+# calculation
+TEST getfattr -n trusted.glusterfs.dht $L1/dir1
+TEST getfattr -n trusted.glusterfs.dht $L2/dir1
+
+TEST umount $M0
+
+cleanup;

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -26,7 +26,7 @@ dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     double percent = 0;
     double percent_inodes = 0;
     uint64_t bytes = 0;
-    uint32_t bpc; /* blocks per chunk */
+    uint64_t total_bytes = 0;
     uint32_t chunks = 0;
 
     conf = this->private;
@@ -49,9 +49,15 @@ dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
          * irrelevant by then.  Meanwhile, it's more important to keep
          * the chunk size small so the layout-calculation code that
          * uses this value can be tested on normal machines.
+         *
+         * Compute the chunk count from the byte size: a filesystem
+         * block can be larger than the 1MB chunk (ZFS reports
+         * f_bsize == recordsize, up to 16MB), so deriving a
+         * blocks-per-chunk divisor as (1MB / f_bsize) truncates to
+         * zero and the division below it crashes with SIGFPE.
          */
-        bpc = (1 << 20) / statvfs->f_bsize;
-        chunks = (statvfs->f_blocks + bpc - 1) / bpc;
+        total_bytes = statvfs->f_blocks * statvfs->f_frsize;
+        chunks = (total_bytes + ((1 << 20) - 1)) >> 20;
     }
 
     if (statvfs->f_files) {


### PR DESCRIPTION
Fixes: #4696

dht_du_info_cbk() derives a blocks-per-chunk divisor as

    bpc = (1 << 20) / statvfs->f_bsize;

When a brick filesystem reports f_bsize larger than 1MB the integer
division truncates bpc to zero and the chunk computation on the next
line divides by zero, killing the process with SIGFPE. ZFS reports
f_bsize == recordsize, up to 16MB with the large_blocks feature, so
any FUSE client (or gfapi consumer) of a volume with a brick on a
recordsize>1m dataset dies on the first statfs reply that reaches
dht_du_info_cbk after mount. Full analysis in #4696.

Compute the chunk count from the byte size instead:

    chunks = (f_blocks * f_frsize + (1MB - 1)) >> 20;

There is no division left, so no f_bsize value can crash it. For
every power-of-two f_bsize <= 1MB the result is bit-identical to the
old arithmetic (bpc divides 1MB exactly, so ceil(blocks / bpc) ==
ceil(blocks * bsize / 1MB)) given f_frsize == f_bsize, which holds
on every Linux local filesystem used as a brick; existing
deployments see no layout change. Above 1MB the chunk stays a fixed
1MB unit for every brick, which keeps weighted-rebalance layout
ratios exact across bricks with different block sizes. f_frsize is
used because it is the POSIX unit of f_blocks and matches the
avail_space computation in the same function.

The included test puts a distribute volume on two recordsize=2m ZFS
bricks and gates on dht_du_info_cbk's completion fingerprint in the
client log; it skips where ZFS (or recordsize > 1M support) is
absent, following the existing ZFS test conventions.

Verified on ZFS 2.4.2 with a single-variable before/after build
(only this file changed): unpatched, the client dies with a SIGFPE
coredump on the first statfs reply and the new test fails; patched,
the test passes 18/18 and the du callback's debug fingerprint
appears for both 2MB-f_bsize subvolumes.
