### PR TITLE
libglusterfs: fix two stale comments in xlator.h

### DIFF
--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -539,8 +539,9 @@ typedef int32_t (*fop_copy_file_range_t)(call_frame_t *frame, xlator_t *this,
                                          size_t len, uint32_t flags,
                                          dict_t *xdata);
 
-/* WARNING: make sure the list is in order with FOP definition in
-   `rpc/xdr/src/glusterfs-fops.x`.
+/* WARNING: make sure the list is in order with the GF_FOP_* enum in
+   glusterfs-fops.h. STACK_WIND derives the op index from a member's
+   position in this struct (get_fop_index_from_fn() in stack.h).
    If it is not in order, mainly the metrics related feature would be broken */
 struct xlator_fops {
     fop_stat_t stat;
@@ -842,9 +843,10 @@ struct _xlator {
     uint32_t child_count;
 };
 
-/* This would be the only structure which needs to be exported by
-   the translators. For the backward compatibility, in 4.x series
-   even the old exported fields will be supported */
+/* This is the only structure a translator needs to export: since
+   GlusterFS 6.0 the loader resolves nothing but the "xlator_api"
+   symbol (xlator_dynload_apis()); the old by-name exports (fops,
+   cbks, init, ...) are not consulted. */
 /* XXX: This struct is in use by GD2, and hence SHOULD NOT be modified.
  * If the struct must be modified, see instructions at the comment with
  * GD2MARKER below.


### PR DESCRIPTION
Two comments in `xlator.h` describe mechanisms that no longer exist:

- The ordering warning above `struct xlator_fops` points at
  `rpc/xdr/src/glusterfs-fops.x`, removed in bb209d42b6, which converted it
  into the `GF_FOP_*` enum in `glusterfs-fops.h` in the same commit. That
  enum is the order authority today; the positional dependency is
  `get_fop_index_from_fn()` in `stack.h`. The comment now names both.

- The comment above `xlator_api_t` promises 4.x-style support for the old
  by-name exports. That fallback was removed by 67bbd5471a ("xlator: make
  'xlator_api' mandatory"), first shipped in 6.0: `xlator_dynload_apis()`
  hard-fails when `dlsym(handle, "xlator_api")` returns NULL and never
  consults the by-name exports. Verified live at ae1d69672f: a module
  exporting only the legacy `fops`/`cbks`/`init` symbols is refused with
  `undefined symbol: xlator_api`. The comment now states the actual contract.

Comment-only change; no functional impact.

Updates: #4699