### PR TITLE
dht: unlock redirected migration on locked subvolume

### DIFF
--- a/tests/bugs/distribute/redirected-target-entrylk.t
+++ b/tests/bugs/distribute/redirected-target-entrylk.t
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../dht.rc
+
+cleanup
+
+TEST glusterd
+TEST pidof glusterd
+
+# Give each brick independent capacity so one hashed destination can cross
+# min-free-disk while another remains a valid redirected destination.
+TEST truncate -s 512M $B0/brick-device-{0,1,2}
+
+TEST L0=$(SETUP_LOOP $B0/brick-device-0)
+TEST MKFS_LOOP $L0
+TEST L1=$(SETUP_LOOP $B0/brick-device-1)
+TEST MKFS_LOOP $L1
+TEST L2=$(SETUP_LOOP $B0/brick-device-2)
+TEST MKFS_LOOP $L2
+
+TEST mkdir -p $B0/${V0}{0,1,2}
+TEST MOUNT_LOOP $L0 $B0/${V0}0
+TEST MOUNT_LOOP $L1 $B0/${V0}1
+TEST MOUNT_LOOP $L2 $B0/${V0}2
+TEST mkdir -p $B0/${V0}{0,1,2}/brick
+
+TEST $CLI volume create $V0 $H0:$B0/${V0}{0,1,2}/brick
+TEST $CLI volume start $V0
+EXPECT "Started" volinfo_field $V0 'Status'
+
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+
+# Create on client-0, then rename to a name hashed on client-1.  This leaves
+# the data on client-0 and a link file on client-1, which makes the file
+# eligible for an explicit migration.
+TEST dht_first_filename_with_hashsubvol "$V0-client-0" "$M0" source
+source_name=$fn_return_val
+TEST dht_first_filename_with_hashsubvol "$V0-client-1" "$M0" redirected
+redirected_name=$fn_return_val
+TEST dd if=/dev/zero of=$M0/$source_name bs=4096 count=1 status=none
+TEST mv $M0/$source_name $M0/$redirected_name
+TEST test -f $B0/${V0}0/brick/$redirected_name
+EXPECT "$V0-client-0" dht_get_linkto_target \
+    $B0/${V0}1/brick/$redirected_name
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+
+# Consume capacity outside the brick directory.  The file remains invisible
+# to Gluster while statfs reports client-1 below the configured threshold.
+TEST fallocate -l 350M $B0/${V0}1/reserved-space
+TEST $CLI volume set $V0 cluster.min-free-disk 40%
+
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M0
+TEST $GFS --volfile-id=/$V0 --volfile-server=$H0 $M1
+
+# Prime DHT's asynchronous disk-usage cache before requesting migration.
+TEST touch $M0/refresh-disk-usage
+TEST rm $M0/refresh-disk-usage
+sleep 2
+
+# Migration first locks client-1, then redirects the data to client-2 because
+# client-1 is below min-free-disk.  Cleanup must unlock the original client-1
+# target, not the reassigned data target.
+TEST setfattr -n trusted.distribute.migrate-data -v force \
+    $M0/$redirected_name
+EXPECT "$V0-client-2" dht_get_linkto_target \
+    $B0/${V0}1/brick/$redirected_name
+TEST test -f $B0/${V0}2/brick/$redirected_name
+
+# A leaked entry lock blocks this same-name operation from another client.
+TEST timeout --kill-after=2 10 mv \
+    $M1/$redirected_name $M1/$redirected_name-renamed
+
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M0
+EXPECT_WITHIN $UMOUNT_TIMEOUT "Y" force_umount $M1
+TEST $CLI volume stop $V0
+UMOUNT_LOOP $B0/${V0}{0,1,2}
+cleanup

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -1521,6 +1521,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *cached_subvol,
     gf_boolean_t target_changed = _gf_false;
     xlator_t *new_target = NULL;
     xlator_t *old_target = NULL;
+    xlator_t *entrylk_subvol = hashed_subvol;
     fd_t *linkto_fd = NULL;
     dict_t *xdata = NULL;
 
@@ -1613,7 +1614,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *cached_subvol,
      * synchronization. So, rebalance too has to acquire an entrylk on
      * hashed subvol.
      */
-    ret = syncop_entrylk(hashed_subvol, DHT_ENTRY_SYNC_DOMAIN, &parent_loc,
+    ret = syncop_entrylk(entrylk_subvol, DHT_ENTRY_SYNC_DOMAIN, &parent_loc,
                          loc->name, ENTRYLK_LOCK, ENTRYLK_WRLCK, NULL, NULL);
     if (ret < 0) {
         *fop_errno = -ret;
@@ -1621,7 +1622,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *cached_subvol,
         gf_msg(this->name, GF_LOG_WARNING, *fop_errno,
                DHT_MSG_MIGRATE_FILE_FAILED,
                "%s: failed to acquire entrylk on subvol %s", loc->path,
-               hashed_subvol->name);
+               entrylk_subvol->name);
         goto out;
     }
 
@@ -2254,14 +2255,14 @@ out:
     }
 
     if (entrylk_locked) {
-        lk_ret = syncop_entrylk(hashed_subvol, DHT_ENTRY_SYNC_DOMAIN,
+        lk_ret = syncop_entrylk(entrylk_subvol, DHT_ENTRY_SYNC_DOMAIN,
                                 &parent_loc, loc->name, ENTRYLK_UNLOCK,
                                 ENTRYLK_UNLOCK, NULL, NULL);
         if (lk_ret < 0) {
             gf_msg(this->name, GF_LOG_WARNING, -lk_ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
                    "%s: failed to unlock entrylk on %s", loc->path,
-                   hashed_subvol->name);
+                   entrylk_subvol->name);
         }
     }
 


### PR DESCRIPTION
A migration takes its rename-synchronization entry lock on the hashed subvolume. If the free-space check later redirects the destination, `hashed_subvol` is reassigned, so cleanup currently sends the unlock to the new target and leaves the original target locked.

Capture the subvolume used for acquisition and use it for both lock and unlock.

The regression creates three independently sized bricks, forces the hashed target below `cluster.min-free-disk`, confirms migration redirects to the third brick, and then renames the file from a second client mount.

Validation on v11.2:
- negative control reproduced the leaked lock twice; the second-client rename timed out after 10 seconds
- fixed run passed 38/38 assertions; the rename completed in 13 ms
- clang-format, shell syntax, diff check, and checkpatch (0 warnings) pass

Signed-off-by: Joe Julian <me@joejulian.name>