### PR TITLE
doc: update translator development guide for current xlator API

### DIFF
--- a/doc/developer-guide/translator-development.md
+++ b/doc/developer-guide/translator-development.md
@@ -1,6 +1,12 @@
 Translator development
 ======================
 
+> **Historical reference:** This tutorial originated as the 2013 “Translator
+> 101” series. It illustrates translator concepts, but it is not a current
+> build or implementation guide. Current translators must export the mandatory
+> `xlator_api` structure; consult an in-tree translator and the current build
+> system before using this material.
+
 Setting the Stage
 -----------------
 


### PR DESCRIPTION
## Summary

- Mark the legacy Translator 101 tutorial as a historical reference.
- Preserve the original tutorial content rather than presenting it as a current implementation guide.

PR#4700 already merged the related `xlator.h` comment cleanup, so this PR is intentionally limited to the documentation warning.

## Testing

- `git diff --check`

Related to #4699
