### PR TITLE
build: detect Python 3.12 correctly

### DIFF
--- a/contrib/aclocal/python.m4
+++ b/contrib/aclocal/python.m4
@@ -85,7 +85,7 @@ python2.1 python2.0])
   dnl library.
 
   AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
-    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
+    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:4]])"`])
   AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
 
   dnl Use the values of $prefix and $exec_prefix for the corresponding


### PR DESCRIPTION
## Summary

- correctly detect the full Python 3.x version in the Autoconf helper
- prevent Python 3.12 from being truncated to 3.1 during RPM builds

## Testing

- configured successfully with Python 3.12
- verified the resulting EL10 RPM build uses `python3.12` for byte-compilation
- `git diff --check`

This fixes the Python version detection issue observed during the EL10 RPM build.