### PR TITLE
bit-rot: use EVP for SHA-256 checksums

### DIFF
--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -9,6 +9,7 @@
 */
 
 #include <ctype.h>
+#include <openssl/evp.h>
 
 #include <glusterfs/logging.h>
 #include <glusterfs/compat-errno.h>
@@ -271,7 +272,7 @@ out:
  */
 static int32_t
 br_object_read_block_and_sign(xlator_t *this, fd_t *fd, br_child_t *child,
-                              off_t offset, size_t size, SHA256_CTX *sha256)
+                              off_t offset, size_t size, EVP_MD_CTX *ctx)
 {
     int32_t ret = -1;
     tbf_t *tbf = NULL;
@@ -308,8 +309,11 @@ br_object_read_block_and_sign(xlator_t *this, fd_t *fd, br_child_t *child,
     for (i = 0; i < count; i++) {
         TBF_THROTTLE_BEGIN(tbf, TBF_OP_HASH, iovec[i].iov_len);
         {
-            SHA256_Update(sha256, (const unsigned char *)(iovec[i].iov_base),
-                          iovec[i].iov_len);
+            if (EVP_DigestUpdate(ctx, iovec[i].iov_base, iovec[i].iov_len) !=
+                1) {
+                ret = -1;
+                goto out;
+            }
         }
         TBF_THROTTLE_BEGIN(tbf, TBF_OP_HASH, iovec[i].iov_len);
     }
@@ -332,18 +336,23 @@ br_calculate_obj_checksum(unsigned char *md, br_child_t *child, fd_t *fd)
     size_t block = BR_HASH_CALC_READ_SIZE;
     xlator_t *this = NULL;
 
-    SHA256_CTX sha256;
+    EVP_MD_CTX *ctx = NULL;
 
     GF_VALIDATE_OR_GOTO("bit-rot", child, out);
     GF_VALIDATE_OR_GOTO("bit-rot", fd, out);
 
     this = child->this;
 
-    SHA256_Init(&sha256);
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        goto out;
+
+    if (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) != 1)
+        goto out;
 
     while (1) {
         ret = br_object_read_block_and_sign(this, fd, child, offset, block,
-                                            &sha256);
+                                            ctx);
         if (ret < 0) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_BLOCK_READ_FAILED,
                     "offset=%" PRIu64, offset, "object-gfid=%s",
@@ -357,10 +366,13 @@ br_calculate_obj_checksum(unsigned char *md, br_child_t *child, fd_t *fd)
         offset += ret;
     }
 
-    if (ret == 0)
-        SHA256_Final(md, &sha256);
+    if (ret == 0 && EVP_DigestFinal_ex(ctx, md, NULL) != 1)
+        ret = -1;
 
 out:
+    if (ctx)
+        EVP_MD_CTX_free(ctx);
+
     return ret;
 }
 


### PR DESCRIPTION
## Description\n\nReplace deprecated OpenSSL SHA-256 low-level APIs with the EVP digest interface in bit-rot signing. This keeps SHA-256 behavior unchanged while supporting OpenSSL 3 builds without deprecated API usage.\n\n## Validation\n\n- Full build completed with make -j 6\n- All non-NFS bit-rot regression tests passed\n- 8 tests executed, 0 failures\n- Focused scrub-status test passed\n