### PR TITLE
rpc: honor timer cancel result before unref

### DIFF
--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -440,9 +440,9 @@ rpc_clnt_reconnect_cleanup(rpc_clnt_connection_t *conn)
     pthread_mutex_lock(&conn->lock);
     {
         if (conn->reconnect) {
-            gf_timer_call_cancel(clnt->ctx, conn->reconnect);
+            if (!gf_timer_call_cancel(clnt->ctx, conn->reconnect))
+                reconnect_unref = _gf_true;
             conn->cleanup_gen++;
-            reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
     }
@@ -482,13 +482,13 @@ rpc_clnt_connection_cleanup(rpc_clnt_connection_t *conn)
 
         /* bailout logic cleanup */
         if (conn->timer) {
-            gf_timer_call_cancel(clnt->ctx, conn->timer);
-            timer_unref = _gf_true;
+            if (!gf_timer_call_cancel(clnt->ctx, conn->timer))
+                timer_unref = _gf_true;
             conn->timer = NULL;
         }
         if (conn->reconnect) {
-            gf_timer_call_cancel(clnt->ctx, conn->reconnect);
-            reconnect_unref = _gf_true;
+            if (!gf_timer_call_cancel(clnt->ctx, conn->reconnect))
+                reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
 
@@ -1810,18 +1810,18 @@ rpc_clnt_disable(struct rpc_clnt *rpc)
         rpc->disabled = 1;
 
         if (conn->timer) {
-            gf_timer_call_cancel(rpc->ctx, conn->timer);
             /* If the event is not fired and it actually cancelled
              * the timer, do the unref else registered call back
              * function will take care of it.
              */
-            timer_unref = _gf_true;
+            if (!gf_timer_call_cancel(rpc->ctx, conn->timer))
+                timer_unref = _gf_true;
             conn->timer = NULL;
         }
 
         if (conn->reconnect) {
-            gf_timer_call_cancel(rpc->ctx, conn->reconnect);
-            reconnect_unref = _gf_true;
+            if (!gf_timer_call_cancel(rpc->ctx, conn->reconnect))
+                reconnect_unref = _gf_true;
             conn->reconnect = NULL;
         }
         conn->status = RPC_STATUS_INITIALIZED;


### PR DESCRIPTION
## Summary

Honor the return value of gf_timer_call_cancel() before dropping the rpc_clnt timer reference.

When a call_bail or reconnect timer has already been dispatched, the callback owns the timer reference. The cleanup path must only unref when cancellation succeeds; otherwise both the cleanup path and callback can unref the same reference.

This fixes the refcount race reported in #4679.

## Changes

- Fix rpc_clnt_reconnect_cleanup()
- Fix rpc_clnt_connection_cleanup() for call_bail and reconnect timers
- Fix rpc_clnt_disable() for call_bail and reconnect timers
- Preserve the existing NULL-gated ping timer ownership behavior

## Validation

- Focused rpc/rpc-lib/src rebuild passed with make -j 6
- git diff --check passed
- No changes outside rpc/rpc-lib/src/rpc-clnt.c