### PR TITLE
build: detect Python 3.12 correctly

### DIFF
--- a/contrib/aclocal/python.m4
+++ b/contrib/aclocal/python.m4
@@ -85,7 +85,7 @@ python2.1 python2.0])
   dnl library.
 
   AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
-    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
+    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:4]])"`])
   AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
 
   dnl Use the values of $prefix and $exec_prefix for the corresponding


### PR DESCRIPTION
This is the issue-named, current-devel replacement for PR #4705.

Updates: #3315

Validation:

- Configured successfully; Autoconf detected Python 3.12; `git diff --check` passed.

The original PR remains open until this replacement is verified.
