### PR TITLE
libglusterfs: use EVP for MD5 checksums

### DIFF
--- a/libglusterfs/src/checksum.c
+++ b/libglusterfs/src/checksum.c
@@ -8,7 +8,7 @@
   cases as published by the Free Software Foundation.
 */
 
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <zlib.h>
 #include <stdint.h>
@@ -40,5 +40,20 @@ gf_rsync_strong_checksum(unsigned char *data, size_t len,
 void
 gf_rsync_md5_checksum(unsigned char *data, size_t len, unsigned char *md5)
 {
-    MD5(data, len, md5);
+    EVP_MD_CTX *ctx = NULL;
+
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return;
+
+    if (EVP_DigestInit_ex(ctx, EVP_md5(), NULL) != 1)
+        goto out;
+
+    if (EVP_DigestUpdate(ctx, data, len) != 1)
+        goto out;
+
+    EVP_DigestFinal_ex(ctx, md5, NULL);
+
+out:
+    EVP_MD_CTX_free(ctx);
 }


### PR DESCRIPTION
This is the issue-named, current-devel replacement for PR #4708.

Fixes: #4243

Validation:

- Configured; `libglusterfs.la` and `checksum.lo` built successfully with `-j 6`.

The original PR remains open until this replacement is verified.
