### PR TITLE
posix: shut down fsyncer cooperatively

### DIFF
--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -154,6 +154,20 @@ delete_posix_diskxl(struct posix_private *priv, glusterfs_ctx_t *ctx)
     }
 }
 
+static void
+posix_stop_fsyncer(struct posix_private *priv)
+{
+    if (!priv->fsyncer)
+        return;
+
+    pthread_mutex_lock(&priv->fsync_mutex);
+    priv->fsyncer_exit = _gf_true;
+    pthread_cond_signal(&priv->fsync_cond);
+    pthread_mutex_unlock(&priv->fsync_mutex);
+    (void)pthread_join(priv->fsyncer, NULL);
+    priv->fsyncer = 0;
+}
+
 /**
  * notify - when parent sends PARENT_UP, send CHILD_UP event from here
  */
@@ -1209,6 +1223,8 @@ posix_init(xlator_t *this)
 out:
     if (ret) {
         if (_private) {
+            posix_stop_fsyncer(_private);
+
             if (_private->dirfd >= 0) {
                 sys_close(_private->dirfd);
                 _private->dirfd = -1;
@@ -1311,14 +1327,7 @@ posix_fini(xlator_t *this)
         ctx->disk_space_check = 0;
     }
 
-    if (priv->fsyncer) {
-        pthread_mutex_lock(&priv->fsync_mutex);
-        priv->fsyncer_exit = _gf_true;
-        pthread_cond_signal(&priv->fsync_cond);
-        pthread_mutex_unlock(&priv->fsync_mutex);
-        (void)pthread_join(priv->fsyncer, NULL);
-        priv->fsyncer = 0;
-    }
+    posix_stop_fsyncer(priv);
 
     /*unlock brick dir*/
     if (priv->mount_lock >= 0) {

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -1312,7 +1312,11 @@ posix_fini(xlator_t *this)
     }
 
     if (priv->fsyncer) {
-        (void)gf_thread_cleanup_xint(priv->fsyncer);
+        pthread_mutex_lock(&priv->fsync_mutex);
+        priv->fsyncer_exit = _gf_true;
+        pthread_cond_signal(&priv->fsync_cond);
+        pthread_mutex_unlock(&priv->fsync_mutex);
+        (void)pthread_join(priv->fsyncer, NULL);
         priv->fsyncer = 0;
     }
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -2383,8 +2383,13 @@ posix_fsyncer_pick(struct posix_private *priv, struct list_head *head)
 
     pthread_mutex_lock(&priv->fsync_mutex);
     {
-        while (list_empty(&priv->fsyncs))
+        while (list_empty(&priv->fsyncs) && !priv->fsyncer_exit)
             pthread_cond_wait(&priv->fsync_cond, &priv->fsync_mutex);
+
+        if (list_empty(&priv->fsyncs)) {
+            pthread_mutex_unlock(&priv->fsync_mutex);
+            return -1;
+        }
 
         count = priv->fsync_queue_count;
         priv->fsync_queue_count = 0;
@@ -2478,6 +2483,9 @@ posix_fsyncer(void *d)
 
         count = posix_fsyncer_pick(priv, &list);
 
+        if (count < 0)
+            break;
+
         gf_nanosleep(priv->batch_fsync_delay_usec * GF_US_IN_NS);
 
         gf_msg_debug(this->name, 0, "picked %d fsyncs", count);
@@ -2508,6 +2516,8 @@ posix_fsyncer(void *d)
                 do_fsync = _gf_false;
         }
     }
+
+    return NULL;
 }
 
 /**

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2679,6 +2679,11 @@ posix_batch_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
     }
 
     pthread_mutex_lock(&priv->fsync_mutex);
+    if (priv->fsyncer_exit) {
+        pthread_mutex_unlock(&priv->fsync_mutex);
+        call_unwind_error(stub, -1, ESHUTDOWN);
+        return 0;
+    }
     {
         list_add_tail(&stub->list, &priv->fsyncs);
         priv->fsync_queue_count++;

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -191,6 +191,7 @@ struct posix_private {
 #endif
 
     pthread_t fsyncer;
+    gf_boolean_t fsyncer_exit;
     struct list_head fsyncs;
     pthread_mutex_t fsync_mutex;
     pthread_cond_t fsync_cond;


### PR DESCRIPTION
## What does this patch do?

Replace cancellation-based POSIX fsyncer shutdown with cooperative shutdown. The worker now observes an exit flag under `fsync_mutex`, drains queued fsync stubs before exiting, and is joined normally from `posix_fini()`. New fsync requests that race with teardown are rejected and unwound with `ESHUTDOWN`.

The same stop helper is also called from the `posix_init()` failure path once the fsyncer has been started, preventing the worker from continuing against freed private state during partial initialization failure.

## Why are we doing this?

`posix_fsyncer_pick()` waits on a condition variable while holding the fsync mutex. Cancellation during that wait can leave the mutex locked, making subsequent destruction unsafe and potentially leaking queued stubs. Cooperative shutdown preserves mutex ownership and gives the worker a defined termination path. Initialization failures must stop the worker before the private state is released as well.

## Validation

- Full repository build completed successfully with `make -j6`.
- `tests/basic/posixonly.t`: 13/13 passed.
- `tests/bugs/core/brick-mux-fd-cleanup.t`: 34/34 passed.
- Focused POSIX target and dependencies built successfully.
- Builds used a RAM-backed copy of the EPEL10 rolling ccache, synced back to persistent storage afterward.
- No dedicated POSIX `check` target exists in this tree.

Fixes: https://github.com/gluster/glusterfs/issues/4685
