### PR TITLE
posix: use safe disk thread removal in fini

### DIFF
--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -1298,18 +1298,7 @@ posix_fini(xlator_t *this)
         pthread_join(ctx->janitor, NULL);
     }
 
-    pthread_mutex_lock(&ctx->xl_lock);
-    {
-        count = --ctx->diskxl_count;
-        if (count == 0)
-            pthread_cond_signal(&ctx->xl_cond);
-    }
-    pthread_mutex_unlock(&ctx->xl_lock);
-
-    if (count == 0) {
-        pthread_join(ctx->disk_space_check, NULL);
-        ctx->disk_space_check = 0;
-    }
+    delete_posix_diskxl(priv, ctx);
 
     if (priv->fsyncer) {
         (void)gf_thread_cleanup_xint(priv->fsyncer);


### PR DESCRIPTION
## What does this patch do?

Use the existing `delete_posix_diskxl()` teardown protocol from `posix_fini()` instead of manually decrementing the shared `diskxl_count` and joining the disk-space thread.

The helper safely marks the brick entry for detachment, waits for the disk-space thread to stop using it, removes it from the shared list, decrements the count exactly once, and joins the shared thread when the last brick is removed.

## Why are we doing this?

The manual `posix_fini()` path could leave a `posix_diskxl` entry on the shared disk-space thread's list during initialization failure, allowing the thread to access freed private state. It could also decrement `diskxl_count` a second time after `PARENT_DOWN` had already removed the brick.

## Validation

- Full repository build completed successfully with `make -j6`.
- `tests/basic/posixonly.t`: 13/13 passed.
- `tests/bugs/core/brick-mux-fd-cleanup.t`: 34/34 passed.
- Focused POSIX target and dependencies built successfully.
- Build used a RAM-backed copy of the EPEL10 rolling ccache, synced back to persistent storage afterward.

Updates: #4684