### PR TITLE
glusterd: keep brick fsids across volume import; never treat fsid 0 as shared

### DIFF
--- a/tests/bugs/glusterd/issue-4640-brick-fsid-survives-volume-sync.t
+++ b/tests/bugs/glusterd/issue-4640-brick-fsid-survives-volume-sync.t
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# gluster/glusterfs#4640 - after a node that was down during a volume
+# transaction rejoins, it imports the volume from a peer. The import used to
+# rebuild every brickinfo without its statfs_fsid, so glusterd stored
+# brick-fsid=0 for all bricks and regenerated the brick volfiles with every
+# local brick "sharing" fsid 0: option shared-brick-count N (N = bricks on the
+# node). posix divides statvfs by N, disperse takes the per-set minimum, and
+# df ends up reporting exactly one data-set for the whole volume.
+#
+# Three properties are checked, one per fix:
+#  A. the locally observed fsids survive a peer import (volume sync)
+#  B. the restart-time fsid repair does not persist a value taken from a
+#     directory that is not the brick (no trusted.glusterfs.volume-id)
+#  C. an unknown fsid (0) is never counted as shared with another brick
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../cluster.rc
+. $(dirname $0)/../../volume.rc
+
+function check_peers {
+        eval \$CLI_$1 peer status | grep 'Peer in Cluster (Connected)' | wc -l
+}
+
+# volume version as persisted by glusterd N
+function gd_vol_version {
+        local wd=$(eval \$CLI_$1 system getwd)
+        grep '^version=' $wd/vols/$V0/info | cut -d= -f2
+}
+
+# brick-fsid as persisted by glusterd N for brick <host>:<path>
+function brick_fsid {
+        local wd=$(eval \$CLI_$1 system getwd)
+        grep '^brick-fsid=' $wd/vols/$V0/bricks/$2:$(echo $3 | tr / -) | cut -d= -f2
+}
+
+# shared-brick-count in the brick volfile glusterd N generated for <host>:<path>
+function shared_brick_count {
+        local wd=$(eval \$CLI_$1 system getwd)
+        local p=${3#/}
+        grep -o 'shared-brick-count [0-9]*' $wd/vols/$V0/$V0.$2.$(echo $p | tr / -).vol | awk '{print $2}'
+}
+
+cleanup
+
+TEST launch_cluster 3
+TEST $CLI_1 peer probe $H2
+TEST $CLI_1 peer probe $H3
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 1
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 2
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 3
+
+# Two bricks on node 3, so that "how many of my bricks share a filesystem" is a
+# real question there. In this harness both live on the same filesystem, so the
+# legitimate shared-brick-count for them is 2.
+B3_1=$B3/${V0}_1
+B3_2=$B3/${V0}_2
+TEST $CLI_1 volume create $V0 $H1:$B1/${V0}_1 $H2:$B2/${V0}_1 $H3:$B3_1 $H3:$B3_2
+TEST $CLI_1 volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field_1 $V0 'Status'
+
+fsid_1=$(brick_fsid 3 $H3 $B3_1)
+fsid_2=$(brick_fsid 3 $H3 $B3_2)
+TEST [ -n "$fsid_1" -a "$fsid_1" != 0 ]
+TEST [ -n "$fsid_2" -a "$fsid_2" != 0 ]
+EXPECT 2 shared_brick_count 3 $H3 $B3_1
+EXPECT 2 shared_brick_count 3 $H3 $B3_2
+
+# ---- A. node 3 is down while the cluster changes the volume -----------------
+TEST kill_node 3
+EXPECT_WITHIN $PROBE_TIMEOUT 1 check_peers 1
+TEST $CLI_1 volume stop $V0
+TEST $CLI_1 volume start $V0
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT 'Started' volinfo_field_1 $V0 'Status'
+
+# node 3 comes back with an older volume version and imports it from a peer
+TEST $glusterd_3
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 1
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 3
+EXPECT_WITHIN $PROBE_TIMEOUT "$(gd_vol_version 1)" gd_vol_version 3
+
+# the import must not lose the fsids glusterd 3 observed at volume create ...
+EXPECT "$fsid_1" brick_fsid 3 $H3 $B3_1
+EXPECT "$fsid_2" brick_fsid 3 $H3 $B3_2
+# ... and the regenerated brick volfiles keep the true shared-brick-count
+EXPECT 2 shared_brick_count 3 $H3 $B3_1
+EXPECT 2 shared_brick_count 3 $H3 $B3_2
+
+# ---- B. + C. a zero fsid stays unknown, and unknown is never "shared" --------
+# The restart-time repair keeps its result in memory; the store is rewritten by
+# the next transaction, so every store assertion below follows a 'volume set'.
+TEST $CLI_1 volume stop $V0
+EXPECT_WITHIN $PROCESS_DOWN_TIMEOUT 'Stopped' volinfo_field_1 $V0 'Status'
+GD3_WD=$($CLI_3 system getwd)
+TEST kill_glusterd 3
+volid_hex=$(getfattr -n trusted.glusterfs.volume-id -e hex --absolute-names $B3_1 | sed -n 's/^trusted.glusterfs.volume-id=//p')
+TEST [ -n "$volid_hex" ]
+# simulate the shape left behind by an import with no old volinfo, or an
+# operator restarting glusterd with the brick filesystems not mounted: the
+# stored fsid is 0 and the brick directories are not the bricks
+TEST sed -i 's/^brick-fsid=.*/brick-fsid=0/' $GD3_WD/vols/$V0/bricks/$H3:*
+TEST setfattr -x trusted.glusterfs.volume-id $B3_1
+TEST setfattr -x trusted.glusterfs.volume-id $B3_2
+TEST start_glusterd 3
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 3
+TEST $CLI_1 volume set $V0 cluster.min-free-inodes 6%
+EXPECT_WITHIN $PROBE_TIMEOUT "$(gd_vol_version 1)" gd_vol_version 3
+
+# B. the restart-time repair must not take an fsid from a non-brick directory
+EXPECT 0 brick_fsid 3 $H3 $B3_1
+EXPECT 0 brick_fsid 3 $H3 $B3_2
+# C. regenerating the volfiles with two unknown fsids must not divide by 2
+EXPECT 1 shared_brick_count 3 $H3 $B3_1
+EXPECT 1 shared_brick_count 3 $H3 $B3_2
+
+# ---- D. once the bricks are back, a restart repairs and the truth returns ----
+TEST kill_glusterd 3
+TEST setfattr -n trusted.glusterfs.volume-id -v $volid_hex $B3_1
+TEST setfattr -n trusted.glusterfs.volume-id -v $volid_hex $B3_2
+TEST start_glusterd 3
+EXPECT_WITHIN $PROBE_TIMEOUT 2 check_peers 3
+TEST $CLI_1 volume set $V0 cluster.min-free-inodes 7%
+EXPECT_WITHIN $PROBE_TIMEOUT "$(gd_vol_version 1)" gd_vol_version 3
+EXPECT "$fsid_1" brick_fsid 3 $H3 $B3_1
+EXPECT "$fsid_2" brick_fsid 3 $H3 $B3_2
+EXPECT 2 shared_brick_count 3 $H3 $B3_1
+EXPECT 2 shared_brick_count 3 $H3 $B3_2
+
+cleanup

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -2663,16 +2663,37 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             struct statvfs brickstat = {
                 0,
             };
-            ret = sys_statvfs(brickinfo->path, &brickstat);
-            if (ret) {
-                gf_msg(this->name, GF_LOG_WARNING, errno,
-                       GD_MSG_BRICKINFO_CREATE_FAIL,
-                       "failed to get statfs() call on brick %s",
-                       brickinfo->path);
-                /* No need for treating it as an error, lets continue
-                   with just a message */
+            uuid_t volid = {
+                0,
+            };
+            /* Only observe the fsid when this path really is the brick, i.e.
+             * it carries the volume-id xattr (the same check brick start
+             * makes). If glusterd is (re)started with the brick filesystem
+             * not mounted, brickinfo->path is an empty directory on the
+             * parent filesystem; observing its fsid here would persist one
+             * shared fsid for every local brick and wrongly divide statvfs
+             * down. Leave the fsid unknown (0) instead - a later restart
+             * with the brick mounted, or a peer import from a node that has
+             * it, will supply the real value. See gluster#4640.
+             */
+            if (sys_lgetxattr(brickinfo->path, GF_XATTR_VOL_ID_KEY, volid,
+                              sizeof(volid)) != sizeof(volid)) {
+                gf_msg_debug(this->name, 0,
+                             "brick %s has no %s xattr (not mounted?); "
+                             "leaving statfs_fsid unset",
+                             brickinfo->path, GF_XATTR_VOL_ID_KEY);
             } else {
-                brickinfo->statfs_fsid = brickstat.f_fsid;
+                ret = sys_statvfs(brickinfo->path, &brickstat);
+                if (ret) {
+                    gf_msg(this->name, GF_LOG_WARNING, errno,
+                           GD_MSG_BRICKINFO_CREATE_FAIL,
+                           "failed to get statfs() call on brick %s",
+                           brickinfo->path);
+                    /* No need for treating it as an error, lets continue
+                       with just a message */
+                } else {
+                    brickinfo->statfs_fsid = brickstat.f_fsid;
+                }
             }
         }
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -4557,6 +4557,13 @@ glusterd_volinfo_copy_brickinfo(glusterd_volinfo_t *old_volinfo,
             old_volinfo, &old_brickinfo);
         if (ret == 0) {
             new_brickinfo->port = old_brickinfo->port;
+            /* statfs_fsid is observed locally (create/add-brick/restart) and
+             * is not carried in the peer payload, so an imported brickinfo
+             * arrives with fsid 0. Copy it from the old brickinfo, like the
+             * port and real_path above, so shared-brick-count stays correct
+             * across a volume sync. See gluster#4640.
+             */
+            new_brickinfo->statfs_fsid = old_brickinfo->statfs_fsid;
 
             if (old_brickinfo->real_path[0] == '\0') {
                 if (!realpath(new_brickinfo->path, abspath)) {
@@ -4595,6 +4602,7 @@ glusterd_volinfo_copy_brickinfo(glusterd_volinfo_t *old_volinfo,
                 new_ta_brickinfo->path, old_volinfo, &old_ta_brickinfo);
             if (ret == 0) {
                 new_ta_brickinfo->port = old_ta_brickinfo->port;
+                new_ta_brickinfo->statfs_fsid = old_ta_brickinfo->statfs_fsid;
 
                 if (old_ta_brickinfo->real_path[0] == '\0') {
                     if (!realpath(new_ta_brickinfo->path, abspath)) {

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -5474,8 +5474,19 @@ gd_set_shared_brick_count(glusterd_volinfo_t *volinfo)
         brickinfo->fs_share_count = 0;
         cds_list_for_each_entry(trav, &volinfo->bricks, brick_list)
         {
-            if (!gf_uuid_compare(trav->uuid, uuid) &&
-                (trav->statfs_fsid == brickinfo->statfs_fsid)) {
+            if (gf_uuid_compare(trav->uuid, uuid))
+                continue;
+            /* A brick always shares a filesystem with itself. Two distinct
+             * bricks are only known to share one when both carry the same
+             * non-zero fsid; fsid 0 means "not observed" (e.g. left behind
+             * by an import or an upgrade), and must never be treated as a
+             * match, or every local brick with an unknown fsid would be
+             * counted as sharing and statvfs would be wrongly divided down.
+             * See gluster#4640.
+             */
+            if (trav == brickinfo ||
+                (brickinfo->statfs_fsid != 0 &&
+                 trav->statfs_fsid == brickinfo->statfs_fsid)) {
                 brickinfo->fs_share_count++;
             }
         }


### PR DESCRIPTION
### Problem

After a node that was down during a volume transaction rejoins the cluster, `df` on the volume drops to the capacity of a **single data-set** and stays there — through glusterd restarts, brick remounts, and volume stop/start. Reported in #4640 (a `36 × (11+4)` disperse volume showing 41 TB of ~1.2 PB); previously #1447 and Red Hat BZ 1517260, where it was worked around with a filter script but the trigger was never pinned down.

### Cause

The symptom surfaces three subsystems away from its cause: a field is dropped in glusterd's management plane, divided in `storage/posix`, and amplified in EC's disperse client — which is why a `df` anomaly is hard to trace back to a peer import.

`shared-brick-count` exists for a good reason: when several bricks live on one filesystem, `posix_statfs` divides the filesystem's `statvfs` by that count so the volume reports the capacity once rather than once per brick (introduced in `61ea2a44b5`, 2017). glusterd derives the count at volfile generation as *"how many of my bricks carry the same stored `statfs_fsid`"* (`gd_set_shared_brick_count`). The fsid is observed locally — at volume create, add-brick, replace-brick, or at glusterd start when the stored value is 0.

The fsid-0 case was already anticipated: `0b0c93578c` (2018) re-observes a stored fsid of 0 at glusterd start, with the note *"Ideally statfs_fsid should never be 0 if done right."* That guard covers the upgrade path — but not the **volume-import** path, and `gd_set_shared_brick_count` itself still treats 0 as a value that matches other zeros. This PR completes that original intent.

1. **Import drops the fsid.** `glusterd_import_new_brick()` rebuilds each brickinfo from the peer payload, which carries no fsid. `glusterd_import_friend_volume()` copies port and `real_path` from the old volinfo (via `glusterd_volinfo_copy_brickinfo()`) but not the fsid, then persists the volinfo with `brick-fsid=0` for every brick and regenerates the volfiles. Every local brick now "shares" fsid 0, so each gets `shared-brick-count N` (N = bricks on the node) and reports 1/N of its size. The node whose `volinfo->version` is lower is the one that imports — the node that was down.
2. **Disperse amplifies it.** `ec_statvfs_combine()` reports the per-set minimum; with one brick of the affected node in every set, the volume reports `k · B` — exactly one data-set (`S · k · B/N`, with `N = S`). This is why @aspandey's arithmetic on the issue (`11 × 4 TB ≈ 41 TB`) is exactly right: it is one disperse set, produced without any misconfiguration.
3. **A restart doesn't fix it, and can make it permanent.** glusterd restart re-observes a stored 0 but does not regenerate volfiles, so the running bricks keep the stale count. And if the restart happens while the brick filesystems are not mounted, the repair reads the *parent* filesystem — one identical, non-zero fsid for every brick — persists it, and nothing recomputes it again.

### Fix (three small changes; no posix or EC change)

The defect is entirely in how glusterd produces and preserves `statfs_fsid`. posix (Link 1) and EC (Link 6) are correct given their inputs and are left untouched.

1. **`glusterd_volinfo_copy_brickinfo()` — carry `statfs_fsid` across import.** It already copies port and `real_path` for exactly this reason: locally-observed facts the peer payload doesn't carry. fsid is the same class. (data and thin-arbiter bricks)
2. **`gd_set_shared_brick_count()` — an unknown fsid (0) is never shared.** Count a brick with itself always, and with another local brick only when both carry the same **non-zero** fsid. This is the invariant `0b0c93578c` already documented (*"should never be 0 if done right"*); the counter now honors it, so an unknown fsid yields `shared-brick-count 1` (no division) rather than N. Any future path that leaves an fsid unset now degrades safely.
3. **`glusterd_store_retrieve_bricks()` — don't observe a non-brick.** Gate the restart-time repair on the path carrying `trusted.glusterfs.volume-id` (the same check `glusterd_brick_start()` makes). If the filesystem isn't mounted, leave the fsid 0 for a later correct observation instead of persisting the parent's — this closes the permanent variant.


### Existing affected clusters

The fix is preventive and self-heals the common case (a stored fsid of 0 is re-observed on the next glusterd restart). A cluster **already** stuck in the permanent variant — a stored *non-zero, identical* fsid from a restart with unmounted bricks — is **not** auto-cured by upgrading (verified: the patched code alone leaves it at one data-set). Such a deployment needs a one-time repair on the affected node: stop glusterd, ensure the brick filesystems are mounted, set `brick-fsid=0` in `/var/lib/glusterd/vols/<vol>/bricks/<this-host>:*`, start glusterd (re-observes the real fsids), then any `gluster volume set <vol> <opt> <current-value>` to regenerate the volfiles. Tested end-to-end on a permanently-affected cluster: it restores full `df` and the true per-filesystem fsids, and leaves brick data untouched (`trusted.glusterfs.volume-id` intact, a canary file bit-identical throughout).

### Test

`tests/bugs/glusterd/issue-4640-brick-fsid-survives-volume-sync.t` (3-glusterd `launch_cluster`, two bricks on one node so a genuine shared count of 2 is also checked): after `kill_node` + `volume stop/start` + rejoin the node's stored fsids and volfile counts survive the import (fix 1); a `brick-fsid=0` with the volume-id xattr removed stays 0 across a restart (fix 3); two unknown fsids regenerate as count 1, not 2 (fix 2); restoring the xattr repairs and the legitimate count 2 returns.

On unpatched devel `a6fa98f65c` the test fails 6/52 (fsid reads 0 after import; unknown fsid counted as shared → count 2; fsid not restored). With the three fixes it passes 52/52.

### Reproduced on a live cluster

3 nodes, `disperse 3 redundancy 1`, one brick per node per set, each brick on its own filesystem, GlusterFS 11.2 (glusterd code identical to 11.1 and devel). Identical node-down stop/start + rejoin in both arms — the import logs the same `Version of volume … differ` line each time — with the affected node's glusterd the only variable:

| rejoining node's glusterd | `df` before | `df` after rejoin | shared-brick-count |
|---|---|---|---|
| unpatched 11.2 | 12 884 901 888 | **4 294 705 152** (one data-set) | 1 → 3 |
| this patch | 12 884 901 888 | **12 884 901 888** | 1 → 1 |

Patching only the node that rejoins is sufficient (`shared-brick-count` is regenerated per-node).

Updates: #4640
