### PR TITLE
ec: give the EC_STATE_DISPATCH case its own block

### DIFF
--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -1371,7 +1371,7 @@ ec_manager_readv(ec_fop_data_t *fop, int32_t state)
 
             return EC_STATE_DISPATCH;
 
-        case EC_STATE_DISPATCH:
+        case EC_STATE_DISPATCH: {
             uintptr_t inode_read_mask = ec_inode_readmask_get(fop->fd->inode,
                                                               fop->xl);
             if (inode_read_mask != 0) {
@@ -1383,6 +1383,7 @@ ec_manager_readv(ec_fop_data_t *fop, int32_t state)
             ec_dispatch_min(fop);
 
             return EC_STATE_PREPARE_ANSWER;
+        }
 
         case EC_STATE_PREPARE_ANSWER:
             cbk = ec_fop_prepare_answer(fop, _gf_true);


### PR DESCRIPTION
20eb810faa (#4496, "Added read_mask on ec_inode to specify bricks for
read") put a declaration directly after the 'case EC_STATE_DISPATCH:'
label in ec_manager_readv(), where a statement stood before it. A label
must be followed by a statement in C17 and earlier; only C23 relaxed
that. GCC 8 and GCC 9 therefore reject the file:

  ec-inode-read.c:1375:13: error: a label can only be part of a
  statement and a declaration is not a statement

GCC 11 and newer accept it, because they offer the C23 relaxation as an
extension in every mode, and the tree pins no -std (configure.ac has
only AC_PROG_CC); clang accepts it too, including under -std=c17. That
is why this went unnoticed: it builds on every toolchain a developer is
likely to be running, and fails only on the older ones that
distributions still build on. glusterfs.spec.in carries
%if ( 0%{?rhel} && 0%{?rhel} >= 8 ) branches, and EL8 ships GCC 8.

Give the case its own compound statement so the declaration is at the
head of a block. It is the only site of its kind in the tree.

Verified in containers, configured --disable-linux-io_uring, against
devel 7ae71fe605:

|                       before         |     after |
| --- | --- |
|  AlmaLinux 8 (gcc 8)  make: Error 2  |     make 0, make install 0, 66 .so |
|  Ubuntu 20.04 (gcc 9) make: Error 2  |     make 0, make install 0, 66 .so |

and no change on CentOS Stream 9 (gcc 11), Debian 12/13 (gcc 12/14),
Fedora 42 (gcc 15), openSUSE Tumbleweed and Arch (gcc 16), which build
either way.

On a compiler that already accepted the file, the change is inert:
compiling ec-inode-read.c before and after with the build's own flags
(minus LTO, so the object holds machine code), ec_manager_readv is 224
instructions both ways and the disassembly differs only in two
immediates -- 0x57d->0x57e and 0x5a2->0x5a3, the __LINE__ values in the
GF_ASSERT and gf_msg below the patch, which rise by one because the
patch adds one line above them.

20eb810faa is on devel only, so no release branch is affected.

Fixes: #4726
Signed-off-by: Thales Antunes de Oliveira Barretto <thales.barretto.git@gmail.com>

