### PR TITLE
build: link the cloudsync s3 plugin against the libraries it uses

### DIFF
--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/Makefile.am
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/Makefile.am
@@ -4,11 +4,12 @@ csp_LTLIBRARIES = cloudsyncs3.la
 cspdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/cloudsync-plugins
 
 cloudsyncs3_la_SOURCES = libcloudsyncs3.c  $(top_srcdir)/xlators/features/cloudsync/src/cloudsync-common.c
-cloudsyncs3_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la
+cloudsyncs3_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la -lcurl -lcrypto
 cloudsyncs3_la_LDFLAGS = -module -export-symbols $(top_srcdir)/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.sym $(GF_XLATOR_LDFLAGS)
-AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src   -I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src -lcurlpp -lcryptopp
+AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src -I$(top_srcdir)/rpc/xdr/src \
+	-I$(top_builddir)/rpc/xdr/src -I$(top_srcdir)/xlators/features/cloudsync/src
 noinst_HEADERS = libcloudsyncs3.h libcloudsyncs3-mem-types.h
-AM_CFLAGS = -Wall -fno-strict-aliasing $(GF_CFLAGS) -lcurl -lcrypto -I$(top_srcdir)/xlators/features/cloudsync/src
+AM_CFLAGS = -Wall -fno-strict-aliasing $(GF_CFLAGS)
 CLEANFILES =
 
 EXTRA_DIST = libcloudsyncs3.sym


### PR DESCRIPTION
cloudsyncs3 declares its link libraries in two variables that are not
link variables:

  AM_CPPFLAGS = ... -lcurlpp -lcryptopp
  AM_CFLAGS   = ... -lcurl -lcrypto -I$(top_srcdir)/xlators/features/cloudsync/src

AM_CPPFLAGS reaches the compiler only, so -lcurlpp and -lcryptopp have
never had any effect. They are the only occurrences of those strings in
the whole tree, no source file includes curlpp or cryptopp, and neither
library is a documented build dependency; they have been inert since the
plugin was added in e3995d5fff. Being silently dropped is the worst part:
a build host without libcurlpp/libcryptopp gets no diagnostic at all,
because the flags never reach the linker to fail.

-lcurl and -lcrypto in AM_CFLAGS do link, but only because automake
happens to replay $(AM_CFLAGS) in its libtool link rule
(cloudsyncs3_la_LINK).  That is not what CFLAGS is for, and the -I in
the same variable is a preprocessor flag that belongs in AM_CPPFLAGS.

Put the libraries the plugin actually uses in LIBADD, move the include
path to AM_CPPFLAGS, and drop the two flags that never did anything.
Both libraries are genuinely needed: libcloudsyncs3.c calls curl_easy_*
and curl_slist_*, and since 6d9290d834 ("cloudsyncs3: use EVP for HMAC
signing") also EVP_DigestSign*, EVP_PKEY_* and EVP_sha1.

No functional change: the patch moves flags between variables without
moving any library.  Built with and without the change, from the same
tree and the same configure flags, on every distribution where the
plugin is built -- CentOS Stream 9, Ubuntu 22.04 and 24.04, Debian 12
and 13, Fedora 42, openSUSE Tumbleweed and Arch (glibc 2.34 through
2.44, gcc 11 through 16) -- cloudsyncs3.so ends up with an identical
DT_NEEDED list on all eight, make install succeeds on all eight, and
ldd -r reports no unresolved curl_* or EVP_* symbol.

Fixes: #4728

