### PR TITLE
build: declare the automake 1.16 requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,11 +12,13 @@ AC_INIT([glusterfs],[m4_esyscmd([build-aux/pkg-version --version])],[gluster-use
 AC_SUBST([PACKAGE_RELEASE],
          [m4_esyscmd([build-aux/pkg-version --release])])
 
-AM_INIT_AUTOMAKE([tar-pax foreign])
-
-# Removes warnings when using automake 1.14 around (...but option 'subdir-objects' is disabled )
-#but libglusterfs fails to build with contrib (Then are not set up that way?)
-#AM_INIT_AUTOMAKE([subdir-objects])
+dnl automake 1.16 is the floor: libglusterfs/src/Makefile.am sets subdir-objects
+dnl (0dbca87d5f, #4593) and compiles $(CONTRIBDIR)/xxhash/xxhash.c out of tree.
+dnl Older automake does not create the .deps directory for such objects, and the
+dnl build dies with
+dnl   ../../contrib/xxhash/.deps/libglusterfs_la-xxhash.Plo: No such file or directory
+dnl Declaring the requirement turns that into a clear message from configure.
+AM_INIT_AUTOMAKE([1.16 tar-pax foreign])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 


### PR DESCRIPTION
libglusterfs/src/Makefile.am sets AUTOMAKE_OPTIONS = subdir-objects
(0dbca87d5f, #4593 "Fix remove subdir-objects is disabled warnings")
and compiles $(CONTRIBDIR)/xxhash/xxhash.c, a source outside its own
directory.  automake older than 1.16 does not create the .deps
directory for such objects, so the build dies well after configure
has succeeded, with a message that names neither automake nor the
option that requires it:

  Makefile:998: ../../contrib/xxhash/.deps/libglusterfs_la-xxhash.Plo:
  No such file or directory

configure.ac declares no minimum, so nothing catches this earlier.  Ask
AM_INIT_AUTOMAKE for 1.16 and let automake report it, and replace the
stale comment underneath -- which described an attempt to enable
subdir-objects globally that was reverted for this very reason ("but
libglusterfs fails to build with contrib") -- with what is actually
required now.

Measured across 10 distributions: automake 1.15.1 (openSUSE Leap 15.6)
is the only version below the floor and the only one that fails.
1.16.1 (AlmaLinux 8, Ubuntu 20.04), 1.16.2 (CentOS Stream 9), 1.16.5
(Debian 12, Ubuntu 22.04/24.04), 1.17 (Debian 13, Fedora 42) and 1.18.1
(openSUSE Tumbleweed, Arch) all build.  1.16.1 is the lowest verified
working version; 1.16.0 was not tested.

With this change, Leap 15.6 stops in twelve seconds with

  configure.ac:21: error: require Automake 1.16, but have 1.15.1

instead of failing minutes into the build, and Debian 13 and CentOS
Stream 9 are unaffected (configure, make and make install all succeed
exactly as before).

No release branch is affected: release-11's libglusterfs/src/Makefile.am
does not set subdir-objects, which is why openSUSE's shipped glusterfs
11.2 builds on Leap today.

Fixes: #4730
