### PR TITLE
afr: fix possble memory leaks in rename

### DIFF
--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -1667,8 +1667,13 @@ afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         afr_transaction_fop_failed(local, child_index);
     }
 
-    if (xattr)
+    if (xattr) {
+        LOCK(&frame->lock);
+        if (local->transaction.changelog_xdata[child_index])
+            dict_unref(local->transaction.changelog_xdata[child_index]);
         local->transaction.changelog_xdata[child_index] = dict_ref(xattr);
+        UNLOCK(&frame->lock);
+    }
 
     call_count = afr_frame_return(frame);
 


### PR DESCRIPTION
when one brick goes down, memory leaks after rename.

rename after one brick offline:
afr_changelog_do
    AFR_ENTRY_RENAME_TRANSACTION
    AFR_ENTRY_TRANSACTION

afr_changelog_cbk(..., cookie = i, xattr = dict1)
    changelog_xdata[i] = dict_ref(dict1);           // dict1 ref=2
afr_changelog_cbk(..., cookie = i, xattr = dict2)   // second
    changelog_xdata[i] = dict_ref(dict2);           // without unref dict1

