### PR TITLE
fusermount: refuse unknown mount options

### DIFF
--- a/contrib/fuse-util/fusermount.c
+++ b/contrib/fuse-util/fusermount.c
@@ -773,10 +773,16 @@ static int do_mount(const char *mnt, char **typep, mode_t rootmode,
 						flags |= flag;
 					else
 						flags  &= ~flag;
-				} else {
+				} else if (opt_eq(s, len, "default_permissions") ||
+					   opt_eq(s, len, "allow_other") ||
+					   begins_with(s, "max_read=") ||
+					   begins_with(s, "blksize=")) {
 					memcpy(d, s, len);
 					d += len;
 					*d++ = ',';
+				} else {
+					fprintf(stderr, "%s: unknown option '%.*s'\n", progname, len, s);
+					exit(1);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: #4735

fusermount-glusterfs (contrib/fuse-util/fusermount.c) is a vendored copy of libfuse's
fusermount (~2009) whose do_mount() forwards unrecognised mount options verbatim to the
privileged mount(2). This ports libfuse 5018a0c (Jann Horn) to whitelist known-harmless
options -- the defense-in-depth part of the CVE-2018-10906 fix; no specific escalation is
claimed.

Normal mounts are unaffected: fsname=/subtype=/nonempty are consumed by earlier branches,
fd=/rootmode=/user_id=/group_id= are excluded and regenerated, standard flags go through
find_mount_flag(), and default_permissions/allow_other/max_read=/blksize= are whitelisted;
only an unrecognised option is refused. Verified on Fedora 43 (SELinux enforcing, glusterfs
11.2, which ships the pre-fix binary): the shipped helper forwards "EVILOPT=pwned" into
mount(2); this build refuses it (no mount(2)) and still accepts a full real option set.
Details in #4735. Supersedes #4486.