### PR TITLE
tests: make timed-out and interrupted tests clean up after themselves

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,15 @@
 #
 
 export TZ=UTC
+
+# This script is routinely run as '... | tee logfile'.  Ctrl-C then kills
+# tee together with us, and any subsequent write to stdout/stderr would
+# kill this script with SIGPIPE in the middle of terminating and sweeping
+# the running test - leaving the test tree orphaned, which is the very
+# bug this harness exists to prevent.  With SIGPIPE ignored such writes
+# fail benignly with EPIPE instead, and supervision runs to completion.
+trap '' PIPE
+
 force="no"
 head="yes"
 retry="yes"
@@ -381,10 +390,13 @@ function run_one_test()
 
     timeout -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t} &
     tpid=$!
+    # Forward FIRST, then talk: an interrupt that also killed our log
+    # consumer leaves stdout/stderr as dead pipes, and although SIGPIPE
+    # is ignored the message is best-effort while the forward is not.
     trap 'interrupted="yes";
-          echo "Interrupted: terminating ${t} and running its cleanup (repeat to force-kill) ..." >&2;
           kill -TERM ${tpid} 2>/dev/null;
-          trap "kill -KILL -${tpid} 2>/dev/null" INT TERM HUP' INT TERM HUP
+          trap "kill -KILL -${tpid} 2>/dev/null" INT TERM HUP;
+          echo "Interrupted: terminating ${t} and running its cleanup (repeat to force-kill) ..." >&2' INT TERM HUP
     wait ${tpid}
     rc=$?
     # When the trap interrupts 'wait', rc is 128+sig rather than the

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -512,8 +512,15 @@ function run_tests()
 
             local cmd_timeout=$run_timeout;
             if [ ${timeout_cmd_exists} == "yes" ]; then
-                if [ $(grep -c "SCRIPT_TIMEOUT=" ${t}) == 1 ] ; then
-                    cmd_timeout=$(grep "SCRIPT_TIMEOUT=" ${t} | cut -f2 -d'=');
+                # Only a real assignment counts (not a comment mentioning
+                # SCRIPT_TIMEOUT), only the numeric value is taken (not
+                # trailing comments), and the last assignment wins.
+                local script_timeout
+                script_timeout=$(sed -n \
+                    's/^[[:space:]]*SCRIPT_TIMEOUT=\([0-9][0-9]*\).*/\1/p' \
+                    ${t} | tail -1)
+                if [ -n "${script_timeout}" ] ; then
+                    cmd_timeout=${script_timeout}
                     echo "Timeout set is ${cmd_timeout}, default ${run_timeout}"
                 fi
             fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,14 @@ skip_known_bugs="yes"
 result_output="/tmp/gluster_regression.txt"
 section_separator="========================================"
 run_timeout=200
-kill_after_time=5
+# Grace given to a signalled test to finish cleaning up.  Used twice by
+# run_one_test: as timeout's -k (SIGKILL if prove survives the SIGTERM) and
+# as the time the test's process group gets to drain after 'timeout'
+# returns, which is the budget force_terminate (tests/include.rc) has to
+# run 'cleanup' (unmounts, daemon shutdown, volume/zpool teardown) before
+# the group is force-killed.  It must fit a full cleanup, not just a
+# signal round-trip.
+kill_after_time=60
 nfs_tests=$RUN_NFS_TESTS
 list_only="no"
 secho="echo"
@@ -325,6 +332,114 @@ function get_bug_list_for_disabled_test ()
 
 }
 
+# Run one test file under 'prove', supervised by 'timeout'.
+#
+# 'timeout' is deliberately NOT given --foreground: without it, 'timeout'
+# runs the test in a dedicated process group and, on expiry, delivers
+# SIGTERM (and, ${kill_after_time} seconds later, SIGKILL) to that whole
+# group, so the bash executing the test file receives the signal and its
+# force_terminate trap (tests/include.rc) gets to run 'cleanup'.  With
+# --foreground only the direct child (prove) was signalled: the test
+# script survived as an orphan, keeping mounts and daemons alive and
+# wedging the next run (see issue #4610).
+#
+# Because the test group is then no longer the terminal's foreground
+# group, Ctrl-C (and TERM/HUP from CI) land on this script instead of the
+# test.  The trap below forwards the interrupt to 'timeout' as SIGTERM,
+# which 'timeout' propagates to the test's group; the run is aborted once
+# the group has drained (see the grace loop below).  A second interrupt
+# escalates to SIGKILL of the whole group ('timeout' is the group leader,
+# so the group is addressable as -pid).
+#
+# The interrupt is forwarded as SIGTERM, not SIGINT, on purpose: coreutils
+# >= 9.x 'timeout' ignores an external SIGINT when running without
+# --foreground (coreutils <= 8.32 forwarded it), while SIGTERM behaves the
+# same on every toolchain, and the include.rc trap handles both alike.
+#
+# Even so, the signalled test may die before its trap can run: when the
+# group SIGTERM kills the test's current foreground command, bash emits
+# its job notice ("Terminated") to the test's stderr - a pipe owned by
+# prove, which just died of the same SIGTERM - so that write is a
+# coin-flip SIGPIPE that kills the test shell before the trap runs
+# (observed with strace: write(2, "Terminated\n") = EPIPE, killed by
+# SIGPIPE).  That is why, after the group has drained or been killed,
+# the environment is additionally swept below by running 'cleanup' on
+# the test's behalf; cleanup is idempotent (tests run it at entry and
+# exit), so sweeping after a cleanup that did run is harmless.
+function run_one_test()
+{
+    local t="$1"
+    local cmd_timeout="$2"
+    local tpid
+    local rc
+    local interrupted=""
+
+    if [ ${timeout_cmd_exists} != "yes" ]; then
+        prove -vmfe '/bin/bash' ${t}
+        return $?
+    fi
+
+    timeout -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t} &
+    tpid=$!
+    trap 'interrupted="yes";
+          echo "Interrupted: terminating ${t} and running its cleanup (repeat to force-kill) ..." >&2;
+          kill -TERM ${tpid} 2>/dev/null;
+          trap "kill -KILL -${tpid} 2>/dev/null" INT TERM HUP' INT TERM HUP
+    wait ${tpid}
+    rc=$?
+    # When the trap interrupts 'wait', rc is 128+sig rather than the
+    # child's real status.  Do NOT loop on 'wait' to fetch it: once a
+    # trapped signal has interrupted 'wait', bash may keep returning
+    # 128+sig from subsequent 'wait' builtins, which livelocks.  The
+    # group drain below supervises the child's whole process group
+    # anyway, and on the interrupt path the run is aborted regardless.
+    # 'timeout' exits as soon as its direct child (prove) dies, but the
+    # test's process group can outlive both: after the group SIGTERM the
+    # test script is still running force_terminate/cleanup.  Do not start
+    # the next test (or the retry) on top of that: give the group
+    # ${kill_after_time} seconds to drain when a cleanup may be running
+    # (timeout or interrupt), then force-kill the leftovers.  The group is
+    # addressable as -tpid because 'timeout' led it.
+    local waited=0
+    if [ ${rc} -eq 124 ] || [ -n "${interrupted}" ]; then
+        while kill -0 -${tpid} 2>/dev/null; do
+            if [ ${waited} -ge ${kill_after_time} ]; then
+                echo "Test group of ${t} still busy after ${kill_after_time}s grace, force-killing it" >&2
+                break
+            fi
+            sleep 1
+            waited=$((waited+1))
+        done
+    fi
+    kill -KILL -${tpid} 2>/dev/null
+    if [ ${rc} -eq 124 ] || [ -n "${interrupted}" ]; then
+        # Sweep the environment in case the test died before (or while)
+        # running 'cleanup' - see the SIGPIPE note above.  Stale fuse
+        # mounts are detached before include.rc is sourced, because its
+        # source-time 'mkdir -p $WORKDIRS' can hang on a dead mount; the
+        # whole sweep is bounded by 'timeout' for the same reason.
+        echo "Sweeping the test environment after ${t}" >&2
+        # ${t} is passed as $0: include.rc locates env.rc by walking up
+        # from $0's directory.  include.rc itself is addressed through
+        # ${regression_testsdir} so the sweep works regardless of $PWD.
+        timeout -k 5 ${kill_after_time} bash -c '
+            for m in $(grep -w fuse.glusterfs /proc/mounts 2>/dev/null |
+                       awk "{print \$2}"); do
+                umount -l "$m" 2>/dev/null
+            done
+            . "$1" >/dev/null 2>&1
+            cleanup >/dev/null 2>&1' "${t}" \
+            "${regression_testsdir}/tests/include.rc" >/dev/null 2>&1
+    fi
+    trap - INT TERM HUP
+    if [ -n "${interrupted}" ]; then
+        [ ${rc} -eq 0 ] && rc=130
+        echo "Aborting the run: interrupted while running ${t} (status ${rc})" >&2
+        exit ${rc}
+    fi
+    return ${rc}
+}
+
 function run_tests()
 {
     RES=0
@@ -401,10 +516,8 @@ function run_tests()
                     cmd_timeout=$(grep "SCRIPT_TIMEOUT=" ${t} | cut -f2 -d'=');
                     echo "Timeout set is ${cmd_timeout}, default ${run_timeout}"
                 fi
-                timeout --foreground -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
-            else
-                prove -vmfe '/bin/bash' ${t}
             fi
+            run_one_test ${t} ${cmd_timeout}
             TMP_RES=$?
             ELAPSEDTIMEMAP[$t]=`expr $(date +%s) - $starttime`
             tar_logs "$t"
@@ -424,11 +537,7 @@ function run_tests()
                 echo "       *********************************"
                 echo ""
 
-                if [ ${timeout_cmd_exists} == "yes" ]; then
-                    timeout --foreground -k ${kill_after_time} ${cmd_timeout} prove -vmfe '/bin/bash' ${t}
-                else
-                    prove -vmfe '/bin/bash' ${t}
-                fi
+                run_one_test ${t} ${cmd_timeout}
                 TMP_RES=$?
                 tar_logs "$t"
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -555,6 +555,17 @@ function run_tests()
                 TESTS_NEEDED_RETRY="${TESTS_NEEDED_RETRY}${t} "
             fi
 
+            # Physically release the space the test's cleanup freed, for
+            # devices that support discard (moved here from cleanup():
+            # cleanup runs at both test entry and exit, so this halves the
+            # calls, and fstrim's duration is unbounded on some devices,
+            # which would eat the post-timeout drain grace above).
+            if [ ${timeout_cmd_exists} == "yes" ]; then
+                timeout 60 fstrim /d 2>/dev/null
+            else
+                fstrim /d 2>/dev/null
+            fi
+
 
             if [ ${TMP_RES} -ne 0 ] ; then
 		if [[ "$t" == *"tests/000-flaky/"* ]]; then

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -781,8 +781,10 @@ function cleanup()
                 return 1;
         fi >&2
 
-        # Physically release unused space
-        fstrim /d
+        # NB: the fstrim that used to run here lives in run-tests.sh now:
+        # cleanup() runs at both test entry and exit, and fstrim's duration
+        # is unbounded on some devices, which stalled every path that waits
+        # for a cleanup to finish.
 
         mkdir -p $WORKDIRS
 	# This is usually the last thing a test script calls, so our return

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -730,7 +730,7 @@ function cleanup()
                         fs=${tmp%%:*}
                         inode=${tmp#*:}
                         file=`find -x ${fs} -inum ${inode} -print -exit`
-                        echo ${file} | grep "$B0/" && \
+                        echo ${file} | grep -q "$B0/" && \
                             LOOPDEVICES="${LOOPDEVICES} $dev"
                 done
                 for l in $LOOPDEVICES;
@@ -739,22 +739,23 @@ function cleanup()
                 done
                 ;;
         *)
-                echo "`uname -s` loopback device supportmissing"
+                echo "`uname -s` loopback device support missing" >&2
                 ;;
         esac
 
         # remove contents of "GLUSTERD_WORKDIR" except hooks and groups
-        # directories.
-        if [ -n $GLUSTERD_WORKDIR ]
+        # directories.  The -n test MUST be quoted: unquoted, [ -n $VAR ]
+        # is true even for an unset VAR, and the find below would then
+        # expand to 'find /* ... -exec rm -rf' and erase the machine.
+        if [ -n "$GLUSTERD_WORKDIR" ]
         then
                 find  $GLUSTERD_WORKDIR/* -maxdepth 0 -name 'hooks' -prune \
                 -o -name 'groups' -prune -o -exec rm -rf '{}' ';'
         else
-                echo "GLUSTERD_WORKDIR is not set"
+                echo "GLUSTERD_WORKDIR is not set" >&2
         fi
 
         # Complete cleanup time
-        rm -rf "$B0/*" "/etc/glusterd/*";
         rm -rf $WORKDIRS
         find $GLUSTERD_PIDFILEDIR -name "*.pid" | xargs rm -rf
         leftover=""

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -147,7 +147,18 @@ _GFS () {
 }
 GFS="_GFS --attribute-timeout=0 --entry-timeout=0";
 
-mkdir -p $WORKDIRS
+# Do not mkdir a workdir that is already a mountpoint: if it is mounted the
+# directory exists by definition, and the path lookup implied by mkdir -p
+# can hang in the kernel (D state) on a stale fuse mount left behind by an
+# earlier killed test - which then wedges every subsequent run before its
+# first test line executes (see issue #4610).  Live mounts are deliberately
+# not touched here: cleanup() is the place that unmounts.
+for _d in $WORKDIRS; do
+        awk -v d="$_d" '$2 == d { found = 1 } END { exit !found }' \
+                /proc/mounts 2>/dev/null && continue
+        mkdir -p "$_d"
+done
+unset _d
 
 case $OSTYPE in
 FreeBSD | Darwin)

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -207,7 +207,11 @@ function dbg()
 function G_LOG()
 {
      local g_log_logdir;
-     g_log_logdir=`$CLI --print-logdir`
+     # LOGDIR is computed once at source time with this same command.
+     # G_LOG runs for every TEST/EXPECT line in the suite (~21000 per
+     # full regression run), so re-executing the CLI here cost minutes
+     # of pure fork/exec per run for a value that cannot change.
+     g_log_logdir=${LOGDIR}
      test -d $g_log_logdir
      if [ $? != 0 ]; then
         return

--- a/tests/include.rc
+++ b/tests/include.rc
@@ -780,7 +780,20 @@ function cleanup()
 
 function force_terminate () {
         local ret=$?;
-        >&2 echo -e "\nreceived external"\
+        # Disarm: a second signal (impatient Ctrl-C, timeout's -k escalation
+        # racing us) must not re-enter this handler and restart cleanup.
+        trap '' INT TERM HUP;
+        # The TAP consumer reading our stdout (prove) usually dies of the
+        # same signal that got us here, so a write to stdout - or to both
+        # streams, under a harness that merges them into one pipe - would
+        # kill this handler with SIGPIPE in the middle of cleanup.  With
+        # SIGPIPE ignored such writes fail benignly with EPIPE instead,
+        # and cleanup runs to the end.
+        trap '' PIPE;
+        # Cleanup chatter is diagnostics, not TAP - route it to stderr for
+        # the rest of the handler.
+        exec 1>&2;
+        echo -e "\nreceived external"\
                         "signal --`kill -l $ret`--, calling 'cleanup' ...\n";
         cleanup;
         exit $ret;


### PR DESCRIPTION
## Summary

This series makes test cleanup deterministic on every abnormal-termination
path — timeout, Ctrl-C, CI abort — by moving supervision of each test into
run-tests.sh, and fixes five smaller harness defects found while proving
it (#4737). It builds on the diagnosis in #4610 / PR #4611: group
signalling is necessary, but not sufficient without supervision. Passing
tests are unaffected (zero added latency, zero outcome flips in a
21-test × 2-node differential).

## The bug

Since 1f03309f3f ("run-tests.sh: stop test on Ctrl-C", 2019), a test that
hits its timeout never cleans up: `timeout --foreground` signals only its
direct child (prove), so the bash running the `.t` never sees SIGTERM and
the `force_terminate` trap (ea980a8a55, 2015 — added for exactly this) is
never invoked on that path. The orphaned test keeps its daemons, mounts and
volumes; the next run then hangs in include.rc's source-time
`mkdir -p $WORKDIRS` on the stale mount, in D state. This is #4610, and
the report is accurate. #4737 documents the full defect chain this series
addresses.

## Why this needs harness supervision, not only a signal change

Three facts, established with strace/ps in containers and on real
hardware (#4737 has the details):

1. Without `--foreground`, Ctrl-C breaks differently: the test group
   leaves the terminal's foreground group, run-tests.sh dies, and the
   detached test tree keeps running invisibly to its full timeout.
2. `timeout` exits the moment prove dies, and its `-k` timer dies with
   it — the orphaned cleanup runs unsupervised, racing the retry and the
   next test.
3. Even correctly signalled, the test usually dies **before its trap
   runs**: bash writes its job notice to stderr — a pipe owned by the
   just-killed prove — and `write(2, "Terminated\n") = EPIPE` kills the
   shell with SIGPIPE (12/12 losses on our hardware). The same race
   affects interactive Ctrl-C cleanup as well.

So cleanup cannot be made reliable from inside the test. The harness has
to own it.

## What the series does

- **1–2**: run-tests.sh supervises each test: group-mode `timeout`;
  INT/TERM/HUP forwarded as TERM (coreutils >= 9 ignores an external
  SIGINT in group mode, <= 8.32 forwarded it — verified on
  8.30/8.32/9.7/9.11 × bash 4.4/5.1/5.2/5.3); a bounded drain for the
  test's own cleanup; then an idempotent `cleanup` sweep on the test's
  behalf, making the outcome independent of the SIGPIPE race.
  `force_terminate` becomes single-shot, SIGPIPE-immune, stderr-only.
- **3**: include.rc no longer mkdirs over an existing mountpoint —
  removes #4610's hang even for residue no supervisor can prevent
  (hard crash).
- **4**: quote cleanup's `[ -n $GLUSTERD_WORKDIR ]` guard so that an
  unset variable can no longer expand the guarded wipe to
  `find /* ... -exec rm -rf`.
- **5**: SCRIPT_TIMEOUT parsed as a real assignment (the grep-count
  parser accepted comments as values and silently dropped dual mentions).
- **6**: G_LOG uses the log directory already cached at source time
  instead of re-executing the gluster CLI per TEST line (21,209 lines per
  full run, ~25ms each — roughly 9 minutes per run). Banner fan-out
  verified byte-identical.
- **7**: fstrim once per test from the harness, bounded by `timeout 60`,
  instead of twice per test inside cleanup with unbounded duration.
- **8**: run-tests.sh itself ignores SIGPIPE and forwards signals before
  printing status: with `./run-tests.sh | tee log`, Ctrl-C killed tee and
  the supervisor then died of SIGPIPE mid-forward, orphaning the tree —
  the same SIGPIPE failure mode one layer up, caught in the first real
  interactive use of the series.

## Evidence (3-node testbed, real daemons; reproducible drivers included)

| Scenario | before | after |
|---|---|---|
| timeout residue (6 runs) | 6/6 dirty: orphan `.t` + glusterd/brick/client + mount | 6/6 clean, +1–2s each |
| timeout + retry | two orphaned test shells running concurrently | sequential, clean, +3s |
| Ctrl-C (plain) | daemons + mount leaked, silently | clean in ~2s, reported; 2nd ^C force-kills |
| Ctrl-C under `\| tee` | supervisor SIGPIPE-killed, whole tree + 7 daemons + 3 mounts survive | tree terminated, swept, abort status 130 |
| passing tests | 34s | 34s (zero added latency) |
| 21 real tests × 2 arms × 2 nodes, opposite order | — | **0 flips**; the 5 constant failures identical everywhere (2 documented pre-existing, 3 gNFS-less build); series equal-or-faster |
| stale-mount wedge (#4610's hang) | deterministic source-time hang | sources through in <1s |

During a real full-suite run, `glusterd-restart-shd-mux.t` timed out
twice mid-suite and was swept cleanly both times; an orphaned geo-rep
test later self-cleaned at its own expiry through the hardened trap. The
interrupt path was exercised twice by a human on a live suite — once
exposing commit 8's bug, once confirming its fix.

## Cost, stated plainly

First Ctrl-C waits for the test's cleanup (~2s measured) before aborting
the run; a second Ctrl-C force-kills immediately. A timed-out test costs
1–3s extra. A genuinely wedged cleanup is force-killed after 60s instead
of racing the next test forever.

## Credit

#4610 / PR #4611 (@chen1195585098) correctly identified both the
regression and its 2019 origin. This series keeps that group-signal
insight and adds the supervision a flag flip alone cannot provide;
1f03309f3f's Ctrl-C behavior is preserved — and now actually includes
cleanup.

Fixes: #4610
Fixes: #4737
