### PR TITLE
build: gcc16 discarded-qualifiers strstr strrchr

### DIFF
--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -174,14 +174,14 @@ static char *
 getChoices(const char *value)
 {
     int i = 0;
-    char *ptr = NULL;
+    const char *ptr = NULL;
     char *tok = NULL;
     char *result = NULL;
     char *newval = NULL;
 
     ptr = strstr(value, "Choices:");
     if (!ptr) {
-        result = ptr;
+        /* result is NULL; */
         goto out;
     }
 
@@ -733,7 +733,7 @@ dht_inode_get_hashed_subvol(inode_t *inode, xlator_t *this, loc_t *loc)
     loc_t populate_loc = {
         0,
     };
-    char *name = NULL;
+    const char *name = NULL;
     xlator_t *hash_subvol = NULL;
 
     if (!inode)

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -463,7 +463,7 @@ int32_t
 ec_loc_setup_path(xlator_t *xl, loc_t *loc)
 {
     static uuid_t root = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    char *name;
+    const char *name;
     int32_t ret = -EINVAL;
 
     if (loc->path != NULL) {

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -941,7 +941,7 @@ out:
 int32_t
 _pl_convert_volume(const char *volume, char **res)
 {
-    char *mdata_vol = NULL;
+    const char *mdata_vol = NULL;
     int ret = 0;
 
     mdata_vol = strrchr(volume, ':');

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -2061,7 +2061,7 @@ _mnt3_get_host_from_peer(const char *peer_addr)
 {
     char *part = NULL;
     size_t host_len = 0;
-    char *colon = NULL;
+    const char *colon = NULL;
 
     colon = strrchr(peer_addr, ':');
     if (!colon) {


### PR DESCRIPTION
Fixes trivial warnings around the use of strrchr and strstr by adding the proper qualifier to the variable. Some warning cases are left unnadressed because they are not trivial and may require some effort to work around.

Updates: #4741 