### PR TITLE
cloudsyncs3: pass a long to CURLOPT_VERBOSE, not an int

### DIFF
--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -437,7 +437,7 @@ aws_download_s3(call_frame_t *frame, void *config)
     struct curl_slist *tmp = NULL;
     xlator_t *this = NULL;
     int ret = 0;
-    int debug = 1;
+    long debug = 1;
     CURLcode res;
     char errbuf[CURL_ERROR_SIZE];
     size_t len = 0;


### PR DESCRIPTION
aws_download_s3() declares `int debug = 1;` and passes it to
curl_easy_setopt(handle, CURLOPT_VERBOSE, debug). curl_easy_setopt is
variadic and CURLOPT_VERBOSE is a CURLOPTTYPE_LONG option, so libcurl
reads the argument with va_arg(arg, long). Passing an int reads back a
long from a slot an int was pushed into -- undefined behaviour that is
merely harmless on LP64.

libcurl's type-check macro flags it: CURLOPT_VERBOSE with a non-long
argument selects the Wcurl_easy_setopt_err_long helper, declared
__attribute__((warning("curl_easy_setopt expects a long argument"))):

    libcloudsyncs3.c:524:5: warning: call to 'Wcurl_easy_setopt_err_long'
    declared with attribute warning: curl_easy_setopt expects a long
    argument [-Wattribute-warning]

It has been wrong since the plugin was added in 2018 (e3995d5fff); it
surfaced now that the plugin builds and links cleanly again (#4729) and
that libcurl decorates curl_easy_setopt with the type check.

Declare `debug` as long. No functional change: verbose mode is still
enabled, the value is now passed with the type the API expects. This is
the only wrong-typed curl_easy_setopt call in the tree.

Verified on Arch (gcc 16.1.1, libcurl 8.21.0, -flto -O2), building the
plugin from the same tree and configure flags before and after. With the
-flto build the diagnostic is printed at the LTO link (CCLD
cloudsyncs3.la): devel 43044799f3 emits the one warning; with debug as
long it emits none; cloudsyncs3.la builds either way.

Fixes: #4743
