### PR TITLE
glusterfsd-mgmt: refresh remote-port on volfile-server failover

### DIFF
--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -2834,6 +2834,7 @@ mgmt_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
             }
             ctx->cmd_args.curr_server = server;
             ctx->cmd_args.volfile_server = server->volfile_server;
+            ctx->cmd_args.volfile_server_port = server->port;
 
             ret = dict_set_str(rpc_trans->options, "remote-host",
                                server->volfile_server);
@@ -2846,9 +2847,24 @@ mgmt_rpc_notify(struct rpc_clnt *rpc, void *mydata, rpc_clnt_event_t event,
                 emval = ENOTCONN;
                 break;
             }
+            /* Backup volfile servers may listen on different ports
+             * (-s host:port); refresh remote-port too, else the reconnect
+             * dials the new host on the previous server's port. The gfapi
+             * failover path (api/src/glfs-mgmt.c) already does this. */
+            ret = dict_set_int32(rpc_trans->options, "remote-port",
+                                 server->port);
+            if (ret != 0) {
+                gf_log("glusterfsd-mgmt", GF_LOG_ERROR,
+                       "failed to set remote-port: %d", server->port);
+                if (!ctx->active) {
+                    need_term = 1;
+                }
+                emval = ENOTCONN;
+                break;
+            }
             gf_log("glusterfsd-mgmt", GF_LOG_INFO,
-                   "connecting to next volfile server %s",
-                   server->volfile_server);
+                   "connecting to next volfile server %s:%d",
+                   server->volfile_server, server->port);
             break;
         case RPC_CLNT_CONNECT:
             ret = glusterfs_volfile_fetch(ctx);


### PR DESCRIPTION
Fixes #4745

## What
On volfile-server failover, `mgmt_rpc_notify()` (`glusterfsd/src/glusterfsd-mgmt.c`)
refreshed only `remote-host` in the transport options, never `remote-port`. Backup volfile
servers configured on different ports (`-s host:port`) were therefore reconnected on the
*previous* server's port, so failover to such a backup fails.

This sets `remote-port` (and the `volfile_server_port` scalar) from `server->port` on
failover, mirroring the gfapi failover path (`api/src/glfs-mgmt.c`) which already does this,
and includes the port in the failover log line.

`server->port` is always initialized to `GF_DEFAULT_BASE_PORT` and only overwritten by a
valid parsed port, so it is never 0 — no default fallback is needed.
`--volfile-server-transport` is a single global (no per-server transport), so only
host/port need refreshing here.

## Testing
Client-side A/B under `strace -e trace=connect` (`-s 127.0.0.1 -s 127.0.0.1:24099`, run
daemon-style so no cluster/root is needed): current `devel` reconnects the backup on the
stale port (connect sequence `24007 → 24007`); patched reconnects on `24099`
(`24007 → 24099`). Homogeneous-port setups are unchanged (`24007 → 24007` on both).

## Related
Successor to the round-robin failover fix (#4166 / #4579), which reworked this same loop but
did not refresh the port. Complementary to the IPv6 volfile-server parse bug (#3918 / #4269),
which corrupts `server->port` on the input side.
