### PR TITLE
libglusterfs: parse IPv6 literals in host:port splitting

### DIFF
--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -2355,10 +2355,90 @@ out:
     return result;
 }
 
+/* True if 'str' is a bare (unbracketed) IPv6 address literal.  Host:port
+ * splitters use this to avoid mistaking an IPv6 literal's internal ':' for a
+ * port separator, which would lop off the final hextet. */
+static gf_boolean_t
+gf_is_ipv6_addr(const char *str)
+{
+    struct in6_addr addr6;
+
+    return (str && inet_pton(AF_INET6, str, &addr6) == 1) ? _gf_true : _gf_false;
+}
+
+/* Split an endpoint of the form "host", "host:port", "[host]" or "[host]:port"
+ * into an allocated host and a port, IPv6-literal aware:
+ *   "[<addr>]:<port>" -> host=<addr>,  port=<port>   (brackets stripped)
+ *   "[<addr>]"        -> host=<addr>,  port=0
+ *   bare "<v6-addr>"  -> host=<addr>,  port=0         (every ':' is address)
+ *   "<host>:<port>"   -> host=<host>,  port=<port>    (IPv4 / hostname)
+ *   "<host>"          -> host=<host>,  port=0
+ * *host_p receives a GF_MALLOC'd NUL-terminated host (caller frees with
+ * GF_FREE); *port_p receives the parsed port, or 0 when the input carries
+ * none.  Returns 0 on success, -1 (with *host_p left unset) on malformed
+ * input or allocation failure. */
+static int
+gf_hostname_port_split(const char *input, char **host_p, int *port_p)
+{
+    char *host = NULL;
+    int port = 0;
+
+    if (!input || !host_p || !port_p)
+        return -1;
+
+    if (input[0] == '[') {
+        /* bracketed literal: [<addr>] or [<addr>]:<port> */
+        const char *close = strchr(input, ']');
+
+        if (!close || close == input + 1)
+            return -1; /* no ']' or empty "[]" */
+        host = gf_strndup(input + 1, close - input - 1);
+        if (host && *(close + 1) == ':')
+            port = (int)strtol(close + 2, NULL, 10);
+    } else if (gf_is_ipv6_addr(input)) {
+        /* bare IPv6 literal: every ':' belongs to the address */
+        host = gf_strdup(input);
+    } else {
+        /* IPv4 / hostname with an optional trailing ":port" */
+        const char *colon = strrchr(input, ':');
+
+        if (colon) {
+            host = gf_strndup(input, colon - input);
+            port = (int)strtol(colon + 1, NULL, 10);
+        } else {
+            host = gf_strdup(input);
+        }
+    }
+
+    if (!host)
+        return -1;
+    *host_p = host;
+    *port_p = (port > 0) ? port : 0;
+    return 0;
+}
+
 char *
 get_host_name(char *word, char **host)
 {
     char *delimiter = NULL;
+
+    if (!word)
+        return NULL;
+
+    if (word[0] == '[') {
+        /* bracketed literal: [<addr>] or [<addr>]:<suffix> -> host=<addr> */
+        delimiter = strchr(word, ']');
+        if (delimiter && delimiter != word + 1) {
+            *delimiter = '\0';
+            *host = word + 1;
+            return *host;
+        }
+    } else if (gf_is_ipv6_addr(word)) {
+        /* bare IPv6 literal: keep the whole address as the host */
+        *host = word;
+        return *host;
+    }
+
     delimiter = strrchr(word, ':');
     if (delimiter)
         *delimiter = '\0';
@@ -2970,8 +3050,6 @@ gf_process_getspec_servers_list(cmd_args_t *cmd_args, const char *servers_list)
 {
     char *tmp = NULL;
     char *address = NULL;
-    char *host = NULL;
-    char *last_colon = NULL;
     char *save_ptr = NULL;
     int port = 0;
     int ret = -1;
@@ -2989,22 +3067,24 @@ gf_process_getspec_servers_list(cmd_args_t *cmd_args, const char *servers_list)
     }
 
     while (1) {
-        last_colon = strrchr(address, ':');
-        if (!last_colon) {
+        char *host = NULL;
+
+        if (gf_hostname_port_split(address, &host, &port)) {
             errno = EINVAL;
             ret = -1;
             break;
         }
-        *last_colon = '\0';
-        host = address;
-        port = atoi(last_colon + 1);
         if (port <= 0) {
+            /* the getspec server list requires an explicit host:port; an
+             * IPv6 literal must therefore be bracketed, e.g. [addr]:port */
+            GF_FREE(host);
             errno = EINVAL;
             ret = -1;
             break;
         }
         ret = gf_set_volfile_server_common(cmd_args, host,
                                            GF_DEFAULT_VOLFILE_TRANSPORT, port);
+        GF_FREE(host);
         if (ret && errno != EEXIST) {
             break;
         }
@@ -3047,20 +3127,18 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
     INIT_LIST_HEAD(&server->list);
     server->port = port;
 
-    duphost = gf_strdup(host);
-    if (!duphost) {
-        errno = ENOMEM;
-        goto out;
-    }
+    {
+        int parsed_port = 0;
 
-    char *lastptr = rindex(duphost, ':');
-    if (lastptr) {
-        *lastptr = '\0';
-        long port_argument = strtol(lastptr + 1, NULL, 0);
-        if (!port_argument) {
-            port_argument = port;
+        /* Split host[:port] IPv6-aware so a bare or bracketed IPv6 literal
+         * keeps every hextet.  server->port keeps the caller's
+         * default unless the string carries an explicit port. */
+        if (gf_hostname_port_split(host, &duphost, &parsed_port)) {
+            errno = EINVAL;
+            goto out;
         }
-        server->port = port_argument;
+        if (parsed_port > 0)
+            server->port = parsed_port;
     }
     server->volfile_server = gf_strdup(duphost);
     if (!server->volfile_server) {

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -2357,13 +2357,31 @@ out:
 
 /* True if 'str' is a bare (unbracketed) IPv6 address literal.  Host:port
  * splitters use this to avoid mistaking an IPv6 literal's internal ':' for a
- * port separator, which would lop off the final hextet. */
+ * port separator, which would lop off the final hextet.  A scoped
+ * literal 'fe80::1%zone' (RFC 4007) is accepted: inet_pton() rejects the
+ * '%zone' suffix, so the address part is validated on its own. */
 static gf_boolean_t
 gf_is_ipv6_addr(const char *str)
 {
     struct in6_addr addr6;
+    const char *pct = NULL;
+    char buf[INET6_ADDRSTRLEN];
 
-    return (str && inet_pton(AF_INET6, str, &addr6) == 1) ? _gf_true : _gf_false;
+    if (!str)
+        return _gf_false;
+
+    pct = strchr(str, '%');
+    if (pct) {
+        size_t len = pct - str;
+
+        if (len == 0 || len >= sizeof(buf))
+            return _gf_false;
+        memcpy(buf, str, len);
+        buf[len] = '\0';
+        str = buf;
+    }
+
+    return (inet_pton(AF_INET6, str, &addr6) == 1) ? _gf_true : _gf_false;
 }
 
 /* Split an endpoint of the form "host", "host:port", "[host]" or "[host]:port"
@@ -2374,17 +2392,19 @@ gf_is_ipv6_addr(const char *str)
  *   "<host>:<port>"   -> host=<host>,  port=<port>    (IPv4 / hostname)
  *   "<host>"          -> host=<host>,  port=0
  * *host_p receives a GF_MALLOC'd NUL-terminated host (caller frees with
- * GF_FREE); *port_p receives the parsed port, or 0 when the input carries
- * none.  Returns 0 on success, -1 (with *host_p left unset) on malformed
- * input or allocation failure. */
+ * GF_FREE); *port_p receives the parsed port when the input carries a valid
+ * one (all-digits, 1..65535), else 0.  A bracketed literal may only be
+ * followed by ":port" or end-of-string.  Returns 0 on success, -1 on malformed
+ * input or allocation failure; *host_p is set to NULL on every -1 path. */
 static int
 gf_hostname_port_split(const char *input, char **host_p, int *port_p)
 {
     char *host = NULL;
-    int port = 0;
+    const char *portstr = NULL;
 
     if (!input || !host_p || !port_p)
         return -1;
+    *host_p = NULL; /* never leave the caller's pointer indeterminate */
 
     if (input[0] == '[') {
         /* bracketed literal: [<addr>] or [<addr>]:<port> */
@@ -2392,11 +2412,14 @@ gf_hostname_port_split(const char *input, char **host_p, int *port_p)
 
         if (!close || close == input + 1)
             return -1; /* no ']' or empty "[]" */
+        /* only ":port" or end-of-string may follow the closing bracket */
+        if (*(close + 1) != '\0' && *(close + 1) != ':')
+            return -1;
         host = gf_strndup(input + 1, close - input - 1);
         if (host && *(close + 1) == ':')
-            port = (int)strtol(close + 2, NULL, 10);
+            portstr = close + 2;
     } else if (gf_is_ipv6_addr(input)) {
-        /* bare IPv6 literal: every ':' belongs to the address */
+        /* bare IPv6 literal (incl. scoped fe80::1%zone): every ':' is address */
         host = gf_strdup(input);
     } else {
         /* IPv4 / hostname with an optional trailing ":port" */
@@ -2404,7 +2427,7 @@ gf_hostname_port_split(const char *input, char **host_p, int *port_p)
 
         if (colon) {
             host = gf_strndup(input, colon - input);
-            port = (int)strtol(colon + 1, NULL, 10);
+            portstr = colon + 1;
         } else {
             host = gf_strdup(input);
         }
@@ -2412,8 +2435,20 @@ gf_hostname_port_split(const char *input, char **host_p, int *port_p)
 
     if (!host)
         return -1;
+
+    *port_p = 0;
+    if (portstr) {
+        char *endptr = NULL;
+        long port = strtol(portstr, &endptr, 10);
+
+        /* a valid port is all-digits and in the TCP range 1..65535; anything
+         * else (empty, trailing junk, out-of-range) leaves the port unset so
+         * the caller can apply its default or reject */
+        if (endptr != portstr && *endptr == '\0' && port >= 1 && port <= 65535)
+            *port_p = (int)port;
+    }
+
     *host_p = host;
-    *port_p = (port > 0) ? port : 0;
     return 0;
 }
 

--- a/tests/bugs/glusterd/bug-3918-ipv6-brick-parse.t
+++ b/tests/bugs/glusterd/bug-3918-ipv6-brick-parse.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Regression test for #3918 (integration side): IPv6 host:port parsing on the
+# real CLI -> glusterd brick path.
+#
+# A bracketed IPv6 brick "[<addr>]:<path>" must be accepted by the CLI and
+# recorded by glusterd with the bare address -- brackets stripped, every hextet
+# intact. On the unpatched get_host_name() / gf_set_volfile_server_common()
+# splitters the CLI rejects "[::1]" ("internet address '[::1]' does not conform
+# to standards"), so the volume create fails and this test fails -- catching the
+# gluster-11 IPv6 regression (#4269 / #4643 / #4670) in situ.
+#
+# Uses IPv6 loopback (::1); skips where that is unavailable.
+#
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+if ! ip -6 addr show dev lo 2>/dev/null | grep -q 'inet6 ::1'; then
+    echo "Skipping: IPv6 loopback (::1) not available" >&2
+    SKIP_TESTS
+    exit 0
+fi
+
+TEST glusterd
+TEST pidof glusterd
+
+# Bracketed IPv6 brick. Fails to parse (CLI rejects) on the unpatched code.
+TEST $CLI volume create $V0 "[::1]:$B0/${V0}0" force
+EXPECT 'Created' volinfo_field $V0 'Status'
+
+# glusterd must have stored the bare "::1" -- not "[::1]", not a truncated ":".
+brick_host=$($CLI volume info $V0 | awk -F': ' '/^Brick1:/{print $2}' | sed 's|:/.*||')
+TEST [ "x$brick_host" = "x::1" ]
+
+cleanup;

--- a/tests/bugs/glusterd/bug-3918-ipv6-host-parse.c
+++ b/tests/bugs/glusterd/bug-3918-ipv6-host-parse.c
@@ -65,6 +65,12 @@ main(void)
           "2620:0000:1111:2222:dddd:cccc:bbbb:aaaa");
     check("::ffff:1.2.3.4", "::ffff:1.2.3.4"); /* IPv4-mapped is a v6 literal */
 
+    /* scoped (zone-ID) literals, RFC 4007: address kept whole, bare or
+     * bracketed (inet_pton rejects the "%zone" suffix, so this is only handled
+     * once gf_is_ipv6_addr validates the address part) */
+    check("fe80::1%lo", "fe80::1%lo");
+    check("[fe80::1%lo]", "fe80::1%lo");
+
     /* bracketed literals: brackets stripped, address intact */
     check("[ff00::1]", "ff00::1");
     check("[ff00::1]:/export/brick", "ff00::1");

--- a/tests/bugs/glusterd/bug-3918-ipv6-host-parse.c
+++ b/tests/bugs/glusterd/bug-3918-ipv6-host-parse.c
@@ -1,0 +1,94 @@
+/*
+  Copyright (c) 2026 Red Hat, Inc. <http://www.redhat.com>
+  This file is part of GlusterFS.
+
+  This file is licensed to you under your choice of the GNU Lesser
+  General Public License, version 3 or any later version (LGPLv3 or
+  later), or the GNU General Public License, version 2 (GPLv2), in all
+  cases as published by the Free Software Foundation.
+*/
+
+/*
+ * Regression test for #3918: IPv6 host:port splitting in common-utils.c.
+ *
+ * get_host_name() split a host token on its LAST ':', which for an
+ * unbracketed IPv6 literal is part of the address, lopping off the final
+ * hextet (ff00::1 -> "ff00:") and, in gf_set_volfile_server_common(), taking
+ * IPv6 bricks/mounts offline (regression from gluster 11, see #4269/#4643).
+ *
+ * This drives the exported get_host_name() over a matrix that pins the fixed
+ * behaviour: bare and bracketed IPv6 literals keep every hextet, brackets are
+ * stripped, and IPv4/hostname/host:path parsing is unchanged. Exit non-zero on
+ * any mismatch so the .t wrapper fails.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* Declared in <glusterfs/common-utils.h>; declared locally here so the tester
+ * builds standalone (the internal header chain pulls atomic.h, which needs
+ * build-time SIZEOF_* defines). Resolved from libglusterfs at link time. */
+char *
+get_host_name(char *word, char **host);
+
+static int failures = 0;
+
+/* get_host_name() mutates 'word' in place and returns a pointer into it (or
+ * NULL). Expect NULL is encoded as a NULL 'expect'. */
+static void
+check(const char *word, const char *expect)
+{
+    char *dup = strdup(word);
+    char *host = NULL;
+    char *rv = get_host_name(dup, &host);
+    const char *got = (rv && host) ? host : NULL;
+
+    int ok = (expect == NULL) ? (got == NULL)
+                              : (got != NULL && strcmp(got, expect) == 0);
+    if (!ok) {
+        fprintf(stderr, "FAIL: get_host_name(\"%s\") -> %s%s%s, expected %s%s%s\n",
+                word, got ? "\"" : "", got ? got : "NULL", got ? "\"" : "",
+                expect ? "\"" : "", expect ? expect : "NULL", expect ? "\"" : "");
+        failures++;
+    }
+    free(dup);
+}
+
+int
+main(void)
+{
+    /* bare IPv6 literals: the whole address is the host (the #3918 bug lopped
+     * the final hextet) */
+    check("ff00::1", "ff00::1");
+    check("::1", "::1");
+    check("2620:0000:1111:2222:dddd:cccc:bbbb:aaaa",
+          "2620:0000:1111:2222:dddd:cccc:bbbb:aaaa");
+    check("::ffff:1.2.3.4", "::ffff:1.2.3.4"); /* IPv4-mapped is a v6 literal */
+
+    /* bracketed literals: brackets stripped, address intact */
+    check("[ff00::1]", "ff00::1");
+    check("[ff00::1]:/export/brick", "ff00::1");
+    check("[2620:0000:1111:2222:dddd:cccc:bbbb:aaaa]:24007",
+          "2620:0000:1111:2222:dddd:cccc:bbbb:aaaa");
+
+    /* IPv6 host:path — the trailing ':/path' is a real delimiter, so the last
+     * ':' split already worked here; must keep working (no regression) */
+    check("ff00::1:/export/brick", "ff00::1");
+
+    /* IPv4 / hostname: last ':' really is the delimiter — unchanged */
+    check("1.2.3.4", NULL);            /* no ':' -> NULL, as before */
+    check("1.2.3.4:24007", "1.2.3.4");
+    check("myhost:/export/brick", "myhost");
+    check("myhost:24007", "myhost");
+    check("myhost", NULL);             /* no ':' -> NULL */
+
+    /* malformed brackets are rejected (NULL), not returned as a bad host */
+    check("[]", NULL);
+
+    if (failures) {
+        fprintf(stderr, "%d get_host_name() case(s) failed\n", failures);
+        return 1;
+    }
+    printf("all get_host_name() IPv6 host:port cases passed\n");
+    return 0;
+}

--- a/tests/bugs/glusterd/bug-3918-ipv6-host-parse.t
+++ b/tests/bugs/glusterd/bug-3918-ipv6-host-parse.t
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Regression test for #3918: IPv6 host:port splitting in common-utils.c.
+#
+# get_host_name() (and the gf_set_volfile_server_common / getspec-list splitters
+# that share its IPv6 detection) split a host token on its LAST ':', which for
+# an unbracketed IPv6 literal is part of the address -- lopping off the final
+# hextet and taking IPv6 bricks/mounts offline (a gluster-11 regression, see
+# #4269/#4643/#4670). This is a pure-parse unit check: it drives the exported
+# get_host_name() over an IPv6/IPv4/hostname matrix, no cluster required.
+#
+. $(dirname $0)/../../include.rc
+
+cleanup;
+
+TESTER_SRC=$(dirname $0)/bug-3918-ipv6-host-parse.c
+TESTER=$(dirname $0)/bug-3918-ipv6-host-parse
+
+# get_host_name() lives in libglusterfs. -lgfapi makes build_tester pull the
+# gluster libdir from pkg-config; -lglusterfs resolves the symbol itself.
+TEST build_tester $TESTER_SRC -lgfapi -lglusterfs
+TEST $TESTER
+
+cleanup_tester $TESTER
+
+cleanup;


### PR DESCRIPTION
Fixes the gluster-11 regression where an IPv6 brick or mount address is
truncated by the last-colon host:port split in `common-utils.c`, taking IPv6
bricks and mounts offline (#4269, #4643, #4670).

### Problem

Three host:port splitters split on the **last** `:`:

| function | splitter | line |
|----------|----------|------|
| `gf_set_volfile_server_common` | `rindex(duphost, ':')` | 3056 |
| `gf_process_getspec_servers_list` | `strrchr(address, ':')` | 2992 |
| `get_host_name` | `strrchr(word, ':')` | 2362 |

For an unbracketed IPv6 literal every `:` belongs to the address, so the last
one is not a port separator: `2620:0000:1111:2222:dddd:cccc:bbbb:aaaa` is truncated
to `2620:…:bbbb`, and `ff00::1` becomes host `ff00:` port `1`. The truncated
address then fails `gf_resolve_ip6()`/`getaddrinfo()` and the brick or mount
goes offline. IPv4 addresses and DNS names are unaffected — their last `:`
really is the port. The three sites also had no bracket handling, so the
documented `[ipv6]:port` form (`mount.glusterfs.8`) failed too:
`[2620:…:aaaa]:24007` parsed to host `[2620:…:aaaa]` with the brackets attached.

This is a regression: the embedded host:port parse in
`gf_set_volfile_server_common` was added in `47207afcbf` (shipped in 11); before
that a bare `-s <ipv6>` was passed through verbatim, so IPv6 worked in 9.6/10.3.
It is the input-side complement of #4746 — that change makes failover honour
`server->port`; this one makes `server->port` correct for IPv6.

### Fix

One file-local `inet_pton(AF_INET6, …)` predicate (the idiom already used at
`common-utils.c:2683` and `socket/src/name.c:369`) plus one bracket/IPv6-aware
host:port splitter, reused by all three sites. Accepted forms:

```
bare <v6-addr>       -> host=<addr>, default port
[<v6-addr>]          -> host=<addr>, default port
[<v6-addr>]:<port>   -> host=<addr>, port=<port>
<host>[:<port>]      -> unchanged (IPv4 / hostname)
```

`gf_process_getspec_servers_list` keeps requiring an explicit port, so an IPv6
literal in a getspec server list must be bracketed (`[addr]:port`), matching the
`mount.glusterfs` contract. `get_host_name` keeps its in-place,
NULL-on-no-colon contract. The change is confined to `common-utils.c` — the two
new helpers are `static` and the three existing functions keep their
signatures, so **`libglusterfs.so` has no ABI or header change** (drop-in;
dependents such as the Samba VFS, QEMU and NFS-Ganesha need no relink).

### Scope

The change lives in the core `libglusterfs`, so it ships to every gluster
process, but the three splitters are only reached at **control-plane host:port
parse points** — never in a FOP / I/O path. The processes that actually execute
the changed code, by call site:

| process | splitter it calls | when |
|---------|-------------------|------|
| `gluster` (CLI) | `get_host_name` | `volume create`/`add-brick <host>:/brick`, `peer probe <host>` |
| `glusterd` | `get_host_name` | building brickinfo from a brick string; resolving a peer identifier |
| `glusterfsd` (brick) / `glusterfs` (FUSE mount) and the helper daemons spawned from the same binary (shd, quotad, bitd/scrub, snapd) | `gf_set_volfile_server_common`, `gf_process_getspec_servers_list` | parsing `-s`/`--volfile-server` at startup, and a getspec server list from glusterd |
| gNFS server (`--enable-gnfs` builds only) | `get_host_name` | NFS client address in mount auth |
| gfapi apps (QEMU, Samba `vfs_glusterfs`, NFS-Ganesha FSAL, …) | `gf_set_volfile_server_common`, `gf_process_getspec_servers_list` | `glfs_set_volfile_server()` / getspec reply |

The reported outage (#4269) is in the **brick process**: `glusterd` records the
hostname correctly, then starts `glusterfsd -s <ipv6>`, and *that* process's
splitter truncated it → `gf_resolve_ip6()` fails → brick offline.

Behaviourally the change is narrow:

- For IPv4 addresses and DNS names the parse output is **byte-identical** to
  before — a pure-IPv4 deployment sees no change.
- It **diverges only for IPv6 host strings** (bare, bracketed, or scoped).
- The one non-IPv6 change is *acceptance*, not correction: `glusterd`/CLI now
  accept a **bracketed** IPv6 brick/host (`[::1]:/brick`) that the old code
  rejected.

Not touched: xlators, FOP handlers, RPC/wire code, the socket transport
(`name.c`), volfiles, on-disk formats, or the glusterd store.

### Verification

- **Unit A/B** — the parse is unit-observable, so a white-box harness drives the
  public `glfs_set_volfile_server()` plus the two library calls directly (no
  cluster). Every IPv6 case is corrected; every IPv4/DNS case is byte-identical
  before and after; ASan clean. Matrix: bare `ff00::1` / `::1` / full 8-hextet,
  `[ipv6]:port`, `[ipv6]`, `ipv4`, `ipv4:port`, `host`, `host:port`.
- **Real cluster** — backported onto stock 11.2, built + installed, and on a
  routable IPv6 a bracketed brick `[<v6>]:/brick` comes **online** with a FUSE
  mount round-tripping data, where stock takes the brick offline
  (`gf_resolve_ip6` on the truncated address).
- **Adversarial / security** — ASan over a hostile input matrix (unterminated /
  nested / empty brackets, oversized ports, zone IDs, multi-KB inputs) plus a
  cross-model review: no memory-safety issue and no new attack surface (these
  host:port strings come from operator config, not from the network).

### Commits

1. **`libglusterfs: parse IPv6 literals in host:port splitting`** — the fix.
2. **`tests: add IPv6 host:port parse regression coverage`** — there was no test
   for these splitters. A unit `.t` drives the exported `get_host_name()` over
   an IPv6/IPv4/hostname matrix (no cluster); an integration `.t` checks a
   bracketed `[::1]:<path>` brick is accepted and recorded as bare `::1` (the
   pre-fix CLI rejects it; skips where `::1` is unavailable).
3. **`libglusterfs: harden IPv6 host:port parse (zone IDs, port range,
   brackets)`** — from the adversarial review: scoped `fe80::1%zone` literals
   (RFC 4007, incl. a getspec double-parse corruption), port range validation
   (reject non-numeric / out-of-range instead of truncating through the `(int)`
   cast), and strict bracket suffixes (`[::1]junk` rejected).

Fixes: #3918
Related: #4269 #4643 #4670 #4205 #3929 #4746

