### PR TITLE
configure: honour the value given to --with-{tcmalloc,libtirpc,ipv6-default}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ BUILD_TCMALLOC=no
 USE_MEMPOOL=yes
 AC_ARG_WITH([tcmalloc],
         [AS_HELP_STRING([--without-tcmalloc],[Use gluster based mempool])],
-        [with_tcmalloc="no"], [with_tcmalloc="yes"])
+        [], [with_tcmalloc="yes"])
 if test "x$with_tcmalloc" = "xyes"; then
     AC_CHECK_LIB([tcmalloc_minimal], [malloc], [],
                  [AC_MSG_ERROR([tcmalloc library needs to be present])])
@@ -382,7 +382,7 @@ dnl use glibc rpc.
 dnl
 AC_ARG_WITH([libtirpc],
         [AS_HELP_STRING([--without-libtirpc],[Use legacy glibc RPC.])],
-        [with_libtirpc="no"], [with_libtirpc="yes"])
+        [], [with_libtirpc="yes"])
 
 dnl For --without-libtirpc, check whether legacy glibc rpc is available.
 if test "x$with_libtirpc" = "xno"; then
@@ -397,7 +397,7 @@ dnl ipv6-default can only be enabled if libtipc is enabled.
 dnl
 AC_ARG_WITH([ipv6-default],
         AS_HELP_STRING([--with-ipv6-default],[Set IPv6 as default.]),
-        [with_ipv6_default=${with_libtirpc}], [with_ipv6_default="no"])
+        [], [with_ipv6_default="no"])
 
 if test x$cross_compiling != xyes; then
     AC_CHECK_FILE([/etc/centos-release])


### PR DESCRIPTION
Three AC_ARG_WITH options assign a constant in the action-if-given
slot. Autoconf runs that slot for every spelling of the option, after
it has already stored the user's choice in with_X, so the assignment
discards the choice and each option only works for the one spelling
its help string documents:

  --with-tcmalloc / --with-tcmalloc=yes  -> with_tcmalloc="no":
      mem-pool compiled in, no -ltcmalloc_minimal, GF_DISABLE_MEMPOOL
      undefined, "Link with TCMALLOC : no" -- silently the opposite
      build, indistinguishable from --without-tcmalloc.
  --with-libtirpc / --with-libtirpc=yes  -> with_libtirpc="no":
      legacy glibc RPC selected; on current glibc configure stops with
      "Your C library lacks support for RPC. Please use libtirpc
      instead.", on old glibc it silently builds against SunRPC.
  --without-ipv6-default -> with_ipv6_default=${with_libtirpc}:
      IPv6 default stays on whenever libtirpc is on.

Leave the third argument empty so autoconf keeps the value. The tests
that follow already handle yes/no, and the ${with_libtirpc} coupling
on ipv6-default is redundant: the block that checks for libtirpc pulls
it in when ipv6-default is requested and turns ipv6-default off when
libtirpc is missing, which is the documented rule. Behaviour for the
documented spellings and for the no-flag default is unchanged;
--with-X=VALUE was never supported by any of the three and still is
not. The one observable difference besides the fixed spellings is the
contradictory pair --with-ipv6-default --without-libtirpc on a glibc
that still ships SunRPC: the libtirpc check now honours the IPv6
request and pulls libtirpc in when it is available, as its comments
describe, where before IPv6 was silently dropped.

The constant assignment appeared for ipv6-default in 5e32811f96 and
for libtirpc in 4bac3a637f (both 2018) and was reused for tcmalloc in
8e37df3092 (2021). Nothing in-tree and no major distribution passes
the non-default spellings, which is why all three stayed latent:
--with-libtirpc stops configure on current glibc, --without-ipv6-default
leaves the IPv6 default on, and --with-tcmalloc silently keeps the
mem-pool -- on 11.0, the build with the mem-pool startup crash (#3941).

Verified on the v11.0 and devel trees: every spelling of the three
options before and after the change.

Fixes: #4748

