### PR TITLE
dht: fix fd-reopen error path clobbering ret/op_errno

### DIFF
--- a/tests/bugs/distribute/fd-reopen-error-path.py
+++ b/tests/bugs/distribute/fd-reopen-error-path.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Helper for fd-reopen-error-path.t: hold an fd open across a DHT file
+# migration, then run fd-based fops on it when told to.
+#
+# usage: fd-reopen-error-path.py FILE GO-MARKER OUT OP[,OP...]
+#
+# Opens FILE read-write and appends "READY" to OUT; waits until GO-MARKER
+# exists; then runs each OP on the held fd and appends "OP=OK" or
+# "OP=<errno name>" to OUT.  Supported OPs: fstat, fallocate, close
+# ("close" must be last).
+
+import errno
+import os
+import sys
+import time
+
+path, marker, out, ops = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4].split(',')
+
+
+def report(line):
+    with open(out, 'a') as f:
+        f.write(line + "\n")
+
+
+fd = os.open(path, os.O_RDWR)
+report("READY")
+while not os.path.exists(marker):
+    time.sleep(0.2)
+for op in ops:
+    try:
+        if op == 'fstat':
+            os.fstat(fd)
+        elif op == 'fallocate':
+            os.posix_fallocate(fd, 0, 8192)
+        elif op == 'close':
+            os.close(fd)
+        else:
+            raise ValueError("unknown op " + op)
+        res = "OK"
+    except OSError as e:
+        res = errno.errorcode.get(e.errno, str(e.errno))
+    report("%s=%s" % (op, res))

--- a/tests/bugs/distribute/fd-reopen-error-path.t
+++ b/tests/bugs/distribute/fd-reopen-error-path.t
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# dht_check_and_open_fd_on_subvol_task() re-opens a migrated file's fd on the
+# new cached subvolume when a fd-based fop returns EBADF/EBADFD.  When that
+# re-open itself fails, the application must see the real errno of the failed
+# open (or a legitimate one) -- not EPERM, and not op_errno 0.
+#
+# Case 1: destination brick down -> the re-open fails with ENOTCONN.
+#         fstat/fallocate/close on the held fd must return ENOTCONN.
+#         (Unpatched: EPERM.)
+# Case 2: destination gfid handle gone -> the re-open fails with ESTALE.
+#         fstat on the held fd must return EBADFD and close() must fail.
+#         (Unpatched: EIO, and close() silently succeeds.)
+#
+# readv/writev/fsync take protocol/client's anonymous-fd fallback and never
+# reach the re-open, so the probes are fstat, fallocate and close (flush).
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+cleanup;
+
+HOLDER=$(dirname $0)/fd-reopen-error-path.py
+
+# Create files PREFIX0.. and rename each to a name hashing elsewhere until one
+# ends up with its data on brick 0 and a linkto on brick 1; print that name.
+function pick_split_file {
+    local prefix=$1 i
+    for i in $(seq 0 63); do
+        echo "data-$i" > $M0/${prefix}a$i
+        mv $M0/${prefix}a$i $M0/${prefix}$i
+        if [ -s $B0/${V0}0/${prefix}$i ] && [ -e $B0/${V0}1/${prefix}$i ] && \
+           getfattr -n trusted.glusterfs.dht.linkto -h --only-values \
+                    $B0/${V0}1/${prefix}$i > /dev/null 2>&1; then
+            echo ${prefix}$i
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Create a file whose data lands on brick 1 (used to probe connectivity).
+function pick_file_on_brick1 {
+    local i
+    for i in $(seq 0 63); do
+        echo "probe-$i" > $M0/z$i
+        if [ -s $B0/${V0}1/z$i ]; then
+            echo z$i
+            return 0
+        fi
+    done
+    return 1
+}
+
+# All probe helpers exit 0: EXPECT_WITHIN stops retrying on a non-zero status.
+function holder_ready {
+    head -n 1 $1 2> /dev/null
+    return 0
+}
+
+function holder_result {
+    grep "^$2=" $1 2> /dev/null | cut -d= -f2
+    return 0
+}
+
+function can_read {
+    cat $1 > /dev/null 2>&1 && echo "OK"
+    return 0
+}
+
+# Path of a brick file's .glusterfs gfid handle.  (getfattr --only-values
+# prints the raw bytes even with -e hex, so parse the "trusted.gfid=0x.." line.)
+function gfid_handle {
+    local gfid=$(getfattr -n trusted.gfid -e hex $1 2> /dev/null | sed -n 's/^trusted.gfid=0x//p')
+    [ ${#gfid} -eq 32 ] || return 0
+    echo "$(dirname $1)/.glusterfs/${gfid:0:2}/${gfid:2:2}/${gfid:0:8}-${gfid:8:4}-${gfid:12:4}-${gfid:16:4}-${gfid:20:12}"
+}
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}{0,1}
+TEST $CLI volume set $V0 performance.quick-read off
+TEST $CLI volume set $V0 performance.io-cache off
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume set $V0 performance.read-ahead off
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.open-behind off
+TEST $CLI volume set $V0 network.ping-timeout 3
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+probe=$(pick_file_on_brick1)
+TEST [ x$probe != x ]
+
+##### Case 1: destination brick down -> re-open fails with ENOTCONN #####
+
+f1=$(pick_split_file p)
+TEST [ x$f1 != x ]
+out1=$B0/holder1.out; go1=$B0/go1
+rm -f $out1 $go1
+$PYTHON $HOLDER $M0/$f1 $go1 $out1 fstat,fallocate,close &
+EXPECT_WITHIN 10 "READY" holder_ready $out1
+
+# Migrate the data brick 0 -> brick 1 while the fd is open on brick 0.
+TEST setfattr -n trusted.distribute.migrate-data -v force $M0/$f1
+TEST [ -s $B0/${V0}1/$f1 ]
+TEST ! [ -e $B0/${V0}0/$f1 ]
+
+TEST kill_brick $V0 $H0 $B0/${V0}1
+TEST touch $go1
+EXPECT_WITHIN 30 "ENOTCONN" holder_result $out1 fstat
+EXPECT_WITHIN 30 "ENOTCONN" holder_result $out1 fallocate
+EXPECT_WITHIN 30 "ENOTCONN" holder_result $out1 close
+
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "OK" can_read $M0/$probe
+
+##### Case 2: destination gfid handle gone -> re-open fails with ESTALE #####
+
+f2=$(pick_split_file q)
+TEST [ x$f2 != x ]
+out2=$B0/holder2.out; go2=$B0/go2
+rm -f $out2 $go2
+$PYTHON $HOLDER $M0/$f2 $go2 $out2 fstat,close &
+EXPECT_WITHIN 10 "READY" holder_ready $out2
+
+TEST setfattr -n trusted.distribute.migrate-data -v force $M0/$f2
+TEST [ -s $B0/${V0}1/$f2 ]
+handle=$(gfid_handle $B0/${V0}1/$f2)
+TEST [ x$handle != x ]
+TEST [ -e $handle ]
+
+# Remove the destination's gfid handle behind a stopped brick, then restart
+# it so the by-gfid open done by the re-open cannot be served from cache.
+TEST kill_brick $V0 $H0 $B0/${V0}1
+TEST rm -f "$handle"
+TEST $CLI volume start $V0 force
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "1" brick_up_status $V0 $H0 $B0/${V0}1
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "OK" can_read $M0/$probe
+
+TEST touch $go2
+EXPECT_WITHIN 30 "EBADFD" holder_result $out2 fstat
+EXPECT_WITHIN 30 "EBADFD" holder_result $out2 close
+
+cleanup;

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -527,9 +527,6 @@ dht_check_and_open_fd_on_subvol_task(void *data)
             ret = 0;
         }
 
-        local->op_errno = -ret;
-        ret = -1;
-
     } else {
         dht_fd_ctx_set(this, fd, subvol);
     }


### PR DESCRIPTION
Fixes: #4750

### Problem

`dht_check_and_open_fd_on_subvol_task()` ends its `syncop_open()` failure path
with two unconditional statements that run *after* the ENOENT/ESTALE if/else
and overwrite whatever it decided (dht-helper.c:523-531 on devel):

```c
        if ((-ret != ENOENT) && (-ret != ESTALE)) {
            local->op_errno = -ret;
            ret = -1;
        } else {
            ret = 0;
        }

        local->op_errno = -ret;     /* clobbers both branches */
        ret = -1;
```

- Real errors (ENOTCONN, EMFILE, EIO, …) reach the application as **EPERM**
  (`-(-1)` = 1).
- ENOENT/ESTALE reach it as **op_ret = -1 with op_errno = 0**: FUSE turns that
  into a 0-byte read, EIO, or a silently "successful" fsync/flush/fallocate
  depending on the FOP; gfapi (`DECODE_SYNCOP_ERR`) returns 0 with errno 0.

### Fix

Delete the two statements. The if/else already handles both cases exactly as
`273c7d5981` intended (BZ 1465075 comment 9: "wind to old subvol and let the
phase1/phase2 checks handle it"); the deleted lines are the pre-existing error
handling from `561f33587e` that that commit wrapped without removing.

### Provenance

| Commit | Date | Effect on this error path |
|---|---|---|
| 561f33587e | 2017-06-26 | Introduces the task; the pair is its only error handling (BZ 1465075). |
| 273c7d5981 | 2017-07-10 | Adds the ENOENT/ESTALE if/else above the pair, leaves the pair. **Defect born.** |
| e09cbb13d8 | 2017-08-04 | Re-open now triggered only on EBADF in the callback; protocol/client still used anon fds for context-less fds, so the block was unreachable from the client. |
| 5c2666ee31 (Gerrit 15804) | 2019-03-28 | protocol/client returns **EBADFD** for a context-less fd; it leaks past the EBADF-only gate (BZ 1758579). |
| 93acace65c | 2019-10-14 | Gate widened to EBADF/EBADFD → the block is reachable again (v6.6, v7.1, v8.0, v9+). |

Unchanged since 2017-07-10; no regression test covers the re-open. Shipped in every release since
3.10.5 / 3.11.2 / 3.12.0; client-reachable in 3.10.5 / 3.11.x and continuously since v6.6 / v7.1 / v8.0.

### Prior reports of this exact log line (never diagnosed)

| Report | Date | Version / path | Evidence |
|---|---|---|---|
| gluster-users "gluster tiering errors" (2017-October/032726) | 2017-10-19 | 3.10.5, Samba 4.6.2 via vfs_glusterfs | 5 × `… dht_check_and_open_fd_on_subvol_task … Failed to open the fd … [Invalid argument]` → EPERM branch; triaged as tiering watermarks. |
| #1373 | 2020-07-15 | 6.9, `gfapi.smbd` | 16 × `… Failed to open the fd … [No such file or directory]` after `client_pre_flush_v2 … remote_fd is -1. EBADFD` → errno-0 branch on FLUSH; stale-closed, "still seeing this in Gluster 8" (2021). |
| BZ 1758579 (+ RHGS 1758432) | 2019-10-04 | mainline, add-brick + rebalance | The EBADFD leak in front of this block; fixed by widening the gate, function body not examined. |

### Why these return values

- **Real errno (case 1).** The identical `-ret`-as-op_errno bug was fixed in posix in 2017 as a bug
  (`eddc888a0d`, review 17414: "we incorrectly use the ret value (-1) as op_errno, logging 'Operation not
  permitted' … propagated to the client"). The sibling `dht_migration_complete_check_task()` in this file
  already reports a failed re-open as `local->op_errno = -ret`. fstat(2) lists no EPERM, and fallocate(2)
  defines EPERM as "file immutable/append-only" — the current value asserts a false cause. ENOTCONN is the
  errno protocol/client already returns for every fop to a down brick.
- **EBADFD (case 2).** `op_ret = -1, op_errno = 0` is invalid at every boundary: syncop cannot represent it
  (`return -op_errno`), gfapi documents "-1 … @errno will be set", libfuse defines a zero error reply as
  success ("or zero for success"; flush/fsync/setxattr are exactly the requests answered that way), and gNFS
  already maps this state to NFS3ERR_SERVERFAULT (`nfs3_cbk_errno_status`). The fix restores the reviewed
  2017 semantics (BZ 1465075 comment 9: wind to the old subvol and let the phase checks handle it); under
  today's EBADF/EBADFD trigger that ends in protocol/client's EBADFD — the errno it has returned since 2012
  for a fd not open on a subvolume, which gfapi also uses for an invalid glfd and which
  `tests/basic/fencing/afr-lock-heal-advanced.c` already expects. Consumers receive it today after brick
  reconnects, so no new errno class is introduced.
- **Recovery is unchanged.** The re-open is retried on every subsequent FOP (the
  "already tried" flag is per-FOP). Measured on both builds: after the destination
  brick returns, the same held fd works again on its next FOP; after a missing
  gfid handle is healed by any named lookup on that path, likewise. The patch
  changes only the errno reported while the fault lasts.
- **Consumer view.** Samba maps EPERM to NT_STATUS_ACCESS_DENIED and has no entry for EBADFD/ESTALE/ENOTCONN
  (default ACCESS_DENIED): SMB clients see the same status as today in case 1 with correct logs, and an error
  instead of a silent success in case 2. NFS-Ganesha likewise falls to its default for EBADFD.
  Alternatives (reporting ESTALE directly; EBADF at protocol/client; a lookup-based
  re-resolution) are discussed in a follow-up comment rather than here.

### What changes / what does not

- A **successful** re-open is untouched: the deleted lines sit inside
  `if (ret < 0)`.
- A failed re-open now reports the real errno (case 1). For ENOENT/ESTALE the
  FOP is wound once more as the 2017 commit intended; with today's
  EBADF/EBADFD-only trigger (`e09cbb13d8`, `93acace65c`) that ends in EBADFD
  from protocol/client rather than errno 0. A lookup-based re-resolution on
  ENOENT/ESTALE would be a further improvement but is out of scope here.

### Scope: which processes are affected

`cluster/distribute` is loaded only by client graphs (FUSE mounts, every gfapi
consumer — Samba `vfs_glusterfs`, NFS-Ganesha, QEMU — and, through per-volume
client graphs, gNFS), by quotad and by the rebalance daemon. Of these, only
**FUSE mounts and gfapi consumers** can reach the changed branch: gNFS serves
I/O through anonymous fds (which never produce EBADFD and make the task return
early), quotad issues no fd fops, and the rebalance daemon drives its migration
fds directly on the subvolumes. Bricks (`glusterfsd`), `glusterd`, `glustershd`,
bitd/scrub and the CLI do not load DHT and are unchanged. No wire, volfile,
option or on-disk change; the success path is untouched; mixed-version
clusters are unaffected at the bricks. The fix takes effect per client on
remount/restart; brick and glusterd restarts are not needed.

### Testing

Reproduced deterministically on a 2-brick pure-distribute volume with a
provenance-matched A/B: two `dht.so` builds from the same tree and make path
differing by exactly this 3-line patch (a per-function binary diff confirms the
only logic change is in `dht_check_and_open_fd_on_subvol_task`; the build uses
`-flto`, so other functions differ only by relocation/padding).

- **Case 1** — dst brick killed after migration (reopen open → ENOTCONN):
  held-fd `fstat`/`fallocate`/`close` return **EPERM** unpatched vs **ENOTCONN**
  patched.
- **Case 2** — dst gfid handle removed, brick restarted (reopen open → ESTALE):
  `fstat` returns **EIO** and `close`/flush returns **silent success** unpatched
  vs **EBADFD** patched — the buggy build swallows the flush failure.

`readv`/`fsync` take protocol/client's anon-fd fallback and never reach the
reopen (unchanged across arms). Patched TU also compiles cleanly with the
production configure flags.

Regression differential, 58 tests (`tests/basic/distribute`, `tests/bugs/distribute`,
the AFR fencing fd tests, `bug-978794.t`), unpatched vs patched on the same host:
48 pass on both, 9 fail on both with identical subtest counts (environment;
they also fail in the current upstream Jammy/Fedora runs), **0 base-pass →
patched-fail**.

No pre-existing regression test reaches this failure branch (the three tests
that hold fds across a rebalance never make the re-open's open fail), so this
series adds `tests/bugs/distribute/fd-reopen-error-path.t` (+ a small Python
fd holder) covering both cases: **5/40 assertions fail unpatched** (EPERM ×3;
EIO and a silently successful close) and **40/40 pass patched**.

### Suggested reviewer

@mohit84 (author of 93acace65c, the EBADFD trigger this path depends on).

### Change summary

- `xlators/cluster/dht/src/dht-helper.c`: 3 deletions
- `tests/bugs/distribute/fd-reopen-error-path.{t,py}`: new regression test
