### PR TITLE
error-gen: honour "error-no" when random-failure is off

### DIFF
--- a/tests/basic/error-gen-error-number.t
+++ b/tests/basic/error-gen-error-number.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# debug/error-gen must inject the errno configured with "error-no"
+# (volume option debug.error-number).  Since efb4636ace (2017) the
+# configured value was only consulted on the random-failure path; with the
+# default random-failure=off every injected failure carried a random errno
+# from error-gen's per-fop list instead.
+#
+# EIO is not in error-gen's MKDIR list, so the unpatched xlator can never
+# produce it here: the assertion fails deterministically without the fix.
+
+. $(dirname $0)/../include.rc
+. $(dirname $0)/../volume.rc
+cleanup;
+
+function mkdir_errmsg {
+    mkdir $1 2>&1 | sed -n 's/.*: //p'
+    return 0
+}
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}0
+TEST $CLI volume set $V0 debug.error-gen posix
+TEST $CLI volume set $V0 debug.error-fops mkdir
+TEST $CLI volume set $V0 debug.error-number EIO
+TEST $CLI volume set $V0 debug.error-failure 100
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+TEST ! mkdir $M0/d1
+EXPECT "Input/output error" mkdir_errmsg $M0/d2
+EXPECT "Input/output error" mkdir_errmsg $M0/d3
+
+# The configured errno must survive a reconfigure as well.
+TEST $CLI volume set $V0 debug.error-number ENOTEMPTY
+EXPECT_WITHIN $PROCESS_UP_TIMEOUT "Directory not empty" mkdir_errmsg $M0/d4
+
+cleanup;

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -226,6 +226,7 @@ error_gen(xlator_t *this, int op_no)
     int error_no_list_size = 0;
 
     egp = this->private;
+    error_no_int = egp->error_no_int;
 
     if (egp->random_failure) {
         /*
@@ -239,7 +240,6 @@ error_gen(xlator_t *this, int op_no)
         LOCK(&egp->lock);
         {
             count = ++(egp->op_count);
-            error_no_int = egp->error_no_int;
             if ((count % egp->failure_iter_no) == 0) {
                 egp->op_count = 0;
                 /* coverity[DC.WEAK_CRYPTO] */


### PR DESCRIPTION
Fixes: #4752

### Problem

Since efb4636ace ("error-gen: fix randomness", 2017-07-26) `error_gen()` copies `egp->error_no_int`
into its local only inside the `random-failure` branch. On the default path (`random-failure off`,
`failure` as a percentage) the local stays 0, so every injected failure carries a random errno from the
per-fop `error_no_list` and the configured `error-no` (`debug.error-number`) is silently ignored.

### Change

Load the configured errno before the branch, restoring the single-path behaviour that predates
efb4636ace. One line moved. The read is unlocked, which is safe: `reconfigure()` already updates
`error_no_int` without `egp->lock`, and the default path reads `egp->failure_iter_no` /
`egp->random_failure` lock-free the same way — the old read-under-lock never synchronised against the
writer.

### Effect on the test suite: three regression tests have been passing vacuously since 2017

Three tests configure a specific fault through error-gen. Since `efb4636ace` they have been passing
without injecting it:

| test | guards against | asks for | got instead, 2017-07 → now |
|------|----------------|----------|-----------------------------|
| `tests/bugs/glusterfs/bug-853690.t` (bug from 2012) | AFR corrupting or split-braining a replica on short writes | `GF_ERROR_SHORT_WRITE` on every `writev` of one replica | a hard writev errno; a short write only when the random pick happened to land on it |
| `tests/bugs/glusterfs/bug-892730.t` (bug from 2012) | EIO from a brick's local filesystem reaching the user | EIO on every lookup from one brick | ENOENT, ENOTDIR, ENAMETOOLONG or EAGAIN — EIO is not in the LOOKUP list, so never |
| `tests/basic/ec/self-heal-read-write-fail.t` (2019) | EC heal proceeding although a read or write failed | EBADF on read, then on write | a random errno from the READ / WRITE lists — EBADF among them, injected only when the random pick landed on it (as bug-853690) |

Their assertions held under the substitute faults (they check AFR divergence, that touch/rm survive a
broken brick, and that a blocked heal makes no progress), so the suite stayed green while not verifying
what the tests were written for. Of the three, only bug-892730 was deterministically denied its errno
(EIO is not in the LOOKUP list); bug-853690 and the EC test each received theirs only when the random
pick happened to land on it. Nothing flaky came of it: none of the three is in the bad-test list or has
been touched since.

With this change they inject what they configure, and all three still pass, so the guarded AFR and EC
behaviour holds; what the bug cost was detection, not a known regression.

### A related short-write crash whose coverage this masked

`bug-853690.t`'s dilution has a second consequence. `77e4878a9e` (2019, bz#1746320) fixed a separate
crash in error-gen's short-write handling (vector count not updated before winding) — a path
`bug-853690.t` is meant to drive on every `writev` but, under this bug, reached only about one `writev`
in seven. That is the same lost-detection effect as the vacuous tests above, not a crash this bug
caused; honouring `error-no` restores full exercise of the path. (`#1230`, a separate DHT NULL-deref on
a random `EBADF` for a loc fop, is independent — `errorgen-coverage.t` sets no `error-no` — but its
`EBADF` / loc-fop interaction with this fix is covered in the reviewer note below.)

### New test

`tests/basic/error-gen-error-number.t`: single-brick volume, `debug.error-fops mkdir`,
`debug.error-number EIO`, then a live reconfigure to ENOTEMPTY. Neither errno is in error-gen's MKDIR
list, so the unpatched xlator cannot pass it.

### Testing

Devel `6daf10f322`, single node (tree at `a6fa98f65c`, error-gen unchanged since):

| test | unpatched xlator | patched |
|------|------------------|---------|
| `error-gen-error-number.t` | FAIL: "Bad address", "Permission denied", "No space left on device" for a configured EIO / ENOTEMPTY | PASS |
| `bug-853690.t` | PASS (hard writev errno) | PASS (short write on every writev) |
| `bug-892730.t` | PASS (ENOENT/ENOTDIR/...) | PASS (EIO) |
| `ec/self-heal-read-write-fail.t` | not run | PASS (EBADF) |

`tests/bugs/nfs/bug-915280.t` and `tests/line-coverage/errorgen-coverage.t` do not configure an errno
and are unaffected.

### Reviewer note: EBADF on loc fops (the #1230 interaction)

ba5e847501 removed `EBADF` from the loc-fop entries of the *random* list so error-gen would stop
handing DHT an `EBADF` on a loc fop (#1230). That curation covers only the substitution path. The
explicit path this change activates — `if (error_no_int) ret = error_no_int;` — has no fop-class guard,
so `debug.error-number EBADF` with a loc fop in `error-fops` returns `EBADF` on that loc fop directly and
can reach the same DHT crash. This is not new: it was already reachable with `random-failure on`, the one
path that honoured `error-no`; this change makes it reachable on the default path too. Whether error-gen
should reject fd-only errnos on loc fops, or this is acceptable "you configured it" debug-tool behaviour,
is a maintainers' call — flagging it for whoever owns error-gen / the author of ba5e847501.
