### PR TITLE
build: fix inverted fdatasync check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1141,7 +1141,7 @@ if test "x${have_llistxattr}" = "xyes"; then
    AC_DEFINE(HAVE_LLISTXATTR, 1, [define if llistxattr exists])
 fi
 
-AC_CHECK_FUNC([fdatasync], [have_fdatasync=no])
+AC_CHECK_FUNC([fdatasync], [have_fdatasync=yes])
 if test "x${have_fdatasync}" = "xyes"; then
    AC_DEFINE(HAVE_FDATASYNC, 1, [define if fdatasync exists])
 fi


### PR DESCRIPTION
AC_CHECK_FUNC([fdatasync], [have_fdatasync=no]) sets the flag in the
action-if-found slot, so on any host that has fdatasync() (all Linux)
HAVE_FDATASYNC was never defined. A regression from ff68a5a1bb (2014);
the check was added as =yes in 1e72418ca5 (2007), and every sibling
probe uses =yes.

No runtime effect: the sole HAVE_FDATASYNC consumer is the crash-time
build-config dump in common-utils.c; sys_fdatasync() in syscall.c is
OS-host gated and never read the macro. Diagnostic accuracy only.

Fixes: #4761

