### PR TITLE
configure: honour --with-ocf instead of silently disabling OCF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -531,10 +531,12 @@ AC_ARG_WITH(tmpfilesdir,
 AC_SUBST(tmpfilesdir)
 
 AC_ARG_WITH([ocf],
-            [AS_HELP_STRING([--without-ocf], [build OCF-compliant cluster resource agents])],
-            ,
-            [OCF_SUBDIR='ocf'],
-            )
+            [AS_HELP_STRING([--without-ocf], [do not build OCF-compliant cluster resource agents])],
+            [with_ocf=$withval],
+            [with_ocf=yes])
+if test "x$with_ocf" != "xno"; then
+   OCF_SUBDIR='ocf'
+fi
 AC_SUBST(OCF_SUBDIR)
 
 AC_ARG_WITH([server],


### PR DESCRIPTION
# configure: honour --with-ocf instead of silently disabling OCF

Fixes: #4760

`AC_ARG_WITH([ocf], …)` set `OCF_SUBDIR='ocf'` only in the
*action-if-not-given* slot and left *action-if-given* empty. Any explicit
`--with-ocf` therefore ran the empty action and left `OCF_SUBDIR` unset, so
`--with-ocf` — the flag a packager uses to *request* the OCF resource
agents — silently disabled them, identically to `--without-ocf`. Only the
no-flag default built them. `OCF_SUBDIR` feeds `SUBDIRS` in
`extras/Makefile.am`, so the mishandled flag dropped `extras/ocf` from both
the build and the install.

The fix captures `$withval` in *action-if-given*, defaults `with_ocf=yes`,
and sets `OCF_SUBDIR` only when `with_ocf` is not `no` — the same
value-discard idiom already fixed for `--with-{tcmalloc,libtirpc,ipv6-default}`
in `a249d07656`. The backwards `--without-ocf` help text is corrected too.

## Behaviour (install-verified)

Real out-of-source `configure` + `make install` A/B on `devel`; the two
`DESTDIR` trees differ by exactly `…/lib/ocf/resource.d/glusterfs/{glusterd,volume}`:

| `./configure` input     | agents before   | agents after         |
|-------------------------|-----------------|----------------------|
| *(no flag — default)*   | installed       | installed            |
| `--without-ocf`         | absent          | absent               |
| `--with-ocf=no`         | absent          | absent               |
| `--with-ocf`            | **absent (bug)**| **installed**        |
| `--with-ocf=yes`        | **absent (bug)**| **installed**        |
| `--with-ocf=<other>`    | absent          | installed (as `yes`) |

Only the affirmative `--with-ocf[=…]` path changes; the default and
`--without-ocf` are unchanged. Upstream `glusterfs.spec.in` never passes
`--with-ocf` (only nothing, or `--without-ocf` under `--without server`),
so packaging is unaffected.

## Provenance

| commit           | date · author            | `--with-ocf` | default      |
|------------------|--------------------------|--------------|--------------|
| `40f5ce0db6`     | 2012-02-20 · Florian Haas | builds       | off (opt-in) |
| `0f851d4dd8`     | 2012-11-06 · Niels de Vos | **disables** | on           |
| *(this patch)*   | —                        | builds       | on           |

The option was born working as an opt-in flag in `40f5ce0db6`, where
`AM_CONDITIONAL(WITH_OCF, [test "$with_ocf" = "yes"])` read the value the
argument parser set. `0f851d4dd8` flipped OCF on by default and switched the
plumbing to `OCF_SUBDIR`/`SUBDIRS`, but dropped that read of `$with_ocf` —
leaving the affirmative `--with-ocf` path dead. Untouched since.

## Risk

Build-system only; no runtime code touched. Default behaviour (agents built)
is unchanged.
