### PR TITLE
configure: remove dead PYTHON_CFLAGS/PYTHON_LIBS computation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,19 +761,6 @@ if test -n "${PYTHON}"; then
 fi
 AM_CONDITIONAL(HAVE_PYTHON, test "x$have_python" = "xyes")
 
-dnl Use pkg-config to get runtime search path missing from ${PYTHON}-config
-dnl Just do "true" on failure so that configure does not bail out
-dnl Note: python 2.6's devel pkg (e.g. in CentOS/RHEL 6) does not have
-dnl pkg-config files, so this work-around instead
-if test "x${PYTHON_VERSION}" = "x2.6"; then
-  PYTHON_CFLAGS=$(python-config --includes)
-  PYTHON_LIBS=$(python-config --libs)
-else
-  PKG_CHECK_MODULES([PYTHON], "python-${PYTHON_VERSION}",,true)
-fi
-
-PYTHON_CFLAGS=$(echo ${PYTHON_CFLAGS} | sed -e 's|-I|-isystem |')
-
 BUILD_PYTHON_SITE_PACKAGES=${pythondir}
 AC_SUBST(BUILD_PYTHON_SITE_PACKAGES)
 


### PR DESCRIPTION
Fixes: #4762

## What

`configure.ac` computes `PYTHON_CFLAGS`/`PYTHON_LIBS` (with a Python-2.6
special case) into variables that nothing uses. They are a fossil of the
`glupy` Python translator: `glupy` embedded CPython and consumed these flags in
`xlators/features/glupy/src/Makefile.am` (`$(PYTHON_CFLAGS)` in `AM_CFLAGS`,
`$(PYTHON_LIBS)` in `glupy_la_LDFLAGS`), but `glupy` was removed in 2018
(`556647fcb8`). That commit deleted the consumer and the configure-side glupy
section that referenced `${PYTHON_CFLAGS}`, but left the computation orphaned.

Nothing has consumed the variables since:

- no `Makefile.am` uses `$(PYTHON_CFLAGS)` / `$(PYTHON_LIBS)`,
- no `*.in` references `@PYTHON_CFLAGS@` / `@PYTHON_LIBS@`,
- no C source includes `<Python.h>`.

Python 2.6 has been EOL since 2013.

## Change

Remove the whole block (`configure.ac`, -13 lines). Python support is
untouched: `have_python` / `HAVE_PYTHON`, `pythondir` →
`BUILD_PYTHON_SITE_PACKAGES`, and `AM_PATH_PYTHON` version detection are all
independent of this block and unchanged. The only observable effect is one
fewer `checking for python-<version>...` line in `configure` output.

## Testing

Real `--enable-debug` A/B builds on 6 distributions spanning autoconf 2.69–2.73
and glibc 2.34–2.43: **Debian 13, Ubuntu 24.04, CentOS Stream 9, Fedora 42,
openSUSE Leap 15.6, openSUSE Tumbleweed**. Arm A = parent (block present),
arm B = this patch (block removed); each arm runs `autogen.sh` → `configure
--enable-debug` → full `make`.

On every distro, both arms: `autogen`/`configure`/`make` succeed with 0 errors,
build `libglusterfs.so` with `-DDEBUG -g -O0`, and produce the **same 76 shared
objects and the same 727 compile commands**. The normalized `gcc` command lines
are **byte-identical A vs B** (0 differing lines, all 6 distros), and
`PYTHON_CFLAGS`/`PYTHON_LIBS`/`<Python.h>` appear in **neither** arm's compile
commands.

The only build-system difference is that arm A's generated Makefiles define the
two now-removed variables (`PYTHON_CFLAGS`, empty `PYTHON_LIBS`) and arm B's do
not — defined-but-never-referenced, hence zero effect on any object. The
generated `configure` drops from 17 `PYTHON_CFLAGS`/`PYTHON_LIBS` references to 0,
confined to the removed pkg-config probe; `BUILD_PYTHON_SITE_PACKAGES` and
`HAVE_PYTHON` are unchanged.
