### PR TITLE
configure: drop duplicate AC_ARG_ENABLE([debug])

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1595,10 +1595,6 @@ fi
 AC_SUBST(UMOUNTD_SUBDIR)
 
 
-# enable debug section
-AC_ARG_ENABLE([debug],
-              AS_HELP_STRING([--enable-debug],[Enable debug build options.]))
-
 dnl Add readline support in CLI if available.
 PKG_CHECK_MODULES([READLINE], [readline], [BUILD_READLINE="yes"],
                   [BUILD_READLINE="no"])
@@ -1708,7 +1704,6 @@ AC_SUBST(UNITTEST_CFLAGS)
 AC_SUBST(UNITTEST_LDFLAGS)
 
 AC_SUBST(CFLAGS)
-# end enable debug section
 
 dnl do not add -lresolv for freebsd
 case $host_os in


### PR DESCRIPTION
Fixes: #4764

## What

`--enable-debug` is declared twice. The first declaration carries the
logic (sets `BUILD_DEBUG` and the debug `-g -O0 -DDEBUG` CFLAGS, consulted
by the LTO gate); the second is bodyless and only re-registers the option.

Autoconf deduplicates the identical help string, so the second declaration
adds no `--enable-debug` line to `./configure --help`. Its only footprint
is a dead `enableval=$enable_debug` stanza in the generated `configure`
(never read) and a misleading `# enable debug section` /
`# end enable debug section` banner — that block actually configures
readline, bash-completion, libaio, io_uring, gnfs, urcu and cmocka.

## Change

Remove the redundant declaration and its two stale banner comments. The
real `--enable-debug` handling is untouched.

## Verification

    grep -c 'AC_ARG_ENABLE(\[debug\]' configure.ac   # 1 (was 2)

Regenerated `configure` before/after and diffed: the only change is the
removal of the dead `enableval=$enable_debug` stanza and the two comments.
`./configure --help` is byte-identical and still lists `--enable-debug`.

Verified with a real `./configure --enable-debug` **and full `make`** on six
distributions (Debian 13, Ubuntu 24.04, CentOS Stream 9, Fedora 42,
openSUSE Leap 15.6, openSUSE Tumbleweed — autoconf 2.69 through 2.73),
each built twice (with and without this patch): the generated build system
(`config.h` + every `Makefile`) is byte-identical, `--enable-debug` sets
`BUILD_DEBUG=yes` and the `-g -O0 -DDEBUG` flags on both arms, and both
builds succeed with identical per-TU compile flags and an identical set of
shared objects. No build-behaviour change.
