### PR TITLE
configure: quote the HAVE_IO_URING description as m4, not a C string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1638,7 +1638,7 @@ case $host_os in
 
             AC_CHECK_HEADER([linux/io_uring.h],
                             [
-                                AC_DEFINE([HAVE_IO_URING], [1], "io_uring support")
+                                AC_DEFINE([HAVE_IO_URING], [1], [io_uring support])
                                 BUILD_LINUX_IO_URING="yes"
                             ])
         fi


### PR DESCRIPTION
`AC_DEFINE([HAVE_IO_URING], [1], "io_uring support")` passed the
description as a double-quoted C string rather than an m4-quoted
`[io_uring support]`. The literal quotes end up in the `config.h`
comment (`/* "io_uring support" */` instead of `/* io_uring support */`).
It is the only `AC_DEFINE` in `configure.ac` written this way; the other
five 3-argument definitions all use the correct `[...]` quoting. The
`#define HAVE_IO_URING 1` itself is unaffected — the defect is cosmetic
and a quoting anti-pattern, not a build break.

Fixes: #4766
