### PR TITLE
dht: bind fd once before opendir fan-out in directory rename

### DIFF
--- a/tests/bugs/distribute/bug-dht-dir-rename-fd-bind.t
+++ b/tests/bugs/distribute/bug-dht-dir-rename-fd-bind.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Regression: dht directory-rename over an existing destination must not inflate
+# the source directory inode's fd_count/active_fd_count.
+#
+# dht_rename_opendir_cbk used to call fd_bind() once per successful per-subvol
+# opendir on a single shared fd, leaving the inode's fd_count/active_fd_count
+# inflated by (dht_subvols - 1). These counters are the ones an operator reads
+# from a statedump when diagnosing fd usage, so the inflation is a correctness
+# bug in the diagnostic output. Fixed by binding the fd exactly once.
+#
+# RED on the buggy dht.so (fd-count = N-1 = 2), GREEN once fd_bind is bound once.
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+
+cleanup;
+
+TEST glusterd
+TEST pidof glusterd
+
+## 3-subvol pure distribute (N=3 -> buggy leaks N-1 = 2)
+TEST $CLI volume create $V0 $H0:$B0/${V0}0 $H0:$B0/${V0}1 $H0:$B0/${V0}2
+# keep a clean dht-over-client graph so no perf xlator opens/holds extra fds
+TEST $CLI volume set $V0 performance.open-behind off
+TEST $CLI volume set $V0 performance.quick-read off
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.read-ahead off
+TEST $CLI volume set $V0 performance.io-cache off
+TEST $CLI volume set $V0 performance.readdir-ahead off
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume set $V0 performance.nl-cache off
+TEST $CLI volume start $V0
+TEST glusterfs --volfile-id=/$V0 --volfile-server=$H0 $M0 \
+     --attribute-timeout=0 --entry-timeout=0
+
+# --- helpers: read a specific inode's fd-count from the mount statedump ---
+# print "present"/"absent" (liveness guard against an empty-grep false pass)
+function inode_present {
+        local sd=$1 g=$2
+        grep -q "gfid=$g" $sd && echo "present" || echo "absent"
+}
+# print the (max) fd-count reported for an inode gfid
+function fdcount_of_gfid {
+        local sd=$1 g=$2
+        grep -A4 "gfid=$g" $sd | grep 'fd-count=' | cut -d= -f2 | sort -nr | head -1
+}
+
+# ============================================================================
+# MEASUREMENT POSITIVE CONTROL: prove the statedump fd-count field reads a
+# genuine NON-ZERO for a legitimately open dir fd. If this fails the assay is
+# broken and the bug assertion below would be vacuous.
+# ============================================================================
+TEST mkdir $M0/ctl_dir
+ctl_gfid=$(getfattr -h -n glusterfs.gfid.string --only-values $M0/ctl_dir 2>/dev/null)
+exec 9<$M0/ctl_dir                        # hold a real O_RDONLY dir fd open
+sd_ctl=$(generate_mount_statedump $V0)
+EXPECT "present" inode_present $sd_ctl $ctl_gfid
+EXPECT "1" fdcount_of_gfid $sd_ctl $ctl_gfid
+exec 9<&-                                 # release it
+rm -f $sd_ctl
+
+# ============================================================================
+# THE BUG: rename a directory over an existing (empty) directory.
+# ============================================================================
+TEST mkdir $M0/src_dir
+TEST mkdir $M0/dst_dir
+src_gfid=$(getfattr -h -n glusterfs.gfid.string --only-values $M0/src_dir 2>/dev/null)
+TEST mv -T $M0/src_dir $M0/dst_dir        # src inode (src_gfid) is now dst_dir
+TEST stat $M0/dst_dir                      # keep the inode looked-up/active
+
+sd=$(generate_mount_statedump $V0)
+# liveness: the renamed inode must actually be in the dump (else a 0 is a lie)
+EXPECT "present" inode_present $sd $src_gfid
+# the regression assertion: no phantom fd counts left on the renamed inode
+EXPECT "0" fdcount_of_gfid $sd $src_gfid
+rm -f $sd
+
+cleanup

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -328,7 +328,6 @@ dht_rename_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    fd_bind(fd);
     STACK_WIND_COOKIE(frame, dht_rename_readdir_cbk, prev, prev,
                       prev->fops->readdir, local->fd, 4096, 0, NULL);
 
@@ -387,6 +386,8 @@ dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         dht_rename_dir_do(frame, this);
         return 0;
     }
+
+    fd_bind(local->fd);
 
     for (i = 0; i < conf->subvolume_cnt; i++) {
         STACK_WIND_COOKIE(frame, dht_rename_opendir_cbk, conf->subvolumes[i],


### PR DESCRIPTION
## What

When DHT renames a directory over an existing destination, it checks the
destination is empty by fanning out `opendir` to all N subvolumes on a single
shared fd. `dht_rename_opendir_cbk` called `fd_bind(fd)` from each per-subvol
callback, so the shared fd was bound N times. `__fd_bind()` increments
`inode->fd_count` and `inode->active_fd_count` unconditionally, so after the
single `fd_unref()` in `dht_local_wipe()` both counters are left inflated by N-1
(N = number of DHT subvolumes). The shared fd is created against the **source**
inode (`fd_create(local->loc.inode, ...)`) and reused to `opendir` the
destination path, so it is the source (renamed) directory's inode that inflates.

This patch binds `local->fd` exactly once, in `dht_rename_dir_lock2_cbk` just
before the opendir fan-out loop. This achieves the same "bind once" invariant as
the sibling `dht_rmdir_opendir_cbk` — which binds its shared fd once, in its
opendir callback after the `is_last_call` barrier — but does it in the wind path
before the fan-out. Binding there is safe because `fd_create` has already
returned a fully initialized fd on the correct inode; the bind does not depend on
any opendir result, and it avoids restructuring the readdir barrier.

## Why it matters

The inflated counters are what the statedump reports (`fd-count` /
`active-fd-count` per inode), which operators read to diagnose fd usage.
Reporting phantom fds on directory inodes can be mistaken for an fd leak. There
is no data-path, crash, or reclamation impact (client inode reclamation is
driven by ref/nlookup, not fd counts) — the fix restores correct diagnostic
output.

## Why the placement is safe

- The fd is bound after the `!dst_cached` early return, so it is bound only on
  the path that actually opens it — preserving prior behaviour on the
  new-name-rename path (which never bound).
- Counters are net-neutral on every path: the single `fd_bind` is matched by the
  single `fd_unref` in `dht_local_wipe`; the unbound paths are underflow-safe
  because `fd_unref`/`fd_destroy` gate their decrements on the fd having been
  bound.
- `opendir`/`readdir` are wound with the fd by pointer; subvolume translators
  use it regardless of its client-side bind state.

## Testing

Adds `tests/bugs/distribute/bug-dht-dir-rename-fd-bind.t`, which renames a
directory over an existing directory on a 3-subvolume volume and asserts the
renamed inode's statedump `fd-count` is 0. The test is self-controlled: a
measurement positive control (a real open dir fd must read `fd-count=1`) and a
liveness guard (the inode block must be present in the statedump) run first, so
the assertion cannot pass vacuously. The test FAILS without this change
(`Got "2" instead of "0"`) and PASSES with it.

Fixes: #4768
