### PR TITLE
dht: redirect SEEK to the migration destination instead of leaking ENXIO

### DIFF
--- a/tests/bugs/distribute/seek-during-rebalance.py
+++ b/tests/bugs/distribute/seek-during-rebalance.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Helper for seek-during-rebalance.t: hold an fd open across an (external) DHT
+# file migration, then run fops on the held fd when told to.
+#
+# usage: seek-during-rebalance.py FILE GO-MARKER OUT OP[,OP...]
+#
+# Opens FILE read-only and appends "READY" to OUT; waits until GO-MARKER exists;
+# then runs each OP on the held fd and appends "OP=<result>" to OUT.
+#   seek_data / seek_hole -> the returned offset, or the errno name (e.g. ENXIO)
+#   fstat / close         -> "OK", or the errno name
+# ("close" must be last.)
+
+import errno
+import os
+import sys
+import time
+
+path, marker, out, ops = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4].split(',')
+
+
+def report(line):
+    with open(out, 'a') as f:
+        f.write(line + "\n")
+
+
+fd = os.open(path, os.O_RDONLY)
+report("READY")
+while not os.path.exists(marker):
+    time.sleep(0.2)
+for op in ops:
+    try:
+        if op == 'seek_data':
+            res = str(os.lseek(fd, 0, os.SEEK_DATA))
+        elif op == 'seek_hole':
+            res = str(os.lseek(fd, 0, os.SEEK_HOLE))
+        elif op == 'fstat':
+            os.fstat(fd)
+            res = "OK"
+        elif op == 'close':
+            os.close(fd)
+            res = "OK"
+        else:
+            raise ValueError("unknown op " + op)
+    except OSError as e:
+        res = errno.errorcode.get(e.errno, str(e.errno))
+    report("%s=%s" % (op, res))

--- a/tests/bugs/distribute/seek-during-rebalance.t
+++ b/tests/bugs/distribute/seek-during-rebalance.t
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# dht_seek_cbk leaks a spurious ENXIO during rebalance instead of redirecting
+# SEEK_DATA/SEEK_HOLE to the destination subvolume.
+#
+# A file whose data is on brick 0 is migrated to brick 1 by an *external*
+# remove-brick while an application holds an fd open on it.  dht_seek_cbk carries
+# no iatt, so unlike readv/writev/attr it cannot detect the migration
+# proactively (IS_DHT_MIGRATION_PHASE2); its only signal is the errno.  The held
+# fd still resolves to brick 0, where the source is now a 0-byte leftover, so
+# SEEK_DATA/SEEK_HOLE return ENXIO (offset >= EOF).  Unpatched dht_seek_cbk
+# returns that ENXIO to the application; the fix lets ENXIO fall through to the
+# migration redirect so the SEEK is re-dispatched to brick 1 where the data is.
+#
+# fstat()/read() on the same fd already redirect, so the bug is SEEK-specific;
+# the test asserts the held fd sees the data (SEEK_DATA == 0) after the fix.
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+cleanup;
+
+HOLDER=$(dirname $0)/seek-during-rebalance.py
+
+# Create files until one lands with its data on brick 0; print its name.
+function pick_file_on_brick0 {
+    local i
+    for i in $(seq 0 63); do
+        echo "seek-me-$i" > $M0/f$i
+        if [ -s $B0/${V0}0/f$i ]; then
+            echo f$i
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Probe helpers all exit 0 so EXPECT_WITHIN keeps retrying (a non-zero status
+# aborts the retry loop).
+function holder_ready {
+    head -n 1 $1 2> /dev/null
+    return 0
+}
+
+function holder_result {
+    grep "^$2=" $1 2> /dev/null | cut -d= -f2
+    return 0
+}
+
+# Migration is complete once the source path is gone and the dst holds the data.
+function src_migrated {
+    if [ ! -e $B0/${V0}0/$1 ] && [ -s $B0/${V0}1/$1 ]; then
+        echo "Y"
+    fi
+    return 0
+}
+
+TEST glusterd
+TEST pidof glusterd
+TEST $CLI volume create $V0 $H0:$B0/${V0}{0,1}
+TEST $CLI volume set $V0 performance.quick-read off
+TEST $CLI volume set $V0 performance.io-cache off
+TEST $CLI volume set $V0 performance.stat-prefetch off
+TEST $CLI volume set $V0 performance.read-ahead off
+TEST $CLI volume set $V0 performance.write-behind off
+TEST $CLI volume set $V0 performance.open-behind off
+TEST $CLI volume start $V0
+TEST $GFS --volfile-id=$V0 --volfile-server=$H0 $M0
+
+f=$(pick_file_on_brick0)
+TEST [ x$f != x ]
+size=$(stat -c %s $M0/$f)
+
+out=$B0/holder.out
+go=$B0/go
+rm -f $out $go
+
+# Hold an fd open BEFORE the migration.  SEEK is probed first: fstat/read would
+# redirect and re-resolve the inode, masking the SEEK bug, so they run after.
+$PYTHON $HOLDER $M0/$f $go $out seek_data,seek_hole,fstat &
+EXPECT_WITHIN 10 "READY" holder_ready $out
+
+# External migration: remove brick 0, moving the data to brick 1.  The held fd
+# is not touched, so it still resolves to brick 0.
+TEST $CLI volume remove-brick $V0 $H0:$B0/${V0}0 start
+EXPECT_WITHIN 30 "Y" src_migrated $f
+
+TEST touch $go
+
+# With the fix, the held-fd SEEK is redirected to brick 1: SEEK_DATA finds data
+# at offset 0 and SEEK_HOLE returns the hole at EOF (== size).  Unpatched,
+# dht_seek_cbk returns the source's spurious ENXIO for both.
+EXPECT_WITHIN 15 "0" holder_result $out seek_data
+EXPECT_WITHIN 15 "$size" holder_result $out seek_hole
+# fstat redirects on both patched and unpatched -- a control that the file is
+# really present on brick 1 the whole time.
+EXPECT_WITHIN 15 "OK" holder_result $out fstat
+
+cleanup;

--- a/xlators/cluster/dht/src/dht-inode-read.c
+++ b/xlators/cluster/dht/src/dht-inode-read.c
@@ -1721,14 +1721,16 @@ dht_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     }
 
     local->op_errno = op_errno;
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    /* SEEK carries no iatt, so unlike readv/writev/attr it cannot spot an
+     * in-progress migration via IS_DHT_MIGRATION_PHASE2().  When rebalance has
+     * truncated the source to 0, SEEK_DATA/SEEK_HOLE returns ENXIO (offset >=
+     * EOF); exempt it here (as ENOENT/ESTALE already are) so it falls through to
+     * the migration redirect below instead of being returned to the client. */
+    if ((op_ret == -1) && !dht_inode_missing(op_errno) && (op_errno != ENXIO)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
     }
-
-    if ((op_ret == -1) && ((op_errno == ENXIO) || (op_errno == EOVERFLOW)))
-        goto out;
 
     if (!op_ret || (local->call_cnt != 1))
         goto out;


### PR DESCRIPTION
Fixes: #4771

### Problem

During rebalance, a `SEEK_DATA`/`SEEK_HOLE` on an fd still open on the source subvolume
can return `ENXIO` to the application even though the file's data is intact on the
destination.

Every DHT FOP callback redirects an in-flight operation to the migration destination
when it detects the file is migrating. The data-path callbacks receive an `iatt` and
detect it proactively via `IS_DHT_MIGRATION_PHASE2(stbuf)`. `dht_seek_cbk` receives no
`iatt`, so its only migration signal is the errno — and it only redirects on
`dht_inode_missing()` (ENOENT/ESTALE):

```c
local->op_errno = op_errno;
if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
    gf_msg_debug(this->name, op_errno, "subvolume %s returned -1", prev->name);
    goto out;
}
if ((op_ret == -1) && ((op_errno == ENXIO) || (op_errno == EOVERFLOW)))
    goto out;                       /* unreachable: caught by the handler above */
```

Near the end of `dht_migrate_file` the source is truncated to 0
(`dht-rebalance.c:2109`) before it is unlinked (`:2154`), while the source's `linkto`
xattr is already set (`:1224`). A `SEEK_DATA` that reaches the 0-byte source returns
`ENXIO` (the normal POSIX "no data at/after offset"). Since that is neither ENOENT nor
ESTALE, `dht_seek_cbk` takes the generic `goto out` and returns it to the client;
`dht_rebalance_complete_check` (the redirect) is never reached.

The explicit `ENXIO`/`EOVERFLOW` check below the generic handler is dead code — it has
been unreachable since it was added alongside the generic handler in the original
SEEK-at-DHT implementation (#3792).

### Fix

Exempt `ENXIO` from the generic handler so the callback falls through to the redirect,
and drop the now-redundant dead check:

```diff
     local->op_errno = op_errno;
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((op_ret == -1) && !dht_inode_missing(op_errno) && (op_errno != ENXIO)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
     }

-    if ((op_ret == -1) && ((op_errno == ENXIO) || (op_errno == EOVERFLOW)))
-        goto out;
-
     if (!op_ret || (local->call_cnt != 1))
         goto out;
```

A window `SEEK_DATA` on the source now falls through to `dht_rebalance_complete_check`,
which reads the source `linkto` xattr, re-resolves to the destination, and `dht_seek2`
re-dispatches the SEEK there. For a non-migrating file the check reads `ENODATA` (no
`linkto`) and unwinds the original errno unchanged, so legitimate end-of-data ENXIO is
preserved.

**Only `ENXIO` is exempted** (the dead check named `EOVERFLOW` too, but that is not
migration-related). `ENXIO` from `SEEK_DATA`/`SEEK_HOLE` means "offset ≥ EOF", so it is
*data-dependent* — the truncated 0-byte source raises it while the full destination does
not, which is exactly why redirecting helps. `EOVERFLOW` means "the seek result does not
fit `off_t`" (`fs/read_write.c` `ksys_lseek`), which is subvolume-independent — the
destination would return the same `EOVERFLOW` — so redirecting it is pointless; and with a
64-bit `off_t` it cannot arise from `SEEK_DATA`/`SEEK_HOLE` at all.

### Cost / trade-off

`ENXIO` is also the normal end-of-data signal for `SEEK_DATA`/`SEEK_HOLE`, so this adds one
`syncop_getxattr(linkto)` on the source per terminal `ENXIO`, even for non-migrating files —
the same check already done for `ENOENT`/`ESTALE`, but hit far more often (sparse scanners
seek to EOF once per file). A cheaper in-memory gate is not available: SEEK has no `iatt`,
and during the in-progress window the inode's migration info is not yet set, so
`dht_inode_ctx_get_mig_info` would not catch it. The cost is accepted because the
alternative is a silent wrong result; reviewers who prefer to bound it may want a volume-level
"rebalance active" guard, which is out of scope for this fix.

### Impact

Low severity (narrow trigger) but a silent wrong result, not a benign retry. The GlusterFS
SEEK FOP only carries `GF_SEEK_DATA`/`GF_SEEK_HOLE` (`gf_seek_what_t`), so the exposed
workloads are sparse-extent scanners (`cp --sparse`, `tar -S`, `qemu-img`), which treat
`SEEK_DATA=ENXIO` as end-of-data and stop — silently producing a short/all-holes copy.
On the same fd during the same window `fstat`/`read` return correct data (they redirect),
so SEEK is the only FOP that leaks the source's ENXIO.

### Testing

A regression test is included: `tests/bugs/distribute/seek-during-rebalance.t`. It holds
an fd open on a file whose data is on brick 0, migrates it to brick 1 with an external
`remove-brick` (so the held fd is not re-resolved), and asserts the held-fd `SEEK_DATA`
returns the data offset (`0`) rather than the source's spurious `ENXIO`. `fstat()` on the
same fd is a control — it redirects on both builds, keeping the failure isolated to SEEK.

- Unpatched: `not ok … 'Got "ENXIO" instead of "0"'` (SEEK_DATA and SEEK_HOLE), `fstat` ok.
- Patched: all pass (SEEK_DATA `0`, SEEK_HOLE `<size>`, `fstat` ok); deterministic across
  repeated runs.

(The same behavior was also confirmed manually on a 2-node volume, and — to make the
timing deterministic — by freezing the rebalance daemon in the truncate→unlink window
under gdb; the committed `.t` reproduces it without that, using the fact that the held fd
keeps hitting the emptied source until something re-resolves it.)

### Change summary

- `xlators/cluster/dht/src/dht-inode-read.c` — `dht_seek_cbk` (1 insertion, 4 deletions)
- `tests/bugs/distribute/seek-during-rebalance.{t,py}` — regression test (new)
