### PR TITLE
contrib/timer-wheel: fix always-false idx < 0 comparison

### DIFF
--- a/contrib/timer-wheel/timer-wheel.c
+++ b/contrib/timer-wheel/timer-wheel.c
@@ -56,7 +56,7 @@ __gf_tw_add_timer (struct tvec_base *base, struct gf_tw_timer_list *timer)
         } else if (idx < 1 << (TVR_BITS + 3*TVN_BITS)) {
                 i = (expires >> (TVR_BITS + 2*TVN_BITS)) & TVN_MASK;
                 vec = base->tv4.vec + i;
-        } else if (idx < 0) {
+        } else if ((long)idx < 0) {
                 vec = base->tv1.vec + (base->timer_sec & TVR_MASK);
         } else {
                 i = (expires >> (TVR_BITS + 3*TVN_BITS)) & TVN_MASK;


### PR DESCRIPTION
Restores the `(signed long)` cast the pre-4.8 Linux cascading timer-wheel port dropped, so
the past-expiry branch in `__gf_tw_add_timer()` is live again.

`idx` is `unsigned long`, so `idx < 0` is always false (`-Wtype-limits`): a timer whose
expiry is already past / `== now` (`idx` wrapped near `ULONG_MAX`) misses all four size
buckets and falls through to `tv5` instead of `tv1`.

Latent for current callers — every insert path adds `base->timer_sec` first, so `idx >= 0`
in practice — so this silences the warning and restores the intended safety net rather than
fixing an observed misfire. One line: `idx < 0` -> `(long)idx < 0`, matching the kernel's
`__internal_add_timer()`.

Fixes: #4770

Draft for discussion.
