### PR TITLE
[RFC] build,gfapi: retire the LFS64 transitional API; fix musl + public glfs.h

### DIFF
--- a/api/src/Makefile.am
+++ b/api/src/Makefile.am
@@ -18,8 +18,7 @@ libgfapi_la_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
         -I$(top_srcdir)/rpc/rpc-lib/src \
         -I$(top_srcdir)/rpc/xdr/src \
         -I$(top_builddir)/rpc/xdr/src \
-        -DDATADIR=\"$(localstatedir)\" \
-        -D__USE_FILE_OFFSET64 -D__USE_LARGEFILE64
+        -DDATADIR=\"$(localstatedir)\"
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)
 

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1873,8 +1873,8 @@ invalid_fs:
 
 GFAPI_SYMVER_PUBLIC_DEFAULT(glfs_copy_file_range, 6.0)
 ssize_t
-pub_glfs_copy_file_range(struct glfs_fd *glfd_in, off64_t *off_in,
-                         struct glfs_fd *glfd_out, off64_t *off_out, size_t len,
+pub_glfs_copy_file_range(struct glfs_fd *glfd_in, off_t *off_in,
+                         struct glfs_fd *glfd_out, off_t *off_out, size_t len,
                          unsigned int flags, struct glfs_stat *statbuf,
                          struct glfs_stat *prestat, struct glfs_stat *poststat)
 {
@@ -1894,8 +1894,8 @@ pub_glfs_copy_file_range(struct glfs_fd *glfd_in, off64_t *off_in,
                     0,
                 };
     dict_t *fop_attr = NULL;
-    off64_t pos_in;
-    off64_t pos_out;
+    off_t pos_in;
+    off_t pos_out;
 
     DECLARE_OLD_THIS;
     __GLFS_ENTRY_VALIDATE_FD(glfd_in, invalid_fs);

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -35,8 +35,8 @@
 #define _FILE_OFFSET_BITS 64
 #endif
 
-#ifndef __USE_FILE_OFFSET64
-#define __USE_FILE_OFFSET64
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
 #endif
 
 #ifndef _GNU_SOURCE
@@ -44,6 +44,7 @@
 #endif
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -54,22 +55,20 @@
 #include <sys/time.h>
 
 /*
- * For off64_t to be defined, we need both
- * __USE_LARGEFILE64 to be true and __off64_t_defnined to be
- * false. But, making __USE_LARGEFILE64 true causes other issues
- * such as redinition of stat and fstat to stat64 and fstat64
- * respectively which again causes compilation issues.
- * Without off64_t being defined, this will not compile as
- * copy_file_range uses off64_t. Hence define it here. First
- * check whether __off64_t_defined is true or not. <unistd.h>
- * sets that flag when it defines off64_t. If __off64_t_defined
- * is false and __USE_FILE_OFFSET64 is true, then go on to define
- * off64_t using __off64_t.
+ * glfs_copy_file_range() uses off64_t.  With _LARGEFILE64_SOURCE in effect
+ * (defined above) glibc provides it from <sys/types.h> and musl defines it
+ * as a macro for off_t.  If the application included libc headers before
+ * glfs.h without LFS64 enabled, neither is present; fall back per libc.
  */
 #ifndef GF_BSD_HOST_OS
-#if defined(__USE_FILE_OFFSET64) && !defined(__off64_t_defined)
+#if defined(__GLIBC__)
+#if !defined(__off64_t_defined)
 typedef __off64_t off64_t;
-#endif /* defined(__USE_FILE_OFFSET64) && !defined(__off64_t_defined) */
+#endif
+#elif !defined(off64_t)
+/* non-glibc Linux libc (musl): off_t is always 64-bit */
+typedef int64_t off64_t;
+#endif
 #else
 #include <stdio.h>
 #ifndef _OFF64_T_DECLARED

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -35,10 +35,6 @@
 #define _FILE_OFFSET_BITS 64
 #endif
 
-#ifndef _LARGEFILE64_SOURCE
-#define _LARGEFILE64_SOURCE
-#endif
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -54,6 +54,35 @@
 #include <stdint.h>
 #include <sys/time.h>
 
+/*
+ * The feature-test defines above only take effect if glfs.h is the first
+ * header in the translation unit.  If a libc header came first, glibc's
+ * <features.h> has already run and will not run again, so the define
+ * arrives too late and is ignored; and a consumer is free to set
+ * _FILE_OFFSET_BITS to something other than 64 itself, which the block
+ * above deliberately does not override.
+ *
+ * On an ABI whose off_t is 32-bit by default, either case leaves the
+ * application with a 4-byte off_t and an 88-byte struct stat while
+ * libgfapi -- always built with _FILE_OFFSET_BITS=64 -- has 8 and 96.
+ * Every glfs_* entry point taking an off_t or a struct stat is then
+ * called with a layout the library does not agree on, and nothing says
+ * so: it compiles, links, and misbehaves at run time.
+ *
+ * The system headers have been included by this point, so glibc's own
+ * conclusion can be read back rather than guessed at.  Both macros below
+ * are glibc's, read here and never defined by us: __USE_FILE_OFFSET64
+ * says <features.h> selected 64-bit offsets, and __OFF_T_MATCHES_OFF64_T
+ * says this ABI has a 64-bit off_t regardless (x86_64, x32 and the other
+ * 64-bit-off_t ABIs).  The non-glibc libcs this tree builds on -- musl
+ * and the BSDs -- have a 64-bit off_t unconditionally.
+ */
+#if defined(__GLIBC__) && !defined(__USE_FILE_OFFSET64) &&                     \
+    !defined(__OFF_T_MATCHES_OFF64_T)
+#error                                                                         \
+    "libgfapi is built with _FILE_OFFSET_BITS=64: compile with -D_FILE_OFFSET_BITS=64 (pkg-config --cflags glusterfs-api), or include glfs.h before any libc header"
+#endif
+
 #if defined(HAVE_SYS_ACL_H) || (defined(USE_POSIX_ACLS) && USE_POSIX_ACLS)
 #include <sys/acl.h>
 #else

--- a/api/src/glfs.h
+++ b/api/src/glfs.h
@@ -54,36 +54,6 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-/*
- * glfs_copy_file_range() uses off64_t.  With _LARGEFILE64_SOURCE in effect
- * (defined above) glibc provides it from <sys/types.h> and musl defines it
- * as a macro for off_t.  If the application included libc headers before
- * glfs.h without LFS64 enabled, neither is present; fall back per libc.
- */
-#ifndef GF_BSD_HOST_OS
-#if defined(__GLIBC__)
-#if !defined(__off64_t_defined)
-typedef __off64_t off64_t;
-#endif
-#elif !defined(off64_t)
-/* non-glibc Linux libc (musl): off_t is always 64-bit */
-typedef int64_t off64_t;
-#endif
-#else
-#include <stdio.h>
-#ifndef _OFF64_T_DECLARED
-/*
- * Including <stdio.h> (done above) should actually define
- * _OFF64_T_DECLARED with off64_t data type being available
- * for consumption. But, off64_t data type is not recognizable
- * for FreeBSD versions less than 11. Hence, int64_t is typedefed
- * to off64_t.
- */
-#define _OFF64_T_DECLARED
-typedef int64_t off64_t;
-#endif /* _OFF64_T_DECLARED */
-#endif /* GF_BSD_HOST_OS */
-
 #if defined(HAVE_SYS_ACL_H) || (defined(USE_POSIX_ACLS) && USE_POSIX_ACLS)
 #include <sys/acl.h>
 #else
@@ -781,8 +751,8 @@ glfs_lseek(glfs_fd_t *fd, off_t offset, int whence) __THROW
     GFAPI_PUBLIC(glfs_lseek, 3.4.0);
 
 ssize_t
-glfs_copy_file_range(struct glfs_fd *glfd_in, off64_t *off_in,
-                     struct glfs_fd *glfd_out, off64_t *off_out, size_t len,
+glfs_copy_file_range(struct glfs_fd *glfd_in, off_t *off_in,
+                     struct glfs_fd *glfd_out, off_t *off_out, size_t len,
                      unsigned int flags, struct glfs_stat *statbuf,
                      struct glfs_stat *prestat,
                      struct glfs_stat *poststat) __THROW

--- a/configure.ac
+++ b/configure.ac
@@ -1848,7 +1848,7 @@ esac
 CONTRIBDIR='$(top_srcdir)/contrib'
 AC_SUBST(CONTRIBDIR)
 
-GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS)'
+GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -D$(GF_HOST_OS)'
 GF_CPPINCLUDES='-include $(top_builddir)/config.h -include $(top_builddir)/site.h -I$(top_srcdir)/libglusterfs/src -I$(top_builddir)/libglusterfs/src'
 if test "x${USE_CONTRIB_URCU}" = "xyes"; then
     GF_CPPINCLUDES="${GF_CPPINCLUDES} -I\$(CONTRIBDIR)/userspace-rcu"

--- a/configure.ac
+++ b/configure.ac
@@ -1848,7 +1848,7 @@ esac
 CONTRIBDIR='$(top_srcdir)/contrib'
 AC_SUBST(CONTRIBDIR)
 
-GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -D$(GF_HOST_OS)'
+GF_CPPDEFINES='-D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D$(GF_HOST_OS)'
 GF_CPPINCLUDES='-include $(top_builddir)/config.h -include $(top_builddir)/site.h -I$(top_srcdir)/libglusterfs/src -I$(top_builddir)/libglusterfs/src'
 if test "x${USE_CONTRIB_URCU}" = "xyes"; then
     GF_CPPINCLUDES="${GF_CPPINCLUDES} -I\$(CONTRIBDIR)/userspace-rcu"

--- a/extras/benchmarking/glfs-bm.c
+++ b/extras/benchmarking/glfs-bm.c
@@ -8,7 +8,6 @@
    cases as published by the Free Software Foundation.
 */
 #define _GNU_SOURCE
-#define __USE_FILE_OFFSET64
 #define _FILE_OFFSET_BITS 64
 
 #include <stdio.h>

--- a/glusterfs-api.pc.in
+++ b/glusterfs-api.pc.in
@@ -9,4 +9,4 @@ Description: GlusterFS API
 Version: @GFAPI_VERSION@
 Requires: @PKGCONFIG_UUID@
 Libs: -L${libdir} @GFAPI_LIBS@ -lgfapi -lglusterfs -lgfrpc -lgfxdr
-Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DUSE_POSIX_ACLS=@USE_POSIX_ACLS@
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -DUSE_POSIX_ACLS=@USE_POSIX_ACLS@

--- a/glusterfs-api.pc.in
+++ b/glusterfs-api.pc.in
@@ -9,4 +9,4 @@ Description: GlusterFS API
 Version: @GFAPI_VERSION@
 Requires: @PKGCONFIG_UUID@
 Libs: -L${libdir} @GFAPI_LIBS@ -lgfapi -lglusterfs -lgfrpc -lgfxdr
-Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D__USE_FILE_OFFSET64 -D__USE_LARGEFILE64 -DUSE_POSIX_ACLS=@USE_POSIX_ACLS@
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DUSE_POSIX_ACLS=@USE_POSIX_ACLS@

--- a/libgfchangelog.pc.in
+++ b/libgfchangelog.pc.in
@@ -9,4 +9,4 @@ Description: GlusterFS Changelog Consumer Library
 Version: @LIBGFCHANGELOG_VERSION@
 Requires: @PKGCONFIG_UUID@
 Libs: -L${libdir} -lgfchangelog -lglusterfs
-Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64

--- a/libgfchangelog.pc.in
+++ b/libgfchangelog.pc.in
@@ -9,4 +9,4 @@ Description: GlusterFS Changelog Consumer Library
 Version: @LIBGFCHANGELOG_VERSION@
 Requires: @PKGCONFIG_UUID@
 Libs: -L${libdir} -lgfchangelog -lglusterfs
-Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D__USE_FILE_OFFSET64 -D__USE_LARGEFILE64
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -5,10 +5,10 @@ noinst_PYTHON = generator.py gen-defaults.py $(top_srcdir)/events/eventskeygen.p
 libglusterfs_la_CFLAGS = $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 	-DDATADIR=\"$(localstatedir)\"
 
-libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
+libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) \
 	-DXLATORDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator\" \
 	-DXLATORPARENTDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)\" \
-	-DXXH_NAMESPACE=GF_ -D__USE_LARGEFILE64 \
+	-DXXH_NAMESPACE=GF_ \
 	-I$(CONTRIBDIR)/rbtree ${ARGP_STANDALONE_CPPFLAGS} \
 	-DSBIN_DIR=\"$(sbindir)\" -I$(CONTRIBDIR)/timer-wheel
 

--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -1663,8 +1663,8 @@ out:
 
 call_stub_t *
 fop_copy_file_range_stub(call_frame_t *frame, fop_copy_file_range_t fn,
-                         fd_t *fd_in, off64_t off_in, fd_t *fd_out,
-                         off64_t off_out, size_t len, uint32_t flags,
+                         fd_t *fd_in, off_t off_in, fd_t *fd_out,
+                         off_t off_out, size_t len, uint32_t flags,
                          dict_t *xdata)
 {
     call_stub_t *stub = NULL;

--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -1535,8 +1535,8 @@ args_namelink_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off64_t off_in,
-                           fd_t *fd_out, off64_t off_out, size_t len,
+args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off_t off_in,
+                           fd_t *fd_out, off_t off_out, size_t len,
                            uint32_t flags, dict_t *xdata)
 {
     if (fd_in)

--- a/libglusterfs/src/generator.py
+++ b/libglusterfs/src/generator.py
@@ -601,9 +601,9 @@ ops['namelink'] = (
 
 ops['copy_file_range'] = (
         ('fop-arg',     'fd_in',                 'fd_t *'),
-        ('fop-arg',     'off_in',                'off64_t '),
+        ('fop-arg',     'off_in',                'off_t'),
         ('fop-arg',     'fd_out',                'fd_t *'),
-        ('fop-arg',     'off_out',               'off64_t '),
+        ('fop-arg',     'off_out',               'off_t'),
         ('fop-arg',     'len',                   'size_t'),
         ('fop-arg',     'flags',                 'uint32_t'),
         ('fop-arg',     'xdata',                 'dict_t *'),

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -585,8 +585,8 @@ fop_namelink_cbk_stub(call_frame_t *frame, fop_namelink_cbk_t fn,
 
 call_stub_t *
 fop_copy_file_range_stub(call_frame_t *frame, fop_copy_file_range_t fn,
-                         fd_t *fd_in, off64_t off_in, fd_t *fd_out,
-                         off64_t off_out, size_t len, uint32_t flags,
+                         fd_t *fd_in, off_t off_in, fd_t *fd_out,
+                         off_t off_out, size_t len, uint32_t flags,
                          dict_t *xdata);
 
 call_stub_t *

--- a/libglusterfs/src/glusterfs/compat.h
+++ b/libglusterfs/src/glusterfs/compat.h
@@ -145,9 +145,6 @@ enum {
 #endif
 #endif
 
-#define F_GETLK64 F_GETLK
-#define F_SETLK64 F_SETLK
-#define F_SETLKW64 F_SETLKW
 #define FALLOC_FL_KEEP_SIZE 0x01      /* default is extend size */
 #define FALLOC_FL_PUNCH_HOLE 0x02     /* de-allocates range */
 #define FALLOC_FL_ZERO_RANGE 0x10     /* zeroes out range */
@@ -227,10 +224,6 @@ gf_extattr_list_reshape(char *list, ssize_t size);
 #define NAME_MAX 255
 #endif
 #endif
-
-#define F_GETLK64 F_GETLK
-#define F_SETLK64 F_SETLK
-#define F_SETLKW64 F_SETLKW
 
 #ifndef FTW_CONTINUE
 #define FTW_CONTINUE 0

--- a/libglusterfs/src/glusterfs/compat.h
+++ b/libglusterfs/src/glusterfs/compat.h
@@ -86,25 +86,7 @@
 #include <limits.h>
 
 #include <libgen.h>
-/*
- * This is where things like off64_t are defined.
- * So include it before declaring _OFF64_T_DECLARED.
- * If the freebsd version has support for off64_t
- * including stdio.h should be sufficient.
- */
 #include <stdio.h>
-
-#ifndef _OFF64_T_DECLARED
-/*
- * Including <stdio.h> (done above) should actually define
- * _OFF64_T_DECLARED with off64_t data type being available
- * for consumption. But, off64_t data type is not recognizable
- * for FreeBSD versions less than 11. Hence, int64_t is typedefed
- * to off64_t.
- */
-#define _OFF64_T_DECLARED
-typedef int64_t off64_t;
-#endif /* _OFF64_T_DECLARED */
 
 #ifndef XATTR_CREATE
 enum {

--- a/libglusterfs/src/glusterfs/default-args.h
+++ b/libglusterfs/src/glusterfs/default-args.h
@@ -444,8 +444,8 @@ int
 args_namelink_store(default_args_t *args, loc_t *loc, dict_t *xdata);
 
 int
-args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off64_t off_in,
-                           fd_t *fd_out, off_t off64_out, size_t len,
+args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off_t off_in,
+                           fd_t *fd_out, off_t off_out, size_t len,
                            uint32_t flags, dict_t *xdata);
 
 void

--- a/libglusterfs/src/glusterfs/defaults.h
+++ b/libglusterfs/src/glusterfs/defaults.h
@@ -56,15 +56,13 @@ typedef struct {
     fd_t *fd;     /* for all the fd based ops */
     fd_t *fd_dst; /* Only for copy_file_range destination */
     off_t offset;
-    /*
-     * According to the man page of copy_file_range,
-     * the offsets for source and destination file
-     * are of type loff_t. But the type loff_t is
-     * linux specific and is actual a typedef of
-     * off64_t.
+    /* Offsets for the copy_file_range source and destination file.
+     * copy_file_range(2) types them loff_t *, which is Linux-only;
+     * off_t is 64-bit here because the whole tree is built with
+     * _FILE_OFFSET_BITS=64, and it exists on every platform.
      */
-    off64_t off_in;  /* For copy_file_range source fd */
-    off64_t off_out; /* For copy_file_range destination fd only */
+    off_t off_in;  /* For copy_file_range source fd */
+    off_t off_out; /* For copy_file_range destination fd only */
     int mask;
     size_t size;
     mode_t mode;
@@ -322,7 +320,7 @@ default_namelink(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 default_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
-                        off64_t off_in, fd_t *fd_out, off64_t off_out,
+                        off_t off_in, fd_t *fd_out, off_t off_out,
                         size_t len, uint32_t flags, dict_t *xdata);
 
 /* Resume */
@@ -546,7 +544,7 @@ default_put_resume(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 int32_t
 default_copy_file_range_resume(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
-                               off_t off64_in, fd_t *fd_out, off64_t off_out,
+                               off_t off_in, fd_t *fd_out, off_t off_out,
                                size_t len, uint32_t flags, dict_t *xdata);
 
 /* _cbk_resume */

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -718,8 +718,8 @@ syncop_entrylk(xlator_t *subvol, const char *volume, loc_t *loc,
                dict_t *xdata_in, dict_t **xdata_out);
 
 int
-syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
-                       fd_t *fd_out, off64_t off_out, size_t len,
+syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off_t off_in,
+                       fd_t *fd_out, off_t off_out, size_t len,
                        uint32_t flags, struct iatt *stbuf,
                        struct iatt *preiatt_dst, struct iatt *postiatt_dst,
                        dict_t *xdata_in, dict_t **xdata_out);

--- a/libglusterfs/src/glusterfs/syscall.h
+++ b/libglusterfs/src/glusterfs/syscall.h
@@ -249,32 +249,15 @@ sys_socket(int domain, int type, int protocol);
 int
 sys_accept(int sock, struct sockaddr *sockaddr, socklen_t *socklen, int flags);
 
-#ifdef GF_BSD_HOST_OS
-#ifndef _OFF64_T_DECLARED
 /*
- * Including <stdio.h> (done above) should actually define
- * _OFF64_T_DECLARED with off64_t data type being available
- * for consumption. But, off64_t data type is not recognizable
- * for FreeBSD versions less than 11. Hence, int64_t is typedefed
- * to off64_t.
- */
-#define _OFF64_T_DECLARED
-typedef int64_t off64_t;
-#endif /* _OFF64_T_DECLARED */
-#endif /* GF_BSD_HOST_OS */
-
-/*
- * According to the man page of copy_file_range, both off_in and off_out are
- * pointers to the data type loff_t (i.e. loff_t *). But, freebsd does not
- * have (and recognize) loff_t. Since loff_t is 64 bits, use off64_t
- * instead.  Since it's a pointer type it should be okay. It just needs
- * to be a pointer-to-64-bit pointer for both 32- and 64-bit platforms.
- * off64_t is recognized by freebsd.
- * TODO: In future, when freebsd can recognize loff_t, probably revisit this
- *       and change the off_in and off_out to (loff_t *).
+ * copy_file_range(2) is declared with loff_t * offsets on Linux, which is
+ * a 64-bit type.  off_t is that same 64-bit type here: every translation
+ * unit is built with _FILE_OFFSET_BITS=64 (see GF_CPPDEFINES), FreeBSD and
+ * musl have a 64-bit off_t unconditionally, and glibc's copy_file_range()
+ * takes __off64_t *, which _FILE_OFFSET_BITS=64 makes identical to off_t *.
  */
 ssize_t
-sys_copy_file_range(int fd_in, off64_t *off_in, int fd_out, off64_t *off_out,
+sys_copy_file_range(int fd_in, off_t *off_in, int fd_out, off_t *off_out,
                     size_t len, unsigned int flags);
 
 int

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -12,7 +12,7 @@
 #define _XLATOR_H
 
 #include <stdint.h>                    // for int32_t
-#include <sys/types.h>                 // for off_t, mode_t, off64_t, dev_t
+#include <sys/types.h>                 // for off_t, mode_t, dev_t
 #include <urcu/arch.h>                 // CAA_CACHE_LINE_SIZE
 #include "glusterfs/glusterfs-fops.h"  // for GF_FOP_MAXVALUE, entrylk_cmd
 #include "glusterfs/atomic.h"          // for gf_atomic_t
@@ -534,8 +534,8 @@ typedef int32_t (*fop_icreate_t)(call_frame_t *frame, xlator_t *this,
 typedef int32_t (*fop_namelink_t)(call_frame_t *frame, xlator_t *this,
                                   loc_t *loc, dict_t *xdata);
 typedef int32_t (*fop_copy_file_range_t)(call_frame_t *frame, xlator_t *this,
-                                         fd_t *fd_in, off64_t off_in,
-                                         fd_t *fd_out, off64_t off_out,
+                                         fd_t *fd_in, off_t off_in,
+                                         fd_t *fd_out, off_t off_out,
                                          size_t len, uint32_t flags,
                                          dict_t *xdata);
 

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -3607,8 +3607,8 @@ syncop_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
-syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
-                       fd_t *fd_out, off64_t off_out, size_t len,
+syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off_t off_in,
+                       fd_t *fd_out, off_t off_out, size_t len,
                        uint32_t flags, struct iatt *stbuf,
                        struct iatt *preiatt_dst, struct iatt *postiatt_dst,
                        dict_t *xdata_in, dict_t **xdata_out)

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -848,7 +848,7 @@ err:
 }
 
 ssize_t
-sys_copy_file_range(int fd_in, off64_t *off_in, int fd_out, off64_t *off_out,
+sys_copy_file_range(int fd_in, off_t *off_in, int fd_out, off_t *off_out,
                     size_t len, unsigned int flags)
 {
     /*

--- a/rpc/xdr/src/Makefile.am
+++ b/rpc/xdr/src/Makefile.am
@@ -19,7 +19,7 @@ lib_LTLIBRARIES = libgfxdr.la
 
 libgfxdr_la_CFLAGS = -Wall $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS)
 
-libgfxdr_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
+libgfxdr_la_CPPFLAGS = $(GF_CPPFLAGS) \
 	-I$(top_srcdir)/libglusterfs/src -I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_builddir)/rpc/xdr/src
 

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -2497,14 +2497,7 @@ afr_lk_is_unlock(int32_t cmd, struct gf_flock *flock)
             return _gf_true;
             break;
 
-#if F_SETLKW != F_SETLKW64
-        case F_SETLKW64:
-#endif
         case F_SETLKW:
-
-#if F_SETLK != F_SETLK64
-        case F_SETLK64:
-#endif
         case F_SETLK:
             if (F_UNLCK == flock->l_type)
                 return _gf_true;

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -1673,23 +1673,14 @@ trace_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
             0,
         };
         switch (cmd) {
-#if F_GETLK != F_GETLK64
-            case F_GETLK64:
-#endif
             case F_GETLK:
                 cmd_str = "GETLK";
                 break;
 
-#if F_SETLK != F_SETLK64
-            case F_SETLK64:
-#endif
             case F_SETLK:
                 cmd_str = "SETLK";
                 break;
 
-#if F_SETLKW != F_SETLKW64
-            case F_SETLKW64:
-#endif
             case F_SETLKW:
                 cmd_str = "SETLKW";
                 break;
@@ -1753,23 +1744,14 @@ trace_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
             0,
         };
         switch (cmd) {
-#if F_GETLK != F_GETLK64
-            case F_GETLK64:
-#endif
             case F_GETLK:
                 cmd_str = "GETLK";
                 break;
 
-#if F_SETLK != F_SETLK64
-            case F_SETLK64:
-#endif
             case F_SETLK:
                 cmd_str = "SETLK";
                 break;
 
-#if F_SETLKW != F_SETLKW64
-            case F_SETLKW64:
-#endif
             case F_SETLKW:
                 cmd_str = "SETLKW";
                 break;

--- a/xlators/features/changelog/lib/src/Makefile.am
+++ b/xlators/features/changelog/lib/src/Makefile.am
@@ -3,7 +3,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 libgfchangelog_la_CFLAGS = -Wall $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 	-DDATADIR=\"$(localstatedir)\"
 
-libgfchangelog_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 -D__USE_LARGEFILE64 -fpic \
+libgfchangelog_la_CPPFLAGS = $(GF_CPPFLAGS) -fpic \
 	-I../../../src/ -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/xlators/features/changelog/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src \

--- a/xlators/features/leases/src/leases.h
+++ b/xlators/features/leases/src/leases.h
@@ -80,13 +80,10 @@
 #define GET_FLAGS_LK(cmd, l_type, fd_flags)                                    \
     do {                                                                       \
         /* TODO: handle F_RESLK_LCK and other glusterfs_lk_recovery_cmds_t */  \
-        if ((cmd == F_SETLKW || cmd == F_SETLKW64 || cmd == F_SETLK ||         \
-             cmd == F_SETLK64) &&                                              \
-            l_type == F_WRLCK)                                                 \
+        if ((cmd == F_SETLKW || cmd == F_SETLK) && l_type == F_WRLCK)          \
             fop_flags = DATA_MODIFY_FOP;                                       \
                                                                                \
-        if (fd_flags & (O_NONBLOCK | O_NDELAY) &&                              \
-            (cmd == F_SETLKW || cmd == F_SETLKW64))                            \
+        if (fd_flags & (O_NONBLOCK | O_NDELAY) && cmd == F_SETLKW)             \
             fop_flags |= BLOCKING_FOP;                                         \
                                                                                \
     } while (0)

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -159,23 +159,14 @@ pl_print_lock(char *str, int size, int cmd, struct gf_flock *flock,
     char *type_str = NULL;
 
     switch (cmd) {
-#if F_GETLK != F_GETLK64
-        case F_GETLK64:
-#endif
         case F_GETLK:
             cmd_str = "GETLK";
             break;
 
-#if F_SETLK != F_SETLK64
-        case F_SETLK64:
-#endif
         case F_SETLK:
             cmd_str = "SETLK";
             break;
 
-#if F_SETLKW != F_SETLKW64
-        case F_SETLKW64:
-#endif
         case F_SETLKW:
             cmd_str = "SETLKW";
             break;

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -59,23 +59,14 @@ pl_print_inodelk(char *str, int size, int cmd, struct gf_flock *flock,
     char *type_str = NULL;
 
     switch (cmd) {
-#if F_GETLK != F_GETLK64
-        case F_GETLK64:
-#endif
         case F_GETLK:
             cmd_str = "GETLK";
             break;
 
-#if F_SETLK != F_SETLK64
-        case F_SETLK64:
-#endif
         case F_SETLK:
             cmd_str = "SETLK";
             break;
 
-#if F_SETLKW != F_SETLKW64
-        case F_SETLKW64:
-#endif
         case F_SETLKW:
             cmd_str = "SETLKW";
             break;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -2734,9 +2734,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
             break;
 
-#if F_GETLK != F_GETLK64
-        case F_GETLK64:
-#endif
         case F_GETLK:
             conf = pl_getlk(pl_inode, reqlock);
             posix_lock_to_flock(conf, flock);
@@ -2744,18 +2741,12 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
             break;
 
-#if F_SETLKW != F_SETLKW64
-        case F_SETLKW64:
-#endif
         case F_SETLKW:
             can_block = 1;
             reqlock->frame = frame;
             reqlock->blocking = can_block;
             /* fall through */
 
-#if F_SETLK != F_SETLK64
-        case F_SETLK64:
-#endif
         case F_SETLK:
             reqlock->frame = frame;
             lock_type = flock->l_type;

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -424,16 +424,13 @@ typedef struct {
     int32_t flags;
 
     off_t off;
-    /*
-     * The man page of copy_file_range tells that the offset
-     * arguments are of type loff_t *. Here in fuse state, the values of
-     * those offsets are saved instead of pointers as the kernel sends
-     * the values of the offsets from those pointers instead of pointers.
-     * But the type loff_t is linux specific and is actually a typedef of
-     * off64_t. Hence using off64_t
+    /* copy_file_range(2) takes the offsets as loff_t *; the fuse
+     * kernel module sends the values rather than the pointers, so the
+     * values are what is kept here.  off_t is 64-bit (the tree is built
+     * with _FILE_OFFSET_BITS=64) and, unlike loff_t, is portable.
      */
-    off64_t off_in;  /* for copy_file_range source fd */
-    off64_t off_out; /* for copy_file_range destination fd */
+    off_t off_in;  /* for copy_file_range source fd */
+    off_t off_out; /* for copy_file_range destination fd */
     size_t size;
     unsigned long nlookup;
     fd_t *fd;

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -16,11 +16,11 @@ client_cmd_to_gf_cmd(int32_t cmd, int32_t *gf_cmd)
 {
     int ret = 0;
 
-    if (cmd == F_GETLK || cmd == F_GETLK64)
+    if (cmd == F_GETLK)
         *gf_cmd = GF_LK_GETLK;
-    else if (cmd == F_SETLK || cmd == F_SETLK64)
+    else if (cmd == F_SETLK)
         *gf_cmd = GF_LK_SETLK;
-    else if (cmd == F_SETLKW || cmd == F_SETLKW64)
+    else if (cmd == F_SETLKW)
         *gf_cmd = GF_LK_SETLKW;
     else if (cmd == F_RESLK_LCK)
         *gf_cmd = GF_LK_RESLK_LCK;
@@ -902,11 +902,11 @@ client_pre_inodelk_v2(gfx_inodelk_req *req, loc_t *loc, int cmd,
 
     GF_ASSERT_AND_GOTO_WITH_ERROR(!gf_uuid_is_null(*((uuid_t *)req->gfid)), out,
                                   op_errno, EINVAL);
-    if (cmd == F_GETLK || cmd == F_GETLK64)
+    if (cmd == F_GETLK)
         gf_cmd = GF_LK_GETLK;
-    else if (cmd == F_SETLK || cmd == F_SETLK64)
+    else if (cmd == F_SETLK)
         gf_cmd = GF_LK_SETLK;
-    else if (cmd == F_SETLKW || cmd == F_SETLKW64)
+    else if (cmd == F_SETLKW)
         gf_cmd = GF_LK_SETLKW;
     else {
         gf_smsg(THIS->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,
@@ -952,11 +952,11 @@ client_pre_finodelk_v2(xlator_t *this, gfx_finodelk_req *req, fd_t *fd, int cmd,
     CLIENT_GET_REMOTE_FD(this, fd, FALLBACK_TO_ANON_FD, remote_fd, op_errno,
                          GFS3_OP_FINODELK, out);
 
-    if (cmd == F_GETLK || cmd == F_GETLK64)
+    if (cmd == F_GETLK)
         gf_cmd = GF_LK_GETLK;
-    else if (cmd == F_SETLK || cmd == F_SETLK64)
+    else if (cmd == F_SETLK)
         gf_cmd = GF_LK_SETLK;
-    else if (cmd == F_SETLKW || cmd == F_SETLKW64)
+    else if (cmd == F_SETLKW)
         gf_cmd = GF_LK_SETLKW;
     else {
         gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_UNKNOWN_CMD,

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -464,8 +464,8 @@ out:
 
 int
 client_pre_copy_file_range_v2(xlator_t *this, gfx_copy_file_range_req *req,
-                              fd_t *fd_in, off64_t off_in, fd_t *fd_out,
-                              off64_t off_out, size_t size, int32_t flags,
+                              fd_t *fd_in, off_t off_in, fd_t *fd_out,
+                              off_t off_out, size_t size, int32_t flags,
                               dict_t **xdata)
 {
     int64_t remote_fd_in = -1;

--- a/xlators/protocol/client/src/client-common.h
+++ b/xlators/protocol/client/src/client-common.h
@@ -251,8 +251,8 @@ client_post_rename_v2(gfx_rename_rsp *rsp, struct iatt *stbuf,
 
 int
 client_pre_copy_file_range_v2(xlator_t *this, gfx_copy_file_range_req *req,
-                              fd_t *fd_in, off64_t off_in, fd_t *fd_out,
-                              off64_t off_out, size_t size, int32_t flags,
+                              fd_t *fd_in, off_t off_in, fd_t *fd_out,
+                              off_t off_out, size_t size, int32_t flags,
                               dict_t **xdata);
 
 void

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -20,8 +20,7 @@ client3_getspec(call_frame_t *frame, xlator_t *this, void *data);
 int
 client_is_setlk(int32_t cmd)
 {
-    if ((cmd == F_SETLK) || (cmd == F_SETLK64) || (cmd == F_SETLKW) ||
-        (cmd == F_SETLKW64)) {
+    if ((cmd == F_SETLK) || (cmd == F_SETLKW)) {
         return 1;
     }
 

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -212,15 +212,13 @@ typedef struct client_args {
     const char *basename;
 
     off_t offset;
-    /*
-     * According to the man page of copy_file_range,
-     * the offsets for source and destination file
-     * are of type loff_t. But the type loff_t is
-     * linux specific and is actual a typedef of
-     * off64_t.
+    /* Offsets for the copy_file_range source and destination file.
+     * copy_file_range(2) types them loff_t *, which is Linux-only;
+     * off_t is 64-bit here because the whole tree is built with
+     * _FILE_OFFSET_BITS=64, and it exists on every platform.
      */
-    off64_t off_in;  /* used in copy_file_range for source fd */
-    off64_t off_out; /* used in copy_file_range for dst fd */
+    off_t off_in;  /* used in copy_file_range for source fd */
+    off_t off_out; /* used in copy_file_range for dst fd */
     int32_t mask;
     int32_t cmd;
     size_t size;

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -138,15 +138,13 @@ struct _server_state {
 
     size_t size;
     off_t offset;
-    /*
-     * According to the man page of copy_file_range,
-     * the offsets for source and destination file
-     * are of type loff_t. But the type loff_t is
-     * linux specific and is actual a typedef of
-     * off64_t.
+    /* Offsets for the copy_file_range source and destination file.
+     * copy_file_range(2) types them loff_t *, which is Linux-only;
+     * off_t is 64-bit here because the whole tree is built with
+     * _FILE_OFFSET_BITS=64, and it exists on every platform.
      */
-    off64_t off_in;  /* source offset in copy_file_range */
-    off64_t off_out; /* destination offset in copy_file_range */
+    off_t off_in;  /* source offset in copy_file_range */
+    off_t off_out; /* destination offset in copy_file_range */
     mode_t mode;
     dev_t dev;
     int cmd;

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -2220,7 +2220,7 @@ unwind:
 
 int32_t
 posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
-                      off64_t off_in, fd_t *fd_out, off64_t off_out, size_t len,
+                      off_t off_in, fd_t *fd_out, off_t off_out, size_t len,
                       uint32_t flags, dict_t *xdata)
 {
     int32_t op_ret = -1;

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -672,7 +672,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 int32_t
 posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
-                      off64_t off_in, fd_t *fd_out, off64_t off_out, size_t len,
+                      off_t off_in, fd_t *fd_out, off_t off_out, size_t len,
                       uint32_t flags, dict_t *xdata);
 
 int32_t


### PR DESCRIPTION
DRAFT/RFC - see #4775.

Updates: #268

Drop the LFS64 transitional API (`off64_t`, `F_*LK64`, glibc-private `__USE_*`). 

1. build: enable LFS64 explicitly; make glfs.h compile on non-glibc libcs
2. build: stop defining glibc-private __USE_FILE_OFFSET64/__USE_LARGEFILE64
3. core: use off_t, not off64_t, for the copy_file_range offsets
4. gfapi: type the glfs_copy_file_range() offsets as off_t *
5. locks, client, afr, trace, leases: drop the dead F_*LK64 alternates
6. gfapi: refuse to compile glfs.h in a half-configured consumer
7. build: stop asking for the LFS64 transitional API

Two layers:
- commits 1-2: aguably mergeable as is
- commits 3–7 touch a public header (`off64_t *` -> `off_t *`, ABI-identical),
add an `#error`, and drop `.pc` flags — the points to agree before a merge-ready PR (see "what needs a decision" in #4775). The `#error` commit is independent and droppable; commits 1–2 can land alone.

Testing:
- For musl — the `off64_t` failure is gone and `glfs.h` becomes includable; native NetBSD/FreeBSD — no regression, and NetBSD's `glfs.h __off64_t` break is fixed.

Breaks:
- distros that ship the 32bit package and require the LFS64 compatibility layer

