### PR TITLE
glusterd/snapshot: allow overriding ZFS_COMMAND at build time

### DIFF
--- a/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
+++ b/xlators/mgmt/glusterd/src/snapshot/glusterd-zfs-snapshot.c
@@ -26,7 +26,9 @@
 #include "mntent_compat.h"
 #endif
 
+#ifndef ZFS_COMMAND
 #define ZFS_COMMAND "/sbin/zfs"
+#endif
 
 extern char snap_mount_dir[VALID_GLUSTERD_PATHMAX];
 
@@ -51,7 +53,8 @@ glusterd_zfs_dataset(char *brick_path, char *pool_name, size_t pool_name_size)
     snprintf(msg, sizeof(msg),
              "running zfs command, "
              "for getting zfs pool name from brick path");
-    runner_add_args(&runner, "zfs", "list", "-Ho", "name", brick_path, NULL);
+    runner_add_args(&runner, ZFS_COMMAND, "list", "-Ho", "name", brick_path,
+                    NULL);
     runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
     runner_log(&runner, "", GF_LOG_DEBUG, msg);
     ret = runner_start(&runner);


### PR DESCRIPTION
# glusterd/snapshot: make the zfs tool path consistent and overridable

Wrap ZFS_COMMAND in an `#ifndef` guard so a packager can override via `CPPFLAGS`
(`-DZFS_COMMAND='"/usr/sbin/zfs"'`) idiom already used in the tree.

The outlier `glusterd_zfs_dataset()` spelled the `zfs list` command as a bare string,
which is now routed through `ZFS_COMMAND` too, so all sites share one definition.

Fixes: #4777

